### PR TITLE
`Paywalls`: improve template 5 checkmark icon

### DIFF
--- a/RevenueCatUI/Templates/Template5View.swift
+++ b/RevenueCatUI/Templates/Template5View.swift
@@ -285,21 +285,13 @@ struct Template5View: TemplateViewType {
         _ package: TemplateViewConfiguration.Package,
         selected: Bool
     ) -> some View {
-        HStack {
-            Constants.checkmarkImage
-                .hidden(if: !selected)
-                .overlay {
-                    if selected {
-                        EmptyView()
-                    } else {
-                        Circle()
-                            .foregroundColor(self.configuration.colors.unselectedOutline)
-                    }
-                }
-                .foregroundColor(self.configuration.colors.selectedOutline)
-
-            Text(package.localization.offerName ?? package.content.productName)
-        }
+      HStack {
+        let systemName = selected ? "checkmark.circle.fill" : "circle.fill"
+        let color = selected ? self.configuration.colors.selectedOutline : self.configuration.colors.unselectedOutline
+        Image(systemName: systemName)
+          .foregroundColor(color)
+        Text(package.localization.offerName ?? package.content.productName)
+      }
     }
 
     private func offerDetails(


### PR DESCRIPTION
### Motivation
<!-- Why is this change required? What problem does it solve? -->
The visual size is different of the checkmark image in selected/unselected state in `Template5View.swift`
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
**Before:** 
<img width="373" alt="image" src="https://github.com/RevenueCat/purchases-ios/assets/5203798/b095a8fc-e21a-4c61-94e8-5495279acdaf">

**After:** 
<img width="372" alt="image" src="https://github.com/RevenueCat/purchases-ios/assets/5203798/9eee2ca9-8525-4cde-b937-772f80774dea">
