### PR TITLE
`Paywalls`: extracted `PaywallViewConfiguration`

### DIFF
--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -1,0 +1,24 @@
+//
+//  PaywallViewConfiguration.swift
+//
+//
+//  Created by Nacho Soto on 1/19/24.
+//
+
+import Foundation
+
+import RevenueCat
+
+/// Parameters needed to configure a ``PaywallView``.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct PaywallViewConfiguration {
+
+    var offering: Offering?
+    var customerInfo: CustomerInfo?
+    var mode: PaywallViewMode = .default
+    var fonts: PaywallFontProvider = DefaultPaywallFontProvider()
+    var displayCloseButton: Bool = false
+    var introEligibility: TrialOrIntroEligibilityChecker?
+    var purchaseHandler: PurchaseHandler?
+
+}

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -59,12 +59,10 @@ public struct PaywallView: View {
         displayCloseButton: Bool = false
     ) {
         self.init(
-            offering: nil,
-            customerInfo: nil,
-            fonts: fonts,
-            displayCloseButton: displayCloseButton,
-            introEligibility: nil,
-            purchaseHandler: nil
+            configuration: .init(
+                fonts: fonts,
+                displayCloseButton: displayCloseButton
+            )
         )
     }
 
@@ -84,35 +82,26 @@ public struct PaywallView: View {
         displayCloseButton: Bool = false
     ) {
         self.init(
-            offering: offering,
-            customerInfo: nil,
-            fonts: fonts,
-            displayCloseButton: displayCloseButton,
-            introEligibility: nil,
-            purchaseHandler: nil
+            configuration: .init(
+                offering: offering,
+                fonts: fonts,
+                displayCloseButton: displayCloseButton
+            )
         )
     }
 
-    init(
-        offering: Offering?,
-        customerInfo: CustomerInfo?,
-        mode: PaywallViewMode = .default,
-        fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
-        displayCloseButton: Bool = false,
-        introEligibility: TrialOrIntroEligibilityChecker?,
-        purchaseHandler: PurchaseHandler?
-    ) {
-        self._introEligibility = .init(wrappedValue: introEligibility ?? .default())
-        self._purchaseHandler = .init(wrappedValue: purchaseHandler ?? .default())
+    init(configuration: PaywallViewConfiguration) {
+        self._introEligibility = .init(wrappedValue: configuration.introEligibility ?? .default())
+        self._purchaseHandler = .init(wrappedValue: configuration.purchaseHandler ?? .default())
         self._offering = .init(
-            initialValue: offering ?? Self.loadCachedCurrentOfferingIfPossible()
+            initialValue: configuration.offering ?? Self.loadCachedCurrentOfferingIfPossible()
         )
         self._customerInfo = .init(
-            initialValue: customerInfo ?? Self.loadCachedCustomerInfoIfPossible()
+            initialValue: configuration.customerInfo ?? Self.loadCachedCustomerInfoIfPossible()
         )
-        self.mode = mode
-        self.fonts = fonts
-        self.displayCloseButton = displayCloseButton
+        self.mode = configuration.mode
+        self.fonts = configuration.fonts
+        self.displayCloseButton = configuration.displayCloseButton
     }
 
     // swiftlint:disable:next missing_docs
@@ -383,11 +372,13 @@ struct PaywallView_Previews: PreviewProvider {
         ForEach(Self.offerings, id: \.self) { offering in
             ForEach(Self.modes, id: \.self) { mode in
                 PaywallView(
-                    offering: offering,
-                    customerInfo: TestData.customerInfo,
-                    mode: mode,
-                    introEligibility: PreviewHelpers.introEligibilityChecker,
-                    purchaseHandler: PreviewHelpers.purchaseHandler
+                    configuration: .init(
+                        offering: offering,
+                        customerInfo: TestData.customerInfo,
+                        mode: mode,
+                        introEligibility: PreviewHelpers.introEligibilityChecker,
+                        purchaseHandler: PreviewHelpers.purchaseHandler
+                    )
                 )
                 .previewLayout(mode.layout)
                 .previewDisplayName("\(offering.paywall?.templateName ?? "")-\(mode)")

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -77,12 +77,9 @@ public class PaywallViewController: UIViewController {
         let view = PaywallView(
             configuration: .init(
                 offering: self.offering,
-                customerInfo: nil,
                 mode: self.mode,
                 fonts: self.fonts,
-                displayCloseButton: self.displayCloseButton,
-                introEligibility: nil,
-                purchaseHandler: nil
+                displayCloseButton: self.displayCloseButton
             )
         )
             .onPurchaseCompleted { [weak self] transaction, customerInfo in

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -74,13 +74,17 @@ public class PaywallViewController: UIViewController {
     }
 
     private lazy var hostingController: UIHostingController<some View> = {
-        let view = PaywallView(offering: self.offering,
-                               customerInfo: nil,
-                               mode: self.mode,
-                               fonts: self.fonts,
-                               displayCloseButton: self.displayCloseButton,
-                               introEligibility: nil,
-                               purchaseHandler: nil)
+        let view = PaywallView(
+            configuration: .init(
+                offering: self.offering,
+                customerInfo: nil,
+                mode: self.mode,
+                fonts: self.fonts,
+                displayCloseButton: self.displayCloseButton,
+                introEligibility: nil,
+                purchaseHandler: nil
+            )
+        )
             .onPurchaseCompleted { [weak self] transaction, customerInfo in
                 guard let self else { return }
                 self.delegate?.paywallViewController?(self, didFinishPurchasingWith: customerInfo)

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -179,12 +179,14 @@ private struct PresentingPaywallModifier: ViewModifier {
         content
             .sheet(item: self.$data, onDismiss: self.onDismiss) { data in
                 PaywallView(
-                    offering: self.offering,
-                    customerInfo: data.customerInfo,
-                    fonts: self.fontProvider,
-                    displayCloseButton: true,
-                    introEligibility: self.introEligibility,
-                    purchaseHandler: self.purchaseHandler
+                    configuration: .init(
+                        offering: self.offering,
+                        customerInfo: data.customerInfo,
+                        fonts: self.fontProvider,
+                        displayCloseButton: true,
+                        introEligibility: self.introEligibility,
+                        purchaseHandler: self.purchaseHandler
+                    )
                 )
                 .onPurchaseCompleted {
                     self.purchaseCompleted?($0)

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -85,43 +85,35 @@ extension View {
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil
     ) -> some View {
         return self
-            .modifier(PresentingPaywallFooterModifier(
-                offering: offering,
-                customerInfo: customerInfo,
-                condensed: condensed,
-                purchaseCompleted: purchaseCompleted,
-                restoreCompleted: restoreCompleted,
-                fontProvider: fonts,
-                introEligibility: introEligibility,
-                purchaseHandler: purchaseHandler
-            ))
+            .modifier(
+                PresentingPaywallFooterModifier(
+                    configuration: .init(
+                        offering: offering,
+                        customerInfo: customerInfo,
+                        mode: condensed ? .condensedFooter : .footer,
+                        fonts: fonts,
+                        displayCloseButton: false,
+                        introEligibility: introEligibility,
+                        purchaseHandler: purchaseHandler
+                    ),
+                    purchaseCompleted: purchaseCompleted,
+                    restoreCompleted: restoreCompleted
+                )
+            )
     }
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 private struct PresentingPaywallFooterModifier: ViewModifier {
 
-    let offering: Offering?
-    let customerInfo: CustomerInfo?
-    let condensed: Bool
-
+    let configuration: PaywallViewConfiguration
     let purchaseCompleted: PurchaseOrRestoreCompletedHandler?
     let restoreCompleted: PurchaseOrRestoreCompletedHandler?
-    let fontProvider: PaywallFontProvider
-    let introEligibility: TrialOrIntroEligibilityChecker?
-    let purchaseHandler: PurchaseHandler?
 
     func body(content: Content) -> some View {
         content
             .safeAreaInset(edge: .bottom) {
-                PaywallView(
-                    offering: self.offering,
-                    customerInfo: self.customerInfo,
-                    mode: self.condensed ? .condensedFooter : .footer,
-                    fonts: self.fontProvider,
-                    introEligibility: self.introEligibility,
-                    purchaseHandler: self.purchaseHandler
-                )
+                PaywallView(configuration: self.configuration)
                 .onPurchaseCompleted {
                     self.purchaseCompleted?($0)
                 }

--- a/Tests/RevenueCatUITests/BaseSnapshotTest.swift
+++ b/Tests/RevenueCatUITests/BaseSnapshotTest.swift
@@ -60,12 +60,16 @@ class BaseSnapshotTest: TestCase {
         introEligibility: TrialOrIntroEligibilityChecker = BaseSnapshotTest.eligibleChecker,
         purchaseHandler: PurchaseHandler = BaseSnapshotTest.purchaseHandler
     ) -> some View {
-        return PaywallView(offering: offering,
-                           customerInfo: TestData.customerInfo,
-                           mode: mode,
-                           fonts: fonts,
-                           introEligibility: introEligibility,
-                           purchaseHandler: purchaseHandler)
+        return PaywallView(
+            configuration: .init(
+                offering: offering,
+                customerInfo: TestData.customerInfo,
+                mode: mode,
+                fonts: fonts,
+                introEligibility: introEligibility,
+                purchaseHandler: purchaseHandler
+            )
+        )
             .environment(\.isRunningSnapshots, true)
     }
 

--- a/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
@@ -137,11 +137,13 @@ private extension PaywallViewEventsTests {
 
     func createView() -> some View {
         PaywallView(
-            offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
-            mode: self.mode,
-            introEligibility: .producing(eligibility: .eligible),
-            purchaseHandler: self.handler
+            configuration: .init(
+                offering: Self.offering.withLocalImages,
+                customerInfo: TestData.customerInfo,
+                mode: self.mode,
+                introEligibility: .producing(eligibility: .eligible),
+                purchaseHandler: self.handler
+            )
         )
         .environment(\.colorScheme, self.scheme)
     }

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -169,4 +169,25 @@ class PurchaseCompletedHandlerTests: TestCase {
     private static let package = TestData.annualPackage
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension PaywallView {
+
+    init(
+        offering: Offering,
+        customerInfo: CustomerInfo,
+        introEligibility: TrialOrIntroEligibilityChecker,
+        purchaseHandler: PurchaseHandler
+    ) {
+        self.init(
+            configuration: .init(
+                offering: offering,
+                customerInfo: customerInfo,
+                introEligibility: introEligibility,
+                purchaseHandler: purchaseHandler
+            )
+        )
+    }
+
+}
+
 #endif

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/SamplePaywallsList.swift
@@ -34,11 +34,15 @@ struct SamplePaywallsList: View {
         case let .template(template, mode):
             switch mode {
             case .fullScreen:
-                PaywallView(offering: Self.loader.offering(for: template),
-                            customerInfo: Self.loader.customerInfo,
-                            displayCloseButton: Self.displayCloseButton,
-                            introEligibility: Self.introEligibility,
-                            purchaseHandler: .default())
+                PaywallView(
+                    configuration: .init(
+                        offering: Self.loader.offering(for: template),
+                        customerInfo: Self.loader.customerInfo,
+                        displayCloseButton: Self.displayCloseButton,
+                        introEligibility: Self.introEligibility,
+                        purchaseHandler: .default()
+                    )
+                )
 
             #if !os(watchOS)
             case .footer, .condensedFooter:
@@ -51,12 +55,16 @@ struct SamplePaywallsList: View {
             }
 
         case let .customFont(template):
-            PaywallView(offering: Self.loader.offering(for: template),
-                        customerInfo: Self.loader.customerInfo,
-                        fonts: Self.customFontProvider,
-                        displayCloseButton: Self.displayCloseButton,
-                        introEligibility: Self.introEligibility,
-                        purchaseHandler: .default())
+            PaywallView(
+                configuration: .init(
+                    offering: Self.loader.offering(for: template),
+                    customerInfo: Self.loader.customerInfo,
+                    fonts: Self.customFontProvider,
+                    displayCloseButton: Self.displayCloseButton,
+                    introEligibility: Self.introEligibility,
+                    purchaseHandler: .default()
+                )
+            )
 
         #if !os(watchOS)
         case let .customPaywall(mode):
@@ -65,16 +73,24 @@ struct SamplePaywallsList: View {
         #endif
 
         case .missingPaywall:
-            PaywallView(offering: Self.loader.offeringWithDefaultPaywall(),
-                        customerInfo: Self.loader.customerInfo,
-                        introEligibility: Self.introEligibility,
-                        purchaseHandler: .default())
+            PaywallView(
+                configuration: .init(
+                    offering: Self.loader.offeringWithDefaultPaywall(),
+                    customerInfo: Self.loader.customerInfo,
+                    introEligibility: Self.introEligibility,
+                    purchaseHandler: .default()
+                )
+            )
 
         case .unrecognizedPaywall:
-            PaywallView(offering: Self.loader.offeringWithUnrecognizedPaywall(),
-                        customerInfo: Self.loader.customerInfo,
-                        introEligibility: Self.introEligibility,
-                        purchaseHandler: .default())
+            PaywallView(
+                configuration: .init(
+                    offering: Self.loader.offeringWithUnrecognizedPaywall(),
+                    customerInfo: Self.loader.customerInfo,
+                    introEligibility: Self.introEligibility,
+                    purchaseHandler: .default()
+                )
+            )
         }
     }
 


### PR DESCRIPTION
The number of parameters was already very large. This refactor combines the different values into its own type.

This is also a preliminary refactor to be able to configure a paywall with an offering identifier instead of an offering, which will be used by the hybrid SDKs.
