### PR TITLE
`Integration Tests`: improve flaky tests

### DIFF
--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -45,7 +45,7 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
         // 3. Request customer info multiple times in parallel
         await withThrowingTaskGroup(of: Void.self) {
             for _ in 0..<requestCount {
-                $0.addTask { _ = try await purchases.customerInfo() }
+                $0.addTask(priority: .background) { _ = try await purchases.customerInfo() }
             }
         }
 
@@ -114,7 +114,7 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
 
     func testCustomerInfoIsOnlyFetchedOnceOnAppLaunch() async throws {
         // 1. Make sure any existing customer info requests finish
-        _ = try await purchases.customerInfo()
+        _ = try? await purchases.customerInfo(fetchPolicy: .fromCacheOnly)
 
         // 2. Verify only one CustomerInfo request was done
         try self.logger.verifyMessageWasLogged(


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/17208/workflows/729d01a6-d644-446c-8514-80b54177ff43/jobs/162052/tests
With #3140 and faster executors in CI, it's become clear that this test is very flaky because it relies on requests not finishing quickly enough.

For the first test, the new implementation ensures that all `customerInfo` calls happen in parallel.
For the second test, it's important that if the first `CustomerInfo` request had finished, we don't make a second one, which would make the test fail.
