### PR TITLE
`Paywalls`: don't dismiss footer paywalls automatically

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -329,7 +329,7 @@ struct LoadedOfferingPaywallView: View {
             .onAppear { self.purchaseHandler.trackPaywallImpression(self.createEventData()) }
             .onDisappear { self.purchaseHandler.trackPaywallClose() }
             .onChangeOf(self.purchaseHandler.purchased) { purchased in
-                if purchased {
+                if self.mode.isFullScreen, purchased {
                     Logger.debug(Strings.dismissing_paywall)
                     self.dismiss()
                 }


### PR DESCRIPTION
Follow up to #3517.

This behavior is the default and not opt-in, and it doesn't make sense on footer paywalls.
