### PR TITLE
removed background color for visionOS

### DIFF
--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -161,7 +161,11 @@ extension View {
 
     func adaptTemplateView(with configuration: TemplateViewConfiguration) -> some View {
         self
+        #if os(visionOS)
+            .background(Material.regular)
+        #else
             .background(configuration.backgroundView)
+        #endif
             .adjustColorScheme(with: configuration)
             .adjustSize(with: configuration.mode)
     }

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -105,7 +105,7 @@ struct PurchaseButton: View {
                 transaction.animation = nil
             }
         }
-        #if targetEnvironment(macCatalyst)
+        #if targetEnvironment(macCatalyst) || os(visionOS)
         .buttonStyle(.plain)
         #endif
     }


### PR DESCRIPTION
| Before | After |
| :-: | :-: |
| <img width="429" alt="Screenshot 2024-02-05 at 12 29 45 PM" src="https://github.com/RevenueCat/purchases-ios/assets/3922667/feefd42c-f7ba-4846-931d-44f34c6e8d4e"> | <img width="487" alt="Screenshot 2024-02-05 at 12 27 25 PM" src="https://github.com/RevenueCat/purchases-ios/assets/3922667/4a4f275b-9c38-4247-b023-3080b9d49a34"> |