### PR TITLE
`Paywalls`: add logs for localization lookup

### DIFF
--- a/Sources/Logging/Strings/PaywallsStrings.swift
+++ b/Sources/Logging/Strings/PaywallsStrings.swift
@@ -24,6 +24,10 @@ enum PaywallsStrings {
     case caching_presented_paywall
     case clearing_presented_paywall
 
+    case looking_up_localization([Locale])
+    case found_localization(Locale)
+    case fallback_localization(localeIdentifier: String)
+
     // MARK: - Events
 
     case event_manager_initialized
@@ -55,6 +59,15 @@ extension PaywallsStrings: LogMessage {
 
         case .clearing_presented_paywall:
             return "PurchasesOrchestrator: clearing presented paywall"
+
+        case let .looking_up_localization(locales):
+            return "Looking up localized configuration for \(locales.map(\.identifier))"
+
+        case let .found_localization(locale):
+            return "Found localized configuration for '\(locale.identifier)'"
+
+        case let .fallback_localization(localeIdentifier):
+            return "Failed looking up localization, using fallback: \(localeIdentifier)"
 
         // MARK: - Events
 


### PR DESCRIPTION
Will make debugging issues like #3633 and https://github.com/RevenueCat/purchases-ios/pull/3633#issuecomment-1931848279 easier.

```
VERBOSE: Looking up localized configuration for ["de_CH", "de"]
VERBOSE: Found localized configuration for 'de'
```
