### PR TITLE
Revert "Run load shedder integration tests on release branches (#3673)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1178,9 +1178,6 @@ workflows:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
-      - loadshedder-integration-tests:
-          xcode_version: '15.2'
-          <<: *release-branches
 
   deploy:
     when:


### PR DESCRIPTION
### Description
This reverts #3673 

I thought we were not running the load shedder integration tests but we are in the SK1 and SK2 jobs. I missed that. Reverting that change.
