### PR TITLE
Allow force dark mode.

### DIFF
--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -20,6 +20,7 @@ struct PaywallViewConfiguration {
     var displayCloseButton: Bool
     var introEligibility: TrialOrIntroEligibilityChecker?
     var purchaseHandler: PurchaseHandler?
+    var isDarkMode: Bool?
 
     init(
         content: Content,
@@ -28,7 +29,8 @@ struct PaywallViewConfiguration {
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
-        purchaseHandler: PurchaseHandler? = nil
+        purchaseHandler: PurchaseHandler? = nil,
+        isDarkMode: Bool? = nil
     ) {
         self.content = content
         self.customerInfo = customerInfo
@@ -37,6 +39,7 @@ struct PaywallViewConfiguration {
         self.displayCloseButton = displayCloseButton
         self.introEligibility = introEligibility
         self.purchaseHandler = purchaseHandler
+        self.isDarkMode = isDarkMode
     }
 
 }
@@ -67,7 +70,8 @@ extension PaywallViewConfiguration {
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
-        purchaseHandler: PurchaseHandler? = nil
+        purchaseHandler: PurchaseHandler? = nil,
+        isDarkMode: Bool? = nil
     ) {
         self.init(
             content: .optionalOffering(offering),
@@ -76,7 +80,8 @@ extension PaywallViewConfiguration {
             fonts: fonts,
             displayCloseButton: displayCloseButton,
             introEligibility: introEligibility,
-            purchaseHandler: purchaseHandler
+            purchaseHandler: purchaseHandler,
+            isDarkMode: isDarkMode
         )
     }
 

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -29,6 +29,7 @@ public struct PaywallView: View {
     private let mode: PaywallViewMode
     private let fonts: PaywallFontProvider
     private let displayCloseButton: Bool
+    private let isDarkMode: Bool?
 
     @Environment(\.locale)
     private var locale
@@ -104,6 +105,7 @@ public struct PaywallView: View {
         self.mode = configuration.mode
         self.fonts = configuration.fonts
         self.displayCloseButton = configuration.displayCloseButton
+        self.isDarkMode = configuration.isDarkMode
     }
 
     // swiftlint:disable:next missing_docs
@@ -118,12 +120,17 @@ public struct PaywallView: View {
         VStack { // Necessary to work around FB12674350 and FB12787354
             if self.introEligibility.isConfigured, self.purchaseHandler.isConfigured {
                 if let offering = self.offering, let customerInfo = self.customerInfo {
-                    self.paywallView(for: offering,
+                    let payWallView = self.paywallView(for: offering,
                                      activelySubscribedProductIdentifiers: customerInfo.activeSubscriptions,
                                      fonts: self.fonts,
                                      checker: self.introEligibility,
                                      purchaseHandler: self.purchaseHandler)
-                    .transition(Self.transition)
+                        .transition(Self.transition)
+                    if let isDarkMode = self.isDarkMode {
+                        payWallView.colorScheme(isDarkMode ? ColorScheme.dark : ColorScheme.light)
+                    }else{
+                        payWallView
+                    }
                 } else {
                     LoadingPaywallView(mode: self.mode, displayCloseButton: self.displayCloseButton)
                         .transition(Self.transition)
@@ -170,7 +177,8 @@ public struct PaywallView: View {
             fonts: fonts,
             displayCloseButton: self.displayCloseButton,
             introEligibility: checker,
-            purchaseHandler: purchaseHandler
+            purchaseHandler: purchaseHandler,
+            isDarkMode: isDarkMode
         )
 
         if let error {
@@ -259,6 +267,7 @@ struct LoadedOfferingPaywallView: View {
     private let mode: PaywallViewMode
     private let fonts: PaywallFontProvider
     private let displayCloseButton: Bool
+    private let isDarkMode: Bool?
 
     @StateObject
     private var introEligibility: IntroEligibilityViewModel
@@ -283,7 +292,8 @@ struct LoadedOfferingPaywallView: View {
         fonts: PaywallFontProvider,
         displayCloseButton: Bool,
         introEligibility: TrialOrIntroEligibilityChecker,
-        purchaseHandler: PurchaseHandler
+        purchaseHandler: PurchaseHandler,
+        isDarkMode: Bool? = nil
     ) {
         self.offering = offering
         self.activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers
@@ -296,6 +306,7 @@ struct LoadedOfferingPaywallView: View {
             wrappedValue: .init(introEligibilityChecker: introEligibility)
         )
         self._purchaseHandler = .init(initialValue: purchaseHandler)
+        self.isDarkMode = isDarkMode
     }
 
     var body: some View {
@@ -353,7 +364,7 @@ struct LoadedOfferingPaywallView: View {
             sessionID: .init(),
             displayMode: self.mode,
             locale: .current,
-            darkMode: self.colorScheme == .dark
+            darkMode: self.isDarkMode ?? (self.colorScheme == .dark)
         )
     }
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -134,6 +134,12 @@ public class PaywallViewController: UIViewController {
     public func updateFont(with fontName: String) {
         self.configuration.fonts = CustomPaywallFontProvider(fontName: fontName)
     }
+    
+    /// - Warning: For internal use only
+    @objc(updateDarkMode:)
+    public func updateDarkMode(with isDarkMode: Bool) {
+        self.configuration.isDarkMode = isDarkMode
+    }
 
     // MARK: - Internal
 


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
* Allow force dark mode, when darkMode boolean is not null
* Currently I have a RN project using paywall and it does not respect the dark mode user preference.

### Description
* Allow devs to change darkmode scheme when isDarkMode is provided.
* If it's null it uses the system colorScheme env variable

Need to check lint and unit test

https://github.com/RevenueCat/purchases-ios/assets/6516487/07637747-f234-4a6a-916a-ebe58ce7a585
