### PR TITLE
`Paywalls`: prioritize `Locale.current` over `Locale.preferredLocales`

### DIFF
--- a/Sources/Logging/Strings/PaywallsStrings.swift
+++ b/Sources/Logging/Strings/PaywallsStrings.swift
@@ -24,7 +24,7 @@ enum PaywallsStrings {
     case caching_presented_paywall
     case clearing_presented_paywall
 
-    case looking_up_localization([Locale])
+    case looking_up_localization(preferred: [Locale], search: [Locale])
     case found_localization(Locale)
     case fallback_localization(localeIdentifier: String)
 
@@ -60,8 +60,9 @@ extension PaywallsStrings: LogMessage {
         case .clearing_presented_paywall:
             return "PurchasesOrchestrator: clearing presented paywall"
 
-        case let .looking_up_localization(locales):
-            return "Looking up localized configuration for \(locales.map(\.identifier))"
+        case let .looking_up_localization(preferred, search):
+            return "Looking up localized configuration for \(preferred.map(\.identifier)), " +
+            "searching for \(search.map(\.identifier))"
 
         case let .found_localization(locale):
             return "Found localized configuration for '\(locale.identifier)'"

--- a/Sources/Paywalls/PaywallData+Localization.swift
+++ b/Sources/Paywalls/PaywallData+Localization.swift
@@ -23,6 +23,8 @@ public extension PaywallData {
 
     // Visible for testing
     internal func localizedConfiguration(for preferredLocales: [Locale]) -> LocalizedConfiguration {
+        // Allows us to search each locale in order of priority, both with the region and without.
+        // Example: [en_UK, es_ES] => [en_UK, en, es_ES, es]
         let locales: [Locale] = preferredLocales.flatMap { [$0, $0.removingRegion].compactMap { $0 } }
 
         Logger.verbose(Strings.paywalls.looking_up_localization(preferred: preferredLocales,

--- a/Sources/Paywalls/PaywallData+Localization.swift
+++ b/Sources/Paywalls/PaywallData+Localization.swift
@@ -50,11 +50,13 @@ public extension PaywallData {
     /// - Returns: The list of locales that paywalls should try to search for.
     /// Includes `Locale.current` and `Locale.preferredLanguages`.
     internal static var localesOrderedByPriority: [Locale] {
-        var result = [.current] + Locale.preferredLocales
+        var result: [Locale] = [.current]
 
         if let withoutRegion = Locale.current.removingRegion {
             result.append(withoutRegion)
         }
+
+        result.append(contentsOf: Locale.preferredLocales)
 
         return result
     }

--- a/Sources/Paywalls/PaywallData+Localization.swift
+++ b/Sources/Paywalls/PaywallData+Localization.swift
@@ -22,8 +22,11 @@ public extension PaywallData {
     }
 
     // Visible for testing
-    internal func localizedConfiguration(for locales: [Locale]) -> LocalizedConfiguration {
-        Logger.verbose(Strings.paywalls.looking_up_localization(locales))
+    internal func localizedConfiguration(for preferredLocales: [Locale]) -> LocalizedConfiguration {
+        let locales: [Locale] = preferredLocales.flatMap { [$0, $0.removingRegion].compactMap { $0 } }
+
+        Logger.verbose(Strings.paywalls.looking_up_localization(preferred: preferredLocales,
+                                                                search: locales))
 
         let result: (locale: Locale, config: LocalizedConfiguration)? = locales
             .lazy
@@ -50,15 +53,7 @@ public extension PaywallData {
     /// - Returns: The list of locales that paywalls should try to search for.
     /// Includes `Locale.current` and `Locale.preferredLanguages`.
     internal static var localesOrderedByPriority: [Locale] {
-        var result: [Locale] = [.current]
-
-        if let withoutRegion = Locale.current.removingRegion {
-            result.append(withoutRegion)
-        }
-
-        result.append(contentsOf: Locale.preferredLocales)
-
-        return result
+        return [.current] + Locale.preferredLocales
     }
 
     private var fallbackLocalizedConfiguration: (String, LocalizedConfiguration) {

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -128,7 +128,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
         let enConfig = try XCTUnwrap(paywall.localizedConfiguration(for: [
             .init(identifier: "en_IN"),
             .init(identifier: "en-IN")
-        ].compactMap { $0 }))
+        ]))
         expect(enConfig.title) == "Paywall"
     }
 
@@ -138,7 +138,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
         let enConfig = try XCTUnwrap(paywall.localizedConfiguration(for: [
             .init(identifier: "en_IN"),
             .init(identifier: "es_ES")
-        ].compactMap { $0 }))
+        ]))
         expect(enConfig.title) == "Paywall"
     }
 

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -127,7 +127,6 @@ class PaywallDataTests: BaseHTTPResponseTest {
 
         let enConfig = try XCTUnwrap(paywall.localizedConfiguration(for: [
             .init(identifier: "en_IN"),
-            .init(identifier: "en-IN").removingRegion,
             .init(identifier: "en-IN")
         ].compactMap { $0 }))
         expect(enConfig.title) == "Paywall"
@@ -138,9 +137,6 @@ class PaywallDataTests: BaseHTTPResponseTest {
 
         let enConfig = try XCTUnwrap(paywall.localizedConfiguration(for: [
             .init(identifier: "en_IN"),
-            .init(identifier: "en-IN").removingRegion,
-            // It's important that `localesOrderedByPriority` puts this after `Locale.current.removingRegion`
-            // So that we give `Locale.current` higher priority.
             .init(identifier: "es_ES")
         ].compactMap { $0 }))
         expect(enConfig.title) == "Paywall"
@@ -152,13 +148,11 @@ class PaywallDataTests: BaseHTTPResponseTest {
         if #available(iOS 17.0, tvOS 17, watchOS 10, *) {
             expected = [
                 "en_US",
-                "en",
                 "en-US"
             ]
         } else {
             expected = [
                 "en_US",
-                "en",
                 // `Locale.preferredLanguages` returns `en` before iOS 17.
                 "en"
             ]

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -127,8 +127,21 @@ class PaywallDataTests: BaseHTTPResponseTest {
 
         let enConfig = try XCTUnwrap(paywall.localizedConfiguration(for: [
             .init(identifier: "en_IN"),
-            .init(identifier: "en-IN"),
-            .init(identifier: "en-IN").removingRegion
+            .init(identifier: "en-IN").removingRegion,
+            .init(identifier: "en-IN")
+        ].compactMap { $0 }))
+        expect(enConfig.title) == "Paywall"
+    }
+
+    func testLocalizedConfigurationLooksForCurrentLocaleWithoutRegionBeforePreferedLocales() throws {
+        let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
+
+        let enConfig = try XCTUnwrap(paywall.localizedConfiguration(for: [
+            .init(identifier: "en_IN"),
+            .init(identifier: "en-IN").removingRegion,
+            // It's important that `localesOrderedByPriority` puts this after `Locale.current.removingRegion`
+            // So that we give `Locale.current` higher priority.
+            .init(identifier: "es_ES")
         ].compactMap { $0 }))
         expect(enConfig.title) == "Paywall"
     }
@@ -139,14 +152,14 @@ class PaywallDataTests: BaseHTTPResponseTest {
         if #available(iOS 17.0, tvOS 17, watchOS 10, *) {
             expected = [
                 "en_US",
-                "en-US",
-                "en"
+                "en",
+                "en-US"
             ]
         } else {
             expected = [
                 "en_US",
-                // `Locale.preferredLanguages` returns `en` before iOS 17.
                 "en",
+                // `Locale.preferredLanguages` returns `en` before iOS 17.
                 "en"
             ]
         }


### PR DESCRIPTION
Fixes #3655.
Follow up to #3633.

This improves upon that PR by using `Locale.current.removingRegion` for each locale **before** trying to look up `Locale.preferredLocales`.

This fixes this scenario:
- Configure your phone with: `en_IN` and `es_ES`
- Launch paywall with localization `en_US` and `es_ES`

Prior to this change, we'd be looking up localizations in this order:
- `en_IN`
- `es_ES`
- `en` (no region)

Because there _is_ a localization for `es_ES` we'd return that one before attempting to look up `Locale.current.removingRegion`.

Example of the new log:
> VERBOSE: Looking up localized configuration for ["en_IN", "es_ES"], searching for ["en_IN", "en", "es_ES", "es"]
> VERBOSE: Found localized configuration for 'en'
