### PR TITLE
`PaywallViewController`: new initializer with `Offering` identifier

### DIFF
--- a/RevenueCatUI/Data/Errors/PaywallError.swift
+++ b/RevenueCatUI/Data/Errors/PaywallError.swift
@@ -22,6 +22,9 @@ enum PaywallError: Error {
     /// RevenueCat dashboard does not have a current offering configured.
     case noCurrentOffering
 
+    /// The selected offering was not found.
+    case offeringNotFound(identifier: String)
+
 }
 
 extension PaywallError: CustomNSError {
@@ -39,6 +42,9 @@ extension PaywallError: CustomNSError {
 
         case .noCurrentOffering:
             return "The RevenueCat dashboard does not have a current offering configured."
+
+        case let .offeringNotFound(identifier):
+            return "The RevenueCat dashboard does not have an offering with identifier '\(identifier)'."
         }
     }
 

--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -13,12 +13,81 @@ import RevenueCat
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct PaywallViewConfiguration {
 
-    var offering: Offering?
+    var content: Content
     var customerInfo: CustomerInfo?
-    var mode: PaywallViewMode = .default
-    var fonts: PaywallFontProvider = DefaultPaywallFontProvider()
-    var displayCloseButton: Bool = false
+    var mode: PaywallViewMode
+    var fonts: PaywallFontProvider
+    var displayCloseButton: Bool
     var introEligibility: TrialOrIntroEligibilityChecker?
     var purchaseHandler: PurchaseHandler?
+
+    init(
+        content: Content,
+        customerInfo: CustomerInfo? = nil,
+        mode: PaywallViewMode = .default,
+        fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        displayCloseButton: Bool = false,
+        introEligibility: TrialOrIntroEligibilityChecker? = nil,
+        purchaseHandler: PurchaseHandler? = nil
+    ) {
+        self.content = content
+        self.customerInfo = customerInfo
+        self.mode = mode
+        self.fonts = fonts
+        self.displayCloseButton = displayCloseButton
+        self.introEligibility = introEligibility
+        self.purchaseHandler = purchaseHandler
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension PaywallViewConfiguration {
+
+    /// Offering selection for the paywall.
+    enum Content {
+
+        case defaultOffering
+        case offering(Offering)
+        case offeringIdentifier(String)
+
+    }
+
+}
+
+// MARK: -
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension PaywallViewConfiguration {
+
+    init(
+        offering: Offering? = nil,
+        customerInfo: CustomerInfo? = nil,
+        mode: PaywallViewMode = .default,
+        fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        displayCloseButton: Bool = false,
+        introEligibility: TrialOrIntroEligibilityChecker? = nil,
+        purchaseHandler: PurchaseHandler? = nil
+    ) {
+        self.init(
+            content: .optionalOffering(offering),
+            customerInfo: customerInfo,
+            mode: mode,
+            fonts: fonts,
+            displayCloseButton: displayCloseButton,
+            introEligibility: introEligibility,
+            purchaseHandler: purchaseHandler
+        )
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension PaywallViewConfiguration.Content {
+
+    /// - Returns: `Content.offering` or `Content.defaultOffering` if `nil`.
+    static func optionalOffering(_ offering: Offering?) -> Self {
+        return offering.map(Self.offering) ?? .defaultOffering
+    }
 
 }

--- a/RevenueCatUI/Helpers/Optional+Extensions.swift
+++ b/RevenueCatUI/Helpers/Optional+Extensions.swift
@@ -1,0 +1,1 @@
+../../Sources/FoundationExtensions/Optional+Extensions.swift

--- a/RevenueCatUI/UIKit/PaywallFooterViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallFooterViewController.swift
@@ -27,27 +27,31 @@ import UIKit
 @objc(RCPaywallFooterViewController)
 public final class PaywallFooterViewController: PaywallViewController {
 
-    override var mode: PaywallViewMode {
-        return .footer
-    }
-
     /// Initialize a `PaywallFooterViewController` with an optional `Offering`.
     /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
     /// `Offerings.current` will be used by default.
     @objc
     public init(offering: Offering? = nil) {
-        super.init(offering: offering,
+        super.init(content: .optionalOffering(offering),
+                   fonts: DefaultPaywallFontProvider(),
+                   displayCloseButton: false)
+    }
+
+    /// Initialize a `PaywallFooterViewController` with an `Offering` identifier.
+    @objc
+    public init(offeringIdentifier: String) {
+        super.init(content: .offeringIdentifier(offeringIdentifier),
                    fonts: DefaultPaywallFontProvider(),
                    displayCloseButton: false)
     }
 
     @available(*, unavailable)
     override init(
-        offering: Offering? = nil,
+        content: PaywallViewConfiguration.Content,
         fonts: PaywallFontProvider,
         displayCloseButton: Bool = false
     ) {
-        super.init(offering: offering,
+        super.init(content: content,
                    fonts: fonts,
                    displayCloseButton: false)
     }
@@ -56,6 +60,11 @@ public final class PaywallFooterViewController: PaywallViewController {
     public required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override class var mode: PaywallViewMode {
+        return .footer
+    }
+
 }
 
 #endif

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -48,7 +48,7 @@ public class PaywallViewController: UIViewController {
     /// Initialize a `PaywallViewController` with an optional `Offering` and ``PaywallFontProvider``.
     /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
     /// `Offerings.current` will be used by default.
-    /// - Parameter fonts: An optional ``PaywallFontProvider``.
+    /// - Parameter fonts: A ``PaywallFontProvider``.
     /// - Parameter displayCloseButton: Set this to `true` to automatically include a close button.
     public convenience init(
         offering: Offering? = nil,
@@ -64,7 +64,7 @@ public class PaywallViewController: UIViewController {
 
     /// Initialize a `PaywallViewController` with an offering identifier.
     /// - Parameter offeringIdentifier: The identifier for the offering with `PaywallData` to display.
-    /// - Parameter fonts: An optional ``PaywallFontProvider``.
+    /// - Parameter fonts: A ``PaywallFontProvider``.
     /// - Parameter displayCloseButton: Set this to `true` to automatically include a close button.
     public convenience init(
         offeringIdentifier: String,

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -139,7 +139,7 @@ extension View {
                 purchaseCancelled: purchaseCancelled,
                 restoreCompleted: restoreCompleted,
                 onDismiss: onDismiss,
-                offering: offering,
+                content: .optionalOffering(offering),
                 fontProvider: fonts,
                 customerInfoFetcher: customerInfoFetcher,
                 introEligibility: introEligibility,
@@ -165,7 +165,7 @@ private struct PresentingPaywallModifier: ViewModifier {
     var restoreCompleted: PurchaseOrRestoreCompletedHandler?
     var onDismiss: (() -> Void)?
 
-    var offering: Offering?
+    var content: PaywallViewConfiguration.Content
     var fontProvider: PaywallFontProvider
 
     var customerInfoFetcher: View.CustomerInfoFetcher
@@ -180,7 +180,7 @@ private struct PresentingPaywallModifier: ViewModifier {
             .sheet(item: self.$data, onDismiss: self.onDismiss) { data in
                 PaywallView(
                     configuration: .init(
-                        offering: self.offering,
+                        content: self.content,
                         customerInfo: data.customerInfo,
                         fonts: self.fontProvider,
                         displayCloseButton: true,

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -88,7 +88,7 @@ extension View {
             .modifier(
                 PresentingPaywallFooterModifier(
                     configuration: .init(
-                        offering: offering,
+                        content: .optionalOffering(offering),
                         customerInfo: customerInfo,
                         mode: condensed ? .condensedFooter : .footer,
                         fonts: fonts,

--- a/Sources/FoundationExtensions/Optional+Extensions.swift
+++ b/Sources/FoundationExtensions/Optional+Extensions.swift
@@ -44,14 +44,3 @@ extension OptionalType {
     }
 
 }
-
-// MARK: -
-
-internal extension Optional where Wrapped == String {
-
-    /// Returns `nil` if `self` is an empty string.
-    var notEmpty: String? {
-        return self.flatMap { $0.notEmpty }
-    }
-
-}

--- a/Sources/FoundationExtensions/String+Extensions.swift
+++ b/Sources/FoundationExtensions/String+Extensions.swift
@@ -61,6 +61,17 @@ extension String {
 
 }
 
+// MARK: -
+
+internal extension Optional where Wrapped == String {
+
+    /// Returns `nil` if `self` is an empty string.
+    var notEmpty: String? {
+        return self.flatMap { $0.notEmpty }
+    }
+
+}
+
 private enum ROT13 {
 
     private static let key: [Character: Character] = {

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -18,11 +18,17 @@ func paywallViewControllerAPI(_ delegate: Delegate, _ offering: Offering?) {
 
     let _: UIViewController = PaywallViewController(fonts: fontProvider)
     let _: UIViewController = PaywallViewController(offering: offering)
+    let _: UIViewController = PaywallViewController(offeringIdentifier: "offering")
     let _: UIViewController = PaywallViewController(displayCloseButton: true)
     let _: UIViewController = PaywallViewController(fonts: fontProvider)
     let _: UIViewController = PaywallViewController(offering: offering, displayCloseButton: true)
     let _: UIViewController = PaywallViewController(offering: offering, fonts: fontProvider)
     let _: UIViewController = PaywallViewController(offering: offering,
+                                                    fonts: fontProvider,
+                                                    displayCloseButton: true)
+    let _: UIViewController = PaywallViewController(offeringIdentifier: "offering", displayCloseButton: true)
+    let _: UIViewController = PaywallViewController(offeringIdentifier: "offering", fonts: fontProvider)
+    let _: UIViewController = PaywallViewController(offeringIdentifier: "offering",
                                                     fonts: fontProvider,
                                                     displayCloseButton: true)
 }
@@ -33,6 +39,7 @@ func paywallFooterViewControllerAPI(_ delegate: Delegate, _ offering: Offering?)
     controller.delegate = delegate
 
     let _: UIViewController = PaywallFooterViewController(offering: offering)
+    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering")
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)


### PR DESCRIPTION
Depends on #3586.

This will be used by the hybrid SDKs to be able to load paywalls with an offering identifier.