### PR TITLE
`Paywalls`: fix empty description when using `custom` package type and `{{ sub_period }}`

### DIFF
--- a/RevenueCatUI/Data/Localization.swift
+++ b/RevenueCatUI/Data/Localization.swift
@@ -53,8 +53,8 @@ enum Localization {
     static func localized(
         packageType: PackageType,
         locale: Locale = .current
-    ) -> String {
-        guard let key = packageType.localizationKey else { return "" }
+    ) -> String? {
+        guard let key = packageType.localizationKey else { return nil }
 
         func value(locale: Locale, default: String?) -> String {
             Self

--- a/RevenueCatUI/Data/TestData.swift
+++ b/RevenueCatUI/Data/TestData.swift
@@ -157,6 +157,13 @@ internal enum TestData {
         offeringIdentifier: Self.offeringIdentifier
     )
 
+    static let unknownPackage = Package(
+        identifier: "Unknown",
+        packageType: .unknown,
+        storeProduct: Self.annualProduct.toStoreProduct(),
+        offeringIdentifier: Self.offeringIdentifier
+    )
+
     static let packageWithIntroOffer = Package(
         identifier: PackageType.monthly.identifier,
         packageType: .monthly,

--- a/RevenueCatUI/Data/TestData.swift
+++ b/RevenueCatUI/Data/TestData.swift
@@ -150,6 +150,12 @@ internal enum TestData {
         storeProduct: Self.annualProduct.toStoreProduct(),
         offeringIdentifier: Self.offeringIdentifier
     )
+    static let customPackage = Package(
+        identifier: "Custom",
+        packageType: .custom,
+        storeProduct: Self.annualProduct.toStoreProduct(),
+        offeringIdentifier: Self.offeringIdentifier
+    )
 
     static let packageWithIntroOffer = Package(
         identifier: PackageType.monthly.identifier,

--- a/RevenueCatUI/Data/Variables.swift
+++ b/RevenueCatUI/Data/Variables.swift
@@ -37,7 +37,7 @@ protocol VariableDataProvider {
     var localizedIntroductoryOfferPrice: String? { get }
     var productName: String { get }
 
-    func periodName(_ locale: Locale) -> String
+    func periodNameOrIdentifier(_ locale: Locale) -> String
     func subscriptionDuration(_ locale: Locale) -> String?
     func normalizedSubscriptionDuration(_ locale: Locale) -> String?
     func introductoryOfferDuration(_ locale: Locale) -> String?
@@ -98,7 +98,7 @@ enum VariableHandler {
         case "price_per_period": return { (provider, _, locale) in provider.localizedPricePerPeriod(locale) }
         case "total_price_and_per_month": return { (provider, _, locale) in provider.localizedPriceAndPerMonth(locale) }
         case "product_name": return { (provider, _, _) in provider.productName }
-        case "sub_period": return { (provider, _, locale) in provider.periodName(locale) }
+        case "sub_period": return { (provider, _, locale) in provider.periodNameOrIdentifier(locale) }
         case "sub_price_per_month": return { (provider, _, _) in provider.localizedPricePerMonth }
         case "sub_price_per_week": return { (provider, _, _) in provider.localizedPricePerWeek }
         case "sub_duration": return { (provider, _, locale) in provider.subscriptionDuration(locale) }

--- a/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
+++ b/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
@@ -40,11 +40,8 @@ extension Package: VariableDataProvider {
     }
 
     func periodName(_ locale: Locale) -> String {
-        if packageType == .custom {
-            return self.identifier
-        }
         return Localization.localized(packageType: self.packageType,
-                                      locale: locale)
+                                      locale: locale) ?? self.identifier
     }
 
     func subscriptionDuration(_ locale: Locale) -> String? {

--- a/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
+++ b/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
@@ -40,6 +40,9 @@ extension Package: VariableDataProvider {
     }
 
     func periodName(_ locale: Locale) -> String {
+        if packageType == .custom {
+            return self.identifier
+        }
         return Localization.localized(packageType: self.packageType,
                                       locale: locale)
     }

--- a/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
+++ b/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
@@ -39,14 +39,14 @@ extension Package: VariableDataProvider {
         return self.storeProduct.localizedTitle
     }
 
-    func periodName(_ locale: Locale) -> String {
+    func periodNameOrIdentifier(_ locale: Locale) -> String {
         return Localization.localized(packageType: self.packageType,
                                       locale: locale) ?? self.identifier
     }
 
     func subscriptionDuration(_ locale: Locale) -> String? {
         guard let period = self.storeProduct.subscriptionPeriod else {
-            return self.periodName(locale)
+            return self.periodNameOrIdentifier(locale)
         }
 
         return Localization.localizedDuration(for: period, locale: locale)
@@ -54,7 +54,7 @@ extension Package: VariableDataProvider {
 
     func normalizedSubscriptionDuration(_ locale: Locale) -> String? {
         guard let period = self.storeProduct.subscriptionPeriod else {
-            return self.periodName(locale)
+            return self.periodNameOrIdentifier(locale)
         }
 
         return Localization.localizedDuration(for: period.normalized, locale: locale)

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -325,7 +325,7 @@ private struct PackageButton: View {
         // Placeholder to make sure consistent layout
         self.offerText(firstRow: "12",
                        secondRow: Localization.localized(packageType: .monthly,
-                                                         locale: self.locale))
+                                                         locale: self.locale) ?? "Monthly")
         .hidden()
         .overlay {
             if let offerName = self.package.localization.offerName {

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -323,24 +323,28 @@ private struct PackageButton: View {
     @ViewBuilder
     private var offerName: some View {
         // Placeholder to make sure consistent layout
-        self.offerText(firstRow: "12",
-                       secondRow: Localization.localized(packageType: .monthly,
-                                                         locale: self.locale) ?? "Monthly")
+        self.offerText(Localization.localizedDuration(for: .init(value: 12, unit: .month),
+                                                      locale: self.locale))
         .hidden()
         .overlay {
             if let offerName = self.package.localization.offerName {
-                let components = offerName.split(separator: " ", maxSplits: 2)
-                if components.count == 2 {
-                    self.offerText(firstRow: String(components[0]),
-                                   secondRow: String(components[1]))
-                } else {
-                    self.offerText(firstRow: nil,
-                                   secondRow: offerName)
-                }
+                self.offerText(offerName)
             } else {
                 self.offerText(firstRow: nil,
                                secondRow: self.package.content.productName)
             }
+        }
+    }
+
+    @ViewBuilder
+    private func offerText(_ text: String) -> some View {
+        let components = text.split(separator: " ", maxSplits: 2)
+        if components.count == 2 {
+            self.offerText(firstRow: String(components[0]),
+                           secondRow: String(components[1]))
+        } else {
+            self.offerText(firstRow: nil,
+                           secondRow: text)
         }
     }
 

--- a/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
@@ -134,6 +134,7 @@ class PackageVariablesTests: TestCase {
         expect(TestData.sixMonthPackage.periodName(Self.english)) == "6 Month"
         expect(TestData.annualPackage.periodName(Self.english)) == "Annual"
         expect(TestData.lifetimePackage.periodName(Self.english)) == "Lifetime"
+        expect(TestData.customPackage.periodName(Self.english)) == "Custom"
     }
 
     func testSpanishPeriodName() {
@@ -143,6 +144,7 @@ class PackageVariablesTests: TestCase {
         expect(TestData.sixMonthPackage.periodName(Self.spanish)) == "6 meses"
         expect(TestData.annualPackage.periodName(Self.spanish)) == "Anual"
         expect(TestData.lifetimePackage.periodName(Self.spanish)) == "Toda la vida"
+        expect(TestData.customPackage.periodName(Self.spanish)) == "Custom"
     }
 
     func testEnglishIntroductoryOfferDuration() {

--- a/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
@@ -135,6 +135,7 @@ class PackageVariablesTests: TestCase {
         expect(TestData.annualPackage.periodName(Self.english)) == "Annual"
         expect(TestData.lifetimePackage.periodName(Self.english)) == "Lifetime"
         expect(TestData.customPackage.periodName(Self.english)) == "Custom"
+        expect(TestData.unknownPackage.periodName(Self.english)) == "Unknown"
     }
 
     func testSpanishPeriodName() {
@@ -145,6 +146,8 @@ class PackageVariablesTests: TestCase {
         expect(TestData.annualPackage.periodName(Self.spanish)) == "Anual"
         expect(TestData.lifetimePackage.periodName(Self.spanish)) == "Toda la vida"
         expect(TestData.customPackage.periodName(Self.spanish)) == "Custom"
+        expect(TestData.unknownPackage.periodName(Self.spanish)) == "Unknown"
+
     }
 
     func testEnglishIntroductoryOfferDuration() {

--- a/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
@@ -128,26 +128,25 @@ class PackageVariablesTests: TestCase {
     }
 
     func testEnglishPeriodName() {
-        expect(TestData.weeklyPackage.periodName(Self.english)) == "Weekly"
-        expect(TestData.monthlyPackage.periodName(Self.english)) == "Monthly"
-        expect(TestData.threeMonthPackage.periodName(Self.english)) == "3 Month"
-        expect(TestData.sixMonthPackage.periodName(Self.english)) == "6 Month"
-        expect(TestData.annualPackage.periodName(Self.english)) == "Annual"
-        expect(TestData.lifetimePackage.periodName(Self.english)) == "Lifetime"
-        expect(TestData.customPackage.periodName(Self.english)) == "Custom"
-        expect(TestData.unknownPackage.periodName(Self.english)) == "Unknown"
+        expect(TestData.weeklyPackage.periodNameOrIdentifier(Self.english)) == "Weekly"
+        expect(TestData.monthlyPackage.periodNameOrIdentifier(Self.english)) == "Monthly"
+        expect(TestData.threeMonthPackage.periodNameOrIdentifier(Self.english)) == "3 Month"
+        expect(TestData.sixMonthPackage.periodNameOrIdentifier(Self.english)) == "6 Month"
+        expect(TestData.annualPackage.periodNameOrIdentifier(Self.english)) == "Annual"
+        expect(TestData.lifetimePackage.periodNameOrIdentifier(Self.english)) == "Lifetime"
+        expect(TestData.customPackage.periodNameOrIdentifier(Self.english)) == "Custom"
+        expect(TestData.unknownPackage.periodNameOrIdentifier(Self.english)) == "Unknown"
     }
 
     func testSpanishPeriodName() {
-        expect(TestData.weeklyPackage.periodName(Self.spanish)) == "Semanalmente"
-        expect(TestData.monthlyPackage.periodName(Self.spanish)) == "Mensual"
-        expect(TestData.threeMonthPackage.periodName(Self.spanish)) == "3 meses"
-        expect(TestData.sixMonthPackage.periodName(Self.spanish)) == "6 meses"
-        expect(TestData.annualPackage.periodName(Self.spanish)) == "Anual"
-        expect(TestData.lifetimePackage.periodName(Self.spanish)) == "Toda la vida"
-        expect(TestData.customPackage.periodName(Self.spanish)) == "Custom"
-        expect(TestData.unknownPackage.periodName(Self.spanish)) == "Unknown"
-
+        expect(TestData.weeklyPackage.periodNameOrIdentifier(Self.spanish)) == "Semanalmente"
+        expect(TestData.monthlyPackage.periodNameOrIdentifier(Self.spanish)) == "Mensual"
+        expect(TestData.threeMonthPackage.periodNameOrIdentifier(Self.spanish)) == "3 meses"
+        expect(TestData.sixMonthPackage.periodNameOrIdentifier(Self.spanish)) == "6 meses"
+        expect(TestData.annualPackage.periodNameOrIdentifier(Self.spanish)) == "Anual"
+        expect(TestData.lifetimePackage.periodNameOrIdentifier(Self.spanish)) == "Toda la vida"
+        expect(TestData.customPackage.periodNameOrIdentifier(Self.spanish)) == "Custom"
+        expect(TestData.unknownPackage.periodNameOrIdentifier(Self.spanish)) == "Unknown"
     }
 
     func testEnglishIntroductoryOfferDuration() {

--- a/Tests/RevenueCatUITests/Data/VariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/VariablesTests.swift
@@ -75,7 +75,7 @@ class VariablesTests: TestCase {
     }
 
     func testPeriodName() {
-        self.provider.periodName = "Monthly"
+        self.provider.periodNameOrIdentifier = "Monthly"
         expect(self.process("{{ sub_period }}")) == "Monthly"
     }
 
@@ -280,15 +280,15 @@ private struct MockVariableProvider: VariableDataProvider {
     var localizedPriceAndPerMonth: String = ""
     var localizedPricePerPeriod: String = ""
     var productName: String = ""
-    var periodName: String = ""
+    var periodNameOrIdentifier: String = ""
     var subscriptionDuration: String?
     var normalizedSubscriptionDuration: String?
     var introductoryOfferDuration: String?
     var introductoryOfferPrice: String = ""
     var relativeDiscount: String?
 
-    func periodName(_ locale: Locale) -> String {
-        return self.periodName
+    func periodNameOrIdentifier(_ locale: Locale) -> String {
+        return self.periodNameOrIdentifier
     }
 
     func subscriptionDuration(_ locale: Locale) -> String? {

--- a/Tests/RevenueCatUITests/LocalizationTests.swift
+++ b/Tests/RevenueCatUITests/LocalizationTests.swift
@@ -206,8 +206,8 @@ class PackageTypeEnglishLocalizationTests: BaseLocalizationTests {
     }
 
     func testOtherValues() {
-        verify(.custom, "")
-        verify(.unknown, "")
+        verify(.custom, nil)
+        verify(.unknown, nil)
     }
 
 }
@@ -228,8 +228,8 @@ class PackageTypeSpanishLocalizationTests: BaseLocalizationTests {
     }
 
     func testOtherValues() {
-        verify(.custom, "")
-        verify(.unknown, "")
+        verify(.custom, nil)
+        verify(.unknown, nil)
     }
 }
 
@@ -250,8 +250,8 @@ class PackageTypeLocalizationWithOnlyLanguageTests: BaseLocalizationTests {
     }
 
     func testOtherValues() {
-        verify(.custom, "")
-        verify(.unknown, "")
+        verify(.custom, nil)
+        verify(.unknown, nil)
     }
 }
 
@@ -271,8 +271,8 @@ class PackageTypeOtherLanguageLocalizationTests: BaseLocalizationTests {
     }
 
     func testOtherValues() {
-        verify(.custom, "")
-        verify(.unknown, "")
+        verify(.custom, nil)
+        verify(.unknown, nil)
     }
 }
 
@@ -386,13 +386,17 @@ private extension BaseLocalizationTests {
 
     func verify(
         _ packageType: PackageType,
-        _ expected: String,
+        _ expected: String?,
         file: StaticString = #file,
         line: UInt = #line
     ) {
         let result = Localization.localized(packageType: packageType,
                                             locale: self.locale)
-        expect(file: file, line: line, result) == expected
+        if let expected {
+            expect(file: file, line: line, result) == expected
+        } else {
+            expect(file: file, line: line, result).to(beNil())
+        }
     }
 
     func verify(


### PR DESCRIPTION
If you select a custom package type and set Offer Period, the paywall would have an empty entry for that package. 


<img width="802" alt="image" src="https://github.com/RevenueCat/purchases-ios/assets/3922667/fa50e15b-b122-4caa-816e-3250f10d5d89">

| Before | After |
| :-: | :-: |
| ![IMG_908CED5B663B-1 (1)](https://github.com/RevenueCat/purchases-ios/assets/3922667/2519c74e-c0d2-44c1-a126-64bd78808384) | ![IMG_B1CED574DF20-1](https://github.com/RevenueCat/purchases-ios/assets/3922667/1eaf17d6-75fd-4e20-86cf-ef93de2d74d3) |