### PR TITLE
`Paywalls`: allow overriding `UIUserInterfaceStyle` in `PaywallViewController` (by @Jjastiny)

### DIFF
--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -134,10 +134,12 @@ public class PaywallViewController: UIViewController {
     public func updateFont(with fontName: String) {
         self.configuration.fonts = CustomPaywallFontProvider(fontName: fontName)
     }
-    
-    /// - Warning: For internal use only
-    @objc(updateWithUserInterfaceStyle:)
-    public func update(with style: UIUserInterfaceStyle) {
+
+    /// Overrides the `UIUserInterfaceStyle` in the underlying paywall.
+    @objc(updateUserInterfaceStyle:)
+    public func updateStyle(style: UIUserInterfaceStyle) {
+        self.loadViewIfNeeded()
+
         self.hostingController?.overrideUserInterfaceStyle = style
     }
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -134,6 +134,12 @@ public class PaywallViewController: UIViewController {
     public func updateFont(with fontName: String) {
         self.configuration.fonts = CustomPaywallFontProvider(fontName: fontName)
     }
+    
+    /// - Warning: For internal use only
+    @objc(updateWithUserInterfaceStyle:)
+    public func update(with style: UIUserInterfaceStyle) {
+        self.hostingController?.overrideUserInterfaceStyle = style
+    }
 
     // MARK: - Internal
 
@@ -301,7 +307,6 @@ private struct PaywallContainerView: View {
             .onPurchaseFailure(self.purchaseFailure)
             .onRestoreFailure(self.restoreFailure)
             .onSizeChange(self.onSizeChange)
-
     }
 
 }

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -137,7 +137,7 @@ public class PaywallViewController: UIViewController {
 
     /// Overrides the `UIUserInterfaceStyle` in the underlying paywall.
     @objc(updateUserInterfaceStyle:)
-    public func updateStyle(style: UIUserInterfaceStyle) {
+    public func updateStyle(_ style: UIUserInterfaceStyle) {
         self.loadViewIfNeeded()
 
         self.hostingController?.overrideUserInterfaceStyle = style

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -36,7 +36,7 @@ func paywallViewControllerAPI(_ delegate: Delegate, _ offering: Offering?) {
     controller.update(with: offering!)
     controller.update(with: "offering_identifier")
     controller.updateFont(with: "Papyrus")
-    controller.updateStyle(style: UIUserInterfaceStyle.dark)
+    controller.updateStyle(UIUserInterfaceStyle.dark)
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -36,6 +36,7 @@ func paywallViewControllerAPI(_ delegate: Delegate, _ offering: Offering?) {
     controller.update(with: offering!)
     controller.update(with: "offering_identifier")
     controller.updateFont(with: "Papyrus")
+    controller.updateStyle(style: UIUserInterfaceStyle.dark)
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)


### PR DESCRIPTION
Original PR: #3647.

`PaywallView` allows overriding it with `.environment(\.colorScheme)`.
This allows doing the same with `PaywallViewController`.

https://github.com/RevenueCat/purchases-ios/assets/6516487/07637747-f234-4a6a-916a-ebe58ce7a585