### PR TITLE
`Paywalls`: `.onRestoreCompleted` is invoked after the restore dialog is dismissed

### DIFF
--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -35,6 +35,11 @@ enum Strings {
     case image_starting_request(URL)
     case image_result(Result<(), ImageLoader.Error>)
 
+    case restoring_purchases
+    case restored_purchases
+    case restore_purchases_with_empty_result
+    case setting_restored_customer_info
+
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
@@ -81,6 +86,18 @@ extension Strings: CustomStringConvertible {
             case let .failure(error):
                 return "Failed loading image: \(error)"
             }
+
+        case .restoring_purchases:
+            return "Restoring purchases"
+
+        case .restored_purchases:
+            return "Restored purchases successfully with unlocked subscriptions"
+
+        case .restore_purchases_with_empty_result:
+            return "Restored purchases successfully with no subscriptions"
+
+        case .setting_restored_customer_info:
+            return "Setting restored customer info"
         }
     }
 

--- a/Tests/RevenueCatUITests/PaywallFooterTests.swift
+++ b/Tests/RevenueCatUITests/PaywallFooterTests.swift
@@ -64,6 +64,8 @@ class PaywallFooterTests: TestCase {
 
         Task {
             _ = try await Self.purchaseHandler.restorePurchases()
+            // Simulates what `RestorePurchasesButton` does after dismissing the alert.
+            Self.purchaseHandler.setRestored(TestData.customerInfo)
         }
 
         expect(customerInfo).toEventually(be(TestData.customerInfo))

--- a/Tests/RevenueCatUITests/PresentIfNeededTests.swift
+++ b/Tests/RevenueCatUITests/PresentIfNeededTests.swift
@@ -72,6 +72,8 @@ class PresentIfNeededTests: TestCase {
 
         Task {
             _ = try await Self.purchaseHandler.restorePurchases()
+            // Simulates what `RestorePurchasesButton` does after dismissing the alert.
+            Self.purchaseHandler.setRestored(TestData.customerInfo)
         }
 
         expect(customerInfo).toEventually(be(TestData.customerInfo))

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -159,6 +159,8 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         Task {
             _ = try await Self.purchaseHandler.restorePurchases()
+            // Simulates what `RestorePurchasesButton` does after dismissing the alert.
+            Self.purchaseHandler.setRestored(TestData.customerInfo)
         }
 
         expect(customerInfo).toEventually(be(TestData.customerInfo))

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -28,7 +28,6 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.purchaseResult).to(beNil())
         expect(handler.restoredCustomerInfo).to(beNil())
         expect(handler.purchased) == false
-        expect(handler.restored) == false
         expect(handler.actionInProgress) == false
     }
 
@@ -61,7 +60,12 @@ class PurchaseHandlerTests: TestCase {
 
         expect(result.info) === TestData.customerInfo
         expect(result.success) == false
-        expect(handler.restored) == true
+        expect(handler.restoredCustomerInfo).to(beNil())
+        expect(handler.purchaseResult).to(beNil())
+        expect(handler.actionInProgress) == false
+
+        handler.setRestored(TestData.customerInfo)
+
         expect(handler.restoredCustomerInfo) === TestData.customerInfo
         expect(handler.purchaseResult).to(beNil())
         expect(handler.actionInProgress) == false

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -132,6 +132,9 @@ struct AppContentView: View {
         #endif
         .sheet(isPresented: self.$showingDefaultPaywall) {
             PaywallView(displayCloseButton: Configuration.defaultDisplayCloseButton)
+                .onRestoreCompleted { _ in
+                    self.showingDefaultPaywall = false
+                }
         }
         .task(id: self.configuration.currentMode) {
             if Purchases.isConfigured {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
@@ -123,6 +123,9 @@ struct OfferingsList: View {
         }
         .sheet(item: self.$presentedPaywall) { paywall in
             PaywallPresenter(offering: paywall.offering, mode: paywall.mode)
+                .onRestoreCompleted { _ in
+                    self.presentedPaywall = nil
+                }
         }
     }
 


### PR DESCRIPTION
Fixes #3617.

This allows users to handle that notification only once the user has dismissed the "purchases restored" dialog.