### PR TITLE
`Paywalls`: open Terms and Privacy Policy links in-app

### DIFF
--- a/RevenueCatUI/Views/FooterView.swift
+++ b/RevenueCatUI/Views/FooterView.swift
@@ -13,7 +13,10 @@
 
 import RevenueCat
 import SwiftUI
+
+#if canImport(WebKit)
 import WebKit
+#endif
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct FooterView: View {
@@ -225,6 +228,7 @@ private struct LinkButton: View {
     }
 
     var body: some View {
+        #if canImport(WebKit)
         Button {
             self.displayLink = true
         } label: {
@@ -247,6 +251,11 @@ private struct LinkButton: View {
                     }
             }
         }
+        #else
+        Link(destination: self.url) {
+            self.content
+        }
+        #endif
     }
 
     @ViewBuilder
@@ -284,8 +293,8 @@ private struct LinkButton: View {
 
 }
 
+#if canImport(WebKit)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 private struct WebView: UIViewRepresentable {
@@ -302,6 +311,7 @@ private struct WebView: UIViewRepresentable {
     func updateUIView(_ uiView: WKWebView, context: Context) {}
 
 }
+#endif
 
 // MARK: - Previews
 

--- a/RevenueCatUI/Views/FooterView.swift
+++ b/RevenueCatUI/Views/FooterView.swift
@@ -228,7 +228,7 @@ private struct LinkButton: View {
     }
 
     var body: some View {
-        #if canImport(WebKit)
+        #if canImport(WebKit) && !os(macOS)
         Button {
             self.displayLink = true
         } label: {
@@ -293,9 +293,8 @@ private struct LinkButton: View {
 
 }
 
-#if canImport(WebKit)
+#if canImport(WebKit) && !os(macOS)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(macOS, unavailable)
 @available(tvOS, unavailable)
 private struct WebView: UIViewRepresentable {
 

--- a/RevenueCatUI/Views/FooterView.swift
+++ b/RevenueCatUI/Views/FooterView.swift
@@ -13,6 +13,7 @@
 
 import RevenueCat
 import SwiftUI
+import WebKit
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct FooterView: View {
@@ -240,11 +241,10 @@ private struct LinkButton: View {
     }
 
     private func link(for title: String, bundle: Bundle) -> some View {
-        Link(
-            Self.localizedString(title, bundle),
-            destination: self.url
-        )
-        .frame(minHeight: Constants.minimumButtonHeight)
+        NavigationLink(destination: WebView(url: self.url)) {
+            Text(Self.localizedString(title, bundle))
+                .frame(minHeight: Constants.minimumButtonHeight)
+        }
     }
 
     private static func localizedString(_ string: String, _ bundle: Bundle) -> String {
@@ -255,6 +255,23 @@ private struct LinkButton: View {
         )
     }
 
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+private struct WebView: UIViewRepresentable {
+    let url: URL
+
+    func makeUIView(context: Context) -> WKWebView {
+        return WKWebView()
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        let request = URLRequest(url: url)
+        uiView.load(request)
+    }
 }
 
 // MARK: - Previews

--- a/RevenueCatUI/Views/FooterView.swift
+++ b/RevenueCatUI/Views/FooterView.swift
@@ -289,16 +289,18 @@ private struct LinkButton: View {
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 private struct WebView: UIViewRepresentable {
+
     let url: URL
 
     func makeUIView(context: Context) -> WKWebView {
-        return WKWebView()
+        let view = WKWebView()
+        view.load(URLRequest(url: self.url))
+
+        return view
     }
 
-    func updateUIView(_ uiView: WKWebView, context: Context) {
-        let request = URLRequest(url: url)
-        uiView.load(request)
-    }
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
 }
 
 // MARK: - Previews


### PR DESCRIPTION
Updated the terms and Privacy Policy links to open within the app, without exiting to Safari

https://github.com/RevenueCat/purchases-ios/assets/685609/e10df16d-1016-4271-9270-35c4ae8a87d4


