### PR TITLE
`StoreProduct`: add localized price per period strings

### DIFF
--- a/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
+++ b/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
@@ -24,11 +24,21 @@ extension Package: VariableDataProvider {
     }
 
     var localizedPricePerWeek: String {
-        return self.priceFormatter.string(from: self.pricePerWeek) ?? ""
+        guard let price = self.storeProduct.localizedPricePerWeek else {
+            Logger.warning(Strings.package_not_subscription(self))
+            return self.storeProduct.localizedPriceString
+        }
+
+        return price
     }
 
     var localizedPricePerMonth: String {
-        return self.priceFormatter.string(from: self.pricePerMonth) ?? ""
+        guard let price = self.storeProduct.localizedPricePerMonth else {
+            Logger.warning(Strings.package_not_subscription(self))
+            return self.storeProduct.localizedPriceString
+        }
+
+        return price
     }
 
     var localizedIntroductoryOfferPrice: String? {
@@ -102,30 +112,6 @@ private extension Package {
 
     var isMonthly: Bool {
         return self.storeProduct.subscriptionPeriod == SubscriptionPeriod(value: 1, unit: .month)
-    }
-
-    var pricePerWeek: NSDecimalNumber {
-        guard let price = self.storeProduct.pricePerWeek else {
-            Logger.warning(Strings.package_not_subscription(self))
-            return self.storeProduct.priceDecimalNumber
-        }
-
-        return price
-    }
-
-    var pricePerMonth: NSDecimalNumber {
-        guard let price = self.storeProduct.pricePerMonth else {
-            Logger.warning(Strings.package_not_subscription(self))
-            return self.storeProduct.priceDecimalNumber
-        }
-
-        return price
-    }
-
-    var priceFormatter: NumberFormatter {
-        // `priceFormatter` can only be `nil` for SK2 products
-        // with an unknown code, which should be rare.
-        return self.storeProduct.priceFormatter ?? .init()
     }
 
     func introDuration(_ locale: Locale) -> String? {

--- a/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -235,14 +235,23 @@ public extension StoreProduct {
     /// The price of the `introductoryPrice` formatted using ``priceFormatter``.
     /// - Returns: `nil` if there is no `introductoryPrice`.
     @objc var localizedIntroductoryPriceString: String? {
-        guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *),
-              let formatter = self.priceFormatter,
-              let intro = self.introductoryDiscount
-        else {
-            return nil
-        }
+        guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *) else { return nil }
+        return self.formattedString(for: self.introductoryDiscount?.priceDecimalNumber)
+    }
 
-        return formatter.string(from: intro.price as NSDecimalNumber)
+    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
+    @objc var localizedPricePerWeek: String? {
+        return self.formattedString(for: self.pricePerWeek)
+    }
+
+    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
+    @objc var localizedPricePerMonth: String? {
+        return self.formattedString(for: self.pricePerMonth)
+    }
+
+    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
+    @objc var localizedPricePerYear: String? {
+        return self.formattedString(for: self.pricePerYear)
     }
 
 }
@@ -315,5 +324,19 @@ public extension StoreProduct {
     @available(watchOS, unavailable, message: "Use localizedPriceString instead")
     @available(macOS, unavailable, message: "Use localizedPriceString instead")
     @objc var priceLocale: Locale { fatalError() }
+
+}
+
+private extension StoreProduct {
+
+    func formattedString(for price: NSDecimalNumber?) -> String? {
+        guard let formatter = self.priceFormatter,
+              let price = price
+        else {
+            return nil
+        }
+
+        return formatter.string(from: price as NSDecimalNumber)
+    }
 
 }

--- a/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -239,16 +239,31 @@ public extension StoreProduct {
         return self.formattedString(for: self.introductoryDiscount?.priceDecimalNumber)
     }
 
+    /// The formatted price per week using ``StoreProduct/priceFormatter``.
+    /// ### Related Symbols
+    /// - ``pricePerWeek``
+    /// - ``localizedPricePerMonth``
+    /// - ``localizedPricePerYear``
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     @objc var localizedPricePerWeek: String? {
         return self.formattedString(for: self.pricePerWeek)
     }
 
+    /// The formatted price per month using ``StoreProduct/priceFormatter``.
+    /// ### Related Symbols
+    /// - ``pricePerMonth``
+    /// - ``localizedPricePerWeek``
+    /// - ``localizedPricePerYear``
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     @objc var localizedPricePerMonth: String? {
         return self.formattedString(for: self.pricePerMonth)
     }
 
+    /// The formatted price per year using ``StoreProduct/priceFormatter``.
+    /// ### Related Symbols
+    /// - ``pricePerYear``
+    /// - ``localizedPricePerWeek``
+    /// - ``localizedPricePerMonth``
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     @objc var localizedPricePerYear: String? {
         return self.formattedString(for: self.pricePerYear)

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -51,6 +51,9 @@ public struct TestStoreProduct {
     public var localizedTitle: String
     public var price: Decimal
     public var localizedPriceString: String
+    public var localizedPricePerWeek: String?
+    public var localizedPricePerMonth: String?
+    public var localizedPricePerYear: String?
     public var productIdentifier: String
     public var productType: StoreProduct.ProductType
     public var localizedDescription: String

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
@@ -19,6 +19,9 @@
     NSString *currencyCode __unused = product.currencyCode;
     NSDecimalNumber *price __unused = product.price;
     NSString *localizedPriceString __unused = product.localizedPriceString;
+    NSString *localizedPricePerWeek __unused = product.localizedPricePerWeek;
+    NSString *localizedPricePerMonth __unused = product.localizedPricePerMonth;
+    NSString *localizedPricePerYear __unused = product.localizedPricePerYear;
     NSString *productIdentifier __unused = product.productIdentifier;
     if (@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)) {
         BOOL isFamilyShareable  __unused = product.isFamilyShareable;

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -20,6 +20,10 @@ func checkStoreProductAPI() {
     // This is mainly for Objective-C
     let _: NSDecimalNumber = product.priceDecimalNumber
     let _: String = product.localizedPriceString
+    let _: String? = product.localizedPricePerWeek
+    let _: String? = product.localizedPricePerMonth
+    let _: String? = product.localizedPricePerYear
+
     let _: String = product.productIdentifier
     if #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *) {
         let _: Bool = product.isFamilyShareable

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
@@ -17,6 +17,9 @@ func checkTestStoreProductAPI() {
     let localizedTitle: String = testProduct.localizedTitle
     let price: Decimal = testProduct.price
     let localizedPriceString: String = testProduct.localizedPriceString
+    let localizedPricePerWeek: String = testProduct.localizedPricePerWeek
+    let localizedPricePerMonth: String = testProduct.localizedPricePerMonth
+    let localizedPricePerYear: String = testProduct.localizedPricePerYear
     let productIdentifier: String = testProduct.productIdentifier
     let productType: StoreProduct.ProductType = testProduct.productType
     let localizedDescription: String = testProduct.localizedDescription

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
@@ -17,9 +17,9 @@ func checkTestStoreProductAPI() {
     let localizedTitle: String = testProduct.localizedTitle
     let price: Decimal = testProduct.price
     let localizedPriceString: String = testProduct.localizedPriceString
-    let localizedPricePerWeek: String = testProduct.localizedPricePerWeek
-    let localizedPricePerMonth: String = testProduct.localizedPricePerMonth
-    let localizedPricePerYear: String = testProduct.localizedPricePerYear
+    let localizedPricePerWeek: String? = testProduct.localizedPricePerWeek
+    let localizedPricePerMonth: String? = testProduct.localizedPricePerMonth
+    let localizedPricePerYear: String? = testProduct.localizedPricePerYear
     let productIdentifier: String = testProduct.productIdentifier
     let productType: StoreProduct.ProductType = testProduct.productType
     let localizedDescription: String = testProduct.localizedDescription

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
@@ -34,6 +34,9 @@ func checkTestStoreProductAPI() {
     testProduct.localizedTitle = localizedTitle
     testProduct.price = price
     testProduct.localizedPriceString = localizedPriceString
+    testProduct.localizedPricePerWeek = localizedPricePerWeek
+    testProduct.localizedPricePerMonth = localizedPricePerMonth
+    testProduct.localizedPricePerYear = localizedPricePerYear
     testProduct.productIdentifier = productIdentifier
     testProduct.productType = productType
     testProduct.localizedDescription = localizedDescription

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -442,6 +442,15 @@ class StoreProductTests: StoreKitConfigTestCase {
         self.logger.verifyMessageWasLogged(Strings.storeKit.sk1_no_known_product_type, level: .debug)
     }
 
+    func testPricePerPeriod() async throws {
+        let sk1Fetcher = ProductsFetcherSK1(requestTimeout: Configuration.storeKitRequestTimeoutDefault)
+
+        let storeProduct = try await sk1Fetcher.product(withIdentifier: Self.productID)
+        expect(storeProduct.localizedPricePerWeek) == "$1.14"
+        expect(storeProduct.localizedPricePerMonth) == "$4.99"
+        expect(storeProduct.localizedPricePerYear) == "$59.88"
+    }
+
 }
 
 @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 7.0, *)


### PR DESCRIPTION
Added `localizedPricePerWeek`, `localizedPricePerMonth` and `localizedPricePerYear`.

I started on this before noticing that we already [have an equivalent at the package level](https://github.com/RevenueCat/purchases-ios/blob/main/RevenueCatUI/Helpers/Package%2BVariableDataProvider.swift#L107), still need to unify them. 