### PR TITLE
`PaywallViewController`: methods for reconfiguring paywall with new offering

### DIFF
--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -29,6 +29,8 @@ public class PaywallViewController: UIViewController {
 
     private var configuration: PaywallViewConfiguration {
         didSet {
+            // Overriding the configuration requires re-creating the `HostingViewController`.
+            // This is used by some Hybrid SDKs that require modifying the content after creation.
             self.hostingController = self.createHostingController()
         }
     }

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -116,11 +116,13 @@ public class PaywallViewController: UIViewController {
     }
 
     /// - Warning: For internal use only
+    @objc(updateWithOffering:)
     public func update(with offering: Offering) {
         self.configuration.content = .offering(offering)
     }
 
     /// - Warning: For internal use only
+    @objc(updateWithOfferingIdentifier:)
     public func update(with offeringIdentifier: String) {
         self.configuration.content = .offeringIdentifier(offeringIdentifier)
     }

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -27,7 +27,11 @@ public class PaywallViewController: UIViewController {
     /// See ``PaywallViewControllerDelegate`` for receiving purchase events.
     @objc public final weak var delegate: PaywallViewControllerDelegate?
 
-    private let configuration: PaywallViewConfiguration
+    private var configuration: PaywallViewConfiguration {
+        didSet {
+            self.hostingController = self.createHostingController()
+        }
+    }
 
     /// Initialize a `PaywallViewController` with an optional `Offering`.
     /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
@@ -98,49 +102,10 @@ public class PaywallViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private lazy var hostingController: UIHostingController<some View> = {
-        let view = PaywallView(configuration: self.configuration)
-            .onPurchaseCompleted { [weak self] transaction, customerInfo in
-                guard let self else { return }
-                self.delegate?.paywallViewController?(self, didFinishPurchasingWith: customerInfo)
-                self.delegate?.paywallViewController?(self,
-                                                      didFinishPurchasingWith: customerInfo,
-                                                      transaction: transaction)
-            }
-            .onPurchaseCancelled { [weak self] in
-                guard let self else { return }
-                self.delegate?.paywallViewControllerDidCancelPurchase?(self)
-            }
-            .onRestoreCompleted { [weak self] customerInfo in
-                guard let self else { return }
-                self.delegate?.paywallViewController?(self, didFinishRestoringWith: customerInfo)
-            }
-            .onSizeChange { [weak self] in
-                guard let self else { return }
-                self.delegate?.paywallViewController?(self, didChangeSizeTo: $0)
-            }
-
-        return .init(rootView: view)
-    }()
-
     public override func loadView() {
         super.loadView()
 
-        self.addChild(self.hostingController)
-        self.view.addSubview(self.hostingController.view)
-        self.hostingController.didMove(toParent: self)
-        self.hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            self.hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            self.hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            self.hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            self.hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        ])
-
-        // make the background of the container clear so that if there are cutouts, they don't get
-        // overridden by the hostingController's view's background.
-        self.hostingController.view.backgroundColor = .clear
+        self.hostingController = self.createHostingController()
     }
 
     public override func viewDidDisappear(_ animated: Bool) {
@@ -150,11 +115,52 @@ public class PaywallViewController: UIViewController {
         super.viewDidDisappear(animated)
     }
 
+    /// - Warning: For internal use only
+    public func update(with offering: Offering) {
+        self.configuration.content = .offering(offering)
+    }
+
+    /// - Warning: For internal use only
+    public func update(with offeringIdentifier: String) {
+        self.configuration.content = .offeringIdentifier(offeringIdentifier)
+    }
+
+    // MARK: - Internal
+
     class var mode: PaywallViewMode {
         return .fullScreen
     }
 
+    // MARK: - Private
+
+    private var hostingController: UIHostingController<PaywallContainerView>? {
+        willSet {
+            guard let oldValue = self.hostingController else { return }
+
+            oldValue.willMove(toParent: nil)
+            oldValue.view.removeFromSuperview()
+            oldValue.removeFromParent()
+        }
+
+        didSet {
+            guard let newController = self.hostingController else { return }
+
+            self.addChild(newController)
+            self.view.addSubview(newController.view)
+            newController.didMove(toParent: self)
+
+            NSLayoutConstraint.activate([
+                newController.view.topAnchor.constraint(equalTo: self.view.topAnchor),
+                newController.view.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+                newController.view.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+                newController.view.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
+            ])
+        }
+    }
+
 }
+
+// MARK: - PaywallViewControllerDelegate
 
 /// Delegate for ``PaywallViewController``.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
@@ -193,6 +199,56 @@ public protocol PaywallViewControllerDelegate: AnyObject {
     @objc(paywallViewController:didChangeSizeTo:)
     optional func paywallViewController(_ controller: PaywallViewController,
                                         didChangeSizeTo size: CGSize)
+
+}
+
+// MARK: - Private
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+private extension PaywallViewController {
+
+    func createHostingController() -> UIHostingController<PaywallContainerView> {
+        let controller = UIHostingController(rootView: PaywallContainerView(configuration: self.configuration,
+                                                                            controller: self))
+
+        // make the background of the container clear so that if there are cutouts, they don't get
+        // overridden by the hostingController's view's background.
+        controller.view.backgroundColor = .clear
+        controller.view.translatesAutoresizingMaskIntoConstraints = false
+
+        return controller
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+private struct PaywallContainerView: View {
+
+    var configuration: PaywallViewConfiguration
+    var controller: PaywallViewController
+
+    var body: some View {
+        PaywallView(configuration: self.configuration)
+            .onPurchaseCompleted { [weak controller = self.controller] transaction, customerInfo in
+                guard let controller else { return }
+                controller.delegate?.paywallViewController?(controller, didFinishPurchasingWith: customerInfo)
+                controller.delegate?.paywallViewController?(controller,
+                                                            didFinishPurchasingWith: customerInfo,
+                                                            transaction: transaction)
+            }
+            .onPurchaseCancelled { [weak controller = self.controller] in
+                guard let controller else { return }
+                controller.delegate?.paywallViewControllerDidCancelPurchase?(controller)
+            }
+            .onRestoreCompleted { [weak controller = self.controller] customerInfo in
+                guard let controller else { return }
+                controller.delegate?.paywallViewController?(controller, didFinishRestoringWith: customerInfo)
+            }
+            .onSizeChange { [weak controller = self.controller] in
+                guard let controller else { return }
+                controller.delegate?.paywallViewController?(controller, didChangeSizeTo: $0)
+            }
+    }
 
 }
 

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -31,6 +31,9 @@ func paywallViewControllerAPI(_ delegate: Delegate, _ offering: Offering?) {
     let _: UIViewController = PaywallViewController(offeringIdentifier: "offering",
                                                     fonts: fontProvider,
                                                     displayCloseButton: true)
+
+    controller.update(with: offering!)
+    controller.update(with: "offering_identifier")
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)


### PR DESCRIPTION
For use by `react-native-purchases`.

This is not the most efficient, but it's required because we don't get the props on React Native until after we've already returned the `UIView`.