### PR TITLE
`Paywalls`: silence logs below `Purchases.logLevel`

### DIFF
--- a/RevenueCatUI/Helpers/Logger.swift
+++ b/RevenueCatUI/Helpers/Logger.swift
@@ -70,6 +70,8 @@ enum Logger {
         function: String = #function,
         line: UInt = #line
     ) {
+        guard Purchases.logLevel <= level else { return }
+
         Purchases.verboseLogHandler(
             level,
             text.description,


### PR DESCRIPTION
I made the wrong assumption that the log level checking was part of `Purchases.verboseLogHandler`,
but it's done by `Logger` outside of that call. Therefore `RevenueCatUI` also needed the check.
