### PR TITLE
`Integration Tests`: disable failure expectation on `iOS 17.4`

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -503,8 +503,8 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testIneligibleForIntroForDifferentProductInSameSubscriptionGroupAfterPurchase() async throws {
-        if Self.storeKit2Setting == .enabledForCompatibleDevices {
-            XCTExpectFailure("This test currently does not pass with SK2 (see FB11889732)")
+        if Self.storeKit2Setting == .enabledForCompatibleDevices, #unavailable(iOS 17.4) {
+            XCTExpectFailure("This test does not pass with SK2 until iOS 17.4 (see FB11889732)")
         }
 
         let productWithNoTrial = try await self.product(Self.group3MonthlyNoTrialProductID)


### PR DESCRIPTION
`FB11889732` was [fixed on iOS 17.4](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-17_4-release-notes#Resolved-Issues):

![Screenshot 2024-01-26 at 10 14 01](https://github.com/RevenueCat/purchases-ios/assets/685609/74b78af7-db15-44e6-bc5a-9587403fec63)

