### PR TITLE
`Paywalls`: open footer links on Safari on Catalyst

### DIFF
--- a/RevenueCatUI/Views/FooterView.swift
+++ b/RevenueCatUI/Views/FooterView.swift
@@ -228,7 +228,7 @@ private struct LinkButton: View {
     }
 
     var body: some View {
-        #if canImport(WebKit) && !os(macOS)
+        #if canImport(WebKit) && !os(macOS) && !targetEnvironment(macCatalyst)
         Button {
             self.displayLink = true
         } label: {


### PR DESCRIPTION
Follow up to #3475.

This new implementation doesn't make sense (and doesn't work very well) on Catalyst. It will now fall back to the previous implementation and open the link on a new window (using the default system browser).
