### PR TITLE
`PaywallViewController`: expose `fontName` for `CustomFontProvider`

### DIFF
--- a/RevenueCatUI/UIKit/PaywallFooterViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallFooterViewController.swift
@@ -46,7 +46,7 @@ public final class PaywallFooterViewController: PaywallViewController {
     }
     
     @objc
-    public init(offeringIdentifier: String, fontName: String){
+    public init(offeringIdentifier: String, fontName: String) {
         super.init(content: .offeringIdentifier(offeringIdentifier),
                    fonts: CustomPaywallFontProvider(fontName: fontName),
                    displayCloseButton: false)

--- a/RevenueCatUI/UIKit/PaywallFooterViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallFooterViewController.swift
@@ -44,6 +44,13 @@ public final class PaywallFooterViewController: PaywallViewController {
                    fonts: DefaultPaywallFontProvider(),
                    displayCloseButton: false)
     }
+    
+    @objc
+    public init(offeringIdentifier: String, fontName: String){
+        super.init(content: .offeringIdentifier(offeringIdentifier),
+                   fonts: CustomPaywallFontProvider(fontName: fontName),
+                   displayCloseButton: false)
+    }
 
     @available(*, unavailable)
     override init(

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -128,6 +128,12 @@ public class PaywallViewController: UIViewController {
     public func update(with offeringIdentifier: String) {
         self.configuration.content = .offeringIdentifier(offeringIdentifier)
     }
+    
+    /// - Warning: For internal use only
+    @objc(updateFontWithFontName:)
+    public func updateFont(with fontName: String){
+        self.configuration.fonts = CustomPaywallFontProvider(fontName: fontName)
+    }
 
     // MARK: - Internal
 

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -31,6 +31,7 @@ func paywallViewControllerAPI(_ delegate: Delegate, _ offering: Offering?) {
     let _: UIViewController = PaywallViewController(offeringIdentifier: "offering",
                                                     fonts: fontProvider,
                                                     displayCloseButton: true)
+    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering", fontName:"Papyrus")
 
     controller.update(with: offering!)
     controller.update(with: "offering_identifier")
@@ -43,6 +44,7 @@ func paywallFooterViewControllerAPI(_ delegate: Delegate, _ offering: Offering?)
 
     let _: UIViewController = PaywallFooterViewController(offering: offering)
     let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering")
+    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering", fontName:"Papyrus")
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -45,7 +45,7 @@ func paywallFooterViewControllerAPI(_ delegate: Delegate, _ offering: Offering?)
 
     let _: UIViewController = PaywallFooterViewController(offering: offering)
     let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering")
-    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering", fontName:"Papyrus")
+    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering", fontName: "Papyrus")
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -35,6 +35,7 @@ func paywallViewControllerAPI(_ delegate: Delegate, _ offering: Offering?) {
 
     controller.update(with: offering!)
     controller.update(with: "offering_identifier")
+    controller.updateFont(with: "Papyrus")
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)


### PR DESCRIPTION
### Checklist
- [❌ ] If applicable, unit tests
- [✅ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
This is the ios counter part to https://github.com/RevenueCat/purchases-android/pull/1589
This exposes the fontName as a parameter and sets CustomFontProvider. 

### Description
Created updateFontWithFontName for PaywallViewController
Created init function for offerIdentifier and fontName

<img width="450" alt="301765252-95f61abb-10a1-4903-a2ef-12572ae3eaff" src="https://github.com/RevenueCat/purchases-ios/assets/6516487/56061916-0391-447a-ae74-57f2dddcf7a7">
