### PR TITLE
`CI`: skip `RevenueCatUI` API tests when generating snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,6 +427,8 @@ jobs:
           path: fastlane/test_output
           destination: scan-test-output
       - run:
+          condition: 
+            - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
           name: RevenueCatUI API Tests
           command: bundle exec fastlane build_revenuecatui_api_tester
 


### PR DESCRIPTION
Small performance optimization. This isn't needed when creating snapshots.
