### PR TITLE
`Paywalls`: improve error display

### DIFF
--- a/RevenueCatUI/Data/LocalizedAlertError.swift
+++ b/RevenueCatUI/Data/LocalizedAlertError.swift
@@ -23,12 +23,16 @@ struct LocalizedAlertError: LocalizedError {
     }
 
     var errorDescription: String? {
-        return "\(self.underlyingError.domain) \(self.underlyingError.code)"
+        if self.underlyingError is ErrorCode {
+            return "Error"
+        } else {
+            return "\(self.underlyingError.domain) \(self.underlyingError.code)"
+        }
     }
 
     var failureReason: String? {
         if let errorCode = self.underlyingError as? ErrorCode {
-            return errorCode.description
+            return "Error \(self.underlyingError.code): \(errorCode.description)"
         } else {
             return self.underlyingError.localizedDescription
         }

--- a/Tests/RevenueCatUITests/Data/LocalizedAlertErrorTests.swift
+++ b/Tests/RevenueCatUITests/Data/LocalizedAlertErrorTests.swift
@@ -1,0 +1,44 @@
+//
+//  LocalizedAlertErrorTests.swift
+//
+//
+//  Created by Nacho Soto on 1/16/24.
+//
+
+import Nimble
+import RevenueCat
+@testable import RevenueCatUI
+import StoreKit
+import XCTest
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+class LocalizedAlertGenericErrorTests: TestCase {
+
+    private static let error = LocalizedAlertError(
+        error: StoreKitError.networkError(URLError(.notConnectedToInternet)) as NSError
+    )
+
+    func testErrorDescription() {
+        expect(Self.error.errorDescription) == "StoreKit.StoreKitError 0"
+    }
+
+    func testFailureReason() {
+        expect(Self.error.failureReason) == "The operation couldn’t be completed. (NSURLErrorDomain error -1009.)"
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+class LocalizedAlertErrorCodeTests: TestCase {
+
+    private static let error = LocalizedAlertError(error: ErrorCode.storeProblemError as NSError)
+
+    func testErrorDescription() {
+        expect(Self.error.errorDescription) == "Error"
+    }
+
+    func testFailureReason() {
+        expect(Self.error.failureReason) == "Error 2: There was a problem with the App Store."
+    }
+
+}


### PR DESCRIPTION
### Before:

This prevents "leaking" _RevenueCat_ in the error dialogs:

![Simulator Screenshot - iPhone 15 Pro Max - 2024-01-16 at 12 45 13](https://github.com/RevenueCat/purchases-ios/assets/685609/a59bce50-a470-44fb-9d36-1553abcc8488)

### After:
With this change, users still get some information about the problem, and we get enough context to be able to diagnose it:

![Simulator Screenshot - iPhone 15 Pro Max - 2024-01-16 at 12 57 15](https://github.com/RevenueCat/purchases-ios/assets/685609/721d0197-5507-4618-9fe1-e0e748b0bc32)

