### PR TITLE
`Paywalls`: new `.onPurchaseFailure` and `.onRestoreFailure` modifiers

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -305,6 +305,10 @@ struct LoadedOfferingPaywallView: View {
                         value: .init(data: self.purchaseHandler.purchaseResult))
             .preference(key: RestoredCustomerInfoPreferenceKey.self,
                         value: self.purchaseHandler.restoredCustomerInfo)
+            .preference(key: PurchaseErrorPreferenceKey.self,
+                        value: self.purchaseHandler.purchaseError as NSError?)
+            .preference(key: RestoreErrorPreferenceKey.self,
+                        value: self.purchaseHandler.restoreError as NSError?)
     }
 
     @ViewBuilder

--- a/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
@@ -46,6 +46,19 @@ extension PurchaseHandler {
             } restore: { $0 }
     }
 
+    /// - Returns: `PurchaseHandler` that throws `error` for purchases and restores.
+    static func failing(_ error: Error) -> Self {
+        return self.init(
+            purchases: MockPurchases { _ in
+                throw error
+            } restorePurchases: {
+                throw error
+            } trackEvent: { event in
+                Logger.debug("Tracking event: \(event)")
+            }
+        )
+    }
+
     /// Creates a copy of this `PurchaseHandler` with a delay.
     func with(delay seconds: TimeInterval) -> Self {
         return self.map { purchaseBlock in {

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -186,6 +186,11 @@ public protocol PaywallViewControllerDelegate: AnyObject {
     @objc(paywallViewControllerDidCancelPurchase:)
     optional func paywallViewControllerDidCancelPurchase(_ controller: PaywallViewController)
 
+    /// Notifies that the purchase operation has failed in a ``PaywallViewController``.
+    @objc(paywallViewController:didFailPurchasingWithError:)
+    optional func paywallViewController(_ controller: PaywallViewController,
+                                        didFailPurchasingWith error: NSError)
+
     /// Notifies that the restore operation has completed in a ``PaywallViewController``.
     ///
     /// - Warning: Receiving a ``CustomerInfo``does not imply that the user has any entitlements,
@@ -194,6 +199,11 @@ public protocol PaywallViewControllerDelegate: AnyObject {
     @objc(paywallViewController:didFinishRestoringWithCustomerInfo:)
     optional func paywallViewController(_ controller: PaywallViewController,
                                         didFinishRestoringWith customerInfo: CustomerInfo)
+
+    /// Notifies that the restore operation has failed in a ``PaywallViewController``.
+    @objc(paywallViewController:didFailRestoringWithError:)
+    optional func paywallViewController(_ controller: PaywallViewController,
+                                        didFailRestoringWith error: NSError)
 
     /// Notifies that the ``PaywallViewController`` was dismissed.
     @objc(paywallViewControllerWasDismissed:)
@@ -228,6 +238,14 @@ private extension PaywallViewController {
                 guard let self else { return }
                 self.delegate?.paywallViewController?(self, didFinishRestoringWith: customerInfo)
             },
+            purchaseFailure: { [weak self] error in
+                guard let self else { return }
+                self.delegate?.paywallViewController?(self, didFailPurchasingWith: error)
+            },
+            restoreFailure: { [weak self] error in
+                guard let self else { return }
+                self.delegate?.paywallViewController?(self, didFailRestoringWith: error)
+            },
             onSizeChange: { [weak self] in
                 guard let self else { return }
                 self.delegate?.paywallViewController?(self, didChangeSizeTo: $0)
@@ -254,6 +272,8 @@ private struct PaywallContainerView: View {
     let purchaseCompleted: PurchaseCompletedHandler
     let purchaseCancelled: PurchaseCancelledHandler
     let restoreCompleted: PurchaseOrRestoreCompletedHandler
+    let purchaseFailure: PurchaseFailureHandler
+    let restoreFailure: PurchaseFailureHandler
     let onSizeChange: (CGSize) -> Void
 
     var body: some View {
@@ -261,6 +281,8 @@ private struct PaywallContainerView: View {
             .onPurchaseCompleted(self.purchaseCompleted)
             .onPurchaseCancelled(self.purchaseCancelled)
             .onRestoreCompleted(self.restoreCompleted)
+            .onPurchaseFailure(self.purchaseFailure)
+            .onRestoreFailure(self.restoreFailure)
             .onSizeChange(self.onSizeChange)
 
     }

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -48,6 +48,8 @@ extension View {
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        purchaseFailure: PurchaseFailureHandler? = nil,
+        restoreFailure: PurchaseFailureHandler? = nil,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
         return self.presentPaywallIfNeeded(
@@ -62,6 +64,8 @@ extension View {
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
             restoreCompleted: restoreCompleted,
+            purchaseFailure: purchaseFailure,
+            restoreFailure: restoreFailure,
             onDismiss: onDismiss
         )
     }
@@ -80,6 +84,10 @@ extension View {
     ///     } restoreCompleted: { customerInfo in
     ///         // If `entitlement_identifier` is active, paywall will dismiss automatically.
     ///         print("Purchases restored")
+    ///     } purchaseFailure: { error in
+    ///         print("Error purchasing: \(error)")
+    ///     } restoreFailure: { error in
+    ///         print("Error restoring purchases: \(error)")
     ///     } onDismiss: {
     ///         print("Paywall was dismissed either manually or automatically after a purchase.")
     ///     }
@@ -99,6 +107,8 @@ extension View {
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        purchaseFailure: PurchaseFailureHandler? = nil,
+        restoreFailure: PurchaseFailureHandler? = nil,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
         return self.presentPaywallIfNeeded(
@@ -108,6 +118,8 @@ extension View {
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
             restoreCompleted: restoreCompleted,
+            purchaseFailure: purchaseFailure,
+            restoreFailure: restoreFailure,
             onDismiss: onDismiss,
             customerInfoFetcher: {
                 guard Purchases.isConfigured else {
@@ -129,6 +141,8 @@ extension View {
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        purchaseFailure: PurchaseFailureHandler? = nil,
+        restoreFailure: PurchaseFailureHandler? = nil,
         onDismiss: (() -> Void)? = nil,
         customerInfoFetcher: @escaping CustomerInfoFetcher
     ) -> some View {
@@ -138,6 +152,8 @@ extension View {
                 purchaseCompleted: purchaseCompleted,
                 purchaseCancelled: purchaseCancelled,
                 restoreCompleted: restoreCompleted,
+                purchaseFailure: purchaseFailure,
+                restoreFailure: restoreFailure,
                 onDismiss: onDismiss,
                 content: .optionalOffering(offering),
                 fontProvider: fonts,
@@ -163,6 +179,8 @@ private struct PresentingPaywallModifier: ViewModifier {
     var purchaseCompleted: PurchaseOrRestoreCompletedHandler?
     var purchaseCancelled: PurchaseCancelledHandler?
     var restoreCompleted: PurchaseOrRestoreCompletedHandler?
+    var purchaseFailure: PurchaseFailureHandler?
+    var restoreFailure: PurchaseFailureHandler?
     var onDismiss: (() -> Void)?
 
     var content: PaywallViewConfiguration.Content
@@ -176,6 +194,8 @@ private struct PresentingPaywallModifier: ViewModifier {
         purchaseCompleted: PurchaseOrRestoreCompletedHandler?,
         purchaseCancelled: PurchaseCancelledHandler?,
         restoreCompleted: PurchaseOrRestoreCompletedHandler?,
+        purchaseFailure: PurchaseFailureHandler?,
+        restoreFailure: PurchaseFailureHandler?,
         onDismiss: (() -> Void)?,
         content: PaywallViewConfiguration.Content,
         fontProvider: PaywallFontProvider,
@@ -187,6 +207,8 @@ private struct PresentingPaywallModifier: ViewModifier {
         self.purchaseCompleted = purchaseCompleted
         self.purchaseCancelled = purchaseCancelled
         self.restoreCompleted = restoreCompleted
+        self.purchaseFailure = purchaseFailure
+        self.restoreFailure = restoreFailure
         self.onDismiss = onDismiss
         self.content = content
         self.fontProvider = fontProvider
@@ -226,6 +248,12 @@ private struct PresentingPaywallModifier: ViewModifier {
                     if !self.shouldDisplay(customerInfo) {
                         self.close()
                     }
+                }
+                .onPurchaseFailure {
+                    self.purchaseFailure?($0)
+                }
+                .onRestoreFailure {
+                    self.restoreFailure?($0)
                 }
                 .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
             }

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -33,7 +33,9 @@ extension View {
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
-        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil
+        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        purchaseFailure: PurchaseFailureHandler? = nil,
+        restoreFailure: PurchaseFailureHandler? = nil
     ) -> some View {
         return self.paywallFooter(
             offering: nil,
@@ -42,7 +44,9 @@ extension View {
             fonts: fonts,
             introEligibility: nil,
             purchaseCompleted: purchaseCompleted,
-            restoreCompleted: restoreCompleted
+            restoreCompleted: restoreCompleted,
+            purchaseFailure: purchaseFailure,
+            restoreFailure: restoreFailure
         )
     }
 
@@ -61,7 +65,9 @@ extension View {
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
-        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil
+        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        purchaseFailure: PurchaseFailureHandler? = nil,
+        restoreFailure: PurchaseFailureHandler? = nil
     ) -> some View {
         return self.paywallFooter(
             offering: offering,
@@ -70,7 +76,9 @@ extension View {
             fonts: fonts,
             introEligibility: nil,
             purchaseCompleted: purchaseCompleted,
-            restoreCompleted: restoreCompleted
+            restoreCompleted: restoreCompleted,
+            purchaseFailure: purchaseFailure,
+            restoreFailure: restoreFailure
         )
     }
 
@@ -82,7 +90,9 @@ extension View {
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         purchaseHandler: PurchaseHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
-        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil
+        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        purchaseFailure: PurchaseFailureHandler? = nil,
+        restoreFailure: PurchaseFailureHandler? = nil
     ) -> some View {
         return self
             .modifier(
@@ -97,7 +107,9 @@ extension View {
                         purchaseHandler: purchaseHandler
                     ),
                     purchaseCompleted: purchaseCompleted,
-                    restoreCompleted: restoreCompleted
+                    restoreCompleted: restoreCompleted,
+                    purchaseFailure: purchaseFailure,
+                    restoreFailure: restoreFailure
                 )
             )
     }
@@ -109,6 +121,8 @@ private struct PresentingPaywallFooterModifier: ViewModifier {
     let configuration: PaywallViewConfiguration
     let purchaseCompleted: PurchaseOrRestoreCompletedHandler?
     let restoreCompleted: PurchaseOrRestoreCompletedHandler?
+    let purchaseFailure: PurchaseFailureHandler?
+    let restoreFailure: PurchaseFailureHandler?
 
     func body(content: Content) -> some View {
         content
@@ -119,6 +133,12 @@ private struct PresentingPaywallFooterModifier: ViewModifier {
                 }
                 .onRestoreCompleted {
                     self.restoreCompleted?($0)
+                }
+                .onPurchaseFailure {
+                    self.purchaseFailure?($0)
+                }
+                .onRestoreFailure {
+                    self.restoreFailure?($0)
                 }
         }
     }

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -58,7 +58,13 @@ final class Delegate: PaywallViewControllerDelegate {
     func paywallViewControllerDidCancelPurchase(_ controller: PaywallViewController) {}
 
     func paywallViewController(_ controller: PaywallViewController,
+                               didFailPurchasingWith error: NSError) {}
+
+    func paywallViewController(_ controller: PaywallViewController,
                                didFinishRestoringWith customerInfo: CustomerInfo) {}
+
+    func paywallViewController(_ controller: PaywallViewController,
+                               didFailRestoringWith error: NSError) {}
 
     func paywallViewControllerWasDismissed(_ controller: PaywallViewController) {}
 

--- a/Tests/RevenueCatUITests/PaywallFooterTests.swift
+++ b/Tests/RevenueCatUITests/PaywallFooterTests.swift
@@ -49,6 +49,26 @@ class PaywallFooterTests: TestCase {
         expect(customerInfo).toEventually(be(TestData.customerInfo))
     }
 
+    func testPresentWithPurchaseFailureHandler() throws {
+        var error: NSError?
+
+        try Text("")
+            .paywallFooter(
+                offering: Self.offering,
+                customerInfo: TestData.customerInfo,
+                introEligibility: .producing(eligibility: .eligible),
+                purchaseHandler: Self.failingHandler,
+                purchaseFailure: { error = $0 }
+            )
+            .addToHierarchy()
+
+        Task {
+            _ = try? await Self.failingHandler.purchase(package: Self.package)
+        }
+
+        expect(error).toEventually(matchError(Self.failureError))
+    }
+
     func testPresentWithRestoreHandler() throws {
         var customerInfo: CustomerInfo?
 
@@ -71,9 +91,31 @@ class PaywallFooterTests: TestCase {
         expect(customerInfo).toEventually(be(TestData.customerInfo))
     }
 
+    func testPresentWithRestoreFailureHandler() throws {
+        var error: NSError?
+
+        try Text("")
+            .paywallFooter(
+                offering: Self.offering,
+                customerInfo: TestData.customerInfo,
+                introEligibility: .producing(eligibility: .eligible),
+                purchaseHandler: Self.failingHandler,
+                restoreFailure: { error = $0 }
+            )
+            .addToHierarchy()
+
+        Task {
+            _ = try? await Self.failingHandler.restorePurchases()
+        }
+
+        expect(error).toEventually(matchError(Self.failureError))
+    }
+
     private static let purchaseHandler: PurchaseHandler = .mock()
+    private static let failingHandler: PurchaseHandler = .failing(failureError)
     private static let offering = TestData.offeringWithNoIntroOffer
     private static let package = TestData.annualPackage
+    private static let failureError: Error = ErrorCode.storeProblemError
 
 }
 

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -29,6 +29,8 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.restoredCustomerInfo).to(beNil())
         expect(handler.purchased) == false
         expect(handler.actionInProgress) == false
+        expect(handler.purchaseError).to(beNil())
+        expect(handler.restoreError).to(beNil())
     }
 
     func testPurchaseSetsCustomerInfo() async throws {
@@ -53,9 +55,27 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.actionInProgress) == false
     }
 
+    func testFailingPurchase() async throws {
+        let error: ErrorCode = .storeProblemError
+
+        let handler: PurchaseHandler = .failing(error)
+
+        do {
+            _ = try await handler.purchase(package: TestData.packageWithIntroOffer)
+            fail("Expected error")
+        } catch let thrownError {
+            expect(thrownError).to(matchError(error))
+        }
+
+        expect(handler.purchaseResult).to(beNil())
+        expect(handler.purchased) == false
+        expect(handler.actionInProgress) == false
+        expect(handler.purchaseError).to(matchError(error))
+        expect(handler.restoreError).to(beNil())
+    }
+
     func testRestorePurchases() async throws {
         let handler: PurchaseHandler = .mock()
-
         let result = try await handler.restorePurchases()
 
         expect(result.info) === TestData.customerInfo
@@ -85,6 +105,23 @@ class PurchaseHandlerTests: TestCase {
         let result = try await handler.restorePurchases()
         expect(result.info) === Self.customerInfoWithNonSubscriptions
         expect(result.success) == true
+    }
+
+    func testFailingRestore() async throws {
+        let error: ErrorCode = .storeProblemError
+        let handler: PurchaseHandler = .failing(error)
+
+        do {
+            _ = try await handler.restorePurchases()
+            fail("Expected error")
+        } catch let thrownError {
+            expect(thrownError).to(matchError(error))
+        }
+        expect(handler.purchaseResult).to(beNil())
+        expect(handler.purchased) == false
+        expect(handler.actionInProgress) == false
+        expect(handler.restoreError).to(matchError(error))
+        expect(handler.purchaseError).to(beNil())
     }
 
     func testCloseEventIsTrackedOnlyAfterImpressionAndOnlyOnce() async throws {


### PR DESCRIPTION
This allows detecting failures in purchases and restores.

This API is available in:
- `.presentPaywallIfNeeded`
- `.paywallFooter`
- `PaywallView()`
- `PaywallViewControllerDelegate`
