### PR TITLE
`Paywalls`: allow empty `packages`

### DIFF
--- a/RevenueCatUI/Data/PaywallData+Validation.swift
+++ b/RevenueCatUI/Data/PaywallData+Validation.swift
@@ -48,11 +48,13 @@ extension Offering {
                 return (paywall, template, nil)
 
             case let .failure(error):
-                // If there are any errors, create a default paywall
-                // with only the configured packages.
-                return (.createDefault(with: paywall.config.packages, locale: locale),
-                        PaywallData.defaultTemplate,
-                        error)
+                let paywall: PaywallData = paywall.config.packages.isEmpty
+                    ? .createDefault(with: self.availablePackages, locale: locale)
+                    : .createDefault(with: paywall.config.packages, locale: locale)
+
+                return (displayablePaywall: paywall,
+                        template: PaywallData.defaultTemplate,
+                        error: error)
             }
         } else {
             // If `Offering` has no paywall, create a default one with all available packages.

--- a/RevenueCatUI/Data/TemplateViewConfiguration.swift
+++ b/RevenueCatUI/Data/TemplateViewConfiguration.swift
@@ -42,14 +42,6 @@ extension TemplateViewConfiguration {
 
     }
 
-    /// Whether a template displays 1 or multiple packages.
-    enum PackageSetting: Equatable {
-
-        case single
-        case multiple
-
-    }
-
     /// Describes the possible displayed packages in a paywall.
     /// See `create(with:filter:setting:)` for how to create these.
     enum PackageConfiguration: Equatable {
@@ -119,7 +111,7 @@ extension TemplateViewConfiguration.PackageConfiguration {
         filter: [String],
         default: String?,
         localization: PaywallData.LocalizedConfiguration,
-        setting: TemplateViewConfiguration.PackageSetting,
+        setting: TemplatePackageSetting,
         locale: Locale = .current
     ) throws -> Self {
         guard !packages.isEmpty else { throw TemplateError.noPackages }

--- a/RevenueCatUI/TemplatePackageSetting.swift
+++ b/RevenueCatUI/TemplatePackageSetting.swift
@@ -1,0 +1,54 @@
+//
+//  TemplatePackageSetting.swift
+//
+//
+//  Created by Nacho Soto on 2/8/24.
+//
+
+import Foundation
+
+/// Whether a template displays 1 or multiple packages.
+enum TemplatePackageSetting: Equatable {
+
+    case single
+    case multiple
+    case multiTier
+
+}
+
+/// Whether a template displays 1 or multiple tiers.
+enum TemplateTierSetting: Equatable {
+
+    /// Single-tier template.
+    case single
+
+    /// Multi-tier template.
+    case multiple
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension PaywallTemplate {
+
+    var packageSetting: TemplatePackageSetting {
+        switch self {
+        case .template1: return .single
+        case .template2: return .multiple
+        case .template3: return .single
+        case .template4: return .multiple
+        case .template5: return .multiple
+        }
+    }
+
+}
+
+extension TemplatePackageSetting {
+
+    var tierSetting: TemplateTierSetting {
+        switch self {
+        case .single, .multiple: return .single
+        case .multiTier: return .multiple
+        }
+    }
+
+}

--- a/RevenueCatUI/TemplatePackageSetting.swift
+++ b/RevenueCatUI/TemplatePackageSetting.swift
@@ -12,7 +12,6 @@ enum TemplatePackageSetting: Equatable {
 
     case single
     case multiple
-    case multiTier
 
 }
 
@@ -21,9 +20,6 @@ enum TemplateTierSetting: Equatable {
 
     /// Single-tier template.
     case single
-
-    /// Multi-tier template.
-    case multiple
 
 }
 
@@ -47,7 +43,6 @@ extension TemplatePackageSetting {
     var tierSetting: TemplateTierSetting {
         switch self {
         case .single, .multiple: return .single
-        case .multiTier: return .multiple
         }
     }
 

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -60,21 +60,6 @@ extension TemplateViewType {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private extension PaywallTemplate {
-
-    var packageSetting: TemplateViewConfiguration.PackageSetting {
-        switch self {
-        case .template1: return .single
-        case .template2: return .multiple
-        case .template3: return .single
-        case .template4: return .multiple
-        case .template5: return .multiple
-        }
-    }
-
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 extension PaywallData {

--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -184,7 +184,10 @@ extension PaywallData {
     public struct Configuration {
 
         /// The list of package identifiers this paywall will display
-        public var packages: [String]
+        public var packages: [String] {
+            get { self._packages }
+            set { self._packages = newValue }
+        }
 
         /// The package to be selected by default.
         public var defaultPackage: String?
@@ -239,7 +242,7 @@ extension PaywallData {
             termsOfServiceURL: URL? = nil,
             privacyURL: URL? = nil
         ) {
-            self.packages = packages
+            self._packages = packages
             self.defaultPackage = defaultPackage
             self._imagesHeic = images
             self.colors = colors
@@ -248,6 +251,9 @@ extension PaywallData {
             self._termsOfServiceURL = termsOfServiceURL
             self._privacyURL = privacyURL
         }
+
+        @DefaultDecodable.EmptyArray
+        var _packages: [String]
 
         var _legacyImages: Images?
         var _imagesHeic: Images?
@@ -471,7 +477,7 @@ extension PaywallData.Configuration.Images: Codable {
 extension PaywallData.Configuration: Codable {
 
     private enum CodingKeys: String, CodingKey {
-        case packages
+        case _packages = "packages"
         case defaultPackage
         case _legacyImages = "images"
         case _imagesHeic = "imagesHeic"


### PR DESCRIPTION
`PaywallData.packages` won't be used by multi-tier paywalls, so we need to allow that.