### PR TITLE
`Xcode 15.3 beta 1`: fix warnings on tests

### DIFF
--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -1714,7 +1714,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 7.0, *)
 private extension PurchasesOrchestratorTests {
 
-    @MainActor
     func fetchSk1Product() async throws -> SK1Product {
         return MockSK1Product(
             mockProductIdentifier: Self.productID,
@@ -1722,7 +1721,6 @@ private extension PurchasesOrchestratorTests {
         )
     }
 
-    @MainActor
     func fetchSk1StoreProduct() async throws -> SK1StoreProduct {
         return try await SK1StoreProduct(sk1Product: fetchSk1Product())
     }

--- a/Tests/StoreKitUnitTests/StoreKit2/StoreKit2CachingProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/StoreKit2CachingProductsManagerTests.swift
@@ -18,13 +18,11 @@ import XCTest
 
 /// Addition to `CachingProductsManagerTests` but for SK2 requests
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-@MainActor
 class StoreKit2CachingProductsManagerTests: StoreKitConfigTestCase {
 
     private var mockManager: MockProductsManager!
     private var cachingManager: CachingProductsManager!
 
-    @MainActor
     override func setUp() async throws {
         try await super.setUp()
 
@@ -120,7 +118,9 @@ class StoreKit2CachingProductsManagerTests: StoreKitConfigTestCase {
         var tasks: [Task<Set<SK2StoreProduct>, Error>] = []
 
         for _ in 0..<5 {
-            tasks.append(Task { try await self.cachingManager.sk2Products(withIdentifiers: [Self.productID]) })
+            tasks.append(Task { [manager = self.cachingManager!] in
+                try await manager.sk2Products(withIdentifiers: [Self.productID])
+            })
         }
 
         for task in tasks {

--- a/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionFetcherTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionFetcherTests.swift
@@ -17,12 +17,10 @@ import StoreKitTest
 import XCTest
 
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-@MainActor
 class StoreKit2TransactionFetcherTests: StoreKitConfigTestCase {
 
     private var fetcher: StoreKit2TransactionFetcher!
 
-    @MainActor
     override func setUp() async throws {
         try await super.setUp()
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()

--- a/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionListenerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionListenerTests.swift
@@ -19,7 +19,6 @@ import XCTest
 
 // swiftlint:disable type_name
 
-@MainActor
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 class StoreKit2TransactionListenerBaseTests: StoreKitConfigTestCase {
 
@@ -201,8 +200,8 @@ class StoreKit2TransactionListenerTransactionUpdatesTests: StoreKit2TransactionL
 
         try self.testSession.buyProduct(productIdentifier: Self.productID)
 
-        try await asyncWait {
-            await self.delegate.invokedTransactionUpdated == true
+        try await asyncWait { [delegate = self.delegate!] in
+            delegate.invokedTransactionUpdated == true
         }
     }
 
@@ -211,8 +210,8 @@ class StoreKit2TransactionListenerTransactionUpdatesTests: StoreKit2TransactionL
 
         await self.listener.listenForTransactions()
 
-        try await asyncWait {
-            await self.delegate.invokedTransactionUpdated == true
+        try await asyncWait { [delegate = self.delegate!] in
+            delegate.invokedTransactionUpdated == true
         }
     }
 
@@ -260,8 +259,8 @@ class StoreKit2TransactionListenerCustomStreamTests: StoreKit2TransactionListene
     func testHandlesAllVerifiedTransactions() async throws {
         await self.listener.listenForTransactions()
 
-        try await asyncWait {
-            return await self.delegate.updatedTransactions.count == 2
+        try await asyncWait { [delegate = self.delegate!] in
+            return delegate.updatedTransactions.count == 2
         }
     }
 
@@ -270,8 +269,8 @@ class StoreKit2TransactionListenerCustomStreamTests: StoreKit2TransactionListene
 
         await self.listener.listenForTransactions()
 
-        try await asyncWait {
-            return await self.delegate.updatedTransactions.count == 2
+        try await asyncWait { [delegate = self.delegate!] in
+            return delegate.updatedTransactions.count == 2
         }
 
         expect(self.delegate.receivedConcurrentRequest) == true
@@ -320,8 +319,8 @@ private extension StoreKit2TransactionListenerBaseTests {
             pollInterval: .milliseconds(100),
             file: file,
             line: line
-        ) {
-            await self.delegate.invokedTransactionUpdated == true
+        ) { [delegate = self.delegate!] in
+            delegate.invokedTransactionUpdated == true
         }
     }
 

--- a/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -35,7 +35,6 @@ class StoreKitConfigTestCase: TestCase {
     var testSession: SKTestSession!
     var userDefaults: UserDefaults!
 
-    @MainActor
     override func setUp() async throws {
         try await super.setUp()
 
@@ -84,9 +83,7 @@ class StoreKitConfigTestCase: TestCase {
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
             Self.transactionsObservation?.cancel()
             Self.transactionsObservation = Task {
-                // Silence warning in tests:
-                // "Making a purchase without listening for transaction updates risks missing successful purchases.
-                for await _ in Transaction.updates {}
+                await Self.listenToTransactionUpdates()
             }
         }
     }
@@ -96,6 +93,15 @@ class StoreKitConfigTestCase: TestCase {
         Self.transactionsObservation = nil
 
         super.tearDown()
+    }
+
+    // `nonisolated` required to work around Swift 5.10 issue.
+    // See https://github.com/RevenueCat/purchases-ios/pull/3599
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    private static nonisolated func listenToTransactionUpdates() async {
+        // Silence warning in tests:
+        // "Making a purchase without listening for transaction updates risks missing successful purchases.
+        for await _ in Transaction.updates {}
     }
 
 }

--- a/Tests/StoreKitUnitTests/StoreMessagesHelperTests.swift
+++ b/Tests/StoreKitUnitTests/StoreMessagesHelperTests.swift
@@ -147,7 +147,11 @@ private final class MockStoreMessage: StoreMessage {
 @available(iOS 16.0, *)
 private final class MockStoreMessagesProvider: StoreMessagesProviderType {
 
-    var stubbedMessages: [StoreMessage] = []
+    private let _stubbedMessages: Atomic<[StoreMessage]> = .init([])
+    var stubbedMessages: [StoreMessage] {
+        get { return self._stubbedMessages.value }
+        set { self._stubbedMessages.value = newValue }
+    }
 
     var messages: AsyncStream<StoreMessage> {
         MockAsyncSequence(with: self.stubbedMessages).toAsyncStream()

--- a/Tests/StoreKitUnitTests/Support/DebugViewSwiftUITests.swift
+++ b/Tests/StoreKitUnitTests/Support/DebugViewSwiftUITests.swift
@@ -18,7 +18,6 @@ import Nimble
 import SwiftUI
 import XCTest
 
-@MainActor
 @available(iOS 16.0, *)
 class DebugViewSwiftUITests: TestCase {
 
@@ -28,10 +27,12 @@ class DebugViewSwiftUITests: TestCase {
         try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
     }
 
+    @MainActor
     func testLoadingState() {
         self.snapshot(.init(), width: 300, height: 400)
     }
 
+    @MainActor
     func testDebugView() throws {
         let model = DebugViewModel()
         model.configuration = .loaded(.init(

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitConfigTestCase+Extensions.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitConfigTestCase+Extensions.swift
@@ -19,7 +19,6 @@ import XCTest
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 extension StoreKitConfigTestCase {
 
-    @MainActor
     @_disfavoredOverload
     @discardableResult
     func simulateAnyPurchase(
@@ -39,7 +38,6 @@ extension StoreKitConfigTestCase {
     }
 
     /// - Returns: `SK2Transaction` ater the purchase succeeded.
-    @MainActor
     @discardableResult
     func simulateAnyPurchase(
         product: SK2Product? = nil,
@@ -63,24 +61,20 @@ extension StoreKitConfigTestCase {
     }
 
     /// - Returns: `SK2Transaction` after the purchase succeeded. This transaction is automatically finished.
-    @MainActor
     func createTransactionWithPurchase(product: SK2Product? = nil) async throws -> Transaction {
         return try await self.simulateAnyPurchase(product: product, finishTransaction: true).underlyingTransaction
     }
 
-    @MainActor
     func fetchSk2Product(_ productID: String = StoreKitConfigTestCase.productID) async throws -> SK2Product {
         let products: [SK2Product] = try await StoreKit.Product.products(for: [productID])
         return try XCTUnwrap(products.first)
     }
 
-    @MainActor
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func fetchSk2StoreProduct(_ productID: String = StoreKitConfigTestCase.productID) async throws -> SK2StoreProduct {
         return SK2StoreProduct(sk2Product: try await self.fetchSk2Product(productID))
     }
 
-    @MainActor
     func createTransaction(
         productID: String? = nil,
         finished: Bool,

--- a/Tests/UnitTests/Diagnostics/FileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/FileHandlerTests.swift
@@ -16,13 +16,11 @@ import Nimble
 @testable import RevenueCat
 import XCTest
 
-@MainActor
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 class BaseFileHandlerTests: TestCase {
 
     fileprivate var handler: FileHandler!
 
-    @MainActor
     override func setUp() async throws {
         try await super.setUp()
 
@@ -31,7 +29,6 @@ class BaseFileHandlerTests: TestCase {
         self.handler = try Self.createWithTemporaryFile()
     }
 
-    @MainActor
     override func tearDown() async throws {
         self.handler = nil
 

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import RevenueCat
 
-@MainActor
 class BaseCustomerInfoManagerTests: TestCase {
+
     static let appUserID = "app_user_id"
 
     var mockOfflineEntitlementsManager: MockOfflineEntitlementsManager!
@@ -164,6 +164,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         expect(self.mockOperationDispatcher.invokedDispatchAsyncOnMainThreadCount) == 1
     }
 
+    @MainActor
     func testFetchAndCacheCustomerInfoIfStaleOnlyRefreshesCacheOnce() {
         mockDeviceCache.stubbedIsCustomerInfoCacheStale = true
         var firstCompletionCalled = false
@@ -242,6 +243,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         expect(self.mockBackend.invokedGetSubscriberDataCount).toEventually(equal(1))
     }
 
+    @MainActor
     func testCustomerInfoFetchesIfNoCache() {
         let appUserID = "myUser"
 

--- a/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
+++ b/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
@@ -255,7 +255,7 @@ private extension BaseCustomerInfoResponseHandlerTests {
             offlineCreator: .init(
                 purchasedProductsFetcher: self.fetcher,
                 productEntitlementMappingFetcher: MappingFetcher(productEntitlementMapping: mapping),
-                creator: self.factory.create
+                creator: { self.factory.create(products: $0, mapping: $1, userID: $2) }
             ),
             userID: self.userID
         )
@@ -333,7 +333,6 @@ private final class CustomerInfoFactory {
         userID: String
     )?
 
-    @Sendable
     func create(products: [PurchasedSK2Product], mapping: ProductEntitlementMapping, userID: String) -> CustomerInfo {
         guard let result = self.stubbedResult else {
             fatalError("Creation requested without stub")

--- a/Tests/UnitTests/OfflineEntitlements/OfflineEntitlementsManagerTests.swift
+++ b/Tests/UnitTests/OfflineEntitlements/OfflineEntitlementsManagerTests.swift
@@ -16,7 +16,6 @@ import Nimble
 import StoreKit
 import XCTest
 
-@MainActor
 class BaseOfflineEntitlementsManagerTests: TestCase {
 
     let mockBackend = MockBackend()

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -15,7 +15,6 @@ import Nimble
 @testable import RevenueCat
 import XCTest
 
-@MainActor
 @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
 class PaywallCacheWarmingTests: TestCase {
 

--- a/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
@@ -16,13 +16,11 @@ import Nimble
 import XCTest
 
 @available(iOS 13.0, tvOS 13.0, watchOS 6.2, macOS 10.15, *)
-@MainActor
 class CachingProductsManagerTests: TestCase {
 
     private var mockManager: MockProductsManager!
     private var cachingManager: CachingProductsManager!
 
-    @MainActor
     override func setUp() async throws {
         try await super.setUp()
 
@@ -120,7 +118,11 @@ class CachingProductsManagerTests: TestCase {
         var tasks: [Task<Set<StoreProduct>, Error>] = []
 
         for _ in 0..<5 {
-            tasks.append(Task { try await self.cachingManager.products(withIdentifiers: [Self.productID]) })
+            tasks.append(
+                Task { [manager = self.cachingManager!] in
+                    try await manager.products(withIdentifiers: [Self.productID])
+                }
+            )
         }
 
         for task in tasks {

--- a/Tests/UnitTests/Purchasing/CachingTrialOrIntroPriceEligibilityCheckerTests.swift
+++ b/Tests/UnitTests/Purchasing/CachingTrialOrIntroPriceEligibilityCheckerTests.swift
@@ -18,7 +18,6 @@ import XCTest
 // swiftlint:disable type_name
 
 @available(iOS 13.0, tvOS 13.0, watchOS 6.2, macOS 10.15, *)
-@MainActor
 class CachingTrialOrIntroPriceEligibilityCheckerTests: TestCase {
 
     private typealias Result = [String: IntroEligibility]

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -16,7 +16,6 @@ import Nimble
 import StoreKit
 import XCTest
 
-@MainActor
 class OfferingsManagerTests: TestCase {
 
     var mockDeviceCache: MockDeviceCache!

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -17,12 +17,19 @@ import XCTest
 
 @testable import RevenueCat
 
-@MainActor
 class BasePurchasesTests: TestCase {
 
     private static let userDefaultsSuiteName = "TestDefaults"
 
     override func setUpWithError() throws {
+        #if swift(>=5.10)
+        // Apple replaced `XCTestCase.addTeardownBlock` with a Swift implementation
+        // which is no longer available on iOS 11/12.
+        guard #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else {
+            throw XCTSkip("addTeardownBlock is not available")
+        }
+        #endif
+
         try super.setUpWithError()
 
         // Some tests rely on the level being at least `.debug`

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
@@ -62,12 +62,12 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
         expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
         expect(self.storeKit1Wrapper.payment).to(beNil())
 
-        var completionCalled = false
+        let completionCalled: Atomic<Bool> = false
 
         let makeDeferredPurchase = try XCTUnwrap(self.purchasesDelegate.makeDeferredPurchase)
 
         makeDeferredPurchase { (_, _, _, _) in
-            completionCalled = true
+            completionCalled.value = true
         }
 
         let transaction = MockTransaction()
@@ -76,7 +76,7 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
         try self.storeKit1WrapperDelegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.storeKit1Wrapper.payment) === payment
-        expect(completionCalled).toEventually(beTrue())
+        expect(completionCalled.value).toEventually(beTrue())
     }
 
     func testCallsShouldAddPromoPaymentDelegateMethod() throws {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -80,6 +80,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(self.backend.postedIsRestore) == false
     }
 
+    @MainActor
     func testPurchaseCallbackIsInvokedWhenProcessingQueueTransactionForSameProduct() {
         // This documents a race condition that we can't detect in the implementation
         // where `PurchasesOrchestrator` can't tell the difference between `StoreKit 1` sending
@@ -117,6 +118,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(callbackInvoked) == true
     }
 
+    @MainActor
     func testHandlesTransactionFromPurchaseAfterReviewingQueueUpdateForSameProductIdentifier() throws {
         // This documents a race condition that we can't detect in the implementation
         // where `PurchasesOrchestrator` can't tell the difference between `StoreKit 1` sending
@@ -181,6 +183,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(self.backend.postedIsRestore) == true
     }
 
+    @MainActor
     func testFinishesTransactionsIfSentToBackendCorrectly() throws {
         var finished = false
 
@@ -230,6 +233,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(self.storeKit1Wrapper.finishCalled).toEventually(beFalse())
     }
 
+    @MainActor
     func testDoesntFinishTransactionIfComputingCustomerInfoOffline() throws {
         // `CustomerInfo.entitlements.verification` isn't available in iOS 12,
         // but offline CustomerInfo isn't supported anyway.
@@ -240,8 +244,8 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         let productID = "com.product.id1"
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: productID))
 
-        self.purchases.purchase(product: product) { (_, _, _, _) in
-            expect(self.storeKit1Wrapper.finishCalled) == false
+        self.purchases.purchase(product: product) { [wrapper = self.storeKit1Wrapper!] (_, _, _, _) in
+            expect(wrapper.finishCalled) == false
 
             finished = true
         }
@@ -286,6 +290,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(self.storeKit1Wrapper.finishCalled) == false
     }
 
+    @MainActor
     func testAfterSendingFinishesFromBackendErrorIfAppropriate() throws {
         var finished = false
 
@@ -341,6 +346,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(self.storeKit1Wrapper.finishCalled) == false
     }
 
+    @MainActor
     func testNotifiesIfTransactionFailsFromStoreKit() throws {
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         var receivedError: Error?
@@ -362,6 +368,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(receivedError).toEventuallyNot(beNil())
     }
 
+    @MainActor
     func testCompletionBlockOnlyCalledOnce() throws {
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
 
@@ -384,6 +391,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(callCount).toEventually(equal(1))
     }
 
+    @MainActor
     func testUserCancelledFalseIfPurchaseSuccessful() throws {
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         var receivedUserCancelled: Bool?
@@ -400,6 +408,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(receivedUserCancelled).toEventually(beFalse())
     }
 
+    @MainActor
     func testUnknownErrorCurrentlySubscribedIsParsedCorrectly() throws {
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         var receivedUserCancelled: Bool?
@@ -439,6 +448,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(receivedUnderlyingError?.code).toEventually(equal(unknownError.code))
     }
 
+    @MainActor
     func testUserCancelledTrueIfSK1PurchaseCancelled() throws {
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
 
@@ -506,6 +516,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(receivedError).to(beNil())
     }
 
+    @MainActor
     func testDoNotSendEmptyReceiptWhenMakingPurchase() throws {
         self.receiptFetcher.shouldReturnReceipt = false
 
@@ -590,6 +601,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(self.backend.postedObserverMode) == false
     }
 
+    @MainActor
     func testNotifiesIfTransactionIsDeferredFromStoreKit() throws {
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         var receivedError: NSError?
@@ -610,6 +622,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(receivedError?.code).toEventually(equal(ErrorCode.paymentPendingError.rawValue))
     }
 
+    @MainActor
     func testPurchasingNilProductIdentifierRetrunsError() {
         let product = StoreProduct(sk1Product: SK1Product())
         var receivedError: Error?
@@ -658,6 +671,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(self.storeKit1Wrapper.finishCalled).toEventually(beTrue())
     }
 
+    @MainActor
     func testPurchasingPackageDoesntThrowPurchaseAlreadyInProgressIfCallbackMakesANewPurchase() throws {
         var receivedError: NSError?
         var secondCompletionCalled = false
@@ -683,6 +697,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(receivedError).to(beNil())
     }
 
+    @MainActor
     func testCallsDelegateAfterBackendResponse() throws {
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
 
@@ -729,6 +744,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(receivedUserCancelled).toEventually(beFalse())
     }
 
+    @MainActor
     func testCompletionBlockNotCalledForDifferentProducts() throws {
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         let otherProduct = MockSK1Product(mockProductIdentifier: "com.product.id2")
@@ -751,6 +767,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(callCount).toEventually(equal(0))
     }
 
+    @MainActor
     func testCallingPurchaseWhileSameProductPendingIssuesError() {
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
 
@@ -842,6 +859,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .onlyIfEmpty
     }
 
+    @MainActor
     func testPaymentSheetCancelledErrorIsParsedCorrectly() throws {
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         var receivedUserCancelled: Bool?
@@ -1086,6 +1104,7 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
         expect(self.storeKit1Wrapper.finishCalled).toEventually(beFalse())
     }
 
+    @MainActor
     func testCancelledErrorInCustomEntitlementComputationModeForSK1Purchase() throws {
         self.setUpPurchasesCustomEntitlementMode()
 

--- a/Tests/UnitTests/Purchasing/StoreKitAbstractions/StoreEnvironmentTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitAbstractions/StoreEnvironmentTests.swift
@@ -16,7 +16,6 @@ import Nimble
 import StoreKit
 import XCTest
 
-@MainActor
 class StoreEnvironmentTests: TestCase {
 
     @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)

--- a/Tests/UnitTests/Purchasing/StoreKitRequestFetcherTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitRequestFetcherTests.swift
@@ -12,7 +12,6 @@ import XCTest
 
 @testable import RevenueCat
 
-@MainActor
 class StoreKitRequestFetcherTests: TestCase {
 
     private var fetcher: StoreKitRequestFetcher!


### PR DESCRIPTION
#3599 made the SDK compile.
These addresses more issues on tests so we can now run them on Xcode 15.3 beta 1 with Swift 5.10