### PR TITLE
`Xcode 15.3 beta 1`: fix compilation errors

### DIFF
--- a/Sources/Networking/InternalAPI.swift
+++ b/Sources/Networking/InternalAPI.swift
@@ -67,3 +67,7 @@ extension InternalAPI {
     }
 
 }
+
+// @unchecked because:
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+extension InternalAPI: @unchecked Sendable {}

--- a/Sources/Paywalls/Events/PaywallEventStore.swift
+++ b/Sources/Paywalls/Events/PaywallEventStore.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-protocol PaywallEventStoreType {
+protocol PaywallEventStoreType: Sendable {
 
     /// Stores `event` into the store.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/Sources/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift
+++ b/Sources/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift
@@ -34,13 +34,6 @@ protocol SK2BeginRefundRequestHelperType: Sendable {
 @available(tvOS, unavailable)
 final class SK2BeginRefundRequestHelper: SK2BeginRefundRequestHelperType {
 
-    /// Calls `initiateSK2RefundRequest` and maps the result for consumption by `BeginRefundRequestHelper`
-    @MainActor
-    func initiateRefundRequest(transactionID: UInt64, windowScene: UIWindowScene) async throws -> RefundRequestStatus {
-        let sk2Result = await initiateSK2RefundRequest(transactionID: transactionID, windowScene: windowScene)
-        return try mapSk2Result(from: sk2Result)
-    }
-
     /* Checks with StoreKit2 that the given `productID` has an existing verified transaction, and maps the
      * result for consumption by `BeginRefundRequestHelper`.
      */
@@ -88,7 +81,21 @@ final class SK2BeginRefundRequestHelper: SK2BeginRefundRequestHelperType {
 @available(iOS 15.0, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
-private extension SK2BeginRefundRequestHelper {
+extension SK2BeginRefundRequestHelperType {
+
+    /// Calls `initiateSK2RefundRequest` and maps the result for consumption by `BeginRefundRequestHelper`
+    @MainActor
+    func initiateRefundRequest(transactionID: UInt64, windowScene: UIWindowScene) async throws -> RefundRequestStatus {
+        let sk2Result = await self.initiateSK2RefundRequest(transactionID: transactionID, windowScene: windowScene)
+        return try self.mapSk2Result(from: sk2Result)
+    }
+
+}
+
+@available(iOS 15.0, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+private extension SK2BeginRefundRequestHelperType {
 
     func getErrorMessage(from sk2Error: Error?) -> String {
         let details = sk2Error?.localizedDescription ?? "No extra info"

--- a/Sources/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift
+++ b/Sources/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift
@@ -16,11 +16,23 @@ import Foundation
 import StoreKit
 import UIKit
 
+@available(iOS 15.0, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+protocol SK2BeginRefundRequestHelperType: Sendable {
+
+    func initiateSK2RefundRequest(transactionID: UInt64, windowScene: UIWindowScene) async ->
+        Result<StoreKit.Transaction.RefundRequestStatus, Error>
+
+    func verifyTransaction(productID: String) async throws -> UInt64
+
+}
+
 /// Helper class responsible for calling into StoreKit2 and translating results/errors for consumption by RevenueCat.
 @available(iOS 15.0, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
-class SK2BeginRefundRequestHelper {
+final class SK2BeginRefundRequestHelper: SK2BeginRefundRequestHelperType {
 
     /// Calls `initiateSK2RefundRequest` and maps the result for consumption by `BeginRefundRequestHelper`
     @MainActor

--- a/Sources/Support/BeginRefundRequestHelper.swift
+++ b/Sources/Support/BeginRefundRequestHelper.swift
@@ -31,10 +31,10 @@ class BeginRefundRequestHelper {
     @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    var sk2Helper: SK2BeginRefundRequestHelper {
+    var sk2Helper: SK2BeginRefundRequestHelperType {
         get {
             // swiftlint:disable:next force_cast
-            return self._sk2Helper! as! SK2BeginRefundRequestHelper
+            return self._sk2Helper! as! SK2BeginRefundRequestHelperType
         }
 
         set {
@@ -71,9 +71,9 @@ class BeginRefundRequestHelper {
     func beginRefundRequest(forProduct productID: String) async throws -> RefundRequestStatus {
         let windowScene = try self.systemInfo.currentWindowScene
 
-        let transactionID = try await sk2Helper.verifyTransaction(productID: productID)
-        return try await sk2Helper.initiateRefundRequest(transactionID: transactionID,
-                                                         windowScene: windowScene)
+        let transactionID = try await self.sk2Helper.verifyTransaction(productID: productID)
+        return try await self.sk2Helper.initiateRefundRequest(transactionID: transactionID,
+                                                              windowScene: windowScene)
     }
 
     @available(iOS 15.0, *)

--- a/Sources/Support/DebugUI/DebugContentViews.swift
+++ b/Sources/Support/DebugUI/DebugContentViews.swift
@@ -374,7 +374,7 @@ private struct DebugPackageView: View {
 
             Section("Purchasing") {
                 Button {
-                    _ = Task<Void, Never> {
+                    _ = Task<Void, Never> { @MainActor in
                         do {
                             self.purchasing = true
                             try await self.purchase()
@@ -407,6 +407,7 @@ private struct DebugPackageView: View {
             }
     }
 
+    @MainActor
     private func purchase() async throws {
         _ = try await Purchases.shared.purchase(package: self.package)
     }


### PR DESCRIPTION
### Changes:
- `InternalAPI` is now `Sendable` to deal with new compilation error
- `PaywallEventStoreType` is now `Sendable`
- Extracted `SK2BeginRefundRequestHelperType` to make `SK2BeginRefundRequestHelper` `Sendable`
- Updated `MockSK2BeginRefundRequestHelper` to be thread-safe and `Sendable`
- Fixed compilation error in `DebugContentViews`
- Fixed compilation error in `DebugViewModel`
- Fixed compilation error in `StoreMessagesHelper`