### PR TITLE
`Optimization`: changed `first` to `first(where:)`

### DIFF
--- a/RevenueCatUI/Data/Localization.swift
+++ b/RevenueCatUI/Data/Localization.swift
@@ -31,7 +31,7 @@ enum Localization {
         return self.unitAbbreviationLengthPriorities
             .lazy
             .compactMap { length in options.first { $0.count == length } }
-            .first
+            .first { _ in true } // See https://github.com/apple/swift/issues/55374
         ?? options.last!
     }
 

--- a/Sources/Paywalls/PaywallData+Localization.swift
+++ b/Sources/Paywalls/PaywallData+Localization.swift
@@ -23,7 +23,8 @@ public extension PaywallData {
         return locales
             .lazy
             .compactMap(self.config(for:))
-            .first ?? self.fallbackLocalizedConfiguration
+            .first { _ in true } // See https://github.com/apple/swift/issues/55374
+            ?? self.fallbackLocalizedConfiguration
     }
 
     private var fallbackLocalizedConfiguration: LocalizedConfiguration {


### PR DESCRIPTION
See https://github.com/apple/swift/issues/55374

`.first` has been broken since 2020.
