### PR TITLE
`HTTPClient`: test all request headers

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		4F15B4A12A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F15B4A02A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift */; };
 		4F15B4A22A678A9C005BEFE8 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
 		4F15B4A32A678B81005BEFE8 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
+		4F174F472B07EA7E00FE538E /* StorefrontProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F174F462B07EA7E00FE538E /* StorefrontProvider.swift */; };
 		4F1E84012A6062C1000AF177 /* ImageSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCEEA622A37A2E9002C2112 /* ImageSnapshot.swift */; };
 		4F1E84022A6062C9000AF177 /* ImageSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCEEA622A37A2E9002C2112 /* ImageSnapshot.swift */; };
 		4F2017D52A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2017D42A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift */; };
@@ -998,6 +999,7 @@
 		4F0CE2BC2A215CE600561895 /* TransactionPosterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionPosterTests.swift; sourceTree = "<group>"; };
 		4F1428A32A4A132C006CD196 /* TestStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStoreProductDiscount.swift; sourceTree = "<group>"; };
 		4F15B4A02A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+NonSubscriptions.swift"; sourceTree = "<group>"; };
+		4F174F462B07EA7E00FE538E /* StorefrontProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorefrontProvider.swift; sourceTree = "<group>"; };
 		4F2017D42A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineStoreKitIntegrationTests.swift; sourceTree = "<group>"; };
 		4F2F2EFE2A3CDAA800652B24 /* FileHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHandler.swift; sourceTree = "<group>"; };
 		4F2F2F132A3CEAB500652B24 /* FileHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHandlerTests.swift; sourceTree = "<group>"; };
@@ -1564,6 +1566,7 @@
 				B372EC53268FEDC60099171E /* StoreProductDiscount.swift */,
 				2D1015D9275959840086173F /* StoreTransaction.swift */,
 				2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */,
+				4F174F462B07EA7E00FE538E /* StorefrontProvider.swift */,
 			);
 			path = StoreKitAbstractions;
 			sourceTree = "<group>";
@@ -3415,6 +3418,7 @@
 				5796A3A927D7C43500653165 /* Deprecations.swift in Sources */,
 				4F0201C42A13C85500091612 /* Assertions.swift in Sources */,
 				5753ED8E294A662400CBAB54 /* DateFormatter+Extensions.swift in Sources */,
+				4F174F472B07EA7E00FE538E /* StorefrontProvider.swift in Sources */,
 				B3AA6238268B926F00894871 /* SystemInfo.swift in Sources */,
 				5746508E275949F20053AB09 /* DispatchTimeInterval+Extensions.swift in Sources */,
 				2D294E5C26DECFD500B8FE4F /* StoreKit2TransactionListener.swift in Sources */,

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -46,6 +46,7 @@ class SystemInfo {
     var observerMode: Bool { return !self.finishTransactions }
 
     private let sandboxEnvironmentDetector: SandboxEnvironmentDetector
+    private let storefrontProvider: StorefrontProviderType
     private let _finishTransactions: Atomic<Bool>
     private let _bundle: Atomic<Bundle>
 
@@ -54,11 +55,7 @@ class SystemInfo {
     }
 
     var storefront: StorefrontType? {
-        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *) {
-            return Storefront.sk1CurrentStorefrontType
-        } else {
-            return nil
-        }
+        return self.storefrontProvider.currentStorefront
     }
 
     static var frameworkVersion: String {
@@ -114,6 +111,7 @@ class SystemInfo {
          operationDispatcher: OperationDispatcher = .default,
          bundle: Bundle = .main,
          sandboxEnvironmentDetector: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector.default,
+         storefrontProvider: StorefrontProviderType = DefaultStorefrontProvider(),
          storeKit2Setting: StoreKit2Setting = .default,
          responseVerificationMode: Signing.ResponseVerificationMode = .default,
          dangerousSettings: DangerousSettings? = nil,
@@ -126,6 +124,7 @@ class SystemInfo {
         self.operationDispatcher = operationDispatcher
         self.storeKit2Setting = storeKit2Setting
         self.sandboxEnvironmentDetector = sandboxEnvironmentDetector
+        self.storefrontProvider = storefrontProvider
         self.responseVerificationMode = responseVerificationMode
         self.dangerousSettings = dangerousSettings ?? DangerousSettings()
         self.clock = clock

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -155,7 +155,6 @@ extension HTTPClient {
         case eTag = "X-RevenueCat-ETag"
         case eTagValidationTime = "X-RC-Last-Refresh-Time"
         case postParameters = "X-Post-Params-Hash"
-        case headerParametersForSignature = "X-Header-Params-Hash"
         case sandbox = "X-Is-Sandbox"
 
     }

--- a/Sources/Purchasing/StoreKitAbstractions/StorefrontProvider.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StorefrontProvider.swift
@@ -1,0 +1,35 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StorefrontProvider.swift
+//
+//  Created by Nacho Soto on 11/17/23.
+
+import Foundation
+
+/// A type that can determine the current `Storefront`.
+protocol StorefrontProviderType {
+
+    var currentStorefront: StorefrontType? { get }
+
+}
+
+/// Main `StorefrontProviderType` implementation.
+/// Relies on StoreKit 1 because StoreKit 2's implementation would be `async`.
+final class DefaultStorefrontProvider: StorefrontProviderType {
+
+    var currentStorefront: StorefrontType? {
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *) {
+            return Storefront.sk1CurrentStorefrontType
+        } else {
+            return nil
+        }
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -85,6 +85,7 @@ class MockHTTPClient: HTTPClient {
 
         let call = Call(request: request,
                         headers: request.headers(with: self.authHeaders,
+                                                 defaultHeaders: self.defaultHeaders,
                                                  verificationMode: verificationMode))
 
         DispatchQueue.main.async {
@@ -117,6 +118,21 @@ class MockHTTPClient: HTTPClient {
 
     private func mock(path: HTTPRequestPath, response: Response) {
         self.mocks[path.url!] = response
+    }
+
+    /// Override headers that depend on the environment to make them stable.
+    override var defaultHeaders: RequestHeaders {
+        var result = super.defaultHeaders
+        result["X-Version"] = "4.0.0"
+        result["X-Client-Build-Version"] = "12345"
+        result["X-Client-Version"] = "17.0.0"
+        result["X-Platform-Version"] = "Version 17.0.0 (Build 21A342)"
+
+        if result.keys.contains("X-Apple-Device-Identifier") {
+            result["X-Apple-Device-Identifier"] = "5D7C0074-07E4-4564-AAA4-4008D0640881"
+        }
+
+        return result
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -124,6 +124,8 @@ class MockHTTPClient: HTTPClient {
     override var defaultHeaders: RequestHeaders {
         var result = super.defaultHeaders
         result["X-Version"] = "4.0.0"
+        // Snapshots are shared across platforms so we need this to be stable.
+        result["X-Platform"] = "iOS"
         result["X-Client-Build-Version"] = "12345"
         result["X-Client-Version"] = "17.0.0"
         result["X-Platform-Version"] = "Version 17.0.0 (Build 21A342)"

--- a/Tests/UnitTests/Networking/Backend/BackendInternalTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendInternalTests.swift
@@ -33,14 +33,16 @@ class BackendInternalTests: BaseBackendTests {
         expect(error).to(beNil())
     }
 
-    func testHealthRequestIsNotAuthenticated() {
+    func testHealthRequestIsNotAuthenticated() throws {
         waitUntil { completed in
             self.internalAPI.healthRequest(signatureVerification: false) { _ in
                 completed()
             }
         }
 
-        expect(self.httpClient.calls.onlyElement?.headers).to(beEmpty())
+        let request = try XCTUnwrap(self.httpClient.calls.onlyElement)
+
+        expect(request.headers.keys).toNot(contain(HTTPClient.RequestHeader.authorization.rawValue))
     }
 
     func testHealthRequestWithFailure() {

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -91,16 +91,10 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
     func testPostsReceiptDataWithTestReceiptIdentifier() throws {
         let identifier = try XCTUnwrap(UUID(uuidString: "12345678-1234-1234-1234-C2C35AE34D09")).uuidString
 
-        self.createDependencies(
-            SystemInfo(
-                platformInfo: nil,
-                finishTransactions: false,
-                dangerousSettings: .init(
-                    autoSyncPurchases: true,
-                    internalSettings: DangerousSettings.Internal(testReceiptIdentifier: identifier)
-                )
-            )
-        )
+        self.createDependencies(dangerousSettings: .init(
+            autoSyncPurchases: true,
+            internalSettings: DangerousSettings.Internal(testReceiptIdentifier: identifier)
+        ))
 
         let path: HTTPRequest.Path = .postReceiptData
 

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -42,6 +42,7 @@ class BaseBackendTests: TestCase {
             SystemInfo(
                 platformInfo: nil,
                 finishTransactions: true,
+                storefrontProvider: MockStorefrontProvider(),
                 responseVerificationMode: self.responseVerificationMode,
                 dangerousSettings: self.dangerousSettings
             )
@@ -136,5 +137,13 @@ extension BaseBackendTests {
             ]
         ] as [String: Any]
     ]
+
+}
+
+private final class MockStorefrontProvider: StorefrontProviderType {
+
+    var currentStorefront: StorefrontType? {
+        return MockStorefront(countryCode: "USA")
+    }
 
 }

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -140,7 +140,7 @@ extension BaseBackendTests {
 
 }
 
-private final class MockStorefrontProvider: StorefrontProviderType {
+final class MockStorefrontProvider: StorefrontProviderType {
 
     var currentStorefront: StorefrontType? {
         return MockStorefront(countryCode: "USA")

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -141,7 +141,12 @@ extension BaseBackendTests {
 final class MockStorefrontProvider: StorefrontProviderType {
 
     var currentStorefront: StorefrontType? {
-        return MockStorefront(countryCode: "USA")
+        // Simulate `DefaultStorefrontProvider` availability.
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *) {
+            return MockStorefront(countryCode: "USA")
+        } else {
+            return nil
+        }
     }
 
 }

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -38,19 +38,17 @@ class BaseBackendTests: TestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.createDependencies(
-            SystemInfo(
-                platformInfo: nil,
-                finishTransactions: true,
-                storefrontProvider: MockStorefrontProvider(),
-                responseVerificationMode: self.responseVerificationMode,
-                dangerousSettings: self.dangerousSettings
-            )
-        )
+        self.createDependencies(dangerousSettings: self.dangerousSettings)
     }
 
-    final func createDependencies(_ systemInfo: SystemInfo) {
-        self.systemInfo = systemInfo
+    final func createDependencies(dangerousSettings: DangerousSettings? = nil) {
+        self.systemInfo =  SystemInfo(
+            platformInfo: nil,
+            finishTransactions: true,
+            storefrontProvider: MockStorefrontProvider(),
+            responseVerificationMode: self.responseVerificationMode,
+            dangerousSettings: dangerousSettings
+        )
         self.httpClient = self.createClient()
         self.operationDispatcher = MockOperationDispatcher()
         self.mockProductEntitlementMappingFetcher = MockProductEntitlementMappingFetcher()

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testCachesCustomerGetsForSameCustomer.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testGetCustomerCallsBackendProperly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testGetsCustomerInfo.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testHandlesGetCustomerInfoErrors.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testHandlesInvalidJSON.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testUpdatesRequestDateFromResponseHeader.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testCachesCustomerGetsForSameCustomer.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testCachesCustomerGetsForSameCustomer.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerCallsBackendProperly.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerCallsBackendProperly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithFailedVerification.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithFailedVerification.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetsCustomerInfo.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetsCustomerInfo.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesGetCustomerInfoErrors.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesGetCustomerInfoErrors.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesInvalidJSON.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesInvalidJSON.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
@@ -12,6 +12,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
@@ -1,7 +1,19 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testUpdatesRequestDateFromResponseHeader.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testUpdatesRequestDateFromResponseHeader.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testCachesCustomerGetsForSameCustomer.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerCallsBackendProperly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithFailedVerification.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetsCustomerInfo.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesGetCustomerInfoErrors.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesInvalidJSON.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testSendsNonceWhenEnabled.1.json
@@ -1,7 +1,20 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testUpdatesRequestDateFromResponseHeader.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testCachesCustomerGetsForSameCustomer.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerCallsBackendProperly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithFailedVerification.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetsCustomerInfo.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesGetCustomerInfoErrors.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesInvalidJSON.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
@@ -1,7 +1,20 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testUpdatesRequestDateFromResponseHeader.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testCachesCustomerGetsForSameCustomer.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerCallsBackendProperly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithFailedVerification.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetsCustomerInfo.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesGetCustomerInfoErrors.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesInvalidJSON.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testSendsNonceWhenEnabled.1.json
@@ -1,7 +1,20 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testUpdatesRequestDateFromResponseHeader.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testCachesCustomerGetsForSameCustomer.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerCallsBackendProperly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithFailedVerification.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetsCustomerInfo.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesGetCustomerInfoErrors.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesInvalidJSON.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testSendsNonceWhenEnabled.1.json
@@ -12,6 +12,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testSendsNonceWhenEnabled.1.json
@@ -1,7 +1,19 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testUpdatesRequestDateFromResponseHeader.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS12-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS12-testEligibilityUnknownIfError.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS12-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS12-testEligibilityUnknownIfUnknownError.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS12-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS12-testPostsProductIdentifiers.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfError.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfError.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfUnknownError.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfUnknownError.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testPostsProductIdentifiers.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testPostsProductIdentifiers.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfUnknownError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testPostsProductIdentifiers.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfUnknownError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testPostsProductIdentifiers.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfUnknownError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testPostsProductIdentifiers.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfError.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfError.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfUnknownError.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfUnknownError.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testPostsProductIdentifiers.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testPostsProductIdentifiers.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsCachesForSameUserID.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsCallsHTTPMethod.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsFailSendsNil.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsNetworkErrorSendsError.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsOneOffering.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCachesForSameUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCachesForSameUserID.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethod.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethod.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsFailSendsNil.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsFailSendsNil.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsNetworkErrorSendsError.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsNetworkErrorSendsError.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsOneOffering.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsOneOffering.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCachesForSameUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethod.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsFailSendsNil.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsNetworkErrorSendsError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsOneOffering.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCachesForSameUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethod.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsFailSendsNil.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsNetworkErrorSendsError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsOneOffering.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCachesForSameUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethod.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsFailSendsNil.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsNetworkErrorSendsError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsOneOffering.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCachesForSameUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethod.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsFailSendsNil.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsNetworkErrorSendsError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsOneOffering.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS12-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS12-testHealthRequestIsNotAuthenticated.1.json
@@ -1,6 +1,17 @@
 {
   "headers" : {
-
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS12-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS12-testHealthRequestWithFailure.1.json
@@ -1,6 +1,17 @@
 {
   "headers" : {
-
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS12-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS12-testHealthRequestWithSuccess.1.json
@@ -1,6 +1,17 @@
 {
   "headers" : {
-
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestIsNotAuthenticated.1.json
@@ -1,6 +1,17 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestIsNotAuthenticated.1.json
@@ -10,6 +10,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithFailure.1.json
@@ -1,6 +1,17 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithFailure.1.json
@@ -10,6 +10,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithSuccess.1.json
@@ -1,6 +1,17 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithSuccess.1.json
@@ -10,6 +10,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestIsNotAuthenticated.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithFailure.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithSuccess.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestIsNotAuthenticated.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithFailure.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithSuccess.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestIsNotAuthenticated.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithFailure.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithSuccess.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestIsNotAuthenticated.1.json
@@ -1,6 +1,17 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestIsNotAuthenticated.1.json
@@ -10,6 +10,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithFailure.1.json
@@ -1,6 +1,17 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithFailure.1.json
@@ -10,6 +10,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithSuccess.1.json
@@ -1,6 +1,17 @@
 {
   "headers" : {
-
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithSuccess.1.json
@@ -10,6 +10,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginCachesForSameUserIDs.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginMakesRightCalls.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginWithFailedVerification.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginWithVerifiedResponse.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCachesForSameUserIDs.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCachesForSameUserIDs.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginMakesRightCalls.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginMakesRightCalls.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
@@ -1,8 +1,20 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
@@ -1,8 +1,20 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCachesForSameUserIDs.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginMakesRightCalls.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithFailedVerification.1.json
@@ -1,8 +1,21 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
@@ -1,8 +1,20 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCachesForSameUserIDs.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginMakesRightCalls.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
@@ -1,8 +1,21 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
@@ -1,8 +1,21 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCachesForSameUserIDs.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginMakesRightCalls.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithFailedVerification.1.json
@@ -1,8 +1,21 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithVerifiedResponse.1.json
@@ -1,8 +1,21 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCachesForSameUserIDs.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCachesForSameUserIDs.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginMakesRightCalls.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginMakesRightCalls.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithFailedVerification.1.json
@@ -1,8 +1,20 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithFailedVerification.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithVerifiedResponse.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithVerifiedResponse.1.json
@@ -1,8 +1,20 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS12-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS12-testGetProductEntitlementMapping.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS12-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS12-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMapping.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMapping.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMapping.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMapping.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMapping.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMapping.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMapping.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS12-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS12-testPostAdServicesCallsHttpClient.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS13-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS13-testPostAdServicesCallsHttpClient.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS13-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS13-testPostAdServicesCallsHttpClient.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS14-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS14-testPostAdServicesCallsHttpClient.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS15-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS15-testPostAdServicesCallsHttpClient.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS16-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS16-testPostAdServicesCallsHttpClient.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS17-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS17-testPostAdServicesCallsHttpClient.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS12-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS12-testPostAttributesPutsDataInDataKey.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS13-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS13-testPostAttributesPutsDataInDataKey.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS13-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS13-testPostAttributesPutsDataInDataKey.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS14-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS14-testPostAttributesPutsDataInDataKey.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS15-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS15-testPostAttributesPutsDataInDataKey.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS16-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS16-testPostAttributesPutsDataInDataKey.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS17-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS17-testPostAttributesPutsDataInDataKey.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS17-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS17-testPostAttributesPutsDataInDataKey.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS12-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS12-testOfferForSigningCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS12-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS12-testOfferForSigningEmptyOffersResponse.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS12-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS12-testOfferForSigningNetworkError.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS12-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS12-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS12-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS12-testOfferForSigningSignatureErrorResponse.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningEmptyOffersResponse.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningEmptyOffersResponse.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNetworkError.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNetworkError.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningSignatureErrorResponse.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningSignatureErrorResponse.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningEmptyOffersResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNetworkError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningSignatureErrorResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningEmptyOffersResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNetworkError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningSignatureErrorResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningEmptyOffersResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNetworkError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningSignatureErrorResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningEmptyOffersResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNetworkError.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningSignatureErrorResponse.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testCachesRequestsForSameReceipt.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesNotPostConsentStatus.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentCurrency.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentCurrency.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentDiscounts.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentDiscounts.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentOffering.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentOffering.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentOfferings.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentOfferings.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentReceipts.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentReceipts.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentRestore.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesntCacheForDifferentRestore.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testFreeTrialPostsCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testGetsEntitlementsWithFailedVerification.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testIndividualParamsCanBeNil.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPayAsYouGoPostsCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPayUpFrontPostsCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -7,7 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Is-Sandbox" : "true",
-    "X-Observer-Mode-Enabled" : "true",
+    "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "true",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testCachesRequestsForSameReceipt.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testCachesRequestsForSameReceipt.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesNotPostConsentStatus.1.json
@@ -12,6 +12,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesNotPostConsentStatus.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.2.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.2.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.2.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.2.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.2.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.2.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testFreeTrialPostsCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testFreeTrialPostsCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
@@ -1,8 +1,20 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -1,8 +1,20 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testIndividualParamsCanBeNil.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testIndividualParamsCanBeNil.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayAsYouGoPostsCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayAsYouGoPostsCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayUpFrontPostsCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayUpFrontPostsCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "true",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -7,10 +7,11 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Is-Sandbox" : "true",
-    "X-Observer-Mode-Enabled" : "true",
+    "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testCachesRequestsForSameReceipt.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesNotPostConsentStatus.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testFreeTrialPostsCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
@@ -1,8 +1,21 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -1,8 +1,21 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testIndividualParamsCanBeNil.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayAsYouGoPostsCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayUpFrontPostsCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -7,7 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Is-Sandbox" : "true",
-    "X-Observer-Mode-Enabled" : "true",
+    "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "true",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testCachesRequestsForSameReceipt.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesNotPostConsentStatus.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testFreeTrialPostsCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
@@ -1,8 +1,21 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -1,8 +1,21 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testIndividualParamsCanBeNil.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayAsYouGoPostsCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayUpFrontPostsCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -7,7 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Is-Sandbox" : "true",
-    "X-Observer-Mode-Enabled" : "true",
+    "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "true",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testCachesRequestsForSameReceipt.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesNotPostConsentStatus.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testFreeTrialPostsCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
@@ -1,8 +1,21 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -1,8 +1,21 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testIndividualParamsCanBeNil.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayAsYouGoPostsCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayUpFrontPostsCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -7,7 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Is-Sandbox" : "true",
-    "X-Observer-Mode-Enabled" : "true",
+    "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "true",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testCachesRequestsForSameReceipt.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesNotPostConsentStatus.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testFreeTrialPostsCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
@@ -1,8 +1,20 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -1,8 +1,20 @@
 {
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d"
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testIndividualParamsCanBeNil.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayAsYouGoPostsCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayUpFrontPostsCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "true",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -7,10 +7,11 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Is-Sandbox" : "true",
-    "X-Observer-Mode-Enabled" : "true",
+    "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -11,7 +11,6 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS12-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS12-testRequestContainsSignatureHeader.1.json
@@ -1,6 +1,17 @@
 {
   "headers" : {
-
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS12-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS12-testRequestFailsIfSignatureVerificationFails.1.json
@@ -1,6 +1,17 @@
 {
   "headers" : {
-
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestContainsSignatureHeader.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestContainsSignatureHeader.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestFailsIfSignatureVerificationFails.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestFailsIfSignatureVerificationFails.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestContainsSignatureHeader.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestFailsIfSignatureVerificationFails.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestContainsSignatureHeader.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestFailsIfSignatureVerificationFails.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestContainsSignatureHeader.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestFailsIfSignatureVerificationFails.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestContainsSignatureHeader.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestContainsSignatureHeader.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestFailsIfSignatureVerificationFails.1.json
@@ -11,6 +11,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestFailsIfSignatureVerificationFails.1.json
@@ -1,6 +1,18 @@
 {
   "headers" : {
-    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : null,

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithMultipleEvents.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithOneEvent.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -46,7 +46,11 @@ class BackendSubscriberAttributesTests: TestCase {
         ] as [String: Any]
     ]
 
-    let systemInfo = SystemInfo(platformInfo: .init(flavor: "Unity", version: "2.3.3"), finishTransactions: true)
+    private let systemInfo = SystemInfo(
+        platformInfo: .init(flavor: "Unity", version: "2.3.3"),
+        finishTransactions: true,
+        storefrontProvider: MockStorefrontProvider()
+    )
 
     override func setUpWithError() throws {
         mockHTTPClient = self.createClient()

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithAdServicesToken.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application\/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithAdServicesToken.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithAdServicesToken.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithAdServicesToken.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithAdServicesToken.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithAdServicesToken.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -1,6 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithAdServicesToken.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithAdServicesToken.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -1,6 +1,19 @@
 {
   "headers" : {
-    "Authorization" : "Bearer the api key"
+    "Authorization" : "Bearer the api key",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "Unity",
+    "X-Platform-Flavor-Version" : "2.3.3",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "Unity",
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
     "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },


### PR DESCRIPTION
This allows us to verify exactly what headers are included in all requests.

It also simplifies the implementation for #3424.