### PR TITLE
Remove `restoreStarted` from extensions

### DIFF
--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -73,7 +73,6 @@ extension View {
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
-        restoreStarted: RestoreStartedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseFailure: PurchaseFailureHandler? = nil,
         restoreFailure: PurchaseFailureHandler? = nil,
@@ -92,7 +91,6 @@ extension View {
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
-            restoreStarted: restoreStarted,
             restoreCompleted: restoreCompleted,
             purchaseFailure: purchaseFailure,
             restoreFailure: restoreFailure,
@@ -118,8 +116,6 @@ extension View {
     ///         print("Purchases restored")
     ///     } purchaseFailure: { error in
     ///         print("Error purchasing: \(error)")
-    ///     } restoreStarted: {
-    ///         print("Restore started")
     ///     } restoreFailure: { error in
     ///         print("Error restoring purchases: \(error)")
     ///     } onDismiss: {
@@ -146,7 +142,6 @@ extension View {
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
-        restoreStarted: RestoreStartedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseFailure: PurchaseFailureHandler? = nil,
         restoreFailure: PurchaseFailureHandler? = nil,
@@ -160,7 +155,7 @@ extension View {
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
-            restoreStarted: restoreStarted,
+            restoreStarted: nil,
             restoreCompleted: restoreCompleted,
             purchaseFailure: purchaseFailure,
             restoreFailure: restoreFailure,

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -35,7 +35,6 @@ extension View {
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
-        restoreStarted: RestoreStartedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseFailure: PurchaseFailureHandler? = nil,
         restoreFailure: PurchaseFailureHandler? = nil
@@ -49,7 +48,6 @@ extension View {
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
-            restoreStarted: restoreStarted,
             restoreCompleted: restoreCompleted,
             purchaseFailure: purchaseFailure,
             restoreFailure: restoreFailure
@@ -73,7 +71,6 @@ extension View {
         purchaseStarted: PurchaseStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseCancelled: PurchaseCancelledHandler? = nil,
-        restoreStarted: RestoreStartedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         purchaseFailure: PurchaseFailureHandler? = nil,
         restoreFailure: PurchaseFailureHandler? = nil
@@ -87,7 +84,7 @@ extension View {
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
-            restoreStarted: restoreStarted,
+            restoreStarted: nil,
             restoreCompleted: restoreCompleted,
             purchaseFailure: purchaseFailure,
             restoreFailure: restoreFailure

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -56,8 +56,6 @@ struct App: View {
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "",
                                     purchaseCancelled: self.purchaseCancelled)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "",
-                                    restoreStarted: self.restoreStarted)
-            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "",
                                     restoreCompleted: self.purchaseOrRestoreCompleted)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "",
                                     purchaseFailure: self.failureHandler)
@@ -82,9 +80,6 @@ struct App: View {
                                     purchaseCancelled: self.purchaseCancelled)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "",
                                     fonts: self.fonts,
-                                    restoreStarted: self.restoreStarted)
-            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "",
-                                    fonts: self.fonts,
                                     restoreCompleted: self.purchaseOrRestoreCompleted)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "",
                                     fonts: self.fonts,
@@ -137,7 +132,6 @@ struct App: View {
                                     purchaseStarted: self.purchaseStarted,
                                     purchaseCompleted: self.purchaseOrRestoreCompleted,
                                     purchaseCancelled: self.purchaseCancelled,
-                                    restoreStarted: self.restoreStarted,
                                     restoreCompleted: self.purchaseOrRestoreCompleted,
                                     purchaseFailure: self.failureHandler,
                                     onDismiss: self.paywallDismissed)
@@ -300,7 +294,6 @@ struct App: View {
                            purchaseStarted: self.purchaseStarted,
                            purchaseCompleted: self.purchaseOrRestoreCompleted,
                            purchaseCancelled: self.purchaseCancelled,
-                           restoreStarted: self.restoreStarted,
                            restoreCompleted: self.purchaseOrRestoreCompleted,
                            purchaseFailure: self.failureHandler,
                            restoreFailure: self.failureHandler)
@@ -333,7 +326,6 @@ struct App: View {
                            purchaseStarted: self.purchaseStarted,
                            purchaseCompleted: self.purchaseOrRestoreCompleted,
                            purchaseCancelled: self.purchaseCancelled,
-                           restoreStarted: self.restoreStarted,
                            restoreCompleted: self.purchaseOrRestoreCompleted,
                            purchaseFailure: self.failureHandler,
                            restoreFailure: self.failureHandler)
@@ -345,8 +337,6 @@ struct App: View {
                            purchaseCompleted: self.purchaseOrRestoreCompleted)
             .paywallFooter(offering: offering,
                            purchaseCancelled: self.purchaseCancelled)
-            .paywallFooter(offering: offering,
-                           restoreStarted: self.restoreStarted)
             .paywallFooter(offering: offering,
                            restoreCompleted: self.purchaseOrRestoreCompleted)
             .paywallFooter(offering: offering,
@@ -372,7 +362,6 @@ struct App: View {
                            purchaseStarted: self.purchaseStarted,
                            purchaseCompleted: self.purchaseOrRestoreCompleted,
                            purchaseCancelled: self.purchaseCancelled,
-                           restoreStarted: self.restoreStarted,
                            restoreCompleted: self.purchaseOrRestoreCompleted,
                            purchaseFailure: self.failureHandler,
                            restoreFailure: self.failureHandler)
@@ -392,7 +381,6 @@ struct App: View {
                            purchaseStarted: self.purchaseStarted,
                            purchaseCompleted: self.purchaseOrRestoreCompleted,
                            purchaseCancelled: self.purchaseCancelled,
-                           restoreStarted: self.restoreStarted,
                            restoreCompleted: self.purchaseOrRestoreCompleted,
                            purchaseFailure: self.failureHandler,
                            restoreFailure: self.failureHandler)

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -142,7 +142,6 @@ struct App: View {
                                     purchaseStarted: nil,
                                     purchaseCompleted: nil,
                                     purchaseCancelled: nil,
-                                    restoreStarted: nil,
                                     restoreCompleted: nil,
                                     purchaseFailure: nil,
                                     restoreFailure: nil,
@@ -214,8 +213,6 @@ struct App: View {
                 self.purchaseOrRestoreCompleted($0)
             } purchaseCancelled: {
                 self.purchaseCancelled()
-            } restoreStarted: {
-                self.restoreStarted()
             } restoreCompleted: {
                 self.purchaseOrRestoreCompleted($0)
             } purchaseFailure: {
@@ -234,7 +231,6 @@ struct App: View {
                                     purchaseStarted: nil,
                                     purchaseCompleted: nil,
                                     purchaseCancelled: nil,
-                                    restoreStarted: nil,
                                     restoreCompleted: nil,
                                     purchaseFailure: nil,
                                     restoreFailure: nil,
@@ -302,7 +298,6 @@ struct App: View {
                            purchaseStarted: nil,
                            purchaseCompleted: nil,
                            purchaseCancelled: nil,
-                           restoreStarted: nil,
                            restoreCompleted: nil,
                            purchaseFailure: nil,
                            restoreFailure: nil)
@@ -390,7 +385,6 @@ struct App: View {
                            purchaseStarted: nil,
                            purchaseCompleted: nil,
                            purchaseCancelled: nil,
-                           restoreStarted: nil,
                            restoreCompleted: nil,
                            purchaseFailure: nil,
                            restoreFailure: nil)


### PR DESCRIPTION
Since we are deprecating the old function in https://github.com/RevenueCat/purchases-ios/pull/3693/files 

I thought it will be simpler to just add both `restoreStarted` and the new `purchaseStarted(package:)`  in the same release. We haven't made a release since I merged #3694 so these are safe to remove for now.

I open this PR in case we want to make a release before #3693 is finished.