### PR TITLE
`Concurrency`: access `UIApplication` properties from `@MainActor`

### DIFF
--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -56,6 +56,11 @@ class OperationDispatcher {
         Self.dispatchOnMainActor(block)
     }
 
+    /// Dispatch block on main thread synchronously if already in the main thread.
+    func dispatchSyncOnMainActor(_ block: @MainActor @escaping @Sendable () -> Void) {
+        Self.dispatchSyncOnMainActor(block)
+    }
+
     func dispatchOnWorkerThread(delay: Delay = .none, block: @escaping @Sendable () -> Void) {
         if delay.hasDelay {
             self.workerQueue.asyncAfter(deadline: .now() + delay.random(), execute: block)
@@ -91,6 +96,14 @@ extension OperationDispatcher {
         }
     }
 
+    static func dispatchSyncOnMainActor(_ block: @MainActor @escaping @Sendable () -> Void) {
+        if Thread.isMainThread,
+            #available(macOS 14.0, iOS 17.0, iOSApplicationExtension 17.0, watchOS 10.0, tvOS 17.0, *) {
+            MainActor.assumeIsolated(block)
+        } else {
+            Self.dispatchOnMainActor(block)
+        }
+    }
 }
 
 // MARK: -

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -97,12 +97,16 @@ extension OperationDispatcher {
     }
 
     static func dispatchSyncOnMainActor(_ block: @MainActor @escaping @Sendable () -> Void) {
+        #if swift(>=5.9)
         if Thread.isMainThread,
             #available(macOS 14.0, iOS 17.0, iOSApplicationExtension 17.0, watchOS 10.0, tvOS 17.0, *) {
             MainActor.assumeIsolated(block)
         } else {
             Self.dispatchOnMainActor(block)
         }
+        #else
+        Self.dispatchOnMainActor(block)
+        #endif
     }
 }
 

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -225,6 +225,7 @@ extension SystemInfo {
 
 extension SystemInfo {
 
+    @MainActor
     static var applicationWillEnterForegroundNotification: Notification.Name {
         #if os(iOS) || os(tvOS) || VISION_OS
             UIApplication.willEnterForegroundNotification
@@ -235,6 +236,7 @@ extension SystemInfo {
         #endif
     }
 
+    @MainActor
     static var applicationDidEnterBackgroundNotification: Notification.Name {
         #if os(iOS) || os(tvOS) || VISION_OS
             UIApplication.didEnterBackgroundNotification

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -605,7 +605,9 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         /// for promotional offers to work.
         self.paymentQueueWrapper.sk2Wrapper?.delegate = purchasesOrchestrator
 
-        self.subscribeToAppStateNotifications()
+        operationDispatcher.dispatchSyncOnMainActor { @Sendable in
+            self.subscribeToAppStateNotifications()
+        }
         self.attributionPoster.postPostponedAttributionDataIfNeeded()
 
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
@@ -1643,6 +1645,7 @@ private extension Purchases {
         self.dispatchSyncSubscriberAttributes()
     }
 
+    @MainActor
     func subscribeToAppStateNotifications() {
         self.notificationCenter.addObserver(self,
                                             selector: #selector(self.applicationWillEnterForeground),

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -233,6 +233,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
 
     // MARK: Notifications
 
+    @MainActor
     func testSubscribesToForegroundNotifications() {
         setupPurchases()
 
@@ -246,6 +247,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
         expect(self.mockSubscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 2
     }
 
+    @MainActor
     func testSubscribesToBackgroundNotifications() {
         setupPurchases()
 


### PR DESCRIPTION
This is the first of several PRs to continue fixing warnings when compiling the SDK with strict concurrency checking, in preparation for Swift 6.0.
