### PR TITLE
`CircleCI`: push pods using Xcode 15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1215,12 +1215,12 @@ workflows:
           xcode_version: '14.3.0'
           <<: *release-tags
       - push-revenuecat-pod:
-          xcode_version: '14.3.0'
+          xcode_version: '15.2'
           requires:
             - make-release
           <<: *release-tags
       - push-revenuecatui-pod:
-          xcode_version: '14.3.0'
+          xcode_version: '15.2'
           requires:
             - make-release
             - push-revenuecat-pod


### PR DESCRIPTION
Follow up to #3262.

Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/17384/workflows/4c13d08f-1970-4e40-b5e6-0cccae0d5ab7/jobs/166078/parallel-runs/0/steps/0-106
