### PR TITLE
`Paywalls`: `.onPaywallTierChange`

### DIFF
--- a/RevenueCatUI/Helpers/TemplateView+MultiTier.swift
+++ b/RevenueCatUI/Helpers/TemplateView+MultiTier.swift
@@ -1,0 +1,42 @@
+//
+//  TemplaterView+MultiTier.swift
+//
+//
+//  Created by Nacho Soto on 2/12/24.
+//
+
+import SwiftUI
+
+import RevenueCat
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension View {
+
+    func notify(selectedTier: PaywallData.Tier, selectedPackage: TemplateViewConfiguration.Package) -> some View {
+        self.preference(
+            key: PaywallCurrentTierPreferenceKey.self,
+            value: .init(tier: selectedTier, localizedName: selectedPackage.localization.tierName ?? "")
+        )
+    }
+
+}
+
+// MARK: - Preference Key
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct PaywallCurrentTierPreferenceKey: PreferenceKey {
+
+    struct Data: Equatable {
+        var tier: PaywallData.Tier
+        var localizedName: String
+    }
+
+    typealias Value = Data?
+
+    static var defaultValue: Value = nil
+
+    static func reduce(value: inout Value, nextValue: () -> Value) {
+        value = nextValue()
+    }
+
+}

--- a/RevenueCatUI/Templates/Template7View.swift
+++ b/RevenueCatUI/Templates/Template7View.swift
@@ -76,6 +76,10 @@ struct Template7View: TemplateViewType {
             .foregroundColor(self.configuration.colors.text1Color)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .animation(Constants.fastAnimation, value: self.selectedPackage)
+            .notify(
+                selectedTier: self.selectedTier,
+                selectedPackage: self.selectedPackage
+            )
     }
 
     @ViewBuilder

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -19,6 +19,7 @@ struct App: View {
     private var purchaseCompleted: PurchaseCompletedHandler = { (_: StoreTransaction?, _: CustomerInfo) in }
     private var purchaseCancelled: PurchaseCancelledHandler = { () in }
     private var failureHandler: PurchaseFailureHandler = { (_: NSError) in }
+    private var paywallTierChange: PaywallTierChangeHandler = { (_: PaywallData.Tier, _: String) in }
     private var paywallDismissed: () -> Void = {}
 
     var body: some View {
@@ -181,6 +182,7 @@ struct App: View {
                            restoreCompleted: self.purchaseOrRestoreCompleted,
                            purchaseFailure: self.failureHandler,
                            restoreFailure: self.failureHandler)
+            .onPaywallTierChange(self.paywallTierChange)
     }
 
     @ViewBuilder

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/CustomPaywall.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/CustomPaywall.swift
@@ -19,19 +19,26 @@ struct CustomPaywall: View {
     var introEligibility: TrialOrIntroEligibilityChecker?
     var purchaseHandler: PurchaseHandler?
 
+    @State
+    private var currentTierName: String?
+
     var body: some View {
         self.content
     }
 
     private var content: some View {
-        CustomPaywallContent()
-            .paywallFooter(offering: self.offering,
-                           customerInfo: self.customerInfo,
-                           condensed: self.condensed,
-                           fonts: DefaultPaywallFontProvider(),
-                           introEligibility: self.introEligibility ?? .default(),
-                           purchaseHandler: self.purchaseHandler ?? .default()
+        CustomPaywallContent(selectedTierName: self.currentTierName)
+            .paywallFooter(
+                offering: self.offering,
+                customerInfo: self.customerInfo,
+                condensed: self.condensed,
+                fonts: DefaultPaywallFontProvider(),
+                introEligibility: self.introEligibility ?? .default(),
+                purchaseHandler: self.purchaseHandler ?? .default()
             )
+            .onPaywallTierChange { _, name in
+                self.currentTierName = name
+            }
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/CustomPaywallContent.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/CustomPaywallContent.swift
@@ -5,6 +5,8 @@
 //  Created by Nacho Soto on 8/25/23.
 //
 
+import RevenueCat
+
 #if DEBUG
 @testable import RevenueCatUI
 #else
@@ -17,6 +19,8 @@ struct CustomPaywallContent: View {
 
     @State private var rotation: Double = 0.0
     @State private var starOpacity: Double = 1
+
+    var selectedTierName: String?
 
     var body: some View {
         self.content
@@ -40,14 +44,21 @@ struct CustomPaywallContent: View {
                 .padding(.top, -60)
                 .padding(.bottom, -80)
 
-            HStack(spacing: 0) {
-                Text("Pawwall")
-                    .font(.system(.largeTitle, design: .rounded).bold())
-                    .foregroundColor(Marketing.color5)
-                    .padding(.leading)
+            HStack(alignment: .firstTextBaseline, spacing: 0) {
+                Group {
+                    Text("Pawwall")
+                        .foregroundColor(Marketing.color5)
 
-                Text("Pro")
-                    .font(.system(.largeTitle, design: .rounded).bold())
+                    Text("Pro")
+
+                    if let selectedTierName = self.selectedTierName {
+                        Text("(\(selectedTierName))")
+                            .font(.system(.title2, design: .rounded).bold())
+                            .foregroundColor(Marketing.color5)
+                    }
+                }
+                .font(.system(.largeTitle, design: .rounded).bold())
+                .padding(.leading)
 
                 Spacer(minLength: 0)
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
@@ -172,25 +172,33 @@ struct OfferingsList: View {
 
 private struct PaywallPresenter: View {
 
+    @State
+    private var selectedTierName: String?
+
     var offering: Offering
     var mode: PaywallViewMode
     var displayCloseButton: Bool = Configuration.defaultDisplayCloseButton
 
     var body: some View {
-        switch self.mode {
-        case .fullScreen:
-            PaywallView(offering: self.offering, displayCloseButton: self.displayCloseButton)
+        Group {
+            switch self.mode {
+            case .fullScreen:
+                PaywallView(offering: self.offering, displayCloseButton: self.displayCloseButton)
 
-        #if !os(watchOS)
-        case .footer:
-            CustomPaywallContent()
-                .paywallFooter(offering: self.offering)
+            #if !os(watchOS)
+            case .footer:
+                CustomPaywallContent(selectedTierName: self.selectedTierName)
+                    .paywallFooter(offering: self.offering)
 
-        case .condensedFooter:
-            CustomPaywallContent()
-                .paywallFooter(offering: self.offering, condensed: true)
-        #endif
+            case .condensedFooter:
+                CustomPaywallContent(selectedTierName: self.selectedTierName)
+                    .paywallFooter(offering: self.offering, condensed: true)
+            #endif
+            }
         }
+        #if !os(watchOS)
+        .onPaywallTierChange { _, name in self.selectedTierName = name }
+        #endif
     }
 
 }


### PR DESCRIPTION
This is useful for implementing custom paywalls using `.footerPaywall` and responding to the tier selected in a paywall.

![simulator_screenshot_E024C30D-F7D3-4022-9FB3-5C4860DCB3ED](https://github.com/RevenueCat/purchases-ios/assets/685609/e167d524-fb08-4790-a15a-1cc4327eaacd)
