### PR TITLE
`Paywalls`: remove empty space when template 4 has no offer details

### DIFF
--- a/RevenueCatUI/Data/TemplateViewConfiguration+Extensions.swift
+++ b/RevenueCatUI/Data/TemplateViewConfiguration+Extensions.swift
@@ -32,6 +32,19 @@ extension TemplateViewConfiguration.PackageConfiguration {
         )
     }
 
+    /// - Returns: `true` if any of the packages produce text for the given `display`.
+    /// This allows determining whether a label is required to be rendered.
+    @MainActor
+    func packagesProduceAnyLabel(
+        for display: IntroEligibilityStateView.Display,
+        eligibility: IntroEligibilityViewModel
+    ) -> Bool {
+        return self.packagesProduceAnyLabel(
+            for: display,
+            eligibility: eligibility.allEligibility
+        )
+    }
+
 }
 
 // MARK: - Implementation
@@ -39,22 +52,44 @@ extension TemplateViewConfiguration.PackageConfiguration {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension TemplateViewConfiguration.PackageConfiguration {
 
+    typealias Eligibility = [Package: IntroEligibilityStatus]
+
     func packagesProduceDifferentLabels(
         for display: IntroEligibilityStateView.Display,
-        eligibility: [Package: IntroEligibilityStatus]
+        eligibility: Eligibility
     ) -> Bool {
+        return self.labels(for: display, eligibility: eligibility).count > 1
+    }
+
+    func packagesProduceAnyLabel(
+        for display: IntroEligibilityStateView.Display,
+        eligibility: Eligibility
+    ) -> Bool {
+        return self
+            .labels(for: display, eligibility: eligibility)
+            .contains { !$0.isEmpty }
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension TemplateViewConfiguration.PackageConfiguration {
+
+    private func labels(
+        for display: IntroEligibilityStateView.Display,
+        eligibility: Eligibility
+    ) -> Set<String> {
         return Set(
             self.all
-                .lazy
-                .map {
-                    IntroEligibilityStateView.text(
-                        for: display,
-                        localization: $0.localization,
-                        introEligibility: eligibility[$0.content]
-                    )
-                }
+            .lazy
+            .map {
+                IntroEligibilityStateView.text(
+                    for: display,
+                    localization: $0.localization,
+                    introEligibility: eligibility[$0.content]
+                )
+            }
         )
-        .count > 1
     }
 
 }

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -90,8 +90,13 @@ struct Template4View: TemplateViewType {
                                        hide: !self.displayingAllPlans)
             }
 
-            self.offerDetails
-                .defaultHorizontalPadding()
+            if self.configuration.packages.packagesProduceAnyLabel(
+                for: .offerDetails,
+                eligibility: self.introEligibility
+            ) {
+                self.offerDetails
+                    .defaultHorizontalPadding()
+            }
 
             self.subscribeButton
                 .defaultHorizontalPadding()


### PR DESCRIPTION
### Before:
<img width="333" alt="Screenshot 2023-11-19 at 16 01 15" src="https://github.com/RevenueCat/purchases-ios/assets/685609/4286c281-b2e9-463b-a368-726ae44bdc69">

### After:
<img width="328" alt="Screenshot 2023-11-19 at 16 01 06" src="https://github.com/RevenueCat/purchases-ios/assets/685609/234b8c8d-f2ec-4ff4-8153-2c461dc92987">