### PR TITLE
`Xcode 15.3 beta 2`: remove `nonisolated` workaround

### DIFF
--- a/Sources/Support/DebugUI/DebugViewModel.swift
+++ b/Sources/Support/DebugUI/DebugViewModel.swift
@@ -69,23 +69,11 @@ final class DebugViewModel: ObservableObject {
         self.customerInfo = await .create { try await Purchases.shared.customerInfo() }
         self.currentAppUserID = Purchases.shared.appUserID
 
-        await self.listenToCustomerInfoChanges()
+        for await info in Purchases.shared.customerInfoStream {
+            self.customerInfo = .loaded(info)
+        }
         #endif
     }
-
-    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-    // `nonisolated` required to work around Swift 5.10 issue.
-    // See https://github.com/RevenueCat/purchases-ios/pull/3599
-    nonisolated private func listenToCustomerInfoChanges() async {
-        for await info in Purchases.shared.customerInfoStream {
-            await self.updateCustomerInfo(info)
-        }
-    }
-
-    private func updateCustomerInfo(_ info: CustomerInfo) {
-        self.customerInfo = .loaded(info)
-    }
-    #endif
 
 }
 

--- a/Sources/Support/StoreMessagesHelper.swift
+++ b/Sources/Support/StoreMessagesHelper.swift
@@ -46,15 +46,13 @@ actor StoreMessagesHelper: StoreMessagesHelperType {
 
     #if os(iOS) || targetEnvironment(macCatalyst) || VISION_OS
 
-    // `nonisolated` required to work around Swift 5.10 issue.
-    // See https://github.com/RevenueCat/purchases-ios/pull/3599
-    nonisolated func deferMessagesIfNeeded() async throws {
+    func deferMessagesIfNeeded() async throws {
         guard !self.showStoreMessagesAutomatically else {
             return
         }
 
         for try await message in self.storeMessagesProvider.messages {
-            await self.add(message)
+            self.deferredMessages.append(message)
         }
     }
 
@@ -69,10 +67,6 @@ actor StoreMessagesHelper: StoreMessagesHelperType {
             }
         }
         self.deferredMessages.removeAll()
-    }
-
-    private func add(_ message: StoreMessage) {
-        self.deferredMessages.append(message)
     }
 
     #endif

--- a/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -95,10 +95,8 @@ class StoreKitConfigTestCase: TestCase {
         super.tearDown()
     }
 
-    // `nonisolated` required to work around Swift 5.10 issue.
-    // See https://github.com/RevenueCat/purchases-ios/pull/3599
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-    private static nonisolated func listenToTransactionUpdates() async {
+    private static func listenToTransactionUpdates() async {
         // Silence warning in tests:
         // "Making a purchase without listening for transaction updates risks missing successful purchases.
         for await _ in Transaction.updates {}


### PR DESCRIPTION
See #3599.

This is listed in the [release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-15_3-release-notes) as fixed.
