### PR TITLE
`Paywalls`: new `.onPurchaseStarted` modifier

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -301,6 +301,8 @@ struct LoadedOfferingPaywallView: View {
     var body: some View {
         // Note: preferences need to be applied after `.toolbar` call
         self.content
+            .preference(key: PurchasedInProgressPreferenceKey.self,
+                        value: self.purchaseHandler.purchaseInProgress)
             .preference(key: PurchasedResultPreferenceKey.self,
                         value: .init(data: self.purchaseHandler.purchaseResult))
             .preference(key: RestoredCustomerInfoPreferenceKey.self,

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -32,6 +32,7 @@ extension View {
     public func paywallFooter(
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseFailure: PurchaseFailureHandler? = nil,
@@ -43,6 +44,7 @@ extension View {
             condensed: condensed,
             fonts: fonts,
             introEligibility: nil,
+            purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             restoreCompleted: restoreCompleted,
             purchaseFailure: purchaseFailure,
@@ -64,6 +66,7 @@ extension View {
         offering: Offering,
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseFailure: PurchaseFailureHandler? = nil,
@@ -75,6 +78,7 @@ extension View {
             condensed: condensed,
             fonts: fonts,
             introEligibility: nil,
+            purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             restoreCompleted: restoreCompleted,
             purchaseFailure: purchaseFailure,
@@ -89,6 +93,7 @@ extension View {
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         purchaseHandler: PurchaseHandler? = nil,
+        purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseFailure: PurchaseFailureHandler? = nil,
@@ -106,6 +111,7 @@ extension View {
                         introEligibility: introEligibility,
                         purchaseHandler: purchaseHandler
                     ),
+                    purchaseStarted: purchaseStarted,
                     purchaseCompleted: purchaseCompleted,
                     restoreCompleted: restoreCompleted,
                     purchaseFailure: purchaseFailure,
@@ -119,6 +125,7 @@ extension View {
 private struct PresentingPaywallFooterModifier: ViewModifier {
 
     let configuration: PaywallViewConfiguration
+    let purchaseStarted: PurchaseStartedHandler?
     let purchaseCompleted: PurchaseOrRestoreCompletedHandler?
     let restoreCompleted: PurchaseOrRestoreCompletedHandler?
     let purchaseFailure: PurchaseFailureHandler?
@@ -128,18 +135,21 @@ private struct PresentingPaywallFooterModifier: ViewModifier {
         content
             .safeAreaInset(edge: .bottom) {
                 PaywallView(configuration: self.configuration)
-                .onPurchaseCompleted {
-                    self.purchaseCompleted?($0)
-                }
-                .onRestoreCompleted {
-                    self.restoreCompleted?($0)
-                }
-                .onPurchaseFailure {
-                    self.purchaseFailure?($0)
-                }
-                .onRestoreFailure {
-                    self.restoreFailure?($0)
-                }
+                    .onPurchaseStarted {
+                        self.purchaseStarted?()
+                    }
+                    .onPurchaseCompleted {
+                        self.purchaseCompleted?($0)
+                    }
+                    .onRestoreCompleted {
+                        self.restoreCompleted?($0)
+                    }
+                    .onPurchaseFailure {
+                        self.purchaseFailure?($0)
+                    }
+                    .onRestoreFailure {
+                        self.restoreFailure?($0)
+                    }
         }
     }
 }

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -15,6 +15,7 @@ struct App: View {
     private var offering: Offering
     private var fonts: PaywallFontProvider
     private var purchaseOrRestoreCompleted: PurchaseOrRestoreCompletedHandler = { (_: CustomerInfo) in }
+    private var purchaseStarted: PurchaseStartedHandler = { }
     private var purchaseCompleted: PurchaseCompletedHandler = { (_: StoreTransaction?, _: CustomerInfo) in }
     private var purchaseCancelled: PurchaseCancelledHandler = { () in }
     private var failureHandler: PurchaseFailureHandler = { (_: NSError) in }
@@ -67,6 +68,7 @@ struct App: View {
                                     restoreCompleted: self.purchaseOrRestoreCompleted,
                                     onDismiss: self.paywallDismissed)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", offering: self.offering, fonts: self.fonts,
+                                    purchaseStarted: self.purchaseStarted,
                                     purchaseCompleted: self.purchaseOrRestoreCompleted,
                                     purchaseCancelled: self.purchaseCancelled,
                                     restoreCompleted: self.purchaseOrRestoreCompleted,
@@ -118,6 +120,8 @@ struct App: View {
             }
             .presentPaywallIfNeeded(offering: self.offering, fonts: self.fonts) { (_: CustomerInfo) in
                 false
+            } purchaseStarted: {
+                self.purchaseStarted()
             } purchaseCompleted: {
                 self.purchaseOrRestoreCompleted($0)
             } purchaseCancelled: {
@@ -167,6 +171,7 @@ struct App: View {
                            purchaseCompleted: self.purchaseOrRestoreCompleted,
                            restoreCompleted: self.purchaseOrRestoreCompleted)
             .paywallFooter(offering: offering, fonts: self.fonts,
+                           purchaseStarted: self.purchaseStarted,
                            purchaseCompleted: self.purchaseOrRestoreCompleted,
                            restoreCompleted: self.purchaseOrRestoreCompleted,
                            purchaseFailure: self.failureHandler,
@@ -176,6 +181,7 @@ struct App: View {
     @ViewBuilder
     var checkOnPurchaseAndRestoreCompleted: some View {
         Text("")
+            .onPurchaseStarted(self.purchaseStarted)
             .onPurchaseCompleted(self.purchaseOrRestoreCompleted)
             .onPurchaseCompleted(self.purchaseCompleted)
             .onPurchaseCancelled(self.purchaseCancelled)

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -48,6 +48,8 @@ func paywallFooterViewControllerAPI(_ delegate: Delegate, _ offering: Offering?)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 final class Delegate: PaywallViewControllerDelegate {
 
+    func paywallViewControllerDidStartPurchase(_ controller: PaywallViewController) {}
+
     func paywallViewController(_ controller: PaywallViewController,
                                didFinishPurchasingWith customerInfo: CustomerInfo) {}
 

--- a/Tests/RevenueCatUITests/Helpers/AsyncTestHelpers.swift
+++ b/Tests/RevenueCatUITests/Helpers/AsyncTestHelpers.swift
@@ -1,0 +1,1 @@
+../../UnitTests/TestHelpers/AsyncTestHelpers.swift

--- a/Tests/RevenueCatUITests/PaywallFooterTests.swift
+++ b/Tests/RevenueCatUITests/PaywallFooterTests.swift
@@ -29,6 +29,26 @@ class PaywallFooterTests: TestCase {
         try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
     }
 
+    func testPresentWithPurchaseStarted() throws {
+        var started = false
+
+        try Text("")
+            .paywallFooter(
+                offering: Self.offering,
+                customerInfo: TestData.customerInfo,
+                introEligibility: .producing(eligibility: .eligible),
+                purchaseHandler: Self.purchaseHandler,
+                purchaseStarted: { started = true }
+            )
+            .addToHierarchy()
+
+        Task {
+            _ = try await Self.purchaseHandler.purchase(package: Self.package)
+        }
+
+        expect(started).toEventually(beTrue())
+    }
+
     func testPresentWithPurchaseHandler() throws {
         var customerInfo: CustomerInfo?
 

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -23,6 +23,27 @@ import XCTest
 @MainActor
 class PurchaseCompletedHandlerTests: TestCase {
 
+    func testOnPurchaseStarted() throws {
+        var started = false
+
+        try PaywallView(
+            offering: Self.offering.withLocalImages,
+            customerInfo: TestData.customerInfo,
+            introEligibility: .producing(eligibility: .eligible),
+            purchaseHandler: Self.purchaseHandler
+        )
+            .onPurchaseStarted {
+                started = true
+            }
+            .addToHierarchy()
+
+        Task {
+            _ = try await Self.purchaseHandler.purchase(package: Self.package)
+        }
+
+        expect(started).toEventually(beTrue())
+    }
+
     func testOnPurchaseCompletedWithCancellation() throws {
         let handler: PurchaseHandler = .cancelling()
 

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -28,6 +28,7 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.purchaseResult).to(beNil())
         expect(handler.restoredCustomerInfo).to(beNil())
         expect(handler.purchased) == false
+        expect(handler.purchaseInProgress) == false
         expect(handler.actionInProgress) == false
         expect(handler.purchaseError).to(beNil())
         expect(handler.restoreError).to(beNil())
@@ -42,6 +43,7 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.purchaseResult?.userCancelled) == false
         expect(handler.restoredCustomerInfo).to(beNil())
         expect(handler.purchased) == true
+        expect(handler.purchaseInProgress) == false
         expect(handler.actionInProgress) == false
     }
 
@@ -52,6 +54,7 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.purchaseResult?.userCancelled) == true
         expect(handler.purchaseResult?.customerInfo) === TestData.customerInfo
         expect(handler.purchased) == false
+        expect(handler.purchaseInProgress) == false
         expect(handler.actionInProgress) == false
     }
 
@@ -69,9 +72,63 @@ class PurchaseHandlerTests: TestCase {
 
         expect(handler.purchaseResult).to(beNil())
         expect(handler.purchased) == false
+        expect(handler.purchaseInProgress) == false
         expect(handler.actionInProgress) == false
         expect(handler.purchaseError).to(matchError(error))
         expect(handler.restoreError).to(beNil())
+    }
+
+    func testInProgressPropertiesDuringPurchase() async throws {
+        self.continueAfterFailure = false
+
+        let asyncHandler = AsyncPurchaseHandler()
+        let handler = asyncHandler.purchaseHandler!
+
+        let task = Task.detached {
+            _ = try await handler.purchase(package: TestData.packageWithIntroOffer)
+        }
+
+        try await asyncWait {
+            handler.actionInProgress && handler.purchaseInProgress
+        }
+
+        expect(handler.purchaseInProgress) == true
+        expect(handler.actionInProgress) == true
+
+        // Finish purchase
+        try asyncHandler.resume()
+
+        // Wait for purchase task to complete
+        _ = try await task.value
+
+        expect(handler.purchaseInProgress) == false
+        expect(handler.actionInProgress) == false
+    }
+
+    func testInProgressPropertiesDuringRestore() async throws {
+        self.continueAfterFailure = false
+
+        let asyncHandler = AsyncPurchaseHandler()
+        let handler = asyncHandler.purchaseHandler!
+
+        let task = Task.detached {
+            _ = try await handler.restorePurchases()
+        }
+
+        try await asyncWait {
+            handler.actionInProgress
+        }
+
+        expect(handler.actionInProgress) == true
+        expect(handler.purchaseInProgress) == false
+
+        // Finish rewstore
+        try asyncHandler.resume()
+
+        // Wait for restore task to complete
+        _ = try await task.value
+
+        expect(handler.actionInProgress) == false
     }
 
     func testRestorePurchases() async throws {
@@ -82,12 +139,14 @@ class PurchaseHandlerTests: TestCase {
         expect(result.success) == false
         expect(handler.restoredCustomerInfo).to(beNil())
         expect(handler.purchaseResult).to(beNil())
+        expect(handler.purchaseInProgress) == false
         expect(handler.actionInProgress) == false
 
         handler.setRestored(TestData.customerInfo)
 
         expect(handler.restoredCustomerInfo) === TestData.customerInfo
         expect(handler.purchaseResult).to(beNil())
+        expect(handler.purchaseInProgress) == false
         expect(handler.actionInProgress) == false
     }
 
@@ -119,6 +178,7 @@ class PurchaseHandlerTests: TestCase {
         }
         expect(handler.purchaseResult).to(beNil())
         expect(handler.purchased) == false
+        expect(handler.purchaseInProgress) == false
         expect(handler.actionInProgress) == false
         expect(handler.restoreError).to(matchError(error))
         expect(handler.purchaseError).to(beNil())
@@ -147,6 +207,50 @@ class PurchaseHandlerTests: TestCase {
         expect(result3) == false
 
     }
+}
+
+// MARK: - Private
+
+/// `PurchaseHandler` decorator that allows controlling when purchases / restores finish.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private final class AsyncPurchaseHandler {
+
+    var continuation: CheckedContinuation<Void, Never>?
+    private(set) var purchaseHandler: PurchaseHandler!
+
+    init() {
+        self.purchaseHandler = .init(
+            purchases: MockPurchases { [weak instance = self] _ in
+                let instance = try XCTUnwrap(instance)
+
+                await instance.createAndWaitForContinuation()
+
+                return (
+                    transaction: nil,
+                    customerInfo: TestData.customerInfo,
+                    userCancelled: false
+                )
+            } restorePurchases: { [weak instance = self] in
+                let instance = try XCTUnwrap(instance)
+                await instance.createAndWaitForContinuation()
+
+                return TestData.customerInfo
+            } trackEvent: { event in
+                Logger.debug("Tracking event: \(event)")
+            }
+        )
+    }
+
+    func resume() throws {
+        try XCTUnwrap(self.continuation).resume(returning: ())
+     }
+
+    private func createAndWaitForContinuation() async {
+        await withCheckedContinuation { [weak self] continuation in
+            self?.continuation = continuation
+        }
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
@@ -22,6 +22,9 @@ struct UpsellView: View {
         .padding()
         .presentPaywallIfNeeded(
             requiredEntitlementIdentifier: Configuration.entitlement,
+            purchaseStarted: {
+                print("Purchase started")
+            },
             purchaseCompleted: { _ in
                 print("Purchase completed")
             },


### PR DESCRIPTION
Similar to #3622.

This API is available in:
- `PaywallView()`
- `.presentPaywallIfNeeded`
- `.paywallFooter`
- `PaywallViewControllerDelegate`
