### PR TITLE
`CircleCI`: fix snapshot generation for iOS 14

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1006,6 +1006,7 @@
 		4F3D56622A1E66A10070105A /* CustomerInfoManagerPostReceiptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerPostReceiptTests.swift; sourceTree = "<group>"; };
 		4F4EECE32AAFA8DA0047DE7A /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		4F4FF3E02A3B731A0028018C /* ETagStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETagStrings.swift; sourceTree = "<group>"; };
+		4F520EF22B06C7A700DB6770 /* CI-RevenueCat-Snapshots.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = "CI-RevenueCat-Snapshots.xctestplan"; path = "Tests/TestPlans/CI-RevenueCat-Snapshots.xctestplan"; sourceTree = "<group>"; };
 		4F54DF3E2A1D8C7500FD72BF /* MockStoreKit2TransactionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreKit2TransactionFetcher.swift; sourceTree = "<group>"; };
 		4F54DF412A1D8D0700FD72BF /* MockTransactionPoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTransactionPoster.swift; sourceTree = "<group>"; };
 		4F5A62AB2A9AD18E0096067E /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/System/iOSSupport/System/Library/Frameworks/SwiftUI.framework; sourceTree = DEVELOPER_DIR; };
@@ -2570,6 +2571,7 @@
 				B3DB3EA828862898008EB151 /* CI-BackendIntegration.xctestplan */,
 				57910CBD29C393A6006209D5 /* CI-RevenueCat.xctestplan */,
 				2C646C282A0EBD0300E5936E /* CI-Snapshots.xctestplan */,
+				4F520EF22B06C7A700DB6770 /* CI-RevenueCat-Snapshots.xctestplan */,
 				4FDE95A92A769E9E006E7D2D /* XC-AllTests.xctestplan */,
 				570896B427595C8100296F1C /* Coverage.xctestplan */,
 				570896B327595C8100296F1C /* RevenueCat.xctestplan */,

--- a/RevenueCat.xcodeproj/xcshareddata/xcschemes/RevenueCat.xcscheme
+++ b/RevenueCat.xcodeproj/xcshareddata/xcschemes/RevenueCat.xcscheme
@@ -123,6 +123,9 @@
          <TestPlanReference
             reference = "container:Tests/TestPlans/XC-AllTests.xctestplan">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Tests/TestPlans/CI-RevenueCat-Snapshots.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/Tests/TestPlans/CI-RevenueCat-Snapshots.xctestplan
+++ b/Tests/TestPlans/CI-RevenueCat-Snapshots.xctestplan
@@ -1,0 +1,50 @@
+{
+  "configurations" : [
+    {
+      "id" : "62C79EF4-8071-439C-B693-34F1E57211FC",
+      "name" : "Configuration 1",
+      "options" : {
+        "testTimeoutsEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "environmentVariableEntries" : [
+      {
+        "key" : "RCRunningTests",
+        "value" : "1"
+      },
+      {
+        "key" : "CIRCLECI_TESTS_GENERATE_SNAPSHOTS",
+        "value" : "1"
+      }
+    ],
+    "maximumTestExecutionTimeAllowance" : 180,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:RevenueCat.xcodeproj",
+      "identifier" : "2DEAC2D926EFE46E006914ED",
+      "name" : "UnitTestsHostApp"
+    },
+    "testExecutionOrdering" : "random",
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:RevenueCat.xcodeproj",
+        "identifier" : "2DC5621D24EC63430031F69B",
+        "name" : "UnitTests"
+      }
+    },
+    {
+      "enabled" : false,
+      "target" : {
+        "containerPath" : "container:RevenueCat.xcodeproj",
+        "identifier" : "5759B330296DF65D002472D5",
+        "name" : "ReceiptParserTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -125,13 +125,19 @@ platform :ios do
   desc "Runs all the iOS tests"
   lane :test_ios do |options|
     generate_snapshots = ENV["CIRCLECI_TESTS_GENERATE_SNAPSHOTS"] == "true"
+
+    # For platforms that fail to run StoreKit tests.
+    # See https://developer.apple.com/forums/thread/724068 and `FB12223404`.
+    skip_sk_tests = options[:skip_sk_tests]
     
-    if options[:skip_sk_tests]
-      # For platforms that fail to run StoreKit tests.
-      # See https://developer.apple.com/forums/thread/724068 and `FB12223404`.
+    if generate_snapshots
+      if skip_sk_tests
+        test_plan = "CI-RevenueCat-Snapshots"
+      else
+        test_plan = "CI-Snapshots"
+      end
+    elsif skip_sk_tests
       test_plan = "CI-RevenueCat"
-    elsif generate_snapshots
-      test_plan = "CI-Snapshots"
     else
       test_plan = "CI-AllTests"
     end


### PR DESCRIPTION
See #2421.

iOS 14 + Snapshots needs a new test plan that doesn't run StoreKit tests.
