### PR TITLE
`Integration Tests`: relaunch tests on each retry

### DIFF
--- a/BackendIntegrationTests/BackendIntegrationTests-All-CI.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-All-CI.xctestplan
@@ -26,6 +26,7 @@
     ],
     "maximumTestExecutionTimeAllowance" : 180,
     "maximumTestRepetitions" : 5,
+    "repeatInNewRunnerProcess" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:RevenueCat.xcodeproj",
       "identifier" : "2DE20B7E26409EB7004C597D",

--- a/BackendIntegrationTests/BackendIntegrationTests-CustomEntitlements.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-CustomEntitlements.xctestplan
@@ -26,6 +26,7 @@
     ],
     "maximumTestExecutionTimeAllowance" : 180,
     "maximumTestRepetitions" : 5,
+    "repeatInNewRunnerProcess" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:RevenueCat.xcodeproj",
       "identifier" : "4F6BEE042A27B02400CD9322",

--- a/BackendIntegrationTests/BackendIntegrationTests-Offline.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-Offline.xctestplan
@@ -26,6 +26,7 @@
     ],
     "maximumTestExecutionTimeAllowance" : 180,
     "maximumTestRepetitions" : 5,
+    "repeatInNewRunnerProcess" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:RevenueCat.xcodeproj",
       "identifier" : "2DE20B6B264087FB004C597D",

--- a/BackendIntegrationTests/BackendIntegrationTests-Other.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-Other.xctestplan
@@ -26,6 +26,7 @@
     ],
     "maximumTestExecutionTimeAllowance" : 180,
     "maximumTestRepetitions" : 5,
+    "repeatInNewRunnerProcess" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:RevenueCat.xcodeproj",
       "identifier" : "2DE20B6B264087FB004C597D",

--- a/BackendIntegrationTests/BackendIntegrationTests-SK1.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-SK1.xctestplan
@@ -26,6 +26,7 @@
     ],
     "maximumTestExecutionTimeAllowance" : 180,
     "maximumTestRepetitions" : 5,
+    "repeatInNewRunnerProcess" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:RevenueCat.xcodeproj",
       "identifier" : "2DE20B7E26409EB7004C597D",

--- a/BackendIntegrationTests/BackendIntegrationTests-SK2.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-SK2.xctestplan
@@ -26,6 +26,7 @@
     ],
     "maximumTestExecutionTimeAllowance" : 180,
     "maximumTestRepetitions" : 5,
+    "repeatInNewRunnerProcess" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:RevenueCat.xcodeproj",
       "identifier" : "2DE20B7E26409EB7004C597D",

--- a/Tests/TestPlans/CI-RevenueCat.xctestplan
+++ b/Tests/TestPlans/CI-RevenueCat.xctestplan
@@ -16,7 +16,10 @@
         "value" : "1"
       }
     ],
-    "testExecutionOrdering" : "random"
+    "maximumTestExecutionTimeAllowance" : 180,
+    "testExecutionOrdering" : "random",
+    "testRepetitionMode" : "retryOnFailure",
+    "testTimeoutsEnabled" : true
   },
   "testTargets" : [
     {


### PR DESCRIPTION
It's pretty puzzling that sometimes we get flaky failures with the exact same issue. I'm hoping that this will make retries more effective.

![Screenshot 2024-01-11 at 15 08 22](https://github.com/RevenueCat/purchases-ios/assets/685609/1881958d-9b28-4d21-a144-f64af1b30a51)
