### PR TITLE
[Paywalls] Remove unscrollable spacing in Template 5.

### DIFF
--- a/RevenueCatUI/Templates/Template5View.swift
+++ b/RevenueCatUI/Templates/Template5View.swift
@@ -142,9 +142,6 @@ struct Template5View: TemplateViewType {
             if self.configuration.mode.isFullScreen {
                 self.title
                     .frame(maxWidth: .infinity, alignment: .leading)
-                
-                self.title
-                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 Spacer()
 

--- a/RevenueCatUI/Templates/Template5View.swift
+++ b/RevenueCatUI/Templates/Template5View.swift
@@ -95,19 +95,21 @@ struct Template5View: TemplateViewType {
     @ViewBuilder
     var verticalFullScreenContent: some View {
         VStack(spacing: self.defaultVerticalPaddingLength) {
-            if self.configuration.mode.isFullScreen {
-                self.headerImage
-            }
+            VStack(spacing: 0) {
+                if self.configuration.mode.isFullScreen {
+                    self.headerImage
+                }
 
-            self.scrollableContent
-                .scrollableIfNecessary(enabled: self.configuration.mode.isFullScreen)
-                .padding(
-                    .top,
-                    self.displayingAllPlans
-                    ? self.defaultVerticalPaddingLength
-                    // Compensate for additional padding on condensed mode + iPad
-                    : self.defaultVerticalPaddingLength.map { $0 * -1 }
-                )
+                self.scrollableContent
+                    .padding(
+                        .top,
+                        self.displayingAllPlans
+                        ? self.defaultVerticalPaddingLength
+                        // Compensate for additional padding on condensed mode + iPad
+                        : self.defaultVerticalPaddingLength.map { $0 * -1 }
+                    )
+                    .scrollableIfNecessary(enabled: self.configuration.mode.isFullScreen)
+            }
 
             if self.configuration.mode.shouldDisplayInlineOfferDetails(displayingAllPlans: self.displayingAllPlans) {
                 self.offerDetails(
@@ -132,14 +134,15 @@ struct Template5View: TemplateViewType {
                         aspectRatio: self.headerAspectRatio,
                         maxWidth: .infinity)
             .clipped()
-
-            Spacer()
         }
     }
 
     private var scrollableContent: some View {
         VStack(spacing: self.defaultVerticalPaddingLength) {
             if self.configuration.mode.isFullScreen {
+                self.title
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                
                 self.title
                     .frame(maxWidth: .infinity, alignment: .leading)
 


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

Neither applicable.

### Motivation
As I was implementing this template (with longer content that needs scrolling), the spacing cut off the headline in a weird way. It also takes up a small bit of vertical space unnecessarily.

### Description
Instead of doing the previous layout: `header image / even space / scrollable content / even space / footer`, I updated the layout to make the header image and scrollable content in a 0 spacing VStack, with the same existing padding _inside_ the scrollable content to have the same initial layout as before. Probably best described with two videos:

Before:
https://github.com/RevenueCat/purchases-ios/assets/997637/0961e99c-8a25-4099-a763-6838ff1ac0ed

After:
https://github.com/RevenueCat/purchases-ios/assets/997637/22274ed2-3ab1-4fc1-894b-83cd8013bce8
