### PR TITLE
`PurchaseTester`: improved `ReceiptInspector` so it accepts receipts with escape sequences

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
@@ -73,7 +73,8 @@ struct ReceiptInspectorView: View {
     func inspectReceipt() async {
         do {
             guard !encodedReceipt.isEmpty else { return }
-            parsedReceipt = try PurchasesReceiptParser.default.parse(base64String: encodedReceipt).debugDescription
+            let receiptWithoutForwardSlashes = encodedReceipt.replacingOccurrences(of: "\\", with: "")
+            parsedReceipt = try PurchasesReceiptParser.default.parse(base64String: receiptWithoutForwardSlashes).debugDescription
             verifyReceiptResult = await ReceiptVerifier().verifyReceipt(base64Encoded: encodedReceipt,
                                                                         sharedSecret: sharedSecret)
         } catch {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
@@ -73,9 +73,12 @@ struct ReceiptInspectorView: View {
     func inspectReceipt() async {
         do {
             guard !encodedReceipt.isEmpty else { return }
+            // in kibana, receipts get encoded with extra `\`s
             let receiptWithoutForwardSlashes = encodedReceipt.replacingOccurrences(of: "\\", with: "")
-            parsedReceipt = try PurchasesReceiptParser.default.parse(base64String: receiptWithoutForwardSlashes).debugDescription
-            verifyReceiptResult = await ReceiptVerifier().verifyReceipt(base64Encoded: encodedReceipt,
+            // just in case you accidentally copied with extra double-quotations
+            let receiptWithoutQuotations = receiptWithoutForwardSlashes.replacingOccurrences(of: "\"", with: "")
+            parsedReceipt = try PurchasesReceiptParser.default.parse(base64String: receiptWithoutQuotations).debugDescription
+            verifyReceiptResult = await ReceiptVerifier().verifyReceipt(base64Encoded: receiptWithoutQuotations,
                                                                         sharedSecret: sharedSecret)
         } catch {
             parsedReceipt = "Couldn't decode receipt. Error:\n\(error)"


### PR DESCRIPTION
Receipts in logs have extra escape sequences now (forward slashes), so this updates the ReceiptInspector tool to be able to accept them for easier usage. 

It also accepts extra `"` so that if you copied slightly incorrectly it still works. 