### PR TITLE
`Integration Tests`: verify `PaywallData` images can be loaded

### DIFF
--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -108,6 +108,17 @@ private final class DefaultPaywallImageFetcher: PaywallImageFetcherType {
 
 // MARK: - Extensions
 
+internal extension PaywallData {
+
+    /// - Returns: all image URLs contained in this paywall.
+    var allImageURLs: [URL] {
+        return self.config.images
+            .allImageNames
+            .map { self.assetBaseURL.appendingPathComponent($0) }
+    }
+
+}
+
 private extension Offerings {
 
     var offeringsToPreWarm: [Offering] {
@@ -149,16 +160,6 @@ private extension Offering {
                 .filter { packageTypes.contains($0.identifier) }
                 .map(\.storeProduct.productIdentifier)
         )
-    }
-
-}
-
-private extension PaywallData {
-
-    var allImageURLs: [URL] {
-        return self.config.images
-            .allImageNames
-            .map { self.assetBaseURL.appendingPathComponent($0) }
     }
 
 }

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -192,4 +192,33 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
         )
     }
 
+    func testRequestPaywallImages() async throws {
+        let offering = try await XCTAsyncUnwrap(try await self.purchases.offerings().current)
+        let paywall = try XCTUnwrap(offering.paywall)
+        let images = paywall.allImageURLs
+
+        expect(images).toNot(beEmpty())
+
+        for imageURL in images {
+            let (data, response) = try await URLSession.shared.data(from: imageURL)
+            let urlResponse = try XCTUnwrap(response as? HTTPURLResponse)
+
+            expect(data)
+                .toNot(
+                    beEmpty(),
+                    description: "Found empty image: \(imageURL)"
+                )
+            expect(urlResponse.statusCode)
+                .to(
+                    equal(200),
+                    description: "Unexpected response for image: \(imageURL)"
+                )
+            expect(urlResponse.value(forHTTPHeaderField: "Content-Type"))
+                .to(
+                    equal("image/jpeg"),
+                    description: "Unexpected content type for image: \(imageURL)"
+                )
+        }
+    }
+
 }


### PR DESCRIPTION
This serves as an extra precaution to avoid regressions with our ability to load paywall images.
