### PR TITLE
`NonSubscriptionTransaction`: expose `storeTransactionIdentifier`

### DIFF
--- a/Sources/Purchasing/NonSubscriptionTransaction.swift
+++ b/Sources/Purchasing/NonSubscriptionTransaction.swift
@@ -32,7 +32,7 @@ public final class NonSubscriptionTransaction: NSObject {
     @objc public let transactionIdentifier: String
 
     /// The unique identifier for the transaction created by the Store.
-    @objc internal let storeTransactionIdentifier: String
+    @objc public let storeTransactionIdentifier: String
 
     init?(with transaction: CustomerInfoResponse.Transaction, productID: String) {
         guard let transactionIdentifier = transaction.transactionIdentifier,

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCNonSubscriptionTransactionAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCNonSubscriptionTransactionAPI.m
@@ -17,6 +17,7 @@
     NSString *pid __unused = transaction.productIdentifier;
     NSDate *pd __unused = transaction.purchaseDate;
     NSString *tid __unused = transaction.transactionIdentifier;
+    NSString *stid __unused = transaction.storeTransactionIdentifier;
 }
 
 @end

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/NonSubscriptionTransactionAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/NonSubscriptionTransactionAPI.swift
@@ -14,4 +14,5 @@ func checkNonSubscriptionTransactionAPI() {
     let _: String = transaction.productIdentifier
     let _: Date = transaction.purchaseDate
     let _: String = transaction.transactionIdentifier
+    let _: String = transaction.storeTransactionIdentifier
 }


### PR DESCRIPTION
Fixes #3636.

This was added in #3009.
It was not made `public` because it was only used for #2841, but as explained in #3636 it can be useful as `public`.
