### PR TITLE
Paywalls: explicitly cache images for paywalls 

### DIFF
--- a/RevenueCatUI/Helpers/ImageLoader.swift
+++ b/RevenueCatUI/Helpers/ImageLoader.swift
@@ -24,9 +24,12 @@ class ImageLoader: ObservableObject {
     @Published var error: Error?
     private var cancellable: AnyCancellable?
     private let cache: URLCache
+    private let urlSessionConfiguration: URLSessionConfiguration
 
-    init(url: URL, cache: URLCache = .shared) {
+    init(url: URL, cache: URLCache) {
         self.cache = cache
+        self.urlSessionConfiguration = URLSessionConfiguration.default
+        urlSessionConfiguration.urlCache = cache
         load(url: url)
     }
 

--- a/RevenueCatUI/Helpers/ImageLoader.swift
+++ b/RevenueCatUI/Helpers/ImageLoader.swift
@@ -1,0 +1,59 @@
+//
+//  ImageLoader.swift
+//
+//
+//  Created by Andrés Boedo on 11/29/23.
+//
+
+import Combine
+import Foundation
+import UIKit
+
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension URLCache {
+    static let imageCache = URLCache(memoryCapacity: 5 * 1000 * 1000, diskCapacity: 30 * 1000 * 1000)
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+class ImageLoader: ObservableObject {
+    @Published var image: UIImage?
+    @Published var error: Error?
+    private var cancellable: AnyCancellable?
+    private let cache: URLCache
+
+    init(url: URL, cache: URLCache = .shared) {
+        self.cache = cache
+        load(url: url)
+    }
+
+    deinit {
+        cancellable?.cancel()
+    }
+
+    func load(url: URL) {
+        let request = URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad)
+        cancellable = URLSession.shared.dataTaskPublisher(for: request)
+            .tryMap { output in
+                guard let httpResponse = output.response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                    throw URLError(.badServerResponse)
+                }
+                return UIImage(data: output.data)
+            }
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                switch completion {
+                case .failure(let error):
+                    self?.error = error
+                    self?.image = nil
+                case .finished:
+                    break
+                }
+            }, receiveValue: { [weak self] image in
+                self?.image = image
+                self?.error = nil
+            })
+    }
+
+}

--- a/RevenueCatUI/Helpers/ImageLoader.swift
+++ b/RevenueCatUI/Helpers/ImageLoader.swift
@@ -9,15 +9,17 @@ import Combine
 import Foundation
 import UIKit
 
-
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension URLCache {
+
     static let imageCache = URLCache(memoryCapacity: 5 * 1000 * 1000, diskCapacity: 30 * 1000 * 1000)
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @MainActor
 class ImageLoader: ObservableObject {
+
     @Published var image: UIImage?
     @Published var error: Error?
     private var cancellable: AnyCancellable?

--- a/RevenueCatUI/Views/RemoteImage.swift
+++ b/RevenueCatUI/Views/RemoteImage.swift
@@ -11,7 +11,6 @@
 //
 //  Created by Nacho Soto on 7/19/23.
 
-import Combine
 import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -73,54 +72,6 @@ struct RemoteImage: View {
     private var placeholderView: some View {
         Rectangle()
             .hidden()
-    }
-
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-extension URLCache {
-    static let imageCache = URLCache(memoryCapacity: 5 * 1000 * 1000, diskCapacity: 30 * 1000 * 1000)
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@MainActor
-class ImageLoader: ObservableObject {
-    @Published var image: UIImage?
-    @Published var error: Error?
-    private var cancellable: AnyCancellable?
-    private let cache: URLCache
-
-    init(url: URL, cache: URLCache = .shared) {
-        self.cache = cache
-        load(url: url)
-    }
-
-    deinit {
-        cancellable?.cancel()
-    }
-
-    func load(url: URL) {
-        let request = URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad)
-        cancellable = URLSession.shared.dataTaskPublisher(for: request)
-            .tryMap { output in
-                guard let httpResponse = output.response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-                    throw URLError(.badServerResponse)
-                }
-                return UIImage(data: output.data)
-            }
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { [weak self] completion in
-                switch completion {
-                case .failure(let error):
-                    self?.error = error
-                    self?.image = nil
-                case .finished:
-                    break
-                }
-            }, receiveValue: { [weak self] image in
-                self?.image = image
-                self?.error = nil
-            })
     }
 
 }

--- a/RevenueCatUI/Views/RemoteImage.swift
+++ b/RevenueCatUI/Views/RemoteImage.swift
@@ -8,63 +8,119 @@
 //      https://opensource.org/licenses/MIT
 //
 //  RemoteImage.swift
-//  
+//
 //  Created by Nacho Soto on 7/19/23.
 
+import Combine
 import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct RemoteImage: View {
 
+    @StateObject private var loader: ImageLoader
+    private let cache: URLCache
+
     let url: URL
     let aspectRatio: CGFloat?
     let maxWidth: CGFloat?
 
-    init(url: URL, aspectRatio: CGFloat? = nil, maxWidth: CGFloat? = nil) {
+    init(url: URL, aspectRatio: CGFloat? = nil, maxWidth: CGFloat? = nil, cache: URLCache = .imageCache) {
         self.url = url
         self.aspectRatio = aspectRatio
         self.maxWidth = maxWidth
+        self.cache = cache
+        self._loader = StateObject(wrappedValue: ImageLoader(url: url, cache: cache))
     }
 
     var body: some View {
-        AsyncImage(
-            url: self.url,
-            transaction: .init(animation: Constants.defaultAnimation)
-        ) { phase in
-            if let image = phase.image {
-                if let aspectRatio {
-                    image
-                        .fitToAspect(aspectRatio, contentMode: .fill)
-                        .frame(maxWidth: self.maxWidth)
-                } else {
-                    image
-                        .resizable()
-                }
+        if let image = loader.image {
+            let uiImage = Image(uiImage: image)
+            if let aspectRatio {
+                uiImage
+                    .fitToAspect(aspectRatio, contentMode: .fill)
+                    .frame(maxWidth: self.maxWidth)
+                    .transition(.opacity.animation(Constants.defaultAnimation))
+
             } else {
-                Group {
-                    if let aspectRatio {
-                        self.placeholderView
-                            .aspectRatio(aspectRatio, contentMode: .fit)
-                    } else {
-                        self.placeholderView
-                    }
+                uiImage
+                    .resizable()
+                    .transition(.opacity.animation(Constants.defaultAnimation))
+            }
+        } else {
+            Group {
+                if let aspectRatio {
+                    self.placeholderView
+                        .aspectRatio(aspectRatio, contentMode: .fit)
+                } else {
+                    self.placeholderView
                 }
-                .frame(maxWidth: self.maxWidth)
-                .overlay {
-                    if let error = phase.error {
-                        DebugErrorView("Error loading image from '\(self.url)': \(error)",
-                                       releaseBehavior: .emptyView)
-                        .font(.footnote)
-                        .textCase(.none)
+            }
+            .frame(maxWidth: self.maxWidth)
+            .transition(.opacity.animation(Constants.defaultAnimation))
+            .overlay {
+                Group {
+                    if let error = loader.error {
+                        DebugErrorView("Error loading image from '\(self.url)': \(error)", releaseBehavior: .emptyView)
+                            .font(.footnote)
+                            .textCase(.none)
                     }
                 }
             }
+
         }
     }
 
     private var placeholderView: some View {
         Rectangle()
             .hidden()
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension URLCache {
+    static let imageCache = URLCache(memoryCapacity: 5 * 1000 * 1000, diskCapacity: 30 * 1000 * 1000)
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+class ImageLoader: ObservableObject {
+    @Published var image: UIImage?
+    @Published var error: Error?
+    private var cancellable: AnyCancellable?
+    private let cache: URLCache
+
+    init(url: URL, cache: URLCache = .shared) {
+        self.cache = cache
+        load(url: url)
+    }
+
+    deinit {
+        cancellable?.cancel()
+    }
+
+    func load(url: URL) {
+        let request = URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad)
+        cancellable = URLSession.shared.dataTaskPublisher(for: request)
+            .tryMap { output in
+                guard let httpResponse = output.response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                    throw URLError(.badServerResponse)
+                }
+                return UIImage(data: output.data)
+            }
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                switch completion {
+                case .failure(let error):
+                    self?.error = error
+                    self?.image = nil
+                case .finished:
+                    break
+                }
+            }, receiveValue: { [weak self] image in
+                self?.image = image
+                self?.error = nil
+            })
     }
 
 }

--- a/RevenueCatUI/Views/RemoteImage.swift
+++ b/RevenueCatUI/Views/RemoteImage.swift
@@ -17,7 +17,6 @@ import SwiftUI
 struct RemoteImage: View {
 
     @StateObject private var loader: ImageLoader
-    private let cache: URLCache
 
     let url: URL
     let aspectRatio: CGFloat?
@@ -27,7 +26,6 @@ struct RemoteImage: View {
         self.url = url
         self.aspectRatio = aspectRatio
         self.maxWidth = maxWidth
-        self.cache = cache
         self._loader = StateObject(wrappedValue: ImageLoader(url: url, cache: cache))
     }
 

--- a/RevenueCatUI/Views/RemoteImage.swift
+++ b/RevenueCatUI/Views/RemoteImage.swift
@@ -33,16 +33,16 @@ struct RemoteImage: View {
     }
 
     var body: some View {
-        if let image = loader.image {
-            let uiImage = Image(uiImage: image)
+        if let loadedUIImage = loader.image {
+            let image = Image(uiImage: loadedUIImage)
             if let aspectRatio {
-                uiImage
+                image
                     .fitToAspect(aspectRatio, contentMode: .fill)
                     .frame(maxWidth: self.maxWidth)
                     .transition(.opacity.animation(Constants.defaultAnimation))
 
             } else {
-                uiImage
+                image
                     .resizable()
                     .transition(.opacity.animation(Constants.defaultAnimation))
             }


### PR DESCRIPTION
This adds explicit caching to images for Paywalls. 

In my testing we seem to be mostly re-fetching images on every load. We're studying also improving the cache headers and that might (hopefully) render this PR unnecessary, but opening this up in the meantime just in case. 

This PR fixes the re-fetching as far as I can tell. 