### PR TITLE
Set StoreKit 2 appAccountToken if our appUserID is an UUID

### DIFF
--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -37,6 +37,8 @@ enum StoreKitStrings {
 
     case sk2_purchasing_added_promotional_offer_option(String)
 
+    case sk2_purchasing_added_uuid_option(UUID)
+
     case sk2_unknown_product_type(String)
 
     case sk1_no_known_product_type
@@ -121,6 +123,9 @@ extension StoreKitStrings: LogMessage {
 
         case let .sk2_purchasing_added_promotional_offer_option(discountIdentifier):
             return "Adding Product.PurchaseOption for discount '\(discountIdentifier)'"
+
+        case let .sk2_purchasing_added_uuid_option(uuid):
+            return "Adding Product.PurchaseOption for .appAccountToken '\(uuid)'"
 
         case let .sk2_unknown_product_type(type):
             return "Product.ProductType '\(type)' unknown, the product type will be undefined."

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -465,6 +465,10 @@ final class PurchasesOrchestrator {
                 .simulatesAskToBuyInSandbox(Purchases.simulatesAskToBuyInSandbox)
             ]
 
+            if let uuid = UUID(uuidString: self.appUserID) {
+                options.insert(.appAccountToken(uuid))
+            }
+
             if let signedData = promotionalOffer {
                 Logger.debug(
                     Strings.storeKit.sk2_purchasing_added_promotional_offer_option(signedData.identifier)

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -466,6 +466,9 @@ final class PurchasesOrchestrator {
             ]
 
             if let uuid = UUID(uuidString: self.appUserID) {
+                Logger.debug(
+                    Strings.storeKit.sk2_purchasing_added_uuid_option(uuid)
+                )
                 options.insert(.appAccountToken(uuid))
             }
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -744,6 +744,47 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         expect(entitlement.latestPurchaseDate) != entitlement.originalPurchaseDate
         expect(transaction.offerID) == offer.discount.offerIdentifier
         expect(transaction.offerType) == .promotional
+        expect(transaction.appAccountToken?.uuidString) == user
+    }
+
+    @available(iOS 15.2, tvOS 15.2, macOS 12.1, watchOS 8.3, *)
+    func testPurchaseWithPromotionalOfferWithNonUUIDappUserId() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let user = "not_a_uuid.\(UUID().uuidString)"
+
+        let (_, created) = try await self.purchases.logIn(user)
+        expect(created) == true
+
+        let product = try await self.monthlyNoIntroProduct
+
+        // 1. Purchase subscription
+
+        var customerInfo = try await self.purchases.purchase(product: product).customerInfo
+        var entitlement = try await self.verifyEntitlementWentThrough(customerInfo)
+
+        // 2. Expire subscription
+
+        try await self.expireSubscription(entitlement)
+        try await self.verifySubscriptionExpired()
+
+        // 3. Get eligible offer
+
+        let offer = try await XCTAsyncUnwrap(await product.eligiblePromotionalOffers().onlyElement)
+
+        // 4. Purchase with offer
+
+        customerInfo = try await self.purchases.purchase(product: product, promotionalOffer: offer).customerInfo
+
+        // 5. Verify offer was applied
+
+        entitlement = try await self.verifyEntitlementWentThrough(customerInfo)
+        let transaction = try await Self.findTransaction(for: product.productIdentifier)
+
+        expect(entitlement.latestPurchaseDate) != entitlement.originalPurchaseDate
+        expect(transaction.offerID) == offer.discount.offerIdentifier
+        expect(transaction.offerType) == .promotional
+        expect(transaction.appAccountToken) == nil
     }
 
     func testCustomerInfoStream() async throws {

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -1137,6 +1137,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         self.customerInfoManager.stubbedCustomerInfoResult = .success(self.mockCustomerInfo)
+        self.mockStoreKit2TransactionListener?.mockResult = .init(.userCancelled)
 
         let product = try await self.fetchSk2Product()
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -1173,6 +1173,39 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testPurchaseSK2IncludesAppUserIdIfUUID() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let uuid = UUID()
+        self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: uuid.uuidString)
+        self.setUpOrchestrator()
+        self.setUpStoreKit2Listener()
+
+        customerInfoManager.stubbedCustomerInfoResult = .success(.emptyInfo)
+        backend.stubbedPostReceiptResult = .success(.emptyInfo)
+
+        let product = try await fetchSk2Product()
+        let result = try await self.orchestrator.purchase(sk2Product: product, package: nil, promotionalOffer: nil)
+        expect(result.transaction?.sk2Transaction?.appAccountToken).to(equal(uuid))
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testPurchaseSK2DoesNotIncludeAppUserIdIfNotUUID() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: "not_a_uuid")
+        self.setUpOrchestrator()
+        self.setUpStoreKit2Listener()
+
+        customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
+        backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
+
+        let product = try await fetchSk2Product()
+        let result = try await self.orchestrator.purchase(sk2Product: product, package: nil, promotionalOffer: nil)
+        expect(result.transaction?.sk2Transaction?.appAccountToken).to(beNil())
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testStoreKit2TransactionListenerDelegate() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
@@ -63,10 +63,17 @@ final class MockStoreKit2TransactionListener: StoreKit2TransactionListenerType {
         self.invokedHandleParameters = (.init(purchaseResult), ())
         self.invokedHandleParametersList.append((.init(purchaseResult), ()))
 
-        let transaction: StoreTransaction? = self.mockTransaction.value.map {
-            StoreTransaction(sk2Transaction: $0,
-                             jwsRepresentation: self.mockJWSToken,
-                             environmentOverride: self.mockEnvironment)
+        var transaction: StoreTransaction
+
+        if let mockTransaction = self.mockTransaction.value {
+            transaction = StoreTransaction(sk2Transaction: mockTransaction,
+                                           jwsRepresentation: self.mockJWSToken,
+                                           environmentOverride: self.mockEnvironment)
+        } else {
+            let result = purchaseResult.verificationResult!
+            transaction = StoreTransaction(sk2Transaction: result.underlyingTransaction,
+                                           jwsRepresentation: result.jwsRepresentation,
+                                           environmentOverride: self.mockEnvironment)
         }
 
         return (self.mockCancelled, transaction)


### PR DESCRIPTION
We already set this for SK1 purchases:

https://github.com/RevenueCat/purchases-ios/blob/daa0e1f3d0b8eaf653d81ef99396caa2a5e95506/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift#L385

However, as explained in the documentation, if this value is not a UUID, it basically gets ignored:

https://developer.apple.com/documentation/storekit/skmutablepayment/1506088-applicationusername

This PR makes sure we do the equivalent in SK2 purchases.