### PR TITLE
`PaywallViewController`: expose `fontName` for `CustomFontProvider` (by @Jjastiny)

### DIFF
--- a/RevenueCatUI/UIKit/PaywallFooterViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallFooterViewController.swift
@@ -44,7 +44,7 @@ public final class PaywallFooterViewController: PaywallViewController {
                    fonts: DefaultPaywallFontProvider(),
                    displayCloseButton: false)
     }
-    
+
     /// Initialize a `PaywallFooterViewController` with an `offeringIdentifier` and custom `fontName`.
     /// - Parameter fontName: a custom font name for this paywall. See ``CustomPaywallFontProvider``.
     @objc

--- a/RevenueCatUI/UIKit/PaywallFooterViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallFooterViewController.swift
@@ -45,6 +45,8 @@ public final class PaywallFooterViewController: PaywallViewController {
                    displayCloseButton: false)
     }
     
+    /// Initialize a `PaywallFooterViewController` with an `offeringIdentifier` and custom `fontName`
+    /// - Parameter fontName: a custom font name for this paywall. See ``CustomPaywallFontProvider``.
     @objc
     public init(offeringIdentifier: String, fontName: String) {
         super.init(content: .offeringIdentifier(offeringIdentifier),

--- a/RevenueCatUI/UIKit/PaywallFooterViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallFooterViewController.swift
@@ -45,7 +45,7 @@ public final class PaywallFooterViewController: PaywallViewController {
                    displayCloseButton: false)
     }
     
-    /// Initialize a `PaywallFooterViewController` with an `offeringIdentifier` and custom `fontName`
+    /// Initialize a `PaywallFooterViewController` with an `offeringIdentifier` and custom `fontName`.
     /// - Parameter fontName: a custom font name for this paywall. See ``CustomPaywallFontProvider``.
     @objc
     public init(offeringIdentifier: String, fontName: String) {

--- a/RevenueCatUI/UIKit/PaywallFooterViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallFooterViewController.swift
@@ -44,6 +44,13 @@ public final class PaywallFooterViewController: PaywallViewController {
                    fonts: DefaultPaywallFontProvider(),
                    displayCloseButton: false)
     }
+    
+    @objc
+    public init(offeringIdentifier: String, fontName: String) {
+        super.init(content: .offeringIdentifier(offeringIdentifier),
+                   fonts: CustomPaywallFontProvider(fontName: fontName),
+                   displayCloseButton: false)
+    }
 
     @available(*, unavailable)
     override init(

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -131,7 +131,7 @@ public class PaywallViewController: UIViewController {
     
     /// - Warning: For internal use only
     @objc(updateFontWithFontName:)
-    public func updateFont(with fontName: String){
+    public func updateFont(with fontName: String) {
         self.configuration.fonts = CustomPaywallFontProvider(fontName: fontName)
     }
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -128,6 +128,12 @@ public class PaywallViewController: UIViewController {
     public func update(with offeringIdentifier: String) {
         self.configuration.content = .offeringIdentifier(offeringIdentifier)
     }
+    
+    /// - Warning: For internal use only
+    @objc(updateFontWithFontName:)
+    public func updateFont(with fontName: String){
+        self.configuration.fonts = CustomPaywallFontProvider(fontName: fontName)
+    }
 
     // MARK: - Internal
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -128,7 +128,7 @@ public class PaywallViewController: UIViewController {
     public func update(with offeringIdentifier: String) {
         self.configuration.content = .offeringIdentifier(offeringIdentifier)
     }
-    
+
     /// - Warning: For internal use only
     @objc(updateFontWithFontName:)
     public func updateFont(with fontName: String) {

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -31,7 +31,7 @@ func paywallViewControllerAPI(_ delegate: Delegate, _ offering: Offering?) {
     let _: UIViewController = PaywallViewController(offeringIdentifier: "offering",
                                                     fonts: fontProvider,
                                                     displayCloseButton: true)
-    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering", fontName:"Papyrus")
+    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering", fontName: "Papyrus")
 
     controller.update(with: offering!)
     controller.update(with: "offering_identifier")

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -31,9 +31,11 @@ func paywallViewControllerAPI(_ delegate: Delegate, _ offering: Offering?) {
     let _: UIViewController = PaywallViewController(offeringIdentifier: "offering",
                                                     fonts: fontProvider,
                                                     displayCloseButton: true)
+    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering", fontName:"Papyrus")
 
     controller.update(with: offering!)
     controller.update(with: "offering_identifier")
+    controller.updateFont(with: "Papyrus")
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
@@ -43,6 +45,7 @@ func paywallFooterViewControllerAPI(_ delegate: Delegate, _ offering: Offering?)
 
     let _: UIViewController = PaywallFooterViewController(offering: offering)
     let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering")
+    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering", fontName: "Papyrus")
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)


### PR DESCRIPTION
Original PR: #3626.

This is the iOS counterpart to https://github.com/RevenueCat/purchases-android/pull/1589
This exposes the `fontName` as a parameter and sets `CustomFontProvider`. 

### Changes:
- Created `updateFontWithFontName` for `PaywallViewController`
- Created init function for `offerIdentifier` and `fontName`

<img width="450" alt="301765252-95f61abb-10a1-4903-a2ef-12572ae3eaff" src="https://github.com/RevenueCat/purchases-ios/assets/6516487/56061916-0391-447a-ae74-57f2dddcf7a7">
