### PR TITLE
`Paywalls`: fix finding locales with different regions

### DIFF
--- a/Sources/FoundationExtensions/Locale+Extensions.swift
+++ b/Sources/FoundationExtensions/Locale+Extensions.swift
@@ -29,4 +29,23 @@ extension Locale {
         #endif
     }
 
+    // swiftlint:disable:next identifier_name
+    var rc_languageCode: String? {
+        #if swift(>=5.9)
+        // `Locale.languageCode` is deprecated
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, visionOS 1.0, *) {
+            return self.language.languageCode?.identifier
+        } else {
+            return self.languageCode
+        }
+        #else
+        return self.languageCode
+        #endif
+    }
+
+    /// - Returns: the same locale as `self` but removing its region.
+    var removingRegion: Self? {
+        return self.rc_languageCode.map(Locale.init(identifier:))
+    }
+
 }

--- a/Sources/Paywalls/PaywallData+Localization.swift
+++ b/Sources/Paywalls/PaywallData+Localization.swift
@@ -18,13 +18,29 @@ public extension PaywallData {
     /// - Returns: the ``PaywallData/LocalizedConfiguration-swift.struct``  to be used
     /// based on `Locale.current` or `Locale.preferredLocales`.
     var localizedConfiguration: LocalizedConfiguration {
-        let locales: [Locale] = [.current] + Locale.preferredLocales
+        return self.localizedConfiguration(for: Self.localesOrderedByPriority)
+    }
 
+    // Visible for testing
+    internal func localizedConfiguration(for locales: [Locale]) -> LocalizedConfiguration {
         return locales
             .lazy
             .compactMap(self.config(for:))
             .first { _ in true } // See https://github.com/apple/swift/issues/55374
             ?? self.fallbackLocalizedConfiguration
+    }
+
+    // Visible for testing
+    /// - Returns: The list of locales that paywalls should try to search for.
+    /// Includes `Locale.current` and `Locale.preferredLanguages`.
+    internal static var localesOrderedByPriority: [Locale] {
+        var result = [.current] + Locale.preferredLocales
+
+        if let withoutRegion = Locale.current.removingRegion {
+            result.append(withoutRegion)
+        }
+
+        return result
     }
 
     private var fallbackLocalizedConfiguration: LocalizedConfiguration {
@@ -40,9 +56,9 @@ public extension PaywallData {
 
 // MARK: -
 
-private extension Locale {
+extension Locale {
 
-    static var preferredLocales: [Self] {
+    fileprivate static var preferredLocales: [Self] {
         return Self.preferredLanguages.map(Locale.init(identifier:))
     }
 

--- a/Tests/UnitTests/FoundationExtensions/LocaleExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/LocaleExtensionsTests.swift
@@ -22,8 +22,26 @@ class LocaleExtensionsTests: TestCase {
         expect(Locale(identifier: "en_US").rc_currencyCode) == "USD"
     }
 
-    func testMissingCurrenctCode() {
+    func testMissingCurrencyCode() {
         expect(Locale(identifier: "").rc_currencyCode).to(beNil())
+    }
+
+    func testLanguageCodeCode() {
+        expect(Locale(identifier: "en_US").rc_languageCode) == "en"
+        expect(Locale(identifier: "en-IN").rc_languageCode) == "en"
+        expect(Locale(identifier: "en").rc_languageCode) == "en"
+    }
+
+    func testMissingLanguageCode() {
+        expect(Locale(identifier: "").rc_languageCode).to(beNil())
+    }
+
+    func testRemovingRegion() {
+        expect(Locale(identifier: "en_US").removingRegion?.identifier) == "en"
+        expect(Locale(identifier: "en-IN").removingRegion?.identifier) == "en"
+        expect(Locale(identifier: "en_ES").removingRegion?.identifier) == "en"
+        expect(Locale(identifier: "en").removingRegion?.identifier) == "en"
+        expect(Locale(identifier: "").removingRegion).to(beNil())
     }
 
 }

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -122,6 +122,25 @@ class PaywallDataTests: BaseHTTPResponseTest {
         expect(esConfig.title) == "Tienda"
     }
 
+    func testLocalizedConfigurationFallsBackToLanguageWithDifferentRegion() throws {
+        let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
+
+        let enConfig = try XCTUnwrap(paywall.localizedConfiguration(for: [
+            .init(identifier: "en_IN"),
+            .init(identifier: "en-IN"),
+            .init(identifier: "en-IN").removingRegion
+        ].compactMap { $0 }))
+        expect(enConfig.title) == "Paywall"
+    }
+
+    func testLocalesOrderedByPriority() {
+        expect(PaywallData.localesOrderedByPriority) == [
+            .init(identifier: "en_US"),
+            .init(identifier: "en-US"),
+            .init(identifier: "en")
+        ]
+    }
+
     func testDoesNotFindLocaleWithMissingLanguage() throws {
         let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
 

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -134,10 +134,10 @@ class PaywallDataTests: BaseHTTPResponseTest {
     }
 
     func testLocalesOrderedByPriority() {
-        expect(PaywallData.localesOrderedByPriority) == [
-            .init(identifier: "en_US"),
-            .init(identifier: "en-US"),
-            .init(identifier: "en")
+        expect(PaywallData.localesOrderedByPriority.map(\.identifier)) == [
+            "en_US",
+            "en-US",
+            "en"
         ]
     }
 

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -133,12 +133,25 @@ class PaywallDataTests: BaseHTTPResponseTest {
         expect(enConfig.title) == "Paywall"
     }
 
-    func testLocalesOrderedByPriority() {
-        expect(PaywallData.localesOrderedByPriority.map(\.identifier)) == [
-            "en_US",
-            "en-US",
-            "en"
-        ]
+    func testLocalesOrderedByPriority() throws {
+        let expected: [String]
+
+        if #available(iOS 17.0, tvOS 17, watchOS 10, *) {
+            expected = [
+                "en_US",
+                "en-US",
+                "en"
+            ]
+        } else {
+            expected = [
+                "en_US",
+                // `Locale.preferredLanguages` returns `en` before iOS 17.
+                "en",
+                "en"
+            ]
+        }
+
+        expect(PaywallData.localesOrderedByPriority.map(\.identifier)) == expected
     }
 
     func testDoesNotFindLocaleWithMissingLanguage() throws {


### PR DESCRIPTION
This was a regression introduced by #3605.

### Example:

Consider a paywall configuration with these locales: `en_US`, `de_DE`.
Running on a device with locale `en_IN` for example.

Before #3605, `PaywallData.localizedConfiguration` would have returned the `en_US` localization. However, that change made it so that it could no longer find a matching localization with a different region.

This fix improves the locale lookup so that if it doesn't find a matching localization with both language AND region, it then tries to look it up with only the language, before falling back to the default localization.
