### PR TITLE
Some `APITester` fixes

### DIFF
--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -5,6 +5,7 @@
 //  Created by Nacho Soto on 1/5/22.
 //
 
+import Foundation
 import RevenueCat
 
 var product: StoreProduct!

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
@@ -5,6 +5,7 @@
 //  Created by Nacho Soto on 1/5/22.
 //
 
+import Foundation
 import RevenueCat
 
 var discount: StoreProductDiscount!

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
@@ -5,6 +5,7 @@
 //  Created by Nacho Soto on 6/26/23.
 //
 
+import Foundation
 import RevenueCat
 
 // swiftlint:disable syntactic_sugar

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/VerificationResultAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/VerificationResultAPI.swift
@@ -8,7 +8,7 @@
 import Foundation
 import RevenueCat
 
-func checkVerificationResultAPI(_ mode: EntitlementVerificationMode = .disabled,
+func checkVerificationResultAPI(_ mode: Configuration.EntitlementVerificationMode = .disabled,
                                 _ result: VerificationResult = .notRequested) {
     let _: Bool = result.isVerified
 


### PR DESCRIPTION
Not sure why but sometimes Xcode gets in a state where it won't compile these without this.