### PR TITLE
`Paywalls`: change style of CTA button to be consistent with other platforms

### DIFF
--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -105,6 +105,9 @@ struct PurchaseButton: View {
                 transaction.animation = nil
             }
         }
+        #if targetEnvironment(macCatalyst)
+        .buttonStyle(.plain)
+        #endif
     }
 
     @ViewBuilder


### PR DESCRIPTION
This is what it looked like before:

![Screenshot 2023-12-08 at 15 31 10](https://github.com/RevenueCat/purchases-ios/assets/685609/59a4591e-9ae9-4e9e-a399-fa80043fe424)

I chose that on purpose to provide a "native" look to paywalls. However, as others have reported, it has several issues:
- It's too small. The button should be the most obvious action to take on the paywall.
- It doesn't respect the configuration for the paywall (background and foreground color).

This looked like a "bug", so the new implementation will provide consistency with what users probably expect:

![Screenshot 2023-12-08 at 15 27 17](https://github.com/RevenueCat/purchases-ios/assets/685609/44403529-6931-43fb-99ae-ce922cc9e47f)
