### PR TITLE
`Paywalls`: new `presentationMode` parameter (by @Lascorbe)

### DIFF
--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -16,6 +16,19 @@ import SwiftUI
 
 #if !os(macOS) && !os(tvOS)
 
+/// Presentation options to use with the [presentPaywallIfNeeded](x-source-tag://presentPaywallIfNeeded) View modifiers.
+///
+/// ### Related Articles
+/// [Documentation](https://rev.cat/paywalls)
+public enum PaywallPresentationMode {
+    
+    public static let `default`: Self = .sheet
+
+    case sheet
+    case fullScreen
+    
+}
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
 @available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
@@ -37,14 +50,19 @@ extension View {
     /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
     /// If `nil` (the default), `Offerings.current` will be used. Note that specifying this parameter means
     /// that it will ignore the offering configured in an active experiment.
-    /// - Parameter fonts: An optional `PaywallFontProvider`.
+    /// - Parameter fonts: An optional ``PaywallFontProvider``.
+    /// - Parameter presentationMode: The desired presentation mode of the ``PaywallView`` (``PaywallPresentationMode``).
+    /// Defaults to `.sheet`.
     ///
     /// ### Related Articles
     /// [Documentation](https://rev.cat/paywalls)
+    ///
+    /// - Tag: presentPaywallIfNeeded
     public func presentPaywallIfNeeded(
         requiredEntitlementIdentifier: String,
         offering: Offering? = nil,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        presentationMode: PaywallPresentationMode = .default,
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
@@ -62,6 +80,7 @@ extension View {
                     .keys
                     .contains(requiredEntitlementIdentifier)
             },
+            presentationMode: presentationMode,
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
@@ -103,11 +122,17 @@ extension View {
     /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
     /// If `nil` (the default), `Offerings.current` will be used. Note that specifying this parameter means
     /// that it will ignore the offering configured in an active experiment.
-    /// - Parameter fonts: An optional `PaywallFontProvider`.
+    /// - Parameter fonts: An optional ``PaywallFontProvider``.
+    /// - Parameter presentationMode: The desired presentation mode of the ``PaywallView`` (``PaywallPresentationMode``).
+    /// Defaults to `.sheet`.
+    ///
+    /// ### Related Articles
+    /// [Documentation](https://rev.cat/paywalls)
     public func presentPaywallIfNeeded(
         offering: Offering? = nil,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
+        presentationMode: PaywallPresentationMode = .default,
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
@@ -120,6 +145,7 @@ extension View {
             offering: offering,
             fonts: fonts,
             shouldDisplay: shouldDisplay,
+            presentationMode: presentationMode,
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
@@ -144,6 +170,7 @@ extension View {
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         purchaseHandler: PurchaseHandler? = nil,
         shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
+        presentationMode: PaywallPresentationMode = .default,
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
@@ -156,6 +183,7 @@ extension View {
         return self
             .modifier(PresentingPaywallModifier(
                 shouldDisplay: shouldDisplay,
+                presentationMode: presentationMode,
                 purchaseStarted: purchaseStarted,
                 purchaseCompleted: purchaseCompleted,
                 purchaseCancelled: purchaseCancelled,
@@ -184,6 +212,7 @@ private struct PresentingPaywallModifier: ViewModifier {
     }
 
     var shouldDisplay: @Sendable (CustomerInfo) -> Bool
+    var presentationMode: PaywallPresentationMode
     var purchaseStarted: PurchaseStartedHandler?
     var purchaseCompleted: PurchaseOrRestoreCompletedHandler?
     var purchaseCancelled: PurchaseCancelledHandler?
@@ -200,6 +229,7 @@ private struct PresentingPaywallModifier: ViewModifier {
 
     init(
         shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
+        presentationMode: PaywallPresentationMode,
         purchaseStarted: PurchaseStartedHandler?,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler?,
         purchaseCancelled: PurchaseCancelledHandler?,
@@ -214,6 +244,7 @@ private struct PresentingPaywallModifier: ViewModifier {
         purchaseHandler: PurchaseHandler?
     ) {
         self.shouldDisplay = shouldDisplay
+        self.presentationMode = presentationMode
         self.purchaseStarted = purchaseStarted
         self.purchaseCompleted = purchaseCompleted
         self.purchaseCancelled = purchaseCancelled
@@ -233,57 +264,71 @@ private struct PresentingPaywallModifier: ViewModifier {
 
     @State
     private var data: Data?
-
+    
     func body(content: Content) -> some View {
-        content
-            .sheet(item: self.$data, onDismiss: self.onDismiss) { data in
-                PaywallView(
-                    configuration: .init(
-                        content: self.content,
-                        customerInfo: data.customerInfo,
-                        fonts: self.fontProvider,
-                        displayCloseButton: true,
-                        introEligibility: self.introEligibility,
-                        purchaseHandler: self.purchaseHandler
-                    )
-                )
-                .onPurchaseStarted {
-                    self.purchaseStarted?()
-                }
-                .onPurchaseCompleted {
-                    self.purchaseCompleted?($0)
-                }
-                .onPurchaseCancelled {
-                    self.purchaseCancelled?()
-                }
-                .onRestoreCompleted { customerInfo in
-                    self.restoreCompleted?(customerInfo)
-
-                    if !self.shouldDisplay(customerInfo) {
-                        self.close()
+        Group {
+            switch presentationMode {
+            case .sheet:
+                content
+                    .sheet(item: self.$data, onDismiss: self.onDismiss) { data in
+                        self.paywallView(data)
                     }
-                }
-                .onPurchaseFailure {
-                    self.purchaseFailure?($0)
-                }
-                .onRestoreFailure {
-                    self.restoreFailure?($0)
-                }
-                .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
+            case .fullScreen:
+                content
+                    .fullScreenCover(item: self.$data, onDismiss: self.onDismiss) { data in
+                        self.paywallView(data)
+                    }
             }
-            .task {
-                guard let info = try? await self.customerInfoFetcher() else { return }
-
-                Logger.debug(Strings.determining_whether_to_display_paywall)
-
-                if self.shouldDisplay(info) {
-                    Logger.debug(Strings.displaying_paywall)
-
-                    self.data = .init(customerInfo: info)
-                } else {
-                    Logger.debug(Strings.not_displaying_paywall)
-                }
+        }
+        .task {
+            guard let info = try? await self.customerInfoFetcher() else { return }
+            
+            Logger.debug(Strings.determining_whether_to_display_paywall)
+            
+            if self.shouldDisplay(info) {
+                Logger.debug(Strings.displaying_paywall)
+                
+                self.data = .init(customerInfo: info)
+            } else {
+                Logger.debug(Strings.not_displaying_paywall)
             }
+        }
+    }
+    
+    private func paywallView(_ data: Data) -> some View {
+        PaywallView(
+            configuration: .init(
+                content: self.content,
+                customerInfo: data.customerInfo,
+                fonts: self.fontProvider,
+                displayCloseButton: true,
+                introEligibility: self.introEligibility,
+                purchaseHandler: self.purchaseHandler
+            )
+        )
+        .onPurchaseStarted {
+            self.purchaseStarted?()
+        }
+        .onPurchaseCompleted {
+            self.purchaseCompleted?($0)
+        }
+        .onPurchaseCancelled {
+            self.purchaseCancelled?()
+        }
+        .onRestoreCompleted { customerInfo in
+            self.restoreCompleted?(customerInfo)
+            
+            if !self.shouldDisplay(customerInfo) {
+                self.close()
+            }
+        }
+        .onPurchaseFailure {
+            self.purchaseFailure?($0)
+        }
+        .onRestoreFailure {
+            self.restoreFailure?($0)
+        }
+        .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
     }
 
     private func close() {

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -21,12 +21,20 @@ import SwiftUI
 /// ### Related Articles
 /// [Documentation](https://rev.cat/paywalls)
 public enum PaywallPresentationMode {
-    
+
+    /// Paywall presented using SwiftUI's `.sheet`.
+    case sheet
+
+    /// Paywall presented using SwiftUI's `.fullScreenCover`.
+    case fullScreen
+
+}
+
+extension PaywallPresentationMode {
+
+    // swiftlint:disable:next missing_docs
     public static let `default`: Self = .sheet
 
-    case sheet
-    case fullScreen
-    
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -51,8 +59,7 @@ extension View {
     /// If `nil` (the default), `Offerings.current` will be used. Note that specifying this parameter means
     /// that it will ignore the offering configured in an active experiment.
     /// - Parameter fonts: An optional ``PaywallFontProvider``.
-    /// - Parameter presentationMode: The desired presentation mode of the ``PaywallView`` (``PaywallPresentationMode``).
-    /// Defaults to `.sheet`.
+    /// - Parameter presentationMode: The desired presentation mode of the paywall. Defaults to `.sheet`.
     ///
     /// ### Related Articles
     /// [Documentation](https://rev.cat/paywalls)
@@ -123,8 +130,7 @@ extension View {
     /// If `nil` (the default), `Offerings.current` will be used. Note that specifying this parameter means
     /// that it will ignore the offering configured in an active experiment.
     /// - Parameter fonts: An optional ``PaywallFontProvider``.
-    /// - Parameter presentationMode: The desired presentation mode of the ``PaywallView`` (``PaywallPresentationMode``).
-    /// Defaults to `.sheet`.
+    /// - Parameter presentationMode: The desired presentation mode of the paywall. Defaults to `.sheet`.
     ///
     /// ### Related Articles
     /// [Documentation](https://rev.cat/paywalls)
@@ -264,7 +270,7 @@ private struct PresentingPaywallModifier: ViewModifier {
 
     @State
     private var data: Data?
-    
+
     func body(content: Content) -> some View {
         Group {
             switch presentationMode {
@@ -282,19 +288,19 @@ private struct PresentingPaywallModifier: ViewModifier {
         }
         .task {
             guard let info = try? await self.customerInfoFetcher() else { return }
-            
+
             Logger.debug(Strings.determining_whether_to_display_paywall)
-            
+
             if self.shouldDisplay(info) {
                 Logger.debug(Strings.displaying_paywall)
-                
+
                 self.data = .init(customerInfo: info)
             } else {
                 Logger.debug(Strings.not_displaying_paywall)
             }
         }
     }
-    
+
     private func paywallView(_ data: Data) -> some View {
         PaywallView(
             configuration: .init(
@@ -317,7 +323,7 @@ private struct PresentingPaywallModifier: ViewModifier {
         }
         .onRestoreCompleted { customerInfo in
             self.restoreCompleted?(customerInfo)
-            
+
             if !self.shouldDisplay(customerInfo) {
                 self.close()
             }

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -81,13 +81,13 @@ extension View {
         return self.presentPaywallIfNeeded(
             offering: offering,
             fonts: fonts,
+            presentationMode: presentationMode,
             shouldDisplay: { info in
                 !info.entitlements
                     .activeInCurrentEnvironment
                     .keys
                     .contains(requiredEntitlementIdentifier)
             },
-            presentationMode: presentationMode,
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
@@ -137,8 +137,8 @@ extension View {
     public func presentPaywallIfNeeded(
         offering: Offering? = nil,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
-        shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
         presentationMode: PaywallPresentationMode = .default,
+        shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
@@ -150,8 +150,8 @@ extension View {
         return self.presentPaywallIfNeeded(
             offering: offering,
             fonts: fonts,
-            shouldDisplay: shouldDisplay,
             presentationMode: presentationMode,
+            shouldDisplay: shouldDisplay,
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
@@ -175,8 +175,8 @@ extension View {
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         purchaseHandler: PurchaseHandler? = nil,
-        shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
         presentationMode: PaywallPresentationMode = .default,
+        shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -43,6 +43,8 @@ struct App: View {
     var checkPresentPaywallIfNeeded: some View {
         Text("")
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "")
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", presentationMode: .sheet)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", presentationMode: .fullScreen)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", onDismiss: self.paywallDismissed)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", offering: nil)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", offering: self.offering)
@@ -81,6 +83,9 @@ struct App: View {
                 false
             } purchaseCompleted: {
                 self.purchaseOrRestoreCompleted($0)
+            }
+            .presentPaywallIfNeeded(presentationMode: .sheet) { (_: CustomerInfo) in
+                false
             }
             .presentPaywallIfNeeded(fonts: self.fonts) { (_: CustomerInfo) in
                 false
@@ -198,6 +203,13 @@ struct App: View {
     private func fontProviders() {
         let _: PaywallFontProvider = DefaultPaywallFontProvider()
         let _: PaywallFontProvider = CustomPaywallFontProvider(fontName: "Papyrus")
+    }
+
+    private func presentationMode(_ mode: PaywallPresentationMode) {
+        switch mode {
+        case .sheet: break
+        case .fullScreen: break
+        }
     }
 
 }


### PR DESCRIPTION
Original PR: #3632 by [Lascorbe](https://github.com/Lascorbe).

### TLDR
- Added a way to present `PaywallView` either as sheet or full screen
- No breaking changes have been made

### Motivation
I wanted to easily present the PaywallView on full screen.

### Description
I added a new enum `PaywallPresentationMode` which currently has 2 options: `.sheet` and `.fullScreen`. I added this as a parameter to the current public `.presentPaywallIfNeeded` modifiers. The default is `sheet` so there are no breaking changes with the current public API.

| Sheet             | Full Screen    |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-05 at 18 08 51](https://github.com/RevenueCat/purchases-ios/assets/1515520/80f4c418-5dd7-4ba9-87a3-1b824bd6fc10)  |  ![Simulator Screenshot - iPhone 15 Pro - 2024-02-05 at 18 44 15](https://github.com/RevenueCat/purchases-ios/assets/1515520/ab05b52b-6132-41d0-a48b-cecf5b857eeb) |
