### PR TITLE
`Paywalls`: fix PaywallViewControllerDelegate access from Objective-C

### DIFF
--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -25,7 +25,7 @@ import UIKit
 public final class PaywallViewController: UIViewController {
 
     /// See ``PaywallViewControllerDelegate`` for receiving purchase events.
-    public weak var delegate: PaywallViewControllerDelegate?
+    @objc public weak var delegate: PaywallViewControllerDelegate?
 
     private let offering: Offering?
     private let displayCloseButton: Bool


### PR DESCRIPTION
Public variables must be exposed with `@objc` to be accessible outside of Swift. This change is necessary to set delegate from host project so that we may dismiss the paywall.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Paywall doesn't seem to be usable in an Objective-C project as there is no way to receive the callback to drop the paywall other than by setting a delegate. 

### Description
Added code to expose the public variable `delegate` in PaywallViewController to Objective-C.
Tested by setting delegate and receiving delegate method callbacks in Obj-C code.
