### PR TITLE
`Paywalls`: new `presentationMode` parameter

### DIFF
--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 #if !os(macOS) && !os(tvOS)
 
-/// Presentation options to use with the View modifiers `.presentPaywallIfNeeded`.
+/// Presentation options to use with the [presentPaywallIfNeeded](x-source-tag://presentPaywallIfNeeded) View modifiers.
 ///
 /// ### Related Articles
 /// [Documentation](https://rev.cat/paywalls)
@@ -48,16 +48,19 @@ extension View {
     /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
     /// If `nil` (the default), `Offerings.current` will be used. Note that specifying this parameter means
     /// that it will ignore the offering configured in an active experiment.
-    /// - Parameter fonts: An optional `PaywallFontProvider`.
-    /// - Parameter presentationMode: The desired presentation mode of the ``PaywallView``. Defaults to ``.sheet``.
+    /// - Parameter fonts: An optional ``PaywallFontProvider``.
+    /// - Parameter presentationMode: The desired presentation mode of the ``PaywallView`` (``PaywallPresentationMode``).
+    /// Defaults to `.sheet`.
     ///
     /// ### Related Articles
     /// [Documentation](https://rev.cat/paywalls)
+    ///
+    /// - Tag: presentPaywallIfNeeded
     public func presentPaywallIfNeeded(
         requiredEntitlementIdentifier: String,
         offering: Offering? = nil,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
-        presentationMode: PaywallPresentationMode = .sheet,
+        presentationMode: PaywallPresentationMode = .default,
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
@@ -117,8 +120,12 @@ extension View {
     /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
     /// If `nil` (the default), `Offerings.current` will be used. Note that specifying this parameter means
     /// that it will ignore the offering configured in an active experiment.
-    /// - Parameter fonts: An optional `PaywallFontProvider`.
-    /// - Parameter presentationMode: The desired presentation mode of the PaywallView. Defaults to ``.sheet``.
+    /// - Parameter fonts: An optional ``PaywallFontProvider``.
+    /// - Parameter presentationMode: The desired presentation mode of the ``PaywallView`` (``PaywallPresentationMode``).
+    /// Defaults to `.sheet`.
+    ///
+    /// ### Related Articles
+    /// [Documentation](https://rev.cat/paywalls)
     public func presentPaywallIfNeeded(
         offering: Offering? = nil,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -267,7 +267,7 @@ private struct PresentingPaywallModifier: ViewModifier {
             case .fullScreen:
                 content
                     .fullScreenCover(item: self.$data, onDismiss: self.onDismiss) { data in
-                        paywallView(data: data)
+                        self.paywallView(data: data)
                     }
             }
         }

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 #if !os(macOS) && !os(tvOS)
 
-/// Presentation options to use with the View modifiers ``presentPaywallIfNeeded``.
+/// Presentation options to use with the View modifiers `.presentPaywallIfNeeded`.
 ///
 /// ### Related Articles
 /// [Documentation](https://rev.cat/paywalls)

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -262,7 +262,7 @@ private struct PresentingPaywallModifier: ViewModifier {
             case .sheet:
                 content
                     .sheet(item: self.$data, onDismiss: self.onDismiss) { data in
-                        paywallView(data: data)
+                        self.paywallView(data: data)
                     }
             case .fullScreen:
                 content

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -21,8 +21,10 @@ import SwiftUI
 /// ### Related Articles
 /// [Documentation](https://rev.cat/paywalls)
 public enum PaywallPresentationMode {
+
     case sheet
     case fullScreen
+    
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -21,6 +21,8 @@ import SwiftUI
 /// ### Related Articles
 /// [Documentation](https://rev.cat/paywalls)
 public enum PaywallPresentationMode {
+    
+    public static let `default`: Self = .sheet
 
     case sheet
     case fullScreen
@@ -130,7 +132,7 @@ extension View {
         offering: Offering? = nil,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
-        presentationMode: PaywallPresentationMode = .sheet,
+        presentationMode: PaywallPresentationMode = .default,
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
@@ -168,7 +170,7 @@ extension View {
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         purchaseHandler: PurchaseHandler? = nil,
         shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
-        presentationMode: PaywallPresentationMode = .sheet,
+        presentationMode: PaywallPresentationMode = .default,
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
@@ -269,12 +271,12 @@ private struct PresentingPaywallModifier: ViewModifier {
             case .sheet:
                 content
                     .sheet(item: self.$data, onDismiss: self.onDismiss) { data in
-                        self.paywallView(data: data)
+                        self.paywallView(data)
                     }
             case .fullScreen:
                 content
                     .fullScreenCover(item: self.$data, onDismiss: self.onDismiss) { data in
-                        self.paywallView(data: data)
+                        self.paywallView(data)
                     }
             }
         }
@@ -293,7 +295,7 @@ private struct PresentingPaywallModifier: ViewModifier {
         }
     }
     
-    private func paywallView(data: Data) -> some View {
+    private func paywallView(_ data: Data) -> some View {
         PaywallView(
             configuration: .init(
                 content: self.content,


### PR DESCRIPTION
### TLDR
- Added a way to present `PaywallView` either as sheet or full screen
- No breaking changes have been made

### Motivation
I wanted to easily present the PaywallView on full screen.

### Description
I added a new enum `PaywallPresentationMode` which currently has 2 options: `.sheet` and `.fullScreen `. I added this as a parameter to the current public `presentPaywallIfNeeded` modifiers. The default is `sheet` so there are no breaking changes with the current public API.

| Sheet             | Full Screen    |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-05 at 18 08 51](https://github.com/RevenueCat/purchases-ios/assets/1515520/80f4c418-5dd7-4ba9-87a3-1b824bd6fc10)  |  ![Simulator Screenshot - iPhone 15 Pro - 2024-02-05 at 18 44 15](https://github.com/RevenueCat/purchases-ios/assets/1515520/ab05b52b-6132-41d0-a48b-cecf5b857eeb) |

PD: I looked for info on how to contribute but it's unclear if I have to open an issue first or not (contributing says open issue, then when opening an issue it says please don't open but contact us at https://app.revenuecat.com/settings/support). I hope this is valid, otherwise let me know how I can proceed.