### PR TITLE
`Paywalls Tester`: remove double close button

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -19,6 +19,13 @@ final class Configuration: ObservableObject {
 
     static let entitlement = "pro"
 
+    #if os(watchOS)
+    // Sheets on watchOS add a close button automatically
+    static let defaultDisplayCloseButton = false
+    #else
+    static let defaultDisplayCloseButton = true
+    #endif
+
     enum Mode: Equatable {
         case custom, testing, demos, listOnly
     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -131,7 +131,7 @@ struct AppContentView: View {
         }
         #endif
         .sheet(isPresented: self.$showingDefaultPaywall) {
-            PaywallView(displayCloseButton: true)
+            PaywallView(displayCloseButton: Configuration.defaultDisplayCloseButton)
         }
         .task(id: self.configuration.currentMode) {
             if Purchases.isConfigured {
@@ -158,7 +158,7 @@ struct AppContentView: View {
 
     #if !os(watchOS)
     private func presentPaywallViewController() {
-        let paywall = PaywallViewController(displayCloseButton: true)
+        let paywall = PaywallViewController(displayCloseButton: Configuration.defaultDisplayCloseButton)
         paywall.modalPresentationStyle = .pageSheet
 
         guard let rootController = UIApplication

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
@@ -171,7 +171,7 @@ private struct PaywallPresenter: View {
 
     var offering: Offering
     var mode: PaywallViewMode
-    var displayCloseButton: Bool = Self.defaultDisplayCloseButton
+    var displayCloseButton: Bool = Configuration.defaultDisplayCloseButton
 
     var body: some View {
         switch self.mode {
@@ -189,12 +189,6 @@ private struct PaywallPresenter: View {
         #endif
         }
     }
-
-    #if os(watchOS)
-    private static let defaultDisplayCloseButton = false
-    #else
-    private static let defaultDisplayCloseButton = true
-    #endif
 
 }
 


### PR DESCRIPTION
Presenting the default paywall was still displaying 2 close buttons
