### PR TITLE
`StoreKitVersion`: simplify `Objective-C` names

### DIFF
--- a/Sources/Misc/StoreKitVersion.swift
+++ b/Sources/Misc/StoreKitVersion.swift
@@ -17,13 +17,15 @@ import Foundation
 @objc(RCStoreKitVersion)
 public enum StoreKitVersion: Int {
 
-    /// Always use StoreKit 1. 
+    /// Always use StoreKit 1.
+    @objc(RCStoreKitVersion1)
     case storeKit1 = 1
 
     /// Always use StoreKit 2 (StoreKit 1 will be used if StoreKit 2 is not available in the current device.)
     ///
     /// - Warning: Make sure you have an In-App Purchase Key configured in your app.
     /// Please see https://rev.cat/in-app-purchase-key-configuration for more info.
+    @objc(RCStoreKitVersion2)
     case storeKit2 = 2
 
 }

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
@@ -14,7 +14,7 @@
 + (void)checkAPI {
     RCConfigurationBuilder *builder = [RCConfiguration builderWithAPIKey:@""];
     RCConfiguration *config __unused = [[[[[[[[[[[[[builder withApiKey:@""]
-                                                   withObserverMode:false storeKitVersion:RCStoreKitVersionStoreKit2]
+                                                   withObserverMode:false storeKitVersion:RCStoreKitVersion2]
                                                   withUserDefaults:NSUserDefaults.standardUserDefaults]
                                                  withAppUserID:@""]
                                                 withAppUserID:nil]
@@ -23,7 +23,7 @@
                                              withStoreKit1Timeout: 1]
                                             withPlatformInfo:[[RCPlatformInfo alloc] initWithFlavor:@"" version:@""]]
                                            withUsesStoreKit2IfAvailable:false]
-                                          withStoreKitVersion:RCStoreKitVersionStoreKit2]
+                                          withStoreKitVersion:RCStoreKitVersion2]
                                          withEntitlementVerificationMode:RCEntitlementVerificationModeInformational]
                                         build];
 }

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCStoreKitVersionAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCStoreKitVersionAPI.m
@@ -12,11 +12,11 @@
 @implementation RCStoreKitVersionAPI
 
 + (void)checkAPI {
-    const __unused int version = RCStoreKitVersionStoreKit1;
+    const __unused RCStoreKitVersion version = RCStoreKitVersion1;
 
     switch (version) {
-        case RCStoreKitVersionStoreKit1:
-        case RCStoreKitVersionStoreKit2:
+        case RCStoreKitVersion1:
+        case RCStoreKitVersion2:
             break;
     }
 }


### PR DESCRIPTION
The word `StoreKit` was unnecessarily duplicated.