### PR TITLE
Fix Chinese localizations

### DIFF
--- a/RevenueCatUI/Resources/zh-Hans.lproj/Localizable.strings
+++ b/RevenueCatUI/Resources/zh-Hans.lproj/Localizable.strings
@@ -14,6 +14,6 @@
 "Monthly" = "每月";
 "Weekly" = "每周";
 "Lifetime" = "永久";
-"%d%% off" = "%d%%折";
+"%d%% off" = "优惠%d%%";
 "Continue" = "继续";
-"Default_offer_details_with_intro_offer" = "开始 {{ sub_offer_duration }} 试用，然后 {{total_price_and_per_month }}。";
+"Default_offer_details_with_intro_offer" = "开始{{ sub_offer_duration }}试用，然后{{ total_price_and_per_month }}。";

--- a/RevenueCatUI/Resources/zh_HK.lproj/Localizable.strings
+++ b/RevenueCatUI/Resources/zh_HK.lproj/Localizable.strings
@@ -14,6 +14,6 @@
 "Monthly" = "每月";
 "Weekly" = "每週";
 "Lifetime" = "永久";
-"%d%% off" = "%d%%折";
+"%d%% off" = "優惠%d%%";
 "Continue" = "繼續";
-"Default_offer_details_with_intro_offer" = "開始 {{ sub_offer_duration }} 試用，然後 {{total_price_and_per_month }}。";
+"Default_offer_details_with_intro_offer" = "開始{{ sub_offer_duration }}試用，然後{{ total_price_and_per_month }}。";

--- a/RevenueCatUI/Resources/zh_TW.lproj/Localizable.strings
+++ b/RevenueCatUI/Resources/zh_TW.lproj/Localizable.strings
@@ -14,6 +14,6 @@
 "Monthly" = "每月";
 "Weekly" = "每週";
 "Lifetime" = "永久";
-"%d%% off" = "%d%%折";
+"%d%% off" = "優惠%d%%";
 "Continue" = "繼續";
-"Default_offer_details_with_intro_offer" = "開始 {{ sub_offer_duration }} 試用，然後 {{total_price_and_per_month }}。";
+"Default_offer_details_with_intro_offer" = "開始{{ sub_offer_duration }}試用，然後{{ total_price_and_per_month }}。";


### PR DESCRIPTION
### Motivation
Resolves #3489

### Description
Another issue I found after looking at the [Localizable.strings](https://github.com/RevenueCat/purchases-ios/pull/3489/files): You can’t directly translate "%d%% off” as "%d%%折” in Chinese. In Chinese, if one item is 20% off, we say it’s “8折” (8 comes from (1-20%)*10).

So if you insist on this translation you will need to change the related code. I would suggest you to simply translate "%d%% off" as "优惠%d%%"(Simplified Chinese) and "優惠%d%%" (Traditional Chinese), which aligns with the word ”off”.

Last issue regarding formatting: "Default_offer_details_with_intro_offer" = "开始 {{ sub_offer_duration }} 试用，然后 {{total_price_and_per_month }}。";  I don’t think we need spaces around “{{ sub_offer_duration }}” and ”{{total_price_and_per_month }}”.
