### PR TITLE
`Paywalls`: ensure footer links open in full-screen sheets

### DIFF
--- a/RevenueCatUI/Views/FooterView.swift
+++ b/RevenueCatUI/Views/FooterView.swift
@@ -250,6 +250,7 @@ private struct LinkButton: View {
                         }
                     }
             }
+            .navigationViewStyle(.stack)
         }
         #else
         Link(destination: self.url) {


### PR DESCRIPTION
Fixes #3518.
Follow up to #3475 and #3508.
