### PR TITLE
`Paywalls`: fix template 5 footer loading view alignment

### DIFF
--- a/RevenueCatUI/Templates/Template5View.swift
+++ b/RevenueCatUI/Templates/Template5View.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Nacho Soto.
 
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length file_length
 
 import RevenueCat
 import SwiftUI
@@ -106,7 +106,11 @@ struct Template5View: TemplateViewType {
                 )
 
             if self.configuration.mode.shouldDisplayInlineOfferDetails(displayingAllPlans: self.displayingAllPlans) {
-                self.offerDetails(package: self.selectedPackage, selected: false)
+                self.offerDetails(
+                    package: self.selectedPackage,
+                    selected: false,
+                    alignment: .center
+                )
             }
 
             self.subscribeButton
@@ -294,13 +298,17 @@ struct Template5View: TemplateViewType {
         }
     }
 
-    private func offerDetails(package: TemplateViewConfiguration.Package, selected: Bool) -> some View {
+    private func offerDetails(
+        package: TemplateViewConfiguration.Package,
+        selected: Bool,
+        alignment: Alignment = Self.packageButtonAlignment
+    ) -> some View {
         IntroEligibilityStateView(
             display: .offerDetails,
             localization: package.localization,
             introEligibility: self.introEligibility[package.content],
             foregroundColor: self.configuration.colors.text1Color,
-            alignment: Self.packageButtonAlignment
+            alignment: alignment
         )
         .fixedSize(horizontal: false, vertical: true)
         .font(self.font(for: .body))


### PR DESCRIPTION
### Before:
<img width="464" alt="Screenshot 2023-12-21 at 10 34 03" src="https://github.com/RevenueCat/purchases-ios/assets/685609/bafac995-8e62-4a98-ba0c-0a97531cd23c">

### After:
<img width="454" alt="Screenshot 2023-12-21 at 10 33 55" src="https://github.com/RevenueCat/purchases-ios/assets/685609/32160d26-6b1d-40d5-a6b2-a7490d4c2b5d">
