### PR TITLE
`Paywalls`: simplified `PaywallViewMode` logic

### DIFF
--- a/RevenueCatUI/Data/PaywallViewMode+Extensions.swift
+++ b/RevenueCatUI/Data/PaywallViewMode+Extensions.swift
@@ -31,27 +31,6 @@ extension PaywallViewMode {
         }
     }
 
-    var shouldDisplayIcon: Bool {
-        switch self {
-        case .fullScreen: return true
-        case .footer, .condensedFooter: return false
-        }
-    }
-
-    var shouldDisplayText: Bool {
-        switch self {
-        case .fullScreen: return true
-        case .footer, .condensedFooter: return false
-        }
-    }
-
-    var shouldDisplayFeatures: Bool {
-        switch self {
-        case .fullScreen: return true
-        case .footer, .condensedFooter: return false
-        }
-    }
-
     var shouldDisplayBackground: Bool {
         switch self {
         case .fullScreen: return true

--- a/RevenueCatUI/Templates/Template1View.swift
+++ b/RevenueCatUI/Templates/Template1View.swift
@@ -65,11 +65,9 @@ struct Template1View: TemplateViewType {
     @ViewBuilder
     private var scrollableContent: some View {
         VStack(spacing: self.defaultVerticalPaddingLength) {
-            if self.configuration.mode.shouldDisplayIcon {
+            if self.configuration.mode.isFullScreen {
                 self.headerImage
-            }
 
-            if self.configuration.mode.shouldDisplayText {
                 Group {
                     Text(.init(self.localization.title))
                         .font(self.font(for: .largeTitle))

--- a/RevenueCatUI/Templates/Template2View.swift
+++ b/RevenueCatUI/Templates/Template2View.swift
@@ -54,7 +54,7 @@ struct Template2View: TemplateViewType {
             Spacer(minLength: VersionDetector.iOS15 ? nil : 0)
 
             self.scrollableContent
-                .scrollableIfNecessary(enabled: self.configuration.mode.shouldDisplayPackages)
+                .scrollableIfNecessary(enabled: self.configuration.mode.isFullScreen)
 
             if self.configuration.mode.shouldDisplayInlineOfferDetails(displayingAllPlans: self.displayingAllPlans) {
                 self.offerDetails(package: self.selectedPackage, selected: false)
@@ -77,18 +77,16 @@ struct Template2View: TemplateViewType {
             // Compensate for additional padding on condensed mode + iPad
             : self.defaultVerticalPaddingLength.map { $0 * -1 }
         )
-        .edgesIgnoringSafeArea(self.configuration.mode.shouldDisplayIcon ? .top : [])
+        .edgesIgnoringSafeArea(self.configuration.mode.isFullScreen ? .top : [])
     }
 
     private var scrollableContent: some View {
         VStack(spacing: self.defaultVerticalPaddingLength) {
-            if self.configuration.mode.shouldDisplayIcon {
+            if self.configuration.mode.isFullScreen {
                 Spacer()
                 self.iconImage
                 Spacer()
-            }
 
-            if self.configuration.mode.shouldDisplayText {
                 Text(.init(self.selectedLocalization.title))
                     .foregroundColor(self.configuration.colors.text1Color)
                     .font(self.font(for: .largeTitle).bold())
@@ -102,9 +100,7 @@ struct Template2View: TemplateViewType {
                     .defaultHorizontalPadding()
 
                 Spacer()
-            }
 
-            if self.configuration.mode.shouldDisplayPackages {
                 self.packages
             } else {
                 self.packages
@@ -285,18 +281,6 @@ private extension Template2View {
 
     var selectedLocalization: ProcessedLocalizedConfiguration {
         return self.selectedPackage.localization
-    }
-
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private extension PaywallViewMode {
-
-    var shouldDisplayPackages: Bool {
-        switch self {
-        case .fullScreen: return true
-        case .footer, .condensedFooter: return false
-        }
     }
 
 }

--- a/RevenueCatUI/Templates/Template3View.swift
+++ b/RevenueCatUI/Templates/Template3View.swift
@@ -37,24 +37,20 @@ struct Template3View: TemplateViewType {
 
     var body: some View {
         VStack(spacing: self.defaultVerticalPaddingLength) {
-            if self.configuration.mode.shouldDisplayIcon {
+            if self.configuration.mode.isFullScreen {
                 if let url = self.configuration.iconImageURL {
                     RemoteImage(url: url, aspectRatio: 1)
                         .frame(width: self.iconSize, height: self.iconSize)
                         .cornerRadius(8)
                 }
-            }
 
-            if self.configuration.mode.shouldDisplayText {
                 Text(.init(self.localization.title))
                     .font(self.font(for: .title))
                     .foregroundStyle(self.configuration.colors.text1Color)
                     .multilineTextAlignment(.center)
 
                 Spacer()
-            }
 
-            if self.configuration.mode.shouldDisplayFeatures {
                 self.features
                     .scrollableIfNecessary()
             }

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -74,16 +74,14 @@ struct Template4View: TemplateViewType {
     @ViewBuilder
     var footerContent: some View {
         VStack(spacing: Self.verticalPadding) {
-            if self.configuration.mode.shouldDisplayText {
+            if self.configuration.mode.isFullScreen {
                 Text(.init(self.selectedPackage.localization.title))
                     .foregroundColor(self.configuration.colors.text1Color)
                     .font(self.font(for: .title).bold())
                     .padding([.horizontal])
                     .padding(.top, Self.verticalPadding)
                     .dynamicTypeSize(...Constants.maximumDynamicTypeSize)
-            }
 
-            if self.configuration.mode.shouldDisplayPackages {
                 self.packagesScrollView
             } else {
                 self.packagesScrollView
@@ -395,20 +393,6 @@ private struct PackageButton: View {
 
     private func font(for textStyle: Font.TextStyle) -> Font {
         return self.configuration.fonts.font(for: textStyle)
-    }
-
-}
-
-// MARK: - Extensions
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private extension PaywallViewMode {
-
-    var shouldDisplayPackages: Bool {
-        switch self {
-        case .fullScreen: return true
-        case .footer, .condensedFooter: return false
-        }
     }
 
 }

--- a/RevenueCatUI/Templates/Template5View.swift
+++ b/RevenueCatUI/Templates/Template5View.swift
@@ -50,7 +50,7 @@ struct Template5View: TemplateViewType {
     @ViewBuilder
     var content: some View {
         VStack(spacing: self.defaultVerticalPaddingLength) {
-            if self.configuration.mode.shouldDisplayIcon {
+            if self.configuration.mode.isFullScreen {
                 if let header = self.configuration.headerImageURL {
                     RemoteImage(url: header,
                                 aspectRatio: self.headerAspectRatio,
@@ -62,7 +62,7 @@ struct Template5View: TemplateViewType {
             }
 
             self.scrollableContent
-                .scrollableIfNecessary(enabled: self.configuration.mode.shouldDisplayPackages)
+                .scrollableIfNecessary(enabled: self.configuration.mode.isFullScreen)
                 .padding(
                     .top,
                     self.displayingAllPlans
@@ -90,7 +90,7 @@ struct Template5View: TemplateViewType {
 
     private var scrollableContent: some View {
         VStack(spacing: self.defaultVerticalPaddingLength) {
-            if self.configuration.mode.shouldDisplayText {
+            if self.configuration.mode.isFullScreen {
                 Text(.init(self.selectedLocalization.title))
                     .font(self.font(for: .largeTitle).bold())
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -102,9 +102,7 @@ struct Template5View: TemplateViewType {
                     .defaultHorizontalPadding()
 
                 Spacer()
-            }
 
-            if self.configuration.mode.shouldDisplayPackages {
                 self.packages
             } else {
                 self.packages
@@ -297,18 +295,6 @@ private extension Template5View {
 
     var selectedLocalization: ProcessedLocalizedConfiguration {
         return self.selectedPackage.localization
-    }
-
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private extension PaywallViewMode {
-
-    var shouldDisplayPackages: Bool {
-        switch self {
-        case .fullScreen: return true
-        case .footer, .condensedFooter: return false
-        }
     }
 
 }


### PR DESCRIPTION
This brings the implementations closer to Android, removing the unnecessary `PaywallViewMode` properties.
