### PR TITLE
`Paywalls`: new `.onPurchaseCancelled` and `paywallViewControllerDidCancelPurchase:`

### DIFF
--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -82,18 +82,22 @@ public class PaywallViewController: UIViewController {
                                introEligibility: nil,
                                purchaseHandler: nil)
             .onPurchaseCompleted { [weak self] transaction, customerInfo in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.delegate?.paywallViewController?(self, didFinishPurchasingWith: customerInfo)
                 self.delegate?.paywallViewController?(self,
                                                       didFinishPurchasingWith: customerInfo,
                                                       transaction: transaction)
             }
+            .onPurchaseCancelled { [weak self] in
+                guard let self else { return }
+                self.delegate?.paywallViewControllerDidCancelPurchase?(self)
+            }
             .onRestoreCompleted { [weak self] customerInfo in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.delegate?.paywallViewController?(self, didFinishRestoringWith: customerInfo)
             }
             .onSizeChange { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.delegate?.paywallViewController?(self, didChangeSizeTo: $0)
             }
 
@@ -143,6 +147,10 @@ public protocol PaywallViewControllerDelegate: AnyObject {
     optional func paywallViewController(_ controller: PaywallViewController,
                                         didFinishPurchasingWith customerInfo: CustomerInfo,
                                         transaction: StoreTransaction?)
+
+    /// Notifies that a purchase has been cancelled in a ``PaywallViewController``.
+    @objc(paywallViewControllerDidCancelPurchase:)
+    optional func paywallViewControllerDidCancelPurchase(_ controller: PaywallViewController)
 
     /// Notifies that the restore operation has completed in a ``PaywallViewController``.
     ///

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -46,6 +46,7 @@ extension View {
         offering: Offering? = nil,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        purchaseCancelled: PurchaseCancelledHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
@@ -59,6 +60,7 @@ extension View {
                     .contains(requiredEntitlementIdentifier)
             },
             purchaseCompleted: purchaseCompleted,
+            purchaseCancelled: purchaseCancelled,
             restoreCompleted: restoreCompleted,
             onDismiss: onDismiss
         )
@@ -73,6 +75,8 @@ extension View {
     ///         !$0.entitlements.active.keys.contains("entitlement_identifier")
     ///     } purchaseCompleted: { customerInfo in
     ///         print("Customer info unlocked entitlement: \(customerInfo.entitlements)")
+    ///     } purchaseCancelled: {
+    ///         print("Purchase was cancelled")
     ///     } restoreCompleted: { customerInfo in
     ///         // If `entitlement_identifier` is active, paywall will dismiss automatically.
     ///         print("Purchases restored")
@@ -93,6 +97,7 @@ extension View {
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        purchaseCancelled: PurchaseCancelledHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
@@ -101,6 +106,7 @@ extension View {
             fonts: fonts,
             shouldDisplay: shouldDisplay,
             purchaseCompleted: purchaseCompleted,
+            purchaseCancelled: purchaseCancelled,
             restoreCompleted: restoreCompleted,
             onDismiss: onDismiss,
             customerInfoFetcher: {
@@ -121,6 +127,7 @@ extension View {
         purchaseHandler: PurchaseHandler? = nil,
         shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        purchaseCancelled: PurchaseCancelledHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         onDismiss: (() -> Void)? = nil,
         customerInfoFetcher: @escaping CustomerInfoFetcher
@@ -129,6 +136,7 @@ extension View {
             .modifier(PresentingPaywallModifier(
                 shouldDisplay: shouldDisplay,
                 purchaseCompleted: purchaseCompleted,
+                purchaseCancelled: purchaseCancelled,
                 restoreCompleted: restoreCompleted,
                 onDismiss: onDismiss,
                 offering: offering,
@@ -153,6 +161,7 @@ private struct PresentingPaywallModifier: ViewModifier {
 
     var shouldDisplay: @Sendable (CustomerInfo) -> Bool
     var purchaseCompleted: PurchaseOrRestoreCompletedHandler?
+    var purchaseCancelled: PurchaseCancelledHandler?
     var restoreCompleted: PurchaseOrRestoreCompletedHandler?
     var onDismiss: (() -> Void)?
 
@@ -179,6 +188,9 @@ private struct PresentingPaywallModifier: ViewModifier {
                 )
                 .onPurchaseCompleted {
                     self.purchaseCompleted?($0)
+                }
+                .onPurchaseCancelled {
+                    self.purchaseCancelled?()
                 }
                 .onRestoreCompleted { customerInfo in
                     self.restoreCompleted?(customerInfo)

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -16,6 +16,7 @@ struct App: View {
     private var fonts: PaywallFontProvider
     private var purchaseOrRestoreCompleted: PurchaseOrRestoreCompletedHandler = { (_: CustomerInfo) in }
     private var purchaseCompleted: PurchaseCompletedHandler = { (_: StoreTransaction?, _: CustomerInfo) in }
+    private var purchaseCancelled: PurchaseCancelledHandler = { () in }
     private var paywallDismissed: () -> Void = {}
 
     var body: some View {
@@ -64,6 +65,11 @@ struct App: View {
                                     purchaseCompleted: self.purchaseOrRestoreCompleted,
                                     restoreCompleted: self.purchaseOrRestoreCompleted,
                                     onDismiss: self.paywallDismissed)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", offering: self.offering, fonts: self.fonts,
+                                    purchaseCompleted: self.purchaseOrRestoreCompleted,
+                                    purchaseCancelled: self.purchaseCancelled,
+                                    restoreCompleted: self.purchaseOrRestoreCompleted,
+                                    onDismiss: self.paywallDismissed)
             .presentPaywallIfNeeded(offering: nil) { (_: CustomerInfo) in false }
             .presentPaywallIfNeeded(offering: self.offering) { (_: CustomerInfo) in false }
             .presentPaywallIfNeeded(fonts: self.fonts) { (_: CustomerInfo) in false }
@@ -93,6 +99,17 @@ struct App: View {
                 false
             } purchaseCompleted: {
                 self.purchaseOrRestoreCompleted($0)
+            } restoreCompleted: {
+                self.purchaseOrRestoreCompleted($0)
+            } onDismiss: {
+                self.paywallDismissed()
+            }
+            .presentPaywallIfNeeded(offering: self.offering, fonts: self.fonts) { (_: CustomerInfo) in
+                false
+            } purchaseCompleted: {
+                self.purchaseOrRestoreCompleted($0)
+            } purchaseCancelled: {
+                self.purchaseCancelled()
             } restoreCompleted: {
                 self.purchaseOrRestoreCompleted($0)
             } onDismiss: {
@@ -140,6 +157,7 @@ struct App: View {
         Text("")
             .onPurchaseCompleted(self.purchaseOrRestoreCompleted)
             .onPurchaseCompleted(self.purchaseCompleted)
+            .onPurchaseCancelled(self.purchaseCancelled)
             .onRestoreCompleted(self.purchaseOrRestoreCompleted)
     }
 

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -45,6 +45,8 @@ final class Delegate: PaywallViewControllerDelegate {
                                didFinishPurchasingWith customerInfo: CustomerInfo,
                                transaction: StoreTransaction?) {}
 
+    func paywallViewControllerDidCancelPurchase(_ controller: PaywallViewController) {}
+
     func paywallViewController(_ controller: PaywallViewController,
                                didFinishRestoringWith customerInfo: CustomerInfo) {}
 

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -38,6 +38,7 @@ class PurchaseHandlerTests: TestCase {
         _ = try await handler.purchase(package: TestData.packageWithIntroOffer)
 
         expect(handler.purchaseResult?.customerInfo) === TestData.customerInfo
+        expect(handler.purchaseResult?.userCancelled) == false
         expect(handler.restoredCustomerInfo).to(beNil())
         expect(handler.purchased) == true
         expect(handler.actionInProgress) == false
@@ -47,7 +48,8 @@ class PurchaseHandlerTests: TestCase {
         let handler: PurchaseHandler = .cancelling()
 
         _ = try await handler.purchase(package: TestData.packageWithIntroOffer)
-        expect(handler.purchaseResult).to(beNil())
+        expect(handler.purchaseResult?.userCancelled) == true
+        expect(handler.purchaseResult?.customerInfo) === TestData.customerInfo
         expect(handler.purchased) == false
         expect(handler.actionInProgress) == false
     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
@@ -22,6 +22,12 @@ struct UpsellView: View {
         .padding()
         .presentPaywallIfNeeded(
             requiredEntitlementIdentifier: Configuration.entitlement,
+            purchaseCompleted: { _ in
+                print("Purchase completed")
+            },
+            purchaseCancelled: {
+                print("Purchase cancelled")
+            },
             onDismiss: {
                 print("Paywall dismissed")
             }


### PR DESCRIPTION
This allows apps to be able to receive notifications when users cancel a purchase.
