### PR TITLE
`CI`: split load shedder integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -977,7 +977,7 @@ jobs:
           name: Create automatic PR
           command: bundle exec fastlane automatic_bump github_rate_limit:10
 
-  loadshedder-integration-tests:
+  integration-tests-all:
     <<: *base-job
     steps:
       - checkout
@@ -985,12 +985,6 @@ jobs:
       - trust-github-key
       - install-dependencies
       - update-spm-installation-commit
-      - run:
-          name: V3 LoadShedder integration tests
-          command: bundle exec fastlane v3_loadshedder_integration_tests
-      - compress_result_bundle:
-          directory: fastlane/test_output/xctest/ios
-          bundle_name: v3LoadShedderIntegration
       - run:
           name: Backend and LoadShedder integration tests
           command: bundle exec fastlane backend_integration_tests test_plan:"BackendIntegrationTests-All-CI"
@@ -1005,6 +999,21 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+
+  loadshedder-integration-tests-v3:
+    <<: *base-job
+    steps:
+      - checkout
+      - setup-git-credentials
+      - trust-github-key
+      - install-dependencies
+      - update-spm-installation-commit
+      - run:
+          name: V3 LoadShedder integration tests
+          command: bundle exec fastlane v3_loadshedder_integration_tests
+      - compress_result_bundle:
+          directory: fastlane/test_output/xctest/ios
+          bundle_name: v3LoadShedderIntegration
   
   deploy-purchase-tester:
     <<: *base-job
@@ -1178,9 +1187,6 @@ workflows:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
-      - loadshedder-integration-tests:
-          xcode_version: '15.2'
-          <<: *release-branches
 
   deploy:
     when:
@@ -1274,7 +1280,9 @@ workflows:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "load_shedder_integration_tests", << pipeline.schedule.name >> ]
     jobs:
-      - loadshedder-integration-tests:
+      - loadshedder-integration-tests-v3:
+          xcode_version: '15.2'
+      - integration-tests-all:
           xcode_version: '15.2'
   
   manual-trigger-bump:

--- a/BackendIntegrationTests/BackendIntegrationTests-Shedder.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-Shedder.xctestplan
@@ -1,0 +1,77 @@
+{
+  "configurations" : [
+    {
+      "id" : "62C79EF4-8071-439C-B693-34F1E57211FC",
+      "name" : "Configuration 1",
+      "options" : {
+        "testTimeoutsEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "environmentVariableEntries" : [
+      {
+        "key" : "RCMockAdServicesToken",
+        "value" : "G9i5hC8lQJeGOfmS+MFycll"
+      },
+      {
+        "key" : "RCRunningTests",
+        "value" : "1"
+      },
+      {
+        "key" : "RCRunningIntegrationTests",
+        "value" : "1"
+      }
+    ],
+    "maximumTestExecutionTimeAllowance" : 180,
+    "maximumTestRepetitions" : 5,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:RevenueCat.xcodeproj",
+      "identifier" : "2DE20B7E26409EB7004C597D",
+      "name" : "BackendIntegrationTestsHostApp"
+    },
+    "testExecutionOrdering" : "random",
+    "testRepetitionMode" : "retryOnFailure",
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "BaseBackendIntegrationTests",
+        "BaseOfflineStoreKitIntegrationTests",
+        "BaseSignatureVerificationIntegrationTests",
+        "BaseStoreKitIntegrationTests",
+        "BaseStoreKitObserverModeIntegrationTests",
+        "DisabledSignatureVerificationIntegrationTests",
+        "DynamicModeSignatureVerificationIntegrationTests",
+        "EnforcedSignatureVerificationIntegrationTests",
+        "InformationalSignatureVerificationIntegrationTests",
+        "OfflineStoreKit1IntegrationTests",
+        "OfflineStoreKit2IntegrationTests",
+        "OfflineStoreKit2JWSIntegrationTests",
+        "OfflineWithNoMappingStoreKitIntegrationTests",
+        "OtherIntegrationTests",
+        "PaywallEventsIntegrationTests",
+        "SignatureVerificationWithoutHeaderHashIntegrationTests",
+        "StoreKit1IntegrationTests",
+        "StoreKit1ObserverModeIntegrationTests",
+        "StoreKit1ObserverModeWithExistingPurchasesTests",
+        "StoreKit2IntegrationTests",
+        "StoreKit2JWSIntegrationTests",
+        "StoreKit2JWSObserverModeIntegrationTests",
+        "StoreKit2JWSObserverModeWithExistingPurchasesTests",
+        "StoreKit2ObserverModeIntegrationTests",
+        "StoreKit2ObserverModeWithExistingPurchasesTests",
+        "SubscriberAttributesManagerIntegrationTests",
+        "TestCase"
+      ],
+      "target" : {
+        "containerPath" : "container:RevenueCat.xcodeproj",
+        "identifier" : "2DE20B6B264087FB004C597D",
+        "name" : "BackendIntegrationTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1019,6 +1019,7 @@
 		4F34AEEB2A5DCCBA00F4BCB0 /* VerificationResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationResultTests.swift; sourceTree = "<group>"; };
 		4F3C98692A44FA60009AECA3 /* ErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponse.swift; sourceTree = "<group>"; };
 		4F3D56622A1E66A10070105A /* CustomerInfoManagerPostReceiptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerPostReceiptTests.swift; sourceTree = "<group>"; };
+		4F4EBE202B7A85D400E57264 /* BackendIntegrationTests-Shedder.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "BackendIntegrationTests-Shedder.xctestplan"; sourceTree = "<group>"; };
 		4F4EECE32AAFA8DA0047DE7A /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		4F4FF3E02A3B731A0028018C /* ETagStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETagStrings.swift; sourceTree = "<group>"; };
 		4F520EF22B06C7A700DB6770 /* CI-RevenueCat-Snapshots.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = "CI-RevenueCat-Snapshots.xctestplan"; path = "Tests/TestPlans/CI-RevenueCat-Snapshots.xctestplan"; sourceTree = "<group>"; };
@@ -2418,6 +2419,7 @@
 				4FE3A57E2B4C6BB40006A7FC /* BackendIntegrationTests-Other.xctestplan */,
 				4FE3A57D2B4C6BB40006A7FC /* BackendIntegrationTests-SK1.xctestplan */,
 				4FE3A57F2B4C6C560006A7FC /* BackendIntegrationTests-SK2.xctestplan */,
+				4F4EBE202B7A85D400E57264 /* BackendIntegrationTests-Shedder.xctestplan */,
 			);
 			path = BackendIntegrationTests;
 			sourceTree = "<group>";

--- a/RevenueCat.xcodeproj/xcshareddata/xcschemes/BackendIntegrationTests.xcscheme
+++ b/RevenueCat.xcodeproj/xcshareddata/xcschemes/BackendIntegrationTests.xcscheme
@@ -50,6 +50,9 @@
          <TestPlanReference
             reference = "container:BackendIntegrationTests/BackendIntegrationTests-All-CI.xctestplan">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:BackendIntegrationTests/BackendIntegrationTests-Shedder.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference


### PR DESCRIPTION
Follow up to #3673.

### Changes:
- Split `loadshedder-integration-tests` into `integration-tests-all` and `loadshedder-integration-tests-v3`
- Removed `loadshedder-integration-tests` from `build_test`: this reverts #3673. We already run loadshedder tests as part of `SK1` and `SK2` test suites.
- Add `BackendIntegrationTests-Shedder` test plane. This isn't used by CI (see above point), but it can be useful to run all of the load shedder tests.
