### PR TITLE
`SandboxEnvironmentDetector`: more tests for `macOS`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -331,6 +331,8 @@
 		4FE6FEE52AA940B800780B45 /* PaywallStoredEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE6FEE42AA940B700780B45 /* PaywallStoredEvent.swift */; };
 		4FE6FEEA2AA940E300780B45 /* PaywallEventStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE6FEE72AA940E300780B45 /* PaywallEventStoreTests.swift */; };
 		4FE6FEEB2AA940E300780B45 /* PaywallEventSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE6FEE82AA940E300780B45 /* PaywallEventSerializerTests.swift */; };
+		4FEF41AB2B4F2F3400CD699F /* MapAppStoreDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEF41AA2B4F2F3400CD699F /* MapAppStoreDetector.swift */; };
+		4FEF41AD2B4F301800CD699F /* MacAppStoreDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEF41AC2B4F301800CD699F /* MacAppStoreDetectorTests.swift */; };
 		4FF017C32AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF017C22AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift */; };
 		4FF017C42AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF017C22AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift */; };
 		4FF6E4B92B069B8C000141ED /* HTTPRequest+Signing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF6E4B82B069B8C000141ED /* HTTPRequest+Signing.swift */; };
@@ -1091,6 +1093,8 @@
 		4FE6FEE72AA940E300780B45 /* PaywallEventStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallEventStoreTests.swift; sourceTree = "<group>"; };
 		4FE6FEE82AA940E300780B45 /* PaywallEventSerializerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallEventSerializerTests.swift; sourceTree = "<group>"; };
 		4FED3AD62AAA7DD4001D4D5E /* purchases-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "purchases-ios"; path = ..; sourceTree = "<group>"; };
+		4FEF41AA2B4F2F3400CD699F /* MapAppStoreDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapAppStoreDetector.swift; sourceTree = "<group>"; };
+		4FEF41AC2B4F301800CD699F /* MacAppStoreDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAppStoreDetectorTests.swift; sourceTree = "<group>"; };
 		4FF017C22AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BaseStoreKitIntegrationTests+Verification.swift"; sourceTree = "<group>"; };
 		4FF6E4B82B069B8C000141ED /* HTTPRequest+Signing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPRequest+Signing.swift"; sourceTree = "<group>"; };
 		4FF8464C2A32554300617F00 /* DiagnosticsStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsStrings.swift; sourceTree = "<group>"; };
@@ -1802,6 +1806,7 @@
 				57FDAAB9284937A0009A48F1 /* SandboxEnvironmentDetector.swift */,
 				57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */,
 				B3AA6237268B926F00894871 /* SystemInfo.swift */,
+				4FEF41AA2B4F2F3400CD699F /* MapAppStoreDetector.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -2050,6 +2055,7 @@
 				57032ABE28C13CE4004FF47A /* StoreKit2SettingTests.swift */,
 				5712BE9129241F7900A83F15 /* TimingUtilTests.swift */,
 				4F8DDB682AAA9189000188F2 /* OperationDispatcherTests.swift */,
+				4FEF41AC2B4F301800CD699F /* MacAppStoreDetectorTests.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -3556,6 +3562,7 @@
 				4F8929192A65EF3000A91EA2 /* EnsureNonEmptyCollectionDecodable.swift in Sources */,
 				35F82BB626A9B8040051DF03 /* AttributionDataMigrator.swift in Sources */,
 				4F5F47082AA91F8A005649D8 /* HealthOperation.swift in Sources */,
+				4FEF41AB2B4F2F3400CD699F /* MapAppStoreDetector.swift in Sources */,
 				A55D08302722368600D919E0 /* SK2BeginRefundRequestHelper.swift in Sources */,
 				35D832CD262A5B7500E60AC5 /* ETagManager.swift in Sources */,
 				A56DFDF0286643BF00EF2E32 /* PostAttributionDataOperation.swift in Sources */,
@@ -3792,6 +3799,7 @@
 				576C8AD927D2BCB90058FA6E /* HTTPRequestTests.swift in Sources */,
 				5766AAE5283E9E9C00FA6091 /* PurchasesGetOfferingsTests.swift in Sources */,
 				2DDF41DA24F6F4DB005BC22D /* ReceiptParserTests.swift in Sources */,
+				4FEF41AD2B4F301800CD699F /* MacAppStoreDetectorTests.swift in Sources */,
 				2D1015E2275A67E40086173F /* SubscriptionPeriodTests.swift in Sources */,
 				579189EB28F47F0F00BF4963 /* MockPurchases.swift in Sources */,
 				574A2EE9282C403800150D40 /* AnyDecodableTests.swift in Sources */,

--- a/Sources/Misc/MapAppStoreDetector.swift
+++ b/Sources/Misc/MapAppStoreDetector.swift
@@ -1,0 +1,72 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MapAppStoreDetector.swift
+//
+//  Created by Nacho Soto on 1/10/24.
+
+import Foundation
+
+/// A type that can determine whether the application is running on the MAS.
+protocol MacAppStoreDetector: Sendable {
+
+    var isMacAppStore: Bool { get }
+
+}
+
+#if os(macOS) || targetEnvironment(macCatalyst)
+
+final class DefaultMacAppStoreDetector: MacAppStoreDetector {
+
+    /// Returns whether the bundle was signed for Mac App Store distribution by checking
+    /// the existence of a specific extension (marker OID) on the code signing certificate.
+    ///
+    /// This routine is inspired by the source code from ProcInfo, the underlying library
+    /// of the WhatsYourSign code signature checking tool developed by Objective-See. Initially,
+    /// it checked the common name but was changed to an extension check to make it more
+    /// future-proof.
+    ///
+    /// For more information, see the following references:
+    /// - https://github.com/objective-see/ProcInfo/blob/master/procInfo/Signing.m#L184-L247
+    /// - https://gist.github.com/lukaskubanek/cbfcab29c0c93e0e9e0a16ab09586996#gistcomment-3993808
+    var isMacAppStore: Bool {
+        var status = noErr
+
+        var code: SecStaticCode?
+        status = SecStaticCodeCreateWithPath(Bundle.main.bundleURL as CFURL, [], &code)
+
+        guard status == noErr, let code = code else {
+            Logger.error(Strings.receipt.error_validating_bundle_signature)
+            return false
+        }
+
+        var requirement: SecRequirement?
+        status = SecRequirementCreateWithString(
+            "anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.9]" as CFString,
+            [], // default
+            &requirement
+        )
+
+        guard status == noErr, let requirement = requirement else {
+            Logger.error(Strings.receipt.error_validating_bundle_signature)
+            return false
+        }
+
+        status = SecStaticCodeCheckValidity(
+            code,
+            [], // default
+            requirement
+        )
+
+        return status == errSecSuccess
+    }
+
+}
+
+#endif

--- a/Sources/Misc/SandboxEnvironmentDetector.swift
+++ b/Sources/Misc/SandboxEnvironmentDetector.swift
@@ -26,13 +26,18 @@ final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
     private let bundle: Atomic<Bundle>
     private let isRunningInSimulator: Bool
     private let receiptFetcher: LocalReceiptFetcherType
+    private let macAppStoreDetector: MacAppStoreDetector?
 
-    init(bundle: Bundle = .main,
-         isRunningInSimulator: Bool = SystemInfo.isRunningInSimulator,
-         receiptFetcher: LocalReceiptFetcherType = LocalReceiptFetcher()) {
+    init(
+        bundle: Bundle = .main,
+        isRunningInSimulator: Bool = SystemInfo.isRunningInSimulator,
+        receiptFetcher: LocalReceiptFetcherType = LocalReceiptFetcher(),
+        macAppStoreDetector: MacAppStoreDetector? = nil
+    ) {
         self.bundle = .init(bundle)
         self.isRunningInSimulator = isRunningInSimulator
         self.receiptFetcher = receiptFetcher
+        self.macAppStoreDetector = macAppStoreDetector
     }
 
     var isSandbox: Bool {
@@ -45,7 +50,7 @@ final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
         }
 
         #if os(macOS) || targetEnvironment(macCatalyst)
-            return !self.isProductionReceipt || !Self.isMacAppStore
+            return !self.isProductionReceipt || !self.isMacAppStore
         #else
             return path.contains("sandboxReceipt")
         #endif
@@ -62,9 +67,12 @@ final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
 
 extension BundleSandboxEnvironmentDetector: Sendable {}
 
+// MARK: -
+
+#if os(macOS) || targetEnvironment(macCatalyst)
+
 private extension BundleSandboxEnvironmentDetector {
 
-    #if os(macOS) || targetEnvironment(macCatalyst)
     var isProductionReceipt: Bool {
         do {
             return try self.receiptFetcher.fetchAndParseLocalReceipt().environment == .production
@@ -74,49 +82,11 @@ private extension BundleSandboxEnvironmentDetector {
         }
     }
 
-    /// Returns whether the bundle was signed for Mac App Store distribution by checking
-    /// the existence of a specific extension (marker OID) on the code signing certificate.
-    ///
-    /// This routine is inspired by the source code from ProcInfo, the underlying library
-    /// of the WhatsYourSign code signature checking tool developed by Objective-See. Initially,
-    /// it checked the common name but was changed to an extension check to make it more
-    /// future-proof.
-    ///
-    /// For more information, see the following references:
-    /// - https://github.com/objective-see/ProcInfo/blob/master/procInfo/Signing.m#L184-L247
-    /// - https://gist.github.com/lukaskubanek/cbfcab29c0c93e0e9e0a16ab09586996#gistcomment-3993808
-
-    static var isMacAppStore: Bool {
-        var status = noErr
-
-        var code: SecStaticCode?
-        status = SecStaticCodeCreateWithPath(Bundle.main.bundleURL as CFURL, [], &code)
-
-        guard status == noErr, let code = code else {
-            Logger.error(Strings.receipt.error_validating_bundle_signature)
-            return false
-        }
-
-        var requirement: SecRequirement?
-        status = SecRequirementCreateWithString(
-            "anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.9]" as CFString,
-            [], // default
-            &requirement
-        )
-
-        guard status == noErr, let requirement = requirement else {
-            Logger.error(Strings.receipt.error_validating_bundle_signature)
-            return false
-        }
-
-        status = SecStaticCodeCheckValidity(
-            code,
-            [], // default
-            requirement
-        )
-
-        return status == errSecSuccess
+    var isMacAppStore: Bool {
+        let detector = self.macAppStoreDetector ?? DefaultMacAppStoreDetector()
+        return detector.isMacAppStore
     }
-    #endif
 
 }
+
+#endif

--- a/Tests/StoreKitUnitTests/TestHelpers/AvailabilityChecks.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/AvailabilityChecks.swift
@@ -74,16 +74,4 @@ enum AvailabilityChecks {
         #endif
     }
 
-    static func skipIfNotMacOS() throws {
-        #if !os(macOS) && !targetEnvironment(macCatalyst)
-        throw XCTSkip("Test only for macOS and Catalyst")
-        #endif
-    }
-
-    static func skipIfMacOS() throws {
-        #if os(macOS) || targetEnvironment(macCatalyst)
-        throw XCTSkip("Test not for macOS")
-        #endif
-    }
-
 }

--- a/Tests/UnitTests/Misc/MacAppStoreDetectorTests.swift
+++ b/Tests/UnitTests/Misc/MacAppStoreDetectorTests.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MacAppStoreDetectorTests.swift
+//
+//  Created by Nacho Soto on 1/10/24.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+#if os(macOS)
+
+class MacAppStoreDetectorTests: TestCase {
+
+    func testIsMacAppStore() {
+        expect(DefaultMacAppStoreDetector().isMacAppStore) == false
+    }
+
+}
+
+#endif


### PR DESCRIPTION
Follow up to #3533 and #3549.

### Changes:
- Split `SandboxEnvironmentDetector` for `macOS`
- Remove unused `AvailabilityChecks` for `macOS`
- Extracted `MacAppStoreDetector`
- Added tests for `DefaultMacAppStoreDetector`
- Added more `SandboxEnvironmentDetector` mocking `MacAppStoreDetector`