### PR TITLE
Paywalls: Add dismissal method in `PaywallViewControllerDelegate`

### DIFF
--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -86,8 +86,8 @@ public final class PaywallViewController: UIViewController {
     }
 
     public override func viewDidDisappear(_ animated: Bool) {
-        if isBeingDismissed {
-            self.delegate?.paywallViewControllerDismissed?(self)
+        if self.isBeingDismissed {
+            self.delegate?.paywallViewControllerWasDismissed?(self)
         }
         super.viewDidDisappear(animated)
     }
@@ -120,7 +120,7 @@ public protocol PaywallViewControllerDelegate: AnyObject {
 
     /// Notifies that the ``PaywallViewController`` was dismissed.
     @objc(paywallViewControllerDismissed:)
-    optional func paywallViewControllerDismissed(_ controller: PaywallViewController)
+    optional func paywallViewControllerWasDismissed(_ controller: PaywallViewController)
 
 }
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -85,6 +85,12 @@ public final class PaywallViewController: UIViewController {
         self.hostingController.view.frame = self.view.bounds
     }
 
+    public override func viewDidDisappear(_ animated: Bool) {
+        if isBeingDismissed {
+            self.delegate?.paywallViewControllerDismissed?(self)
+        }
+        super.viewDidDisappear(animated)
+    }
 }
 
 /// Delegate for ``PaywallViewController``.
@@ -111,6 +117,10 @@ public protocol PaywallViewControllerDelegate: AnyObject {
     @objc(paywallViewController:didFinishRestoringWithCustomerInfo:)
     optional func paywallViewController(_ controller: PaywallViewController,
                                         didFinishRestoringWith customerInfo: CustomerInfo)
+
+    /// Notifies that the ``PaywallViewController`` was dismissed.
+    @objc(paywallViewControllerDismissed:)
+    optional func paywallViewControllerDismissed(_ controller: PaywallViewController)
 
 }
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -119,7 +119,7 @@ public protocol PaywallViewControllerDelegate: AnyObject {
                                         didFinishRestoringWith customerInfo: CustomerInfo)
 
     /// Notifies that the ``PaywallViewController`` was dismissed.
-    @objc(paywallViewControllerDismissed:)
+    @objc(paywallViewControllerWasDismissed:)
     optional func paywallViewControllerWasDismissed(_ controller: PaywallViewController)
 
 }

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -32,7 +32,7 @@ final class Delegate: PaywallViewControllerDelegate {
     func paywallViewController(_ controller: PaywallViewController,
                                didFinishRestoringWith customerInfo: CustomerInfo) {}
 
-    func paywallViewControllerDismissed(_ controller: PaywallViewController) {}
+    func paywallViewControllerWasDismissed(_ controller: PaywallViewController) {}
 
 }
 

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -32,6 +32,8 @@ final class Delegate: PaywallViewControllerDelegate {
     func paywallViewController(_ controller: PaywallViewController,
                                didFinishRestoringWith customerInfo: CustomerInfo) {}
 
+    func paywallViewControllerDismissed(_ controller: PaywallViewController) {}
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)


### PR DESCRIPTION
### Description
This adds a new method to the `PaywallViewControllerDelegate` to indicate when the `PaywallViewController` is dismissed.

This will be useful to listen to responses in the hybrids, since we need to present the paywall and wait until it's been purchased/dismissed before returning a value for the hybrids.

This will be needed to fix: https://github.com/RevenueCat/purchases-flutter/issues/886
