### PR TITLE
`Paywalls`: fix `PaywallColor.init(light:dark:)`

### DIFF
--- a/RevenueCatUI/Helpers/ColorInformation+MultiScheme.swift
+++ b/RevenueCatUI/Helpers/ColorInformation+MultiScheme.swift
@@ -58,9 +58,15 @@ private extension PaywallColor {
 
     /// Creates a dynamic color for 2 ``ColorScheme``s from 2 optional colors.
     init?(light: PaywallColor?, dark: PaywallColor?) {
-        guard let light, let dark else { return nil }
-
-        self.init(light: light, dark: dark)
+        if let light, let dark {
+            self.init(light: light, dark: dark)
+        } else if let light {
+            self = light
+        } else if let dark {
+            self = dark
+        } else {
+            return nil
+        }
     }
 
 }


### PR DESCRIPTION
We probably didn't notice this because `PaywallData.Configuration.ColorInformation.multiScheme` checks for the existence of `dark` before.

However, this new implementation helps with the upcoming tier color overrides.
