### PR TITLE
`Paywalls`: new `.onRestoreStarted` modifier

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -307,6 +307,8 @@ struct LoadedOfferingPaywallView: View {
                         value: .init(data: self.purchaseHandler.purchaseResult))
             .preference(key: RestoredCustomerInfoPreferenceKey.self,
                         value: self.purchaseHandler.restoredCustomerInfo)
+            .preference(key: RestoreInProgressPreferenceKey.self,
+                        value: self.purchaseHandler.restoreInProgress)
             .preference(key: PurchaseErrorPreferenceKey.self,
                         value: self.purchaseHandler.purchaseError as NSError?)
             .preference(key: RestoreErrorPreferenceKey.self,

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -201,6 +201,10 @@ public protocol PaywallViewControllerDelegate: AnyObject {
     optional func paywallViewController(_ controller: PaywallViewController,
                                         didFailPurchasingWith error: NSError)
 
+    /// Notifies that a restore has started in a ``PaywallViewController``.
+    @objc(paywallViewControllerDidStartRestore:)
+    optional func paywallViewControllerDidStartRestore(_ controller: PaywallViewController)
+
     /// Notifies that the restore operation has completed in a ``PaywallViewController``.
     ///
     /// - Warning: Receiving a ``CustomerInfo``does not imply that the user has any entitlements,
@@ -257,6 +261,10 @@ private extension PaywallViewController {
                 guard let self else { return }
                 self.delegate?.paywallViewController?(self, didFailPurchasingWith: error)
             },
+            restoreStarted: { [weak self] in
+                guard let self else { return }
+                self.delegate?.paywallViewControllerDidStartRestore?(self)
+            },
             restoreFailure: { [weak self] error in
                 guard let self else { return }
                 self.delegate?.paywallViewController?(self, didFailRestoringWith: error)
@@ -289,7 +297,9 @@ private struct PaywallContainerView: View {
     let purchaseCancelled: PurchaseCancelledHandler
     let restoreCompleted: PurchaseOrRestoreCompletedHandler
     let purchaseFailure: PurchaseFailureHandler
+    let restoreStarted: RestoreStartedHandler
     let restoreFailure: PurchaseFailureHandler
+
     let onSizeChange: (CGSize) -> Void
 
     var body: some View {
@@ -297,8 +307,9 @@ private struct PaywallContainerView: View {
             .onPurchaseStarted(self.purchaseStarted)
             .onPurchaseCompleted(self.purchaseCompleted)
             .onPurchaseCancelled(self.purchaseCancelled)
-            .onRestoreCompleted(self.restoreCompleted)
             .onPurchaseFailure(self.purchaseFailure)
+            .onRestoreStarted(self.restoreStarted)
+            .onRestoreCompleted(self.restoreCompleted)
             .onRestoreFailure(self.restoreFailure)
             .onSizeChange(self.onSizeChange)
 

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -73,6 +73,7 @@ extension View {
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
+        restoreStarted: RestoreStartedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseFailure: PurchaseFailureHandler? = nil,
         restoreFailure: PurchaseFailureHandler? = nil,
@@ -91,6 +92,7 @@ extension View {
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
+            restoreStarted: restoreStarted,
             restoreCompleted: restoreCompleted,
             purchaseFailure: purchaseFailure,
             restoreFailure: restoreFailure,
@@ -116,6 +118,8 @@ extension View {
     ///         print("Purchases restored")
     ///     } purchaseFailure: { error in
     ///         print("Error purchasing: \(error)")
+    ///     } restoreStarted: {
+    ///         print("Restore started")
     ///     } restoreFailure: { error in
     ///         print("Error restoring purchases: \(error)")
     ///     } onDismiss: {
@@ -142,6 +146,7 @@ extension View {
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
+        restoreStarted: RestoreStartedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseFailure: PurchaseFailureHandler? = nil,
         restoreFailure: PurchaseFailureHandler? = nil,
@@ -155,6 +160,7 @@ extension View {
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
+            restoreStarted: restoreStarted,
             restoreCompleted: restoreCompleted,
             purchaseFailure: purchaseFailure,
             restoreFailure: restoreFailure,
@@ -180,6 +186,7 @@ extension View {
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
+        restoreStarted: RestoreStartedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseFailure: PurchaseFailureHandler? = nil,
         restoreFailure: PurchaseFailureHandler? = nil,
@@ -195,6 +202,7 @@ extension View {
                 purchaseCancelled: purchaseCancelled,
                 restoreCompleted: restoreCompleted,
                 purchaseFailure: purchaseFailure,
+                restoreStarted: restoreStarted,
                 restoreFailure: restoreFailure,
                 onDismiss: onDismiss,
                 content: .optionalOffering(offering),
@@ -224,6 +232,7 @@ private struct PresentingPaywallModifier: ViewModifier {
     var purchaseCancelled: PurchaseCancelledHandler?
     var restoreCompleted: PurchaseOrRestoreCompletedHandler?
     var purchaseFailure: PurchaseFailureHandler?
+    var restoreStarted: RestoreStartedHandler?
     var restoreFailure: PurchaseFailureHandler?
     var onDismiss: (() -> Void)?
 
@@ -241,6 +250,7 @@ private struct PresentingPaywallModifier: ViewModifier {
         purchaseCancelled: PurchaseCancelledHandler?,
         restoreCompleted: PurchaseOrRestoreCompletedHandler?,
         purchaseFailure: PurchaseFailureHandler?,
+        restoreStarted: RestoreStartedHandler?,
         restoreFailure: PurchaseFailureHandler?,
         onDismiss: (() -> Void)?,
         content: PaywallViewConfiguration.Content,
@@ -254,6 +264,7 @@ private struct PresentingPaywallModifier: ViewModifier {
         self.purchaseStarted = purchaseStarted
         self.purchaseCompleted = purchaseCompleted
         self.purchaseCancelled = purchaseCancelled
+        self.restoreStarted = restoreStarted
         self.restoreCompleted = restoreCompleted
         self.purchaseFailure = purchaseFailure
         self.restoreFailure = restoreFailure
@@ -320,6 +331,9 @@ private struct PresentingPaywallModifier: ViewModifier {
         }
         .onPurchaseCancelled {
             self.purchaseCancelled?()
+        }
+        .onRestoreStarted {
+            self.restoreStarted?()
         }
         .onRestoreCompleted { customerInfo in
             self.restoreCompleted?(customerInfo)

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -35,6 +35,7 @@ extension View {
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
+        restoreStarted: RestoreStartedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseFailure: PurchaseFailureHandler? = nil,
         restoreFailure: PurchaseFailureHandler? = nil
@@ -48,6 +49,7 @@ extension View {
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
+            restoreStarted: restoreStarted,
             restoreCompleted: restoreCompleted,
             purchaseFailure: purchaseFailure,
             restoreFailure: restoreFailure
@@ -71,6 +73,7 @@ extension View {
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
+        restoreStarted: RestoreStartedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseFailure: PurchaseFailureHandler? = nil,
         restoreFailure: PurchaseFailureHandler? = nil
@@ -84,6 +87,7 @@ extension View {
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
+            restoreStarted: restoreStarted,
             restoreCompleted: restoreCompleted,
             purchaseFailure: purchaseFailure,
             restoreFailure: restoreFailure
@@ -100,6 +104,7 @@ extension View {
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
+        restoreStarted: RestoreStartedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseFailure: PurchaseFailureHandler? = nil,
         restoreFailure: PurchaseFailureHandler? = nil
@@ -119,8 +124,9 @@ extension View {
                     purchaseStarted: purchaseStarted,
                     purchaseCompleted: purchaseCompleted,
                     purchaseCancelled: purchaseCancelled,
-                    restoreCompleted: restoreCompleted,
                     purchaseFailure: purchaseFailure,
+                    restoreStarted: restoreStarted,
+                    restoreCompleted: restoreCompleted,
                     restoreFailure: restoreFailure
                 )
             )
@@ -131,11 +137,14 @@ extension View {
 private struct PresentingPaywallFooterModifier: ViewModifier {
 
     let configuration: PaywallViewConfiguration
+
     let purchaseStarted: PurchaseStartedHandler?
     let purchaseCompleted: PurchaseOrRestoreCompletedHandler?
     let purchaseCancelled: PurchaseCancelledHandler?
-    let restoreCompleted: PurchaseOrRestoreCompletedHandler?
     let purchaseFailure: PurchaseFailureHandler?
+
+    let restoreStarted: RestoreStartedHandler?
+    let restoreCompleted: PurchaseOrRestoreCompletedHandler?
     let restoreFailure: PurchaseFailureHandler?
 
     func body(content: Content) -> some View {
@@ -156,6 +165,9 @@ private struct PresentingPaywallFooterModifier: ViewModifier {
                     }
                     .onPurchaseFailure {
                         self.purchaseFailure?($0)
+                    }
+                    .onRestoreStarted {
+                        self.restoreStarted?()
                     }
                     .onRestoreFailure {
                         self.restoreFailure?($0)

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -30,6 +30,9 @@ public typealias PurchaseCancelledHandler = @MainActor @Sendable () -> Void
 /// A closure used for notifying of failures during purchases or restores.
 public typealias PurchaseFailureHandler = @MainActor @Sendable (NSError) -> Void
 
+/// A closure used for notifying of restore initiation.
+public typealias RestoreStartedHandler = @MainActor @Sendable () -> Void
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
 extension View {
@@ -121,6 +124,26 @@ extension View {
         _ handler: @escaping PurchaseCancelledHandler
     ) -> some View {
         return self.modifier(OnPurchaseCancelledModifier(handler: handler))
+    }
+
+    /// Invokes the given closure when a restore begins.
+    /// Example:
+    /// ```swift
+    ///  @State
+    ///  var body: some View {
+    ///     PaywallView()
+    ///         .onRestoreStarted {
+    ///             print("Restore started")
+    ///         }
+    ///  }
+    /// ```
+    ///
+    /// ### Related Articles
+    /// [Documentation](https://rev.cat/paywalls)
+    public func onRestoreStarted(
+        _ handler: @escaping RestoreStartedHandler
+    ) -> some View {
+        return self.modifier(OnRestoreStartedModifier(handler: handler))
     }
 
     /// Invokes the given closure when restore purchases is completed.
@@ -248,6 +271,22 @@ private struct OnPurchaseCancelledModifier: ViewModifier {
         content
             .onPreferenceChange(PurchasedResultPreferenceKey.self) { result in
                 if let result, result.userCancelled {
+                    self.handler()
+                }
+            }
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct OnRestoreStartedModifier: ViewModifier {
+
+    let handler: RestoreStartedHandler
+
+    func body(content: Content) -> some View {
+        content
+            .onPreferenceChange(RestoreInProgressPreferenceKey.self) { inProgress in
+                if inProgress {
                     self.handler()
                 }
             }

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -72,7 +72,7 @@ struct App: View {
                                     onDismiss: self.paywallDismissed)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", offering: self.offering, fonts: self.fonts,
                                     purchaseCompleted: self.purchaseOrRestoreCompleted,
-                                    purchaseCancelled: self.purchaseCancelled
+                                    purchaseCancelled: self.purchaseCancelled,
                                     restoreCompleted: self.purchaseOrRestoreCompleted,
                                     onDismiss: self.paywallDismissed)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", offering: self.offering, fonts: self.fonts,

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -18,6 +18,7 @@ struct App: View {
     private var purchaseStarted: PurchaseStartedHandler = { }
     private var purchaseCompleted: PurchaseCompletedHandler = { (_: StoreTransaction?, _: CustomerInfo) in }
     private var purchaseCancelled: PurchaseCancelledHandler = { () in }
+    private var restoreStarted: RestoreStartedHandler = { }
     private var failureHandler: PurchaseFailureHandler = { (_: NSError) in }
     private var paywallDismissed: () -> Void = {}
 
@@ -70,9 +71,21 @@ struct App: View {
                                     restoreCompleted: self.purchaseOrRestoreCompleted,
                                     onDismiss: self.paywallDismissed)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", offering: self.offering, fonts: self.fonts,
+                                    purchaseCompleted: self.purchaseOrRestoreCompleted,
+                                    purchaseCancelled: self.purchaseCancelled
+                                    restoreCompleted: self.purchaseOrRestoreCompleted,
+                                    onDismiss: self.paywallDismissed)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", offering: self.offering, fonts: self.fonts,
                                     purchaseStarted: self.purchaseStarted,
                                     purchaseCompleted: self.purchaseOrRestoreCompleted,
                                     purchaseCancelled: self.purchaseCancelled,
+                                    restoreCompleted: self.purchaseOrRestoreCompleted,
+                                    onDismiss: self.paywallDismissed)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", offering: self.offering, fonts: self.fonts,
+                                    purchaseStarted: self.purchaseStarted,
+                                    purchaseCompleted: self.purchaseOrRestoreCompleted,
+                                    purchaseCancelled: self.purchaseCancelled,
+                                    restoreStarted: self.restoreStarted,
                                     restoreCompleted: self.purchaseOrRestoreCompleted,
                                     onDismiss: self.paywallDismissed)
             .presentPaywallIfNeeded(offering: nil) { (_: CustomerInfo) in false }
@@ -131,6 +144,8 @@ struct App: View {
                 self.purchaseOrRestoreCompleted($0)
             } purchaseCancelled: {
                 self.purchaseCancelled()
+            } restoreStarted: {
+                self.restoreStarted()
             } restoreCompleted: {
                 self.purchaseOrRestoreCompleted($0)
             } purchaseFailure: {
@@ -179,6 +194,7 @@ struct App: View {
                            purchaseStarted: self.purchaseStarted,
                            purchaseCompleted: self.purchaseOrRestoreCompleted,
                            purchaseCancelled: self.purchaseCancelled,
+                           restoreStarted: self.restoreStarted,
                            restoreCompleted: self.purchaseOrRestoreCompleted,
                            purchaseFailure: self.failureHandler,
                            restoreFailure: self.failureHandler)
@@ -191,6 +207,7 @@ struct App: View {
             .onPurchaseCompleted(self.purchaseOrRestoreCompleted)
             .onPurchaseCompleted(self.purchaseCompleted)
             .onPurchaseCancelled(self.purchaseCancelled)
+            .onRestoreStarted(self.onRestoreStarted)
             .onRestoreCompleted(self.purchaseOrRestoreCompleted)
     }
 

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -207,7 +207,7 @@ struct App: View {
             .onPurchaseCompleted(self.purchaseOrRestoreCompleted)
             .onPurchaseCompleted(self.purchaseCompleted)
             .onPurchaseCancelled(self.purchaseCancelled)
-            .onRestoreStarted(self.onRestoreStarted)
+            .onRestoreStarted(self.restoreStarted)
             .onRestoreCompleted(self.purchaseOrRestoreCompleted)
     }
 

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -65,6 +65,8 @@ final class Delegate: PaywallViewControllerDelegate {
     func paywallViewController(_ controller: PaywallViewController,
                                didFailPurchasingWith error: NSError) {}
 
+    func paywallViewControllerDidStartRestore(_ controller: PaywallViewController) {}
+
     func paywallViewController(_ controller: PaywallViewController,
                                didFinishRestoringWith customerInfo: CustomerInfo) {}
 

--- a/Tests/RevenueCatUITests/PaywallFooterTests.swift
+++ b/Tests/RevenueCatUITests/PaywallFooterTests.swift
@@ -89,6 +89,26 @@ class PaywallFooterTests: TestCase {
         expect(error).toEventually(matchError(Self.failureError))
     }
 
+    func testPresentWithRestoreStarted() throws {
+        var started = false
+
+        try Text("")
+            .paywallFooter(
+                offering: Self.offering,
+                customerInfo: TestData.customerInfo,
+                introEligibility: .producing(eligibility: .eligible),
+                purchaseHandler: Self.purchaseHandler,
+                restoreStarted: { started = true }
+            )
+            .addToHierarchy()
+
+        Task {
+            _ = try await Self.purchaseHandler.restorePurchases()
+        }
+
+        expect(started).toEventually(beTrue())
+    }
+
     func testPresentWithRestoreHandler() throws {
         var customerInfo: CustomerInfo?
 

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -185,6 +185,27 @@ class PurchaseCompletedHandlerTests: TestCase {
         expect(error).toEventually(matchError(Self.failureError))
     }
 
+    func testOnRestoreStarted() throws {
+        var started = false
+
+        try PaywallView(
+            offering: Self.offering.withLocalImages,
+            customerInfo: TestData.customerInfo,
+            introEligibility: .producing(eligibility: .eligible),
+            purchaseHandler: Self.purchaseHandler
+        )
+            .onRestoreStarted {
+                started = true
+            }
+            .addToHierarchy()
+
+        Task {
+            _ = try await Self.purchaseHandler.restorePurchases()
+        }
+
+        expect(started).toEventually(beTrue())
+    }
+
     func testOnRestoreCompleted() throws {
         var customerInfo: CustomerInfo?
 

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -29,6 +29,7 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.restoredCustomerInfo).to(beNil())
         expect(handler.purchased) == false
         expect(handler.purchaseInProgress) == false
+        expect(handler.restoreInProgress) == false
         expect(handler.actionInProgress) == false
         expect(handler.purchaseError).to(beNil())
         expect(handler.restoreError).to(beNil())
@@ -44,6 +45,7 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.restoredCustomerInfo).to(beNil())
         expect(handler.purchased) == true
         expect(handler.purchaseInProgress) == false
+        expect(handler.restoreInProgress) == false
         expect(handler.actionInProgress) == false
     }
 
@@ -55,6 +57,7 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.purchaseResult?.customerInfo) === TestData.customerInfo
         expect(handler.purchased) == false
         expect(handler.purchaseInProgress) == false
+        expect(handler.restoreInProgress) == false
         expect(handler.actionInProgress) == false
     }
 
@@ -73,6 +76,7 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.purchaseResult).to(beNil())
         expect(handler.purchased) == false
         expect(handler.purchaseInProgress) == false
+        expect(handler.restoreInProgress) == false
         expect(handler.actionInProgress) == false
         expect(handler.purchaseError).to(matchError(error))
         expect(handler.restoreError).to(beNil())
@@ -94,6 +98,7 @@ class PurchaseHandlerTests: TestCase {
 
         expect(handler.purchaseInProgress) == true
         expect(handler.actionInProgress) == true
+        expect(handler.restoreInProgress) == false
 
         // Finish purchase
         try asyncHandler.resume()
@@ -121,6 +126,7 @@ class PurchaseHandlerTests: TestCase {
 
         expect(handler.actionInProgress) == true
         expect(handler.purchaseInProgress) == false
+        expect(handler.restoreInProgress) == true
 
         // Finish rewstore
         try asyncHandler.resume()
@@ -141,6 +147,7 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.purchaseResult).to(beNil())
         expect(handler.purchaseInProgress) == false
         expect(handler.actionInProgress) == false
+        expect(handler.restoreInProgress) == false
 
         handler.setRestored(TestData.customerInfo)
 
@@ -148,6 +155,7 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.purchaseResult).to(beNil())
         expect(handler.purchaseInProgress) == false
         expect(handler.actionInProgress) == false
+        expect(handler.restoreInProgress) == false
     }
 
     func testRestorePurchasesWithActiveSubscriptions() async throws {
@@ -180,6 +188,7 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.purchased) == false
         expect(handler.purchaseInProgress) == false
         expect(handler.actionInProgress) == false
+        expect(handler.restoreInProgress) == false
         expect(handler.restoreError).to(matchError(error))
         expect(handler.purchaseError).to(beNil())
     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
@@ -1,5 +1,5 @@
 //
-//  LockedView.swift
+//  UpsellView.swift
 //  PaywallsTester
 //
 //  Created by Andrés Boedo on 9/28/23.
@@ -33,6 +33,15 @@ struct UpsellView: View {
             },
             onDismiss: {
                 print("Paywall dismissed")
+            },
+            onRestoreCompleted: { _ in
+                print("Restore completed")
+            },
+            onRestoreStarted: {
+                print("Restore started")
+            },
+            onRestoreFailure: {
+                print("Restore failed")
             }
         )
     }


### PR DESCRIPTION
Similar to #3627.

This API is available in:
- `PaywallView()`
- `.presentPaywallIfNeeded`
- `.paywallFooter`
- `PaywallViewControllerDelegate`