### PR TITLE
`PaywallFooterViewController`: ensure that safe area inset is set on `PaywallView`

### DIFF
--- a/RevenueCatUI/UIKit/PaywallFooterViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallFooterViewController.swift
@@ -15,6 +15,7 @@
 #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
 
 import RevenueCat
+import SwiftUI
 import UIKit
 
 /// A view controller for displaying `PaywallData` for an `Offering` in a footer format.
@@ -51,6 +52,75 @@ public final class PaywallFooterViewController: PaywallViewController {
     public required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    // MARK: -
+
+    public override var additionalSafeAreaInsets: UIEdgeInsets {
+        didSet {
+            // Ideally setting self.hostingController.additionalSafeAreaInsets
+            // would propagate it to SwiftUI, but it doesn't.
+            // Instead we modify the internal state to manually pass the value to SwiftUI.
+            self.viewModel.bottomSafeArea = self.additionalSafeAreaInsets
+        }
+    }
+
+    private let viewModel: PaywallWrapperViewModel = .init()
+
+    override func createViewController() -> UIViewController {
+        let view = PaywallWrapper(viewModel: self.viewModel) {
+            super.createPaywallView()
+        }
+        return UIHostingController(rootView: view)
+    }
+
+}
+
+// MARK: - Inset
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+final class PaywallWrapperViewModel: ObservableObject {
+
+    @Published
+    var bottomSafeArea: UIEdgeInsets = .zero
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+private struct PaywallWrapper<Paywall: View>: View {
+
+    private let paywallView: Paywall
+
+    @ObservedObject
+    private var viewModel: PaywallWrapperViewModel
+
+    init(viewModel: PaywallWrapperViewModel, paywallView: () -> Paywall) {
+        self.viewModel = viewModel
+        self.paywallView = paywallView()
+    }
+
+    var body: some View {
+        if #available(iOS 17.0, *) {
+            self.paywallView
+                .safeAreaPadding(self.viewModel.bottomSafeArea.asInsets)
+        } else {
+            self.paywallView
+                .safeAreaInset(edge: .bottom) {
+                    Rectangle()
+                        .hidden()
+                        .frame(height: self.viewModel.bottomSafeArea.bottom)
+                }
+        }
+    }
+
+}
+
+private extension UIEdgeInsets {
+
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+    var asInsets: EdgeInsets {
+        return .init(top: self.top, leading: self.left, bottom: self.bottom, trailing: self.right)
+    }
+
 }
 
 #endif


### PR DESCRIPTION
Turns out that `UIHostingController` ignores the safe area, so SwiftUI thinks there is no safe area.

Alternative fix in case https://github.com/RevenueCat/react-native-purchases/pull/834 doesn't work