### PR TITLE
`Paywalls`: add 4 new variables

### DIFF
--- a/RevenueCatUI/Data/Localization.swift
+++ b/RevenueCatUI/Data/Localization.swift
@@ -35,6 +35,18 @@ enum Localization {
         ?? options.last!
     }
 
+    /// - Returns: an appropriate unabbreviated description for the given `unit`.
+    static func unitLocalizedString(
+        for period: SubscriptionPeriod,
+        locale: Locale = .current
+    ) -> String {
+        return self.unitLocalizedString(
+            for: period,
+            styles: Self.preferedFullStyles(for: locale),
+            locale: locale
+        ).first!
+    }
+
     static func localizedDuration(
         for subscriptionPeriod: SubscriptionPeriod,
         locale: Locale = .current
@@ -170,6 +182,12 @@ private extension Localization {
         case "de": return [.full]
         default: return [.full, .brief, .abbreviated]
         }
+    }
+
+    static func preferedFullStyles(for locale: Locale) -> [DateComponentsFormatter.UnitsStyle] {
+        // `.full` for all locales, but this allows customizing it
+        // if needed, like `preferedAbbreviationStyles`.
+        return [.full]
     }
 
     /// The order in which unit abbreviations are preferred.

--- a/RevenueCatUI/Data/Variables.swift
+++ b/RevenueCatUI/Data/Variables.swift
@@ -38,12 +38,16 @@ protocol VariableDataProvider {
     var productName: String { get }
 
     func periodNameOrIdentifier(_ locale: Locale) -> String
+    func periodNameAbbreviation(_ locale: Locale) -> String?
+    func periodLength(_ locale: Locale) -> String?
     func subscriptionDuration(_ locale: Locale) -> String?
     func normalizedSubscriptionDuration(_ locale: Locale) -> String?
     func introductoryOfferDuration(_ locale: Locale) -> String?
 
     func localizedPricePerPeriod(_ locale: Locale) -> String
+    func localizedPricePerPeriodFull(_ locale: Locale) -> String
     func localizedPriceAndPerMonth(_ locale: Locale) -> String
+    func localizedPriceAndPerMonthFull(_ locale: Locale) -> String
     func localizedRelativeDiscount(_ discount: Double?, _ locale: Locale) -> String?
 
 }
@@ -96,9 +100,15 @@ enum VariableHandler {
         case "app_name": return { (provider, _, _) in provider.applicationName }
         case "price": return { (provider, _, _) in provider.localizedPrice }
         case "price_per_period": return { (provider, _, locale) in provider.localizedPricePerPeriod(locale) }
+        case "price_per_period_full": return { (provider, _, locale) in provider.localizedPricePerPeriodFull(locale) }
         case "total_price_and_per_month": return { (provider, _, locale) in provider.localizedPriceAndPerMonth(locale) }
+        case "total_price_and_per_month_full": return { (provider, _, locale) in
+            provider.localizedPriceAndPerMonthFull(locale)
+        }
         case "product_name": return { (provider, _, _) in provider.productName }
         case "sub_period": return { (provider, _, locale) in provider.periodNameOrIdentifier(locale) }
+        case "sub_period_length": return { (provider, _, locale) in provider.periodLength(locale) }
+        case "sub_period_abbreviated": return { (provider, _, locale) in provider.periodNameAbbreviation(locale) }
         case "sub_price_per_month": return { (provider, _, _) in provider.localizedPricePerMonth }
         case "sub_price_per_week": return { (provider, _, _) in provider.localizedPricePerWeek }
         case "sub_duration": return { (provider, _, locale) in provider.subscriptionDuration(locale) }

--- a/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
+++ b/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
@@ -54,6 +54,22 @@ extension Package: VariableDataProvider {
                                       locale: locale) ?? self.identifier
     }
 
+    func periodNameAbbreviation(_ locale: Locale) -> String? {
+        guard let period = self.storeProduct.subscriptionPeriod else {
+            return nil
+        }
+
+        return Localization.abbreviatedUnitLocalizedString(for: period, locale: locale)
+    }
+
+    func periodLength(_ locale: Locale) -> String? {
+        guard let period = self.storeProduct.subscriptionPeriod else {
+            return nil
+        }
+
+        return Localization.unitLocalizedString(for: period, locale: locale)
+    }
+
     func subscriptionDuration(_ locale: Locale) -> String? {
         guard let period = self.storeProduct.subscriptionPeriod else {
             return self.periodNameOrIdentifier(locale)
@@ -83,6 +99,15 @@ extension Package: VariableDataProvider {
         return "\(self.localizedPrice)/\(unit)"
     }
 
+    func localizedPricePerPeriodFull(_ locale: Locale) -> String {
+        guard let period = self.storeProduct.subscriptionPeriod else {
+            return self.localizedPrice
+        }
+
+        let unit = Localization.unitLocalizedString(for: period, locale: locale)
+        return "\(self.localizedPrice)/\(unit)"
+    }
+
     func localizedPriceAndPerMonth(_ locale: Locale) -> String {
         if !self.isSubscription || self.isMonthly {
             return self.localizedPricePerPeriod(locale)
@@ -90,6 +115,16 @@ extension Package: VariableDataProvider {
             let unit = Localization.abbreviatedUnitLocalizedString(for: .init(value: 1, unit: .month),
                                                                    locale: locale)
             return "\(self.localizedPricePerPeriod(locale)) (\(self.localizedPricePerMonth)/\(unit))"
+        }
+    }
+
+    func localizedPriceAndPerMonthFull(_ locale: Locale) -> String {
+        if !self.isSubscription || self.isMonthly {
+            return self.localizedPricePerPeriodFull(locale)
+        } else {
+            let unit = Localization.unitLocalizedString(for: .init(value: 1, unit: .month),
+                                                        locale: locale)
+            return "\(self.localizedPricePerPeriodFull(locale)) (\(self.localizedPricePerMonth)/\(unit))"
         }
     }
 

--- a/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
@@ -83,6 +83,24 @@ class PackageVariablesTests: TestCase {
         == "٣.٩٩ درهم"
     }
 
+    func testEnglishLocalizedPricePerPeriodFull() {
+        expect(TestData.weeklyPackage.localizedPricePerPeriodFull(Self.english)) == "$1.99/week"
+        expect(TestData.monthlyPackage.localizedPricePerPeriodFull(Self.english)) == "$6.99/month"
+        expect(TestData.threeMonthPackage.localizedPricePerPeriodFull(Self.english)) == "$4.99/3months"
+        expect(TestData.sixMonthPackage.localizedPricePerPeriodFull(Self.english)) == "$7.99/6months"
+        expect(TestData.annualPackage.localizedPricePerPeriodFull(Self.english)) == "$53.99/year"
+        expect(TestData.lifetimePackage.localizedPricePerPeriodFull(Self.english)) == "$119.49"
+    }
+
+    func testSpanishLocalizedPricePerPeriodFull() {
+        expect(TestData.weeklyPackage.localizedPricePerPeriodFull(Self.spanish)) == "$1.99/semana"
+        expect(TestData.monthlyPackage.localizedPricePerPeriodFull(Self.spanish)) == "$6.99/mes"
+        expect(TestData.threeMonthPackage.localizedPricePerPeriodFull(Self.spanish)) == "$4.99/3meses"
+        expect(TestData.sixMonthPackage.localizedPricePerPeriodFull(Self.spanish)) == "$7.99/6meses"
+        expect(TestData.annualPackage.localizedPricePerPeriodFull(Self.spanish)) == "$53.99/año"
+        expect(TestData.lifetimePackage.localizedPricePerPeriodFull(Self.spanish)) == "$119.49"
+    }
+
     func testEnglishLocalizedPriceAndPerMonth() {
         expect(TestData.weeklyPackage.localizedPriceAndPerMonth(Self.english)) == "$1.99/wk ($8.64/mo)"
         expect(TestData.monthlyPackage.localizedPriceAndPerMonth(Self.english)) == "$6.99/mo"
@@ -118,6 +136,24 @@ class PackageVariablesTests: TestCase {
         == arabicPrice
     }
 
+    func testEnglishLocalizedPriceAndPerMonthFull() {
+        expect(TestData.weeklyPackage.localizedPriceAndPerMonthFull(Self.english)) == "$1.99/week ($8.64/month)"
+        expect(TestData.monthlyPackage.localizedPriceAndPerMonthFull(Self.english)) == "$6.99/month"
+        expect(TestData.threeMonthPackage.localizedPriceAndPerMonthFull(Self.english)) == "$4.99/3months ($1.66/month)"
+        expect(TestData.sixMonthPackage.localizedPriceAndPerMonthFull(Self.english)) == "$7.99/6months ($1.33/month)"
+        expect(TestData.annualPackage.localizedPriceAndPerMonthFull(Self.english)) == "$53.99/year ($4.49/month)"
+        expect(TestData.lifetimePackage.localizedPriceAndPerMonthFull(Self.english)) == "$119.49"
+    }
+
+    func testSpanishLocalizedPriceAndPerMonthFull() {
+        expect(TestData.weeklyPackage.localizedPriceAndPerMonthFull(Self.spanish)) == "$1.99/semana ($8.64/mes)"
+        expect(TestData.monthlyPackage.localizedPriceAndPerMonthFull(Self.spanish)) == "$6.99/mes"
+        expect(TestData.threeMonthPackage.localizedPriceAndPerMonthFull(Self.spanish)) == "$4.99/3meses ($1.66/mes)"
+        expect(TestData.sixMonthPackage.localizedPriceAndPerMonthFull(Self.spanish)) == "$7.99/6meses ($1.33/mes)"
+        expect(TestData.annualPackage.localizedPriceAndPerMonthFull(Self.spanish)) == "$53.99/año ($4.49/mes)"
+        expect(TestData.lifetimePackage.localizedPriceAndPerMonthFull(Self.spanish)) == "$119.49"
+    }
+
     func testProductName() {
         expect(TestData.weeklyPackage.productName) == "Weekly"
         expect(TestData.monthlyPackage.productName) == "Monthly"
@@ -147,6 +183,50 @@ class PackageVariablesTests: TestCase {
         expect(TestData.lifetimePackage.periodNameOrIdentifier(Self.spanish)) == "Toda la vida"
         expect(TestData.customPackage.periodNameOrIdentifier(Self.spanish)) == "Custom"
         expect(TestData.unknownPackage.periodNameOrIdentifier(Self.spanish)) == "Unknown"
+    }
+
+    func testEnglishPeriodAbbreviation() {
+        expect(TestData.weeklyPackage.periodNameAbbreviation(Self.english)) == "wk"
+        expect(TestData.monthlyPackage.periodNameAbbreviation(Self.english)) == "mo"
+        expect(TestData.threeMonthPackage.periodNameAbbreviation(Self.english)) == "3mo"
+        expect(TestData.sixMonthPackage.periodNameAbbreviation(Self.english)) == "6mo"
+        expect(TestData.annualPackage.periodNameAbbreviation(Self.english)) == "yr"
+        expect(TestData.lifetimePackage.periodNameAbbreviation(Self.english)).to(beNil())
+        expect(TestData.customPackage.periodNameAbbreviation(Self.english)) == "yr"
+        expect(TestData.unknownPackage.periodNameAbbreviation(Self.english)) == "yr"
+    }
+
+    func testSpanishPeriodAbbreviation() {
+        expect(TestData.weeklyPackage.periodNameAbbreviation(Self.spanish)) == "sem"
+        expect(TestData.monthlyPackage.periodNameAbbreviation(Self.spanish)) == "m."
+        expect(TestData.threeMonthPackage.periodNameAbbreviation(Self.spanish)) == "3m"
+        expect(TestData.sixMonthPackage.periodNameAbbreviation(Self.spanish)) == "6m"
+        expect(TestData.annualPackage.periodNameAbbreviation(Self.spanish)) == "año"
+        expect(TestData.lifetimePackage.periodNameAbbreviation(Self.spanish)).to(beNil())
+        expect(TestData.customPackage.periodNameAbbreviation(Self.spanish)) == "año"
+        expect(TestData.unknownPackage.periodNameAbbreviation(Self.spanish)) == "año"
+    }
+
+    func testEnglishPeriodLength() {
+        expect(TestData.weeklyPackage.periodLength(Self.english)) == "week"
+        expect(TestData.monthlyPackage.periodLength(Self.english)) == "month"
+        expect(TestData.threeMonthPackage.periodLength(Self.english)) == "3months"
+        expect(TestData.sixMonthPackage.periodLength(Self.english)) == "6months"
+        expect(TestData.annualPackage.periodLength(Self.english)) == "year"
+        expect(TestData.lifetimePackage.periodLength(Self.english)).to(beNil())
+        expect(TestData.customPackage.periodLength(Self.english)) == "year"
+        expect(TestData.unknownPackage.periodLength(Self.english)) == "year"
+    }
+
+    func testSpanishPeriodLength() {
+        expect(TestData.weeklyPackage.periodLength(Self.spanish)) == "semana"
+        expect(TestData.monthlyPackage.periodLength(Self.spanish)) == "mes"
+        expect(TestData.threeMonthPackage.periodLength(Self.spanish)) == "3meses"
+        expect(TestData.sixMonthPackage.periodLength(Self.spanish)) == "6meses"
+        expect(TestData.annualPackage.periodLength(Self.spanish)) == "año"
+        expect(TestData.lifetimePackage.periodLength(Self.spanish)).to(beNil())
+        expect(TestData.customPackage.periodLength(Self.spanish)) == "año"
+        expect(TestData.unknownPackage.periodLength(Self.spanish)) == "año"
     }
 
     func testEnglishIntroductoryOfferDuration() {

--- a/Tests/RevenueCatUITests/Data/VariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/VariablesTests.swift
@@ -54,6 +54,11 @@ class VariablesTests: TestCase {
         expect(self.process("{{ price_per_period }}")) == "$3.99/yr"
     }
 
+    func testPricePerPeriodFull() {
+        self.provider.localizedPricePerPeriodFull = "$3.99/year"
+        expect(self.process("{{ price_per_period_full }}")) == "$3.99/year"
+    }
+
     func testPricePerWeek() {
         self.provider.localizedPricePerWeek = "$3.99"
         expect(self.process("{{ sub_price_per_week }} per week")) == "$3.99 per week"
@@ -69,6 +74,11 @@ class VariablesTests: TestCase {
         expect(self.process("{{ total_price_and_per_month }}")) == self.provider.localizedPriceAndPerMonth
     }
 
+    func testTotalPriceAndPerMonthFull() {
+        self.provider.localizedPriceAndPerMonthFull = "$49.99/year ($4.16/month)"
+        expect(self.process("{{ total_price_and_per_month_full }}")) == self.provider.localizedPriceAndPerMonthFull
+    }
+
     func testProductName() {
         self.provider.productName = "MindSnacks"
         expect(self.process("Purchase {{ product_name }}")) == "Purchase MindSnacks"
@@ -77,6 +87,16 @@ class VariablesTests: TestCase {
     func testPeriodName() {
         self.provider.periodNameOrIdentifier = "Monthly"
         expect(self.process("{{ sub_period }}")) == "Monthly"
+    }
+
+    func testPeriodLength() {
+        self.provider.periodLength = "month"
+        expect(self.process("{{ sub_period_length }}")) == "month"
+    }
+
+    func testPeriodAbbreviation() {
+        self.provider.periodNameAbbreviation = "mo"
+        expect(self.process("{{ sub_period_abbreviated }}")) == "mo"
     }
 
     func testSubscriptionDuration() {
@@ -278,9 +298,13 @@ private struct MockVariableProvider: VariableDataProvider {
     var localizedPricePerWeek: String = ""
     var localizedPricePerMonth: String = ""
     var localizedPriceAndPerMonth: String = ""
+    var localizedPriceAndPerMonthFull: String = ""
     var localizedPricePerPeriod: String = ""
+    var localizedPricePerPeriodFull: String = ""
     var productName: String = ""
     var periodNameOrIdentifier: String = ""
+    var periodNameAbbreviation: String = ""
+    var periodLength: String = ""
     var subscriptionDuration: String?
     var normalizedSubscriptionDuration: String?
     var introductoryOfferDuration: String?
@@ -289,6 +313,14 @@ private struct MockVariableProvider: VariableDataProvider {
 
     func periodNameOrIdentifier(_ locale: Locale) -> String {
         return self.periodNameOrIdentifier
+    }
+
+    func periodNameAbbreviation(_ locale: Locale) -> String? {
+        return self.periodNameAbbreviation
+    }
+
+    func periodLength(_ locale: Locale) -> String? {
+        return self.periodLength
     }
 
     func subscriptionDuration(_ locale: Locale) -> String? {
@@ -307,8 +339,16 @@ private struct MockVariableProvider: VariableDataProvider {
         return self.localizedPricePerPeriod
     }
 
+    func localizedPricePerPeriodFull(_ locale: Locale) -> String {
+        return self.localizedPricePerPeriodFull
+    }
+
     func localizedPriceAndPerMonth(_ locale: Locale) -> String {
         return self.localizedPriceAndPerMonth
+    }
+
+    func localizedPriceAndPerMonthFull(_ locale: Locale) -> String {
+        return self.localizedPriceAndPerMonthFull
     }
 
     var localizedIntroductoryOfferPrice: String? {


### PR DESCRIPTION
### Added:
- `price_per_period_full`
- `total_price_and_per_month_full`
- `sub_period_length`
- `sub_period_abbreviated`
