### PR TITLE
`Paywalls`: always dismiss paywalls automatically after a purchase

### DIFF
--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -28,6 +28,29 @@ extension View {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension View {
+
+    /// Wraps the 2 `onChange(of:)` implementations in iOS 17+ and below depending on what's available
+    @inlinable
+    @ViewBuilder
+    public func onChangeOf<V>(
+        _ value: V,
+        perform action: @escaping (_ newValue: V) -> Void
+    ) -> some View where V: Equatable {
+        #if swift(>=5.9)
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
+            self.onChange(of: value) { _, newValue in action(newValue) }
+        } else {
+            self.onChange(of: value) { newValue in action(newValue) }
+        }
+        #else
+        self.onChange(of: value) { _, newValue in action(newValue) }
+        #endif
+    }
+
+}
+
 // MARK: - Scrolling
 
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)

--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -45,7 +45,7 @@ extension View {
             self.onChange(of: value) { newValue in action(newValue) }
         }
         #else
-        self.onChange(of: value) { _, newValue in action(newValue) }
+        self.onChange(of: value) { newValue in action(newValue) }
         #endif
     }
 

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -189,13 +189,8 @@ struct Template4View: TemplateViewType {
                 }
             }
         }
-        #if swift(>=5.9) && os(visionOS)
-        .onChange(of: self.dynamicTypeSize) { _, _ in self.packageContentHeight = nil }
-        .onChange(of: self.containerWidth) { _, _ in self.packageContentHeight = nil }
-        #else
-        .onChange(of: self.dynamicTypeSize) { _ in self.packageContentHeight = nil }
-        .onChange(of: self.containerWidth) { _ in self.packageContentHeight = nil }
-        #endif
+        .onChangeOf(self.dynamicTypeSize) { _ in self.packageContentHeight = nil }
+        .onChangeOf(self.containerWidth) { _ in self.packageContentHeight = nil }
         .hidden()
     }
 

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -179,8 +179,6 @@ private struct PresentingPaywallModifier: ViewModifier {
                 )
                 .onPurchaseCompleted {
                     self.purchaseCompleted?($0)
-
-                    self.close()
                 }
                 .onRestoreCompleted { customerInfo in
                     self.restoreCompleted?(customerInfo)

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -24,7 +24,7 @@ import SwiftUI
 struct LoadingPaywallView: View {
 
     var mode: PaywallViewMode
-    var dismiss: (() -> Void)?
+    var displayCloseButton: Bool
 
     var shimmer: Bool = true
 
@@ -42,7 +42,7 @@ struct LoadingPaywallView: View {
             template: Self.template,
             mode: self.mode,
             fonts: DefaultPaywallFontProvider(),
-            dismiss: dismiss,
+            displayCloseButton: self.displayCloseButton,
             introEligibility: Self.introEligibility,
             purchaseHandler: Self.purchaseHandler
         )
@@ -232,7 +232,7 @@ struct LoadingPaywallView_Previews: PreviewProvider {
 
     static var previews: some View {
         ForEach(PaywallViewMode.allCases, id: \.self) { mode in
-            LoadingPaywallView(mode: mode)
+            LoadingPaywallView(mode: mode, displayCloseButton: true)
                 .previewDisplayName("\(mode)")
         }
     }

--- a/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
@@ -33,17 +33,17 @@ class OtherPaywallViewTests: BaseSnapshotTest {
     }
 
     func testLoadingPaywallView() {
-        LoadingPaywallView(mode: .fullScreen, shimmer: false)
+        LoadingPaywallView(mode: .fullScreen, displayCloseButton: false, shimmer: false)
             .snapshot(size: Self.fullScreenSize)
     }
 
     func testLoadingFooterPaywallView() {
-        LoadingPaywallView(mode: .footer, shimmer: false)
+        LoadingPaywallView(mode: .footer, displayCloseButton: false, shimmer: false)
             .snapshot(size: Self.footerSize)
     }
 
     func testLoadingCondensedFooterPaywallView() {
-        LoadingPaywallView(mode: .condensedFooter, shimmer: false)
+        LoadingPaywallView(mode: .condensedFooter, displayCloseButton: false, shimmer: false)
             .snapshot(size: Self.footerSize)
     }
 


### PR DESCRIPTION
 Fixes #3516.

This logic only existed for `.presentPaywallIfNeeded`. However, it should apply to `PaywallView` when presented manually as well.

This is also consistent with how Android works, reduces boilerplate code required by users, and removes the possibility that a paywall is still presented after a purchase, which doesn't make sense since our paywalls don't have a mode for "already subscribed".