### PR TITLE
`Trusted Entitlements`: tests for signature verification without header hash

### DIFF
--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -47,6 +47,7 @@ enum NetworkStrings {
     #if DEBUG
     case api_request_forcing_server_error(HTTPRequest)
     case api_request_forcing_signature_failure(HTTPRequest)
+    case api_request_disabling_header_parameter_signature_verification(HTTPRequest)
     #endif
 
 }
@@ -136,6 +137,9 @@ extension NetworkStrings: LogMessage {
 
         case let .api_request_forcing_signature_failure(request):
             return "Returning fake signature verification failure for '\(request.description)'"
+
+        case let .api_request_disabling_header_parameter_signature_verification(request):
+            return "Disabling header parameter signature verification for '\(request.description)'"
         #endif
         }
     }

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -21,6 +21,7 @@ import Foundation
         #if DEBUG
         let forceServerErrors: Bool
         let forceSignatureFailures: Bool
+        let disableHeaderSignatureVerification: Bool
         let testReceiptIdentifier: String?
 
         init(
@@ -28,12 +29,14 @@ import Foundation
             usesStoreKit2JWS: Bool = false,
             forceServerErrors: Bool = false,
             forceSignatureFailures: Bool = false,
+            disableHeaderSignatureVerification: Bool = false,
             testReceiptIdentifier: String? = nil
         ) {
             self.enableReceiptFetchRetry = enableReceiptFetchRetry
             self.usesStoreKit2JWS = usesStoreKit2JWS
             self.forceServerErrors = forceServerErrors
             self.forceSignatureFailures = forceSignatureFailures
+            self.disableHeaderSignatureVerification = disableHeaderSignatureVerification
             self.testReceiptIdentifier = testReceiptIdentifier
         }
         #else
@@ -44,6 +47,7 @@ import Foundation
             self.enableReceiptFetchRetry = enableReceiptFetchRetry
             self.usesStoreKit2JWS = usesStoreKit2JWS
         }
+
         #endif
 
         static let `default`: Self = .init()
@@ -134,9 +138,13 @@ internal protocol InternalDangerousSettingsType: Sendable {
     /// Whether `HTTPClient` will fake invalid signatures.
     var forceSignatureFailures: Bool { get }
 
+    /// Used to verify that the backend signs correctly without this part of the signature.
+    var disableHeaderSignatureVerification: Bool { get }
+
     /// Allows defining the receipt identifier for `PostReceiptDataOperation`.
     /// This allows the backend to disambiguate between receipts created across separate test invocations.
     var testReceiptIdentifier: String? { get }
+
     #endif
 
 }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -569,7 +569,7 @@ extension HTTPRequest {
            verificationMode.isEnabled,
            self.path.supportsSignatureVerification {
             let headerParametersSignature = HTTPClient.headerParametersForSignatureHeader(
-                with: defaultHeaders, 
+                with: defaultHeaders,
                 path: self.path
             )
 

--- a/Sources/Security/HTTPRequest+Signing.swift
+++ b/Sources/Security/HTTPRequest+Signing.swift
@@ -80,9 +80,7 @@ extension HTTPRequest {
 
 }
 
-// MARK: - Private
-
-private extension HTTPRequest {
+extension HTTPRequest {
 
     /// Ordered list of header keys that will be included in the signature.
     static let headersToSign: [HTTPClient.RequestHeader] = [
@@ -90,6 +88,8 @@ private extension HTTPRequest {
     ]
 
 }
+
+// MARK: - Private
 
 private let postParameterHashingAlgorithmName = "sha256"
 private let fieldSeparator = Data(bytes: [0x00], count: 1)

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -240,6 +240,7 @@ extension BaseBackendIntegrationTests: InternalDangerousSettingsType {
     var usesStoreKit2JWS: Bool { false }
     var forceServerErrors: Bool { return self.serverIsDown }
     var forceSignatureFailures: Bool { return false }
+    var disableHeaderSignatureVerification: Bool { return false }
     var testReceiptIdentifier: String? { return self.testUUID.uuidString }
 
     final func serverDown() { self.serverIsDown = true }

--- a/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
@@ -11,6 +11,8 @@
 //
 //  Created by Nacho Soto on 3/21/23.
 
+// swiftlint:disable type_name
+
 import Nimble
 @testable import RevenueCat
 import SnapshotTesting
@@ -89,6 +91,24 @@ class LoadShedderStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
             timeout: .seconds(5),
             pollInterval: .milliseconds(100)
         )
+    }
+
+}
+
+/// Header verification (see `HTTPRequest.headerParametersForSignatureHeader`) is enabled by default,
+/// but this helps verify that the backend is still signing correctly without it for older SDK versions.
+/// See also `SignatureVerificationWithoutHeaderHashIntegrationTests`.
+class LoadShedderSignatureVerificationWithoutHeaderHashIntegrationTests: LoadShedderStoreKit1IntegrationTests {
+
+    override var disableHeaderSignatureVerification: Bool { return true }
+
+    override func tearDown() {
+        self.logger.verifyMessageWasLogged(
+            "Disabling header parameter signature verification",
+            level: .warn
+        )
+
+        super.tearDown()
     }
 
 }

--- a/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
@@ -59,6 +59,12 @@ class InformationalSignatureVerificationIntegrationTests: BaseSignatureVerificat
         expect(info.entitlements.verification) == .verified
     }
 
+    func testHeaderVerificationIsNotDisabled() async throws {
+        _ = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
+
+        self.logger.verifyMessageWasNotLogged("Disabling header parameter signature verification")
+    }
+
     func testCustomerInfo304ResponseWithValidSignature() async throws {
         // 1. Fetch user once
         _ = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
@@ -331,6 +337,23 @@ class DynamicModeSignatureVerificationIntegrationTests: BaseSignatureVerificatio
                     description: "Unexpected error: \(error)"
                 )
         }
+    }
+
+}
+
+/// Header verification (see `HTTPRequest.headerParametersForSignatureHeader`) is enabled by default,
+/// but this helps verify that the backend is still signing correctly without it for older SDK versions.
+class SignatureVerificationWithoutHeaderHashIntegrationTests: EnforcedSignatureVerificationIntegrationTests {
+
+    override var disableHeaderSignatureVerification: Bool { return true }
+
+    override func tearDown() {
+        self.logger.verifyMessageWasLogged(
+            "Disabling header parameter signature verification",
+            level: .warn
+        )
+
+        super.tearDown()
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -86,7 +86,8 @@ class MockHTTPClient: HTTPClient {
         let call = Call(request: request,
                         headers: request.headers(with: self.authHeaders,
                                                  defaultHeaders: self.defaultHeaders,
-                                                 verificationMode: verificationMode))
+                                                 verificationMode: verificationMode,
+                                                 internalSettings: self.systemInfo.dangerousSettings.internalSettings))
 
         DispatchQueue.main.async {
             self.calls.append(call)

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1636,7 +1636,7 @@ extension BaseHTTPClientTests {
         }
     }
 
-    struct BodyWithSignature: HTTPRequestBody {
+    struct BodyWithSignature: HTTPRequestBody, Equatable {
         var key1: String
         var key2: String
 


### PR DESCRIPTION
Follow up to #3424. This adds coverage to ensure that the backend continues to sign correctly for old SDK versions that don't support this.