### PR TITLE
`Paywalls`: improve `FooterView` text alignment

### DIFF
--- a/RevenueCatUI/Views/FooterView.swift
+++ b/RevenueCatUI/Views/FooterView.swift
@@ -280,6 +280,7 @@ private struct LinkButton: View {
 
     private func linkContent(for title: String, bundle: Bundle) -> some View {
         Text(Self.localizedString(title, bundle))
+            .multilineTextAlignment(.center)
             .frame(minHeight: Constants.minimumButtonHeight)
     }
 


### PR DESCRIPTION
These seemed to be the default before, but it broke with #3475.

Difference (before and after):
![Screenshot 2023-12-18 at 15 09 51](https://github.com/RevenueCat/purchases-ios/assets/685609/1e2e8c69-51b0-4500-8e30-28e4c357907d)

This restores the layout shown on the left side.