### PR TITLE
`CustomerInfo`: conform to `Identifiable`

### DIFF
--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -306,6 +306,17 @@ extension CustomerInfo: HTTPResponseBody {
 
 }
 
+// MARK: -
+
+extension CustomerInfo: Identifiable {
+
+    // swiftlint:disable:next missing_docs
+    public var id: String {
+        return self.originalAppUserId
+    }
+
+}
+
 // MARK: - Private
 
 private extension CustomerInfo {

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/CustomerInfoAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/CustomerInfoAPI.swift
@@ -38,6 +38,8 @@ func checkCustomerInfoAPI() {
 
     let rawData: [String: Any] = customerInfo.rawData
 
+    let _: String = customerInfo.id
+
     print(customerInfo!, entitlementInfo, asubs, appis, led!, nst, oav!, opd!, rDate!, fSeen,
           oaud!, murl!, edfpi!, pdfpi!, exdf!, pdfe!, desc, rawData)
 }


### PR DESCRIPTION
This will be used by `RevenueCatUI` for #3620.