### PR TITLE
`Tests`: Organize and Improve PurchasesOrchestrator Tests

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -42,7 +42,7 @@
 		2D803F6826F144C40069D717 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 2D803F6726F144C40069D717 /* Nimble */; };
 		2D803F6926F149E70069D717 /* RevenueCat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DC5621624EC63420031F69B /* RevenueCat.framework */; };
 		2D8D03B52799A2B90044C2ED /* DocCDocumentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = 2D8D03B42799A2B90044C2ED /* DocCDocumentation.docc */; };
-		2D90F8B126FD1E52009B9142 /* PurchasesOrchestratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8FC8AB26E01AE70049A85C /* PurchasesOrchestratorTests.swift */; };
+		2D90F8B126FD1E52009B9142 /* BasePurchasesOrchestratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8FC8AB26E01AE70049A85C /* BasePurchasesOrchestratorTests.swift */; };
 		2D90F8B326FD2082009B9142 /* MockProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35C9439E087F63ECC4F59 /* MockProductsManager.swift */; };
 		2D90F8B426FD208B009B9142 /* MockStoreKit1Wrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B515326D44B0A00BD2BD7 /* MockStoreKit1Wrapper.swift */; };
 		2D90F8B526FD2093009B9142 /* MockSystemInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B514626D44A0D00BD2BD7 /* MockSystemInfo.swift */; };
@@ -202,10 +202,14 @@
 		37E3578711F5FDD5DC6458A8 /* AttributionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3521731D8DC16873F55F3 /* AttributionFetcher.swift */; };
 		37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3507939634ED5A9280544 /* Strings.swift */; };
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
+		4D322E382B7E7B170004AF53 /* PurchasesOrchestratorSK2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D322E372B7E7B170004AF53 /* PurchasesOrchestratorSK2Tests.swift */; };
+		4D322E3A2B7E7B570004AF53 /* PurchasesOrchestratorSK1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D322E392B7E7B570004AF53 /* PurchasesOrchestratorSK1Tests.swift */; };
+		4D322E3C2B7E7E250004AF53 /* PurchasesOrchestratorCommonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D322E3B2B7E7E250004AF53 /* PurchasesOrchestratorCommonTests.swift */; };
 		4D6ABB0C2AF13F9400BB2A08 /* StoreKit2Receipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6ABB0B2AF13F9400BB2A08 /* StoreKit2Receipt.swift */; };
 		4D6ABB0E2AF13FB100BB2A08 /* StoreEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6ABB0D2AF13FB100BB2A08 /* StoreEnvironment.swift */; };
 		4D6ABB102AF13FBD00BB2A08 /* SK2AppTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6ABB0F2AF13FBD00BB2A08 /* SK2AppTransaction.swift */; };
 		4D72E8622B221EA600BF9EFE /* StoreEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D24EF3F2B04EA6000E586D2 /* StoreEnvironmentTests.swift */; };
+		4D7A3E282B85729E00ABDE67 /* PurchasesOrchestratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D7A3E272B85729E00ABDE67 /* PurchasesOrchestratorTests.swift */; };
 		4DBC30962B1DFA97001D33C7 /* StoreKitVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBC30952B1DFA97001D33C7 /* StoreKitVersion.swift */; };
 		4DBF1F362B4D572400D52354 /* LocalReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBF1F352B4D572400D52354 /* LocalReceiptFetcher.swift */; };
 		4DBF1F372B4D572400D52354 /* LocalReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBF1F352B4D572400D52354 /* LocalReceiptFetcher.swift */; };
@@ -851,7 +855,7 @@
 		2D8D03B42799A2B90044C2ED /* DocCDocumentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = DocCDocumentation.docc; sourceTree = "<group>"; };
 		2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriberAttributeTests.swift; sourceTree = "<group>"; };
 		2D8F622224D30F9D00F993AA /* ReceiptParsingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptParsingError.swift; sourceTree = "<group>"; };
-		2D8FC8AB26E01AE70049A85C /* PurchasesOrchestratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesOrchestratorTests.swift; sourceTree = "<group>"; };
+		2D8FC8AB26E01AE70049A85C /* BasePurchasesOrchestratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePurchasesOrchestratorTests.swift; sourceTree = "<group>"; };
 		2D90F8C926FD257A009B9142 /* MockStoreKit2TransactionListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreKit2TransactionListener.swift; sourceTree = "<group>"; };
 		2D90F8CB26FD2BA1009B9142 /* StoreKitConfigTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitConfigTestCase.swift; sourceTree = "<group>"; };
 		2D971CC02744364C0093F35F /* SKError+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SKError+Extensions.swift"; sourceTree = "<group>"; };
@@ -999,9 +1003,13 @@
 		37E35F783903362B65FB7AF3 /* MockProductsRequestFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockProductsRequestFactory.swift; sourceTree = "<group>"; };
 		37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateFormatter+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		4D24EF3F2B04EA6000E586D2 /* StoreEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreEnvironmentTests.swift; sourceTree = "<group>"; };
+		4D322E372B7E7B170004AF53 /* PurchasesOrchestratorSK2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesOrchestratorSK2Tests.swift; sourceTree = "<group>"; };
+		4D322E392B7E7B570004AF53 /* PurchasesOrchestratorSK1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesOrchestratorSK1Tests.swift; sourceTree = "<group>"; };
+		4D322E3B2B7E7E250004AF53 /* PurchasesOrchestratorCommonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesOrchestratorCommonTests.swift; sourceTree = "<group>"; };
 		4D6ABB0B2AF13F9400BB2A08 /* StoreKit2Receipt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreKit2Receipt.swift; sourceTree = "<group>"; };
 		4D6ABB0D2AF13FB100BB2A08 /* StoreEnvironment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreEnvironment.swift; sourceTree = "<group>"; };
 		4D6ABB0F2AF13FBD00BB2A08 /* SK2AppTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SK2AppTransaction.swift; sourceTree = "<group>"; };
+		4D7A3E272B85729E00ABDE67 /* PurchasesOrchestratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesOrchestratorTests.swift; sourceTree = "<group>"; };
 		4DBC30952B1DFA97001D33C7 /* StoreKitVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitVersion.swift; sourceTree = "<group>"; };
 		4DBF1F352B4D572400D52354 /* LocalReceiptFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalReceiptFetcher.swift; sourceTree = "<group>"; };
 		4DC546262AD44BBE005CDB35 /* EncodedAppleReceipt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncodedAppleReceipt.swift; sourceTree = "<group>"; };
@@ -1691,7 +1699,11 @@
 				57488C8129CB91D20000EE7E /* OfflineEntitlements */,
 				4FCEEA5F2A379CD6002C2112 /* Support */,
 				A563F587271E076800246E0C /* BeginRefundRequestHelperTests.swift */,
-				2D8FC8AB26E01AE70049A85C /* PurchasesOrchestratorTests.swift */,
+				2D8FC8AB26E01AE70049A85C /* BasePurchasesOrchestratorTests.swift */,
+				4D7A3E272B85729E00ABDE67 /* PurchasesOrchestratorTests.swift */,
+				4D322E392B7E7B570004AF53 /* PurchasesOrchestratorSK1Tests.swift */,
+				4D322E372B7E7B170004AF53 /* PurchasesOrchestratorSK2Tests.swift */,
+				4D322E3B2B7E7E250004AF53 /* PurchasesOrchestratorCommonTests.swift */,
 				2D34D9D127481D9B00C05DB6 /* TrialOrIntroPriceEligibilityCheckerSK2Tests.swift */,
 				35E1CE1F26E022C20008560A /* TrialOrIntroPriceEligibilityCheckerSK1Tests.swift */,
 				2D69384426DFF93300FCDBC0 /* StoreProductTests.swift */,
@@ -3298,7 +3310,9 @@
 				F5FCD3FC27DA2034003BDC04 /* PriceFormatterProviderTests.swift in Sources */,
 				F5355163286B70E0009CA47A /* OfferingsManagerStoreKitTests.swift in Sources */,
 				5791A1C82767FC9400C972AA /* ManageSubscriptionsHelperTests.swift in Sources */,
+				4D322E3A2B7E7B570004AF53 /* PurchasesOrchestratorSK1Tests.swift in Sources */,
 				4F5D52D92A5713A800E1C758 /* DebugViewSwiftUITests.swift in Sources */,
+				4D322E382B7E7B170004AF53 /* PurchasesOrchestratorSK2Tests.swift in Sources */,
 				2D9C5EC826F280510057FC45 /* StoreProductTests.swift in Sources */,
 				3543914426F911F300E669DF /* MockCustomerInfoManager.swift in Sources */,
 				5738F46E278CAC520096D623 /* StoreTransactionTests.swift in Sources */,
@@ -3340,6 +3354,7 @@
 				B3CAFF1F285CEAAA0048A994 /* MockOfferingsAPI.swift in Sources */,
 				F55FFA632763F60700995146 /* TransactionsManagerTests.swift in Sources */,
 				575A8EE62922C9F300936709 /* MockStoreKit2TransactionListenerDelegate.swift in Sources */,
+				4D7A3E282B85729E00ABDE67 /* PurchasesOrchestratorTests.swift in Sources */,
 				2D222BAB27FB7008003D5F37 /* LocalReceiptParserStoreKitTests.swift in Sources */,
 				B31C8BEF285BDD76001017B7 /* MockIdentityAPI.swift in Sources */,
 				571E7AD4279F2D0C003B3606 /* StoreKitTestHelpers.swift in Sources */,
@@ -3376,12 +3391,13 @@
 				57C381E3279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */,
 				576C8AB927D2996C0058FA6E /* CurrentTestCaseTracker.swift in Sources */,
 				B3BE0264275942D500915B4C /* AvailabilityChecks.swift in Sources */,
+				4D322E3C2B7E7E250004AF53 /* PurchasesOrchestratorCommonTests.swift in Sources */,
 				2D90F8B326FD2082009B9142 /* MockProductsManager.swift in Sources */,
 				575A8EE32922C5E100936709 /* AsyncTestHelpers.swift in Sources */,
 				57DE80BF2807705F008D6C6F /* XCTestCase+Extensions.swift in Sources */,
 				2D90F8CA26FD257A009B9142 /* MockStoreKit2TransactionListener.swift in Sources */,
 				35B745A82711001A00458D46 /* MockManageSubscriptionsHelper.swift in Sources */,
-				2D90F8B126FD1E52009B9142 /* PurchasesOrchestratorTests.swift in Sources */,
+				2D90F8B126FD1E52009B9142 /* BasePurchasesOrchestratorTests.swift in Sources */,
 				A563F589271E1DAD00246E0C /* MockBeginRefundRequestHelper.swift in Sources */,
 				57F3C10C29B7EAE90004FD7E /* MockUserDefaults.swift in Sources */,
 				2D90F8B426FD208B009B9142 /* MockStoreKit1Wrapper.swift in Sources */,

--- a/Sources/Misc/StoreKitVersion.swift
+++ b/Sources/Misc/StoreKitVersion.swift
@@ -33,7 +33,7 @@ public enum StoreKitVersion: Int {
 public extension StoreKitVersion {
 
     /// Let RevenueCat use the most appropiate version of StoreKit
-    static let `default` = Self.storeKit1
+    static let `default` = Self.storeKit2
 
 }
 

--- a/Tests/StoreKitUnitTests/BasePurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/BasePurchasesOrchestratorTests.swift
@@ -1,0 +1,254 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesOrchestratorTests.swift
+//
+//  Created by Andrés Boedo on 1/9/21.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import StoreKit
+import XCTest
+
+@available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 7.0, *)
+class BasePurchasesOrchestratorTests: StoreKitConfigTestCase {
+
+    var productsManager: MockProductsManager!
+    var purchasedProductsFetcher: MockPurchasedProductsFetcher!
+    var storeKit1Wrapper: MockStoreKit1Wrapper!
+    var systemInfo: MockSystemInfo!
+    var subscriberAttributesManager: MockSubscriberAttributesManager!
+    var attribution: Attribution!
+    var attributionFetcher: MockAttributionFetcher!
+    var operationDispatcher: MockOperationDispatcher!
+    var receiptFetcher: MockReceiptFetcher!
+    var receiptParser: MockReceiptParser!
+    var customerInfoManager: MockCustomerInfoManager!
+    var paymentQueueWrapper: EitherPaymentQueueWrapper!
+    var backend: MockBackend!
+    var offerings: MockOfferingsAPI!
+    var currentUserProvider: MockCurrentUserProvider!
+    var transactionsManager: MockTransactionsManager!
+    var deviceCache: MockDeviceCache!
+    var mockManageSubsHelper: MockManageSubscriptionsHelper!
+    var mockBeginRefundRequestHelper: MockBeginRefundRequestHelper!
+    var mockOfferingsManager: MockOfferingsManager!
+    var mockStoreMessagesHelper: MockStoreMessagesHelper!
+    var mockTransactionFetcher: MockStoreKit2TransactionFetcher!
+
+    var orchestrator: PurchasesOrchestrator!
+
+    static let mockUserID = "appUserID"
+
+    class var storeKitVersion: StoreKitVersion { return .default }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.setUpSystemInfo()
+
+        self.productsManager = MockProductsManager(systemInfo: self.systemInfo,
+                                                   requestTimeout: Configuration.storeKitRequestTimeoutDefault)
+        self.purchasedProductsFetcher = .init()
+        self.operationDispatcher = MockOperationDispatcher()
+        self.receiptFetcher = MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: self.systemInfo)
+        self.mockTransactionFetcher = MockStoreKit2TransactionFetcher()
+        self.receiptParser = MockReceiptParser()
+        self.deviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo)
+        self.backend = MockBackend()
+        self.offerings = try XCTUnwrap(self.backend.offerings as? MockOfferingsAPI)
+
+        self.mockOfferingsManager = MockOfferingsManager(deviceCache: self.deviceCache,
+                                                         operationDispatcher: self.operationDispatcher,
+                                                         systemInfo: self.systemInfo,
+                                                         backend: self.backend,
+                                                         offeringsFactory: OfferingsFactory(),
+                                                         productsManager: self.productsManager)
+        self.setUpStoreKit1Wrapper()
+
+        self.customerInfoManager = MockCustomerInfoManager(
+            offlineEntitlementsManager: MockOfflineEntitlementsManager(),
+            operationDispatcher: OperationDispatcher(),
+            deviceCache: self.deviceCache,
+            backend: self.backend,
+            transactionFetcher: MockStoreKit2TransactionFetcher(),
+            transactionPoster: self.transactionPoster,
+            systemInfo: self.systemInfo
+        )
+        self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: Self.mockUserID)
+        self.transactionsManager = MockTransactionsManager(receiptParser: MockReceiptParser())
+        self.attributionFetcher = MockAttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
+                                                         systemInfo: self.systemInfo)
+        self.subscriberAttributesManager = MockSubscriberAttributesManager(
+            backend: self.backend,
+            deviceCache: self.deviceCache,
+            operationDispatcher: MockOperationDispatcher(),
+            attributionFetcher: self.attributionFetcher,
+            attributionDataMigrator: MockAttributionDataMigrator())
+        self.mockManageSubsHelper = MockManageSubscriptionsHelper(systemInfo: self.systemInfo,
+                                                                  customerInfoManager: self.customerInfoManager,
+                                                                  currentUserProvider: self.currentUserProvider)
+        self.mockBeginRefundRequestHelper = MockBeginRefundRequestHelper(systemInfo: self.systemInfo,
+                                                                         customerInfoManager: self.customerInfoManager,
+                                                                         currentUserProvider: self.currentUserProvider)
+        self.mockStoreMessagesHelper = .init()
+        self.mockTransactionFetcher = MockStoreKit2TransactionFetcher()
+        self.setUpStoreKit1Wrapper()
+        self.setUpAttribution()
+        self.setUpOrchestrator()
+        self.setUpStoreKit2Listener()
+    }
+
+    func setUpStoreKit2Listener() {
+        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+            self.orchestrator._storeKit2TransactionListener = MockStoreKit2TransactionListener()
+        }
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    var mockStoreKit2TransactionListener: MockStoreKit2TransactionListener? {
+        return self.orchestrator.storeKit2TransactionListener as? MockStoreKit2TransactionListener
+    }
+
+    func setUpSystemInfo(
+        finishTransactions: Bool = true
+    ) {
+        let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "1.2.3")
+
+        self.systemInfo = .init(platformInfo: platformInfo,
+                                finishTransactions: finishTransactions,
+                                storeKitVersion: Self.storeKitVersion)
+        self.systemInfo.stubbedIsSandbox = true
+    }
+
+    func setUpStoreKit1Wrapper() {
+        self.storeKit1Wrapper = MockStoreKit1Wrapper(observerMode: self.systemInfo.observerMode)
+        self.storeKit1Wrapper.mockAddPaymentTransactionState = .purchased
+        self.storeKit1Wrapper.mockCallUpdatedTransactionInstantly = true
+
+        self.paymentQueueWrapper = .left(self.storeKit1Wrapper)
+    }
+
+    func setUpAttribution() {
+        let attributionPoster = AttributionPoster(deviceCache: self.deviceCache,
+                                                  currentUserProvider: self.currentUserProvider,
+                                                  backend: self.backend,
+                                                  attributionFetcher: self.attributionFetcher,
+                                                  subscriberAttributesManager: self.subscriberAttributesManager)
+
+        self.attribution = Attribution(subscriberAttributesManager: self.subscriberAttributesManager,
+                                       currentUserProvider: MockCurrentUserProvider(mockAppUserID: Self.mockUserID),
+                                       attributionPoster: attributionPoster,
+                                       systemInfo: self.systemInfo)
+    }
+
+    func setUpOrchestrator() {
+        self.orchestrator = PurchasesOrchestrator(productsManager: self.productsManager,
+                                                  paymentQueueWrapper: self.paymentQueueWrapper,
+                                                  systemInfo: self.systemInfo,
+                                                  subscriberAttributes: self.attribution,
+                                                  operationDispatcher: self.operationDispatcher,
+                                                  receiptFetcher: self.receiptFetcher,
+                                                  receiptParser: self.receiptParser,
+                                                  transactionFetcher: self.mockTransactionFetcher,
+                                                  customerInfoManager: self.customerInfoManager,
+                                                  backend: self.backend,
+                                                  transactionPoster: self.transactionPoster,
+                                                  currentUserProvider: self.currentUserProvider,
+                                                  transactionsManager: self.transactionsManager,
+                                                  deviceCache: self.deviceCache,
+                                                  offeringsManager: self.mockOfferingsManager,
+                                                  manageSubscriptionsHelper: self.mockManageSubsHelper,
+                                                  beginRefundRequestHelper: self.mockBeginRefundRequestHelper,
+                                                  storeMessagesHelper: self.mockStoreMessagesHelper)
+        self.storeKit1Wrapper.delegate = self.orchestrator
+    }
+
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+    func setUpOrchestrator(
+        storeKit2TransactionListener: StoreKit2TransactionListenerType,
+        storeKit2StorefrontListener: StoreKit2StorefrontListener
+    ) {
+        self.orchestrator = PurchasesOrchestrator(productsManager: self.productsManager,
+                                                  paymentQueueWrapper: self.paymentQueueWrapper,
+                                                  systemInfo: self.systemInfo,
+                                                  subscriberAttributes: self.attribution,
+                                                  operationDispatcher: self.operationDispatcher,
+                                                  receiptFetcher: self.receiptFetcher,
+                                                  receiptParser: self.receiptParser,
+                                                  transactionFetcher: self.mockTransactionFetcher,
+                                                  customerInfoManager: self.customerInfoManager,
+                                                  backend: self.backend,
+                                                  transactionPoster: self.transactionPoster,
+                                                  currentUserProvider: self.currentUserProvider,
+                                                  transactionsManager: self.transactionsManager,
+                                                  deviceCache: self.deviceCache,
+                                                  offeringsManager: self.mockOfferingsManager,
+                                                  manageSubscriptionsHelper: self.mockManageSubsHelper,
+                                                  beginRefundRequestHelper: self.mockBeginRefundRequestHelper,
+                                                  storeKit2TransactionListener: storeKit2TransactionListener,
+                                                  storeKit2StorefrontListener: storeKit2StorefrontListener,
+                                                  storeMessagesHelper: self.mockStoreMessagesHelper)
+        self.storeKit1Wrapper.delegate = self.orchestrator
+    }
+
+    var transactionPoster: TransactionPoster {
+        return .init(
+            productsManager: self.productsManager,
+            receiptFetcher: self.receiptFetcher,
+            transactionFetcher: self.mockTransactionFetcher,
+            backend: self.backend,
+            paymentQueueWrapper: self.paymentQueueWrapper,
+            systemInfo: self.systemInfo,
+            operationDispatcher: self.operationDispatcher
+        )
+    }
+}
+
+@available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 7.0, *)
+extension BasePurchasesOrchestratorTests {
+
+    func fetchSk1Product() async throws -> SK1Product {
+        return MockSK1Product(
+            mockProductIdentifier: Self.productID,
+            mockSubscriptionGroupIdentifier: "group1"
+        )
+    }
+
+    func fetchSk1StoreProduct() async throws -> SK1StoreProduct {
+        return try await SK1StoreProduct(sk1Product: fetchSk1Product())
+    }
+
+    var mockCustomerInfo: CustomerInfo { .emptyInfo }
+
+    static let testProduct = TestStoreProduct(
+        localizedTitle: "Product",
+        price: 3.99,
+        localizedPriceString: "$3.99",
+        productIdentifier: "product",
+        productType: .autoRenewableSubscription,
+        localizedDescription: "Description"
+    ).toStoreProduct()
+
+    static let paywallEventCreationData: PaywallEvent.CreationData = .init(
+        id: .init(uuidString: "72164C05-2BDC-4807-8918-A4105F727DEB")!,
+        date: .init(timeIntervalSince1970: 1694029328)
+    )
+
+    static let paywallEvent: PaywallEvent.Data = .init(
+        offeringIdentifier: "offering",
+        paywallRevision: 5,
+        sessionID: .init(),
+        displayMode: .fullScreen,
+        localeIdentifier: "en_US",
+        darkMode: true
+    )
+
+}

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorCommonTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorCommonTests.swift
@@ -18,7 +18,9 @@ import StoreKit
 import XCTest
 
 @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 7.0, *)
-class PurchasesOrchestratorCommonTests: PurchasesOrchestratorTestCase {
+class PurchasesOrchestratorCommonTests: BasePurchasesOrchestratorTests {
+
+    // MARK: - TestStoreProduct
 
     func testPurchasingTestProductFails() async throws {
         let error = await withCheckedContinuation { continuation in
@@ -48,7 +50,9 @@ class PurchasesOrchestratorCommonTests: PurchasesOrchestratorTestCase {
         expect(error).to(matchError(ErrorCode.productNotAvailableForPurchaseError))
     }
 
-#if os(iOS) || targetEnvironment(macCatalyst) || VISION_OS
+    #if os(iOS) || targetEnvironment(macCatalyst) || VISION_OS
+
+    // MARK: - showManageSubscription
 
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
@@ -64,6 +68,8 @@ class PurchasesOrchestratorCommonTests: PurchasesOrchestratorTestCase {
 
         expect(receivedError).to(matchError(ErrorCode.customerInfoError))
     }
+
+    // MARK: - RefundRequest
 
     @available(iOS 15.0, macCatalyst 15.0, *)
     @available(watchOS, unavailable)
@@ -153,7 +159,9 @@ class PurchasesOrchestratorCommonTests: PurchasesOrchestratorTestCase {
         }
     }
 
-#endif
+    #endif
+
+    // MARK: - allowSharingAppStoreAccount
 
     func testRestorePurchasesDoesNotLogWarningIfAllowSharingAppStoreAccountIsNotDefined() async throws {
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
@@ -201,5 +209,4 @@ class PurchasesOrchestratorCommonTests: PurchasesOrchestratorTestCase {
             level: .warn
         )
     }
-
 }

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
@@ -18,11 +18,13 @@ import StoreKit
 import XCTest
 
 @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 7.0, *)
-class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
+class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOrchestratorTests {
+
+    override class var storeKitVersion: StoreKitVersion { .storeKit1 }
 
     // MARK: - StoreFront Changes
 
-    func testClearCachedProductsAndOfferingsAfterStorefrontChangesWithSK1() async throws {
+    func testClearCachedProductsAndOfferingsAfterStorefrontChanges() async throws {
         self.orchestrator.storeKit1WrapperDidChangeStorefront(storeKit1Wrapper)
 
         expect(self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateCount) == 1
@@ -31,8 +33,7 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
 
     // MARK: - Purchasing
 
-    func testPurchaseSK1PackageSendsReceiptToBackendIfSuccessful() async throws {
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
+    func testPurchasePostsReceipt() async throws {
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
         let product = try await self.fetchSk1Product()
@@ -57,32 +58,147 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
         expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .always
 
         expect(self.backend.invokedPostReceiptDataCount) == 1
+        expect(self.backend.invokedPostReceiptData).to(beTrue())
+        expect(self.backend.invokedPostReceiptDataParameters?.data).toNot(beNil())
         expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
         expect(self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingID) == "offering"
         expect(self.backend.invokedPostReceiptDataParameters?.transactionData.source.initiationSource) == .purchase
     }
 
-    func testSK1PurchaseDoesNotAlwaysRefreshReceiptInProduction() async throws {
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
+    func testPurchaseReturnsCorrectValues() async throws {
+        backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
+
+        let product = try await self.fetchSk1Product()
+        let payment = storeKit1Wrapper.payment(with: product)
+
+        let (transaction, customerInfo, error, userCancelled) = await withCheckedContinuation { continuation in
+            orchestrator.purchase(sk1Product: product,
+                                  payment: payment,
+                                  package: nil,
+                                  wrapper: self.storeKit1Wrapper) { transaction, customerInfo, error, userCancelled in
+                continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
+            }
+        }
+
+        expect(transaction?.sk1Transaction?.productIdentifier) == product.productIdentifier
+        expect(userCancelled) == false
+        expect(error).to(beNil())
+
+        let expectedCustomerInfo: CustomerInfo = .emptyInfo
+        expect(customerInfo) == expectedCustomerInfo
+    }
+
+    func testPurchaseDoesNotPostReceiptIfPurchaseFailed() async throws {
+        storeKit1Wrapper.mockAddPaymentTransactionState = .failed
+        storeKit1Wrapper.mockTransactionError = NSError(domain: SKErrorDomain,
+                                                        code: SKError.Code.paymentCancelled.rawValue)
+
+        let product = try await self.fetchSk1Product()
+        let offer = PromotionalOffer.SignedData(identifier: "",
+                                                keyIdentifier: "",
+                                                nonce: UUID(),
+                                                signature: "",
+                                                timestamp: 0)
+
+        let (transaction, customerInfo, error, userCancelled) = await withCheckedContinuation { continuation in
+            orchestrator.purchase(sk1Product: product,
+                                  promotionalOffer: offer,
+                                  package: nil,
+                                  wrapper: self.storeKit1Wrapper) { transaction, customerInfo, error, userCancelled in
+                continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
+            }
+        }
+        expect(self.backend.invokedPostReceiptData) == false
+        expect(transaction?.sk1Transaction?.transactionState) == .failed
+        expect(customerInfo).to(beNil())
+        expect(error).to(matchError(ErrorCode.purchaseCancelledError))
+        expect(userCancelled) == true
+    }
+
+    func testPurchaseWithPromotionalOfferPostsReceiptIfSuccessful() async throws {
+        backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
+
+        let product = try await fetchSk1Product()
+        let storeProduct = StoreProduct(sk1Product: product)
+
+        let offer = PromotionalOffer.SignedData(identifier: "",
+                                                keyIdentifier: "",
+                                                nonce: UUID(),
+                                                signature: "",
+                                                timestamp: 0)
+
+        _ = await withCheckedContinuation { continuation in
+            orchestrator.purchase(sk1Product: product,
+                                  promotionalOffer: offer,
+                                  package: nil,
+                                  wrapper: self.storeKit1Wrapper) { transaction, customerInfo, error, userCancelled in
+                continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
+            }
+        }
+
+        expect(self.backend.invokedPostReceiptDataCount) == 1
+        expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
+    }
+
+    func testPurchaseWithInvalidPromotionalOfferSignatureFails() async throws {
+        storeKit1Wrapper.mockAddPaymentTransactionState = .failed
+        storeKit1Wrapper.mockTransactionError = NSError(domain: SKErrorDomain,
+                                                        code: SKError.Code.invalidSignature.rawValue)
+        let product = try await self.fetchSk1Product()
+        let offer = PromotionalOffer.SignedData(identifier: "",
+                                                keyIdentifier: "",
+                                                nonce: UUID(),
+                                                signature: "",
+                                                timestamp: 0)
+
+        let (transaction, customerInfo, error, userCancelled) = await withCheckedContinuation { continuation in
+            orchestrator.purchase(sk1Product: product,
+                                  promotionalOffer: offer,
+                                  package: nil,
+                                  wrapper: self.storeKit1Wrapper) { transaction, customerInfo, error, userCancelled in
+                continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
+            }
+        }
+        expect(transaction).toNot(beNil())
+        expect(customerInfo).to(beNil())
+        expect(error).to(matchError(ErrorCode.invalidPromotionalOfferError))
+        expect(userCancelled) == false
+        expect(self.backend.invokedPostReceiptData) == false
+    }
+
+    func testPurchaseCancelled() async throws {
+        storeKit1Wrapper.mockAddPaymentTransactionState = .failed
+        storeKit1Wrapper.mockTransactionError = NSError(domain: SKErrorDomain,
+                                                        code: SKError.Code.paymentCancelled.rawValue)
+        let product = try await self.fetchSk1Product()
+        let (transaction, customerInfo, error, userCancelled) = await withCheckedContinuation { continuation in
+            orchestrator.purchase(product: StoreProduct(sk1Product: product),
+                                  package: nil) { transaction, customerInfo, error, userCancelled in
+                continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
+            }
+        }
+        expect(transaction).toNot(beNil())
+        expect(customerInfo).to(beNil())
+        expect(error).to(matchError(ErrorCode.purchaseCancelledError))
+        expect(userCancelled) == true
+        expect(self.backend.invokedPostReceiptData) == false
+    }
+
+    // MARK: - Purchasing, StoreKit 1 only
+
+    func testPurchaseSK1DoesNotAlwaysRefreshReceiptInProduction() async throws {
         self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
 
         self.systemInfo.stubbedIsSandbox = false
 
         let product = try await self.fetchSk1Product()
-        let storeProduct = try await self.fetchSk1StoreProduct()
-
-        let package = Package(identifier: "package",
-                              packageType: .monthly,
-                              storeProduct: .from(product: storeProduct),
-                              offeringIdentifier: "offering")
-
         let payment = self.storeKit1Wrapper.payment(with: product)
 
         _ = await withCheckedContinuation { continuation in
             self.orchestrator.purchase(
                 sk1Product: product,
                 payment: payment,
-                package: package,
+                package: nil,
                 wrapper: self.storeKit1Wrapper
             ) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
@@ -93,7 +209,7 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
         expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .onlyIfEmpty
     }
 
-    func testPurchaseSK1PackageRetriesReceiptFetchIfEnabled() async throws {
+    func testPurchaseSK1RetriesReceiptFetchIfEnabled() async throws {
         self.systemInfo = .init(
             platformInfo: nil,
             finishTransactions: false,
@@ -103,24 +219,16 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
         )
         self.setUpStoreKit1Wrapper()
         self.setUpOrchestrator()
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
         self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
 
         let product = try await self.fetchSk1Product()
-        let storeProduct = StoreProduct(sk1Product: product)
-
-        let package = Package(identifier: "package",
-                              packageType: .monthly,
-                              storeProduct: storeProduct,
-                              offeringIdentifier: "offering")
-
         let payment = self.storeKit1Wrapper.payment(with: product)
 
         _ = await withCheckedContinuation { continuation in
             self.orchestrator.purchase(
                 sk1Product: product,
                 payment: payment,
-                package: package,
+                package: nil,
                 wrapper: self.storeKit1Wrapper
             ) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
@@ -129,7 +237,7 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
 
         expect(self.receiptFetcher.receiptDataCalled) == true
         expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .retryUntilProductIsFound(
-            productIdentifier: storeProduct.productIdentifier,
+            productIdentifier: product.productIdentifier,
             maximumRetries: TransactionPoster.receiptRetryCount,
             sleepDuration: TransactionPoster.receiptRetrySleepDuration
         )
@@ -138,17 +246,10 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
         expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
     }
 
-    func testPurchaseSK1PackageWithNoProductIdentifierDoesNotPostReceipt() async throws {
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
+    func testPurchaseSK1WithNoProductIdentifierDoesNotPostReceipt() async throws {
         self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
 
         let product = try await self.fetchSk1Product()
-        let storeProduct = StoreProduct(sk1Product: product)
-        let package = Package(identifier: "package",
-                              packageType: .monthly,
-                              storeProduct: storeProduct,
-                              offeringIdentifier: "offering")
-
         let payment = self.storeKit1Wrapper.payment(with: product)
         payment.productIdentifier = ""
 
@@ -157,7 +258,7 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
             self.orchestrator.purchase(
                 sk1Product: product,
                 payment: payment,
-                package: package,
+                package: nil,
                 wrapper: self.storeKit1Wrapper
             ) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
@@ -175,10 +276,27 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
         expect(self.backend.invokedPostReceiptDataCount) == 0
     }
 
+    func testPurchaseSK1ReturnsMissingReceiptErrorIfSendReceiptFailed() async throws {
+        let product = try await self.fetchSk1Product()
+        let payment = self.storeKit1Wrapper.payment(with: product)
+        self.receiptFetcher.shouldReturnReceipt = false
+
+        let (_, _, error, _) = try await withCheckedThrowingContinuation { continuation in
+            self.orchestrator.purchase(
+                sk1Product: product,
+                payment: payment,
+                package: nil,
+                wrapper: self.storeKit1Wrapper
+            ) { transaction, customerInfo, error, userCancelled in
+                continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
+            }
+        }
+        expect(error).to(matchError(ErrorCode.missingReceiptFileError))
+    }
+
     // MARK: - Paywalls
 
-    func testPurchaseSK1PackageWithPresentedPaywall() async throws {
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
+    func testPurchaseWithPresentedPaywall() async throws {
         self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
 
         let product = try await self.fetchSk1Product()
@@ -205,7 +323,7 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
         ) == Self.paywallEvent
     }
 
-    func testFailedSK1PurchaseRemembersPresentedPaywall() async throws {
+    func testPurchaseFailureRemembersPresentedPaywall() async throws {
         func purchase() async throws {
             let product = try await self.fetchSk1Product()
             let payment = self.storeKit1Wrapper.payment(with: product)
@@ -223,7 +341,6 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
         }
 
         self.orchestrator.track(paywallEvent: .impression(Self.paywallEventCreationData, Self.paywallEvent))
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
 
         self.backend.stubbedPostReceiptResult = .failure(.unexpectedBackendResponse(.customerInfoNil))
         try await purchase()
@@ -241,27 +358,17 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
 
     // MARK: - AdServices and Attributes
 
-    func testPurchaseSK1PackageDoesNotPostAdServicesTokenIfNotEnabled() async throws {
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
+    func testPurchaseDoesNotPostAdServicesTokenIfNotEnabled() async throws {
         self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
         self.attributionFetcher.adServicesTokenToReturn = "token"
-
         let product = try await self.fetchSk1Product()
-        let storeProduct = StoreProduct(sk1Product: product)
-
-        let package = Package(identifier: "package",
-                              packageType: .monthly,
-                              storeProduct: storeProduct,
-                              offeringIdentifier: "offering")
-
         let payment = self.storeKit1Wrapper.payment(with: product)
 
         _ = await withCheckedContinuation { continuation in
             self.orchestrator.purchase(
                 sk1Product: product,
                 payment: payment,
-                package: package,
+                package: nil,
                 wrapper: self.storeKit1Wrapper
             ) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
@@ -274,13 +381,17 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
     @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    func testPurchaseSK1PackageWithSubscriberAttributesAndAdServicesToken() async throws {
+    func testPurchasePostsAdServicesTokenAndSubscriberAttributes() async throws {
         try AvailabilityChecks.skipIfTVOrWatchOSOrMacOS()
         try AvailabilityChecks.iOS14_3APIAvailableOrSkipTest()
 
         // Test for custom entitlement computation mode.
         // Without that mode, the token is posted upon calling `enableAdServicesAttributionTokenCollection`
-        self.systemInfo = .init(finishTransactions: true, customEntitlementsComputation: true)
+        self.systemInfo = .init(
+            finishTransactions: true,
+            customEntitlementsComputation: true,
+            storeKitVersion: .storeKit1
+        )
         self.setUpAttribution()
         self.setUpOrchestrator()
 
@@ -290,20 +401,11 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
             "attribute_2": .init(attribute: .email, value: "email")
         ]
 
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
         self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
         self.attributionFetcher.adServicesTokenToReturn = "token"
         self.subscriberAttributesManager.stubbedUnsyncedAttributesByKeyResult = attributes
         self.attribution.enableAdServicesAttributionTokenCollection()
-
         let product = try await self.fetchSk1Product()
-        let storeProduct = StoreProduct(sk1Product: product)
-
-        let package = Package(identifier: "package",
-                              packageType: .monthly,
-                              storeProduct: storeProduct,
-                              offeringIdentifier: "offering")
 
         let payment = self.storeKit1Wrapper.payment(with: product)
 
@@ -311,7 +413,7 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
             self.orchestrator.purchase(
                 sk1Product: product,
                 payment: payment,
-                package: package,
+                package: nil,
                 wrapper: self.storeKit1Wrapper
             ) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
@@ -326,13 +428,11 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
 
     // MARK: - Promotional Offers
 
-    func testGetSK1PromotionalOffer() async throws {
-        customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
+    func testGetPromotionalOfferWorksIfThereIsATransaction() async throws {
         offerings.stubbedPostOfferCompletionResult = .success(("signature", "identifier", UUID(), 12345))
         self.receiptParser.stubbedReceiptHasTransactionsResult = true
 
         let product = try await fetchSk1Product()
-
         let storeProductDiscount = MockStoreProductDiscount(offerIdentifier: "offerid1",
                                                             currencyCode: product.priceLocale.currencyCode,
                                                             price: 11.1,
@@ -356,7 +456,8 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
             self.receiptFetcher.mockReceiptData.asFetchToken
     }
 
-    func testGetSK1PromotionalOfferFailsWithIneligibleIfNoReceiptIsFound() async throws {
+    func testGetPromotionalOfferSK1FailsWithIneligibleIfNoReceiptIsFound() async throws {
+        self.receiptParser.stubbedReceiptHasTransactionsResult = true
         self.receiptFetcher.shouldReturnReceipt = false
 
         let product = try await self.fetchSk1Product()
@@ -375,6 +476,7 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
                                                    product: StoreProduct(sk1Product: product),
                                                    completion: completion)
             }
+            fail("Expected error")
         } catch {
             expect(error).to(matchError(ErrorCode.ineligibleError))
         }
@@ -382,7 +484,7 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
         expect(self.offerings.invokedPostOffer) == false
     }
 
-    func testGetSK1PromotionalOfferFailsWithIneligibleIfReceiptHasNoTransactions() async throws {
+    func testGetPromotionalOfferFailsWithIneligibleIfNoTransactionIsFound() async throws {
         self.receiptParser.stubbedReceiptHasTransactionsResult = false
 
         let product = try await self.fetchSk1Product()
@@ -401,6 +503,7 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
                                                    product: StoreProduct(sk1Product: product),
                                                    completion: completion)
             }
+            fail("Expected error")
         } catch {
             expect(error).to(matchError(ErrorCode.ineligibleError))
         }
@@ -408,35 +511,7 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
         expect(self.offerings.invokedPostOffer) == false
     }
 
-    func testGetSK1PromotionalOfferWorksWhenReceiptHasTransactions() async throws {
-        customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
-        offerings.stubbedPostOfferCompletionResult = .success(("signature", "identifier", UUID(), 12345))
-        self.receiptParser.stubbedReceiptHasTransactionsResult = true
-
-        let product = try await self.fetchSk1Product()
-        let storeProductDiscount = MockStoreProductDiscount(offerIdentifier: "offerid1",
-                                                            currencyCode: product.priceLocale.currencyCode,
-                                                            price: 11.1,
-                                                            localizedPriceString: "$11.10",
-                                                            paymentMode: .payAsYouGo,
-                                                            subscriptionPeriod: .init(value: 1, unit: .month),
-                                                            numberOfPeriods: 2,
-                                                            type: .promotional)
-
-        let result = try await Async.call { completion in
-            orchestrator.promotionalOffer(forProductDiscount: storeProductDiscount,
-                                          product: StoreProduct(sk1Product: product),
-                                          completion: completion)
-        }
-
-        expect(result.signedData.identifier) == storeProductDiscount.offerIdentifier
-
-        expect(self.offerings.invokedPostOfferCount) == 1
-        expect(self.offerings.invokedPostOfferParameters?.offerIdentifier) == storeProductDiscount.offerIdentifier
-    }
-
-    func testGetSK1PromotionalOfferFailsWithIneligibleDiscount() async throws {
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
+    func testGetPromotionalOfferFailsWithIneligibleIfBackendReturnsIneligible() async throws {
         self.offerings.stubbedPostOfferCompletionResult = .failure(
             .networkError(
                 .errorResponse(
@@ -464,7 +539,6 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
                                                    product: StoreProduct(sk1Product: product),
                                                    completion: completion)
             }
-
             fail("Expected error")
         } catch let purchasesError as PurchasesError {
             expect(purchasesError.error).to(matchError(ErrorCode.ineligibleError))
@@ -473,36 +547,92 @@ class PurchasesOrchestratorSK1Tests: PurchasesOrchestratorTestCase {
         }
     }
 
-    func testPurchaseSK1PackageWithDiscountSendsReceiptToBackendIfSuccessful() async throws {
-        customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
-        offerings.stubbedPostOfferCompletionResult = .success(("signature", "identifier", UUID(), 12345))
-        backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
+    // MARK: - TransactionListenerDelegate
 
-        let product = try await fetchSk1Product()
-        let storeProduct = StoreProduct(sk1Product: product)
-        let package = Package(identifier: "package",
-                              packageType: .monthly,
-                              storeProduct: storeProduct,
-                              offeringIdentifier: "offering")
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testDoesNotListenForSK2TransactionsWithSK2Disabled() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        let offer = PromotionalOffer.SignedData(identifier: "",
-                                                keyIdentifier: "",
-                                                nonce: UUID(),
-                                                signature: "",
-                                                timestamp: 0)
+        let transactionListener = MockStoreKit2TransactionListener()
 
-        _ = await withCheckedContinuation { continuation in
-            orchestrator.purchase(sk1Product: product,
-                                  promotionalOffer: offer,
-                                  package: package,
-                                  wrapper: self.storeKit1Wrapper) { transaction, customerInfo, error, userCancelled in
-                continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
-            }
+        self.setUpOrchestrator(storeKit2TransactionListener: transactionListener,
+                               storeKit2StorefrontListener: StoreKit2StorefrontListener(delegate: nil))
+
+        expect(transactionListener.invokedDelegateSetter).toEventually(beTrue())
+        expect(transactionListener.invokedListenForTransactions) == false
+    }
+
+    // MARK: - Sync Purchases
+
+    func testSyncPurchasesPostsReceipt() async throws {
+        self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
+
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+                                                                     isRestore: false,
+                                                                     initiationSource: .purchase)
+
+        expect(self.backend.invokedPostReceiptData).to(beTrue())
+        expect(self.backend.invokedPostReceiptDataParameters?.data) == .receipt(self.receiptFetcher.mockReceiptData)
+        expect(customerInfo) == mockCustomerInfo
+    }
+
+    func testSyncPurchasesDoesntPostReceiptAndReturnsCustomerInfoIfNoTransaction() async throws {
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
+        self.receiptParser.stubbedReceiptHasTransactionsResult = false
+
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+                                                                     isRestore: false,
+                                                                     initiationSource: .purchase)
+        expect(self.backend.invokedPostReceiptData).to(beFalse())
+        expect(self.customerInfoManager.invokedCustomerInfo).to(beFalse())
+        expect(customerInfo) == mockCustomerInfo
+    }
+
+    func testSyncPurchasesPostsReceiptIfNoTransactionsAndEmptyOriginalPurchaseDate() async throws {
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = try .init(data: [
+            "request_date": "2019-08-16T10:30:42Z",
+            "subscriber": [
+                "first_seen": "2019-07-17T00:05:54Z",
+                "original_app_user_id": "app_user_id",
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
+                "original_application_version": "1.0"
+            ] as [String: Any]
+        ])
+        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
+        self.receiptParser.stubbedReceiptHasTransactionsResult = false
+
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+                                                                     isRestore: false,
+                                                                     initiationSource: .purchase)
+        expect(self.backend.invokedPostReceiptData).to(beTrue())
+        expect(self.customerInfoManager.invokedCustomerInfo).to(beFalse())
+        expect(customerInfo) == mockCustomerInfo
+    }
+
+    func testSyncPurchasesCallsSuccessDelegateMethod() async throws {
+        self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
+
+        let receivedCustomerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+                                                                             isRestore: false,
+                                                                             initiationSource: .purchase)
+
+        expect(receivedCustomerInfo) === mockCustomerInfo
+    }
+
+    func testSyncPurchasesPassesErrorOnFailure() async throws {
+        let expectedError: BackendError = .missingAppUserID()
+
+        self.backend.stubbedPostReceiptResult = .failure(expectedError)
+
+        do {
+            _ = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+                                                          isRestore: false,
+                                                          initiationSource: .purchase)
+            fail("Expected error")
+        } catch {
+            expect(error).to(matchError(expectedError.asPurchasesError))
         }
-
-        expect(self.backend.invokedPostReceiptDataCount) == 1
-        expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
-        expect(self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingID) == "offering"
     }
 
 }

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -9,246 +9,55 @@
 //
 //  PurchasesOrchestratorTests.swift
 //
-//  Created by Andrés Boedo on 1/9/21.
+//  Created by Mark Villacampa on 20/2/24.
 
-import Foundation
-import Nimble
-@testable import RevenueCat
-import StoreKit
-import XCTest
+protocol PurchasesOrchestratorTests {
 
-@available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 7.0, *)
-class PurchasesOrchestratorTestCase: StoreKitConfigTestCase {
+    // MARK: - StoreFront Changes
 
-    var productsManager: MockProductsManager!
-    var purchasedProductsFetcher: MockPurchasedProductsFetcher!
-    var storeKit1Wrapper: MockStoreKit1Wrapper!
-    var systemInfo: MockSystemInfo!
-    var subscriberAttributesManager: MockSubscriberAttributesManager!
-    var attribution: Attribution!
-    var attributionFetcher: MockAttributionFetcher!
-    var operationDispatcher: MockOperationDispatcher!
-    var receiptFetcher: MockReceiptFetcher!
-    var receiptParser: MockReceiptParser!
-    var customerInfoManager: MockCustomerInfoManager!
-    var paymentQueueWrapper: EitherPaymentQueueWrapper!
-    var backend: MockBackend!
-    var offerings: MockOfferingsAPI!
-    var currentUserProvider: MockCurrentUserProvider!
-    var transactionsManager: MockTransactionsManager!
-    var deviceCache: MockDeviceCache!
-    var mockManageSubsHelper: MockManageSubscriptionsHelper!
-    var mockBeginRefundRequestHelper: MockBeginRefundRequestHelper!
-    var mockOfferingsManager: MockOfferingsManager!
-    var mockStoreMessagesHelper: MockStoreMessagesHelper!
-    var mockTransactionFetcher: MockStoreKit2TransactionFetcher!
+    func testClearCachedProductsAndOfferingsAfterStorefrontChanges() async throws
 
-    var orchestrator: PurchasesOrchestrator!
+    // MARK: - Purchasing
 
-    static let mockUserID = "appUserID"
+    func testPurchasePostsReceipt() async throws
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    func testPurchaseReturnsCorrectValues() async throws
 
-        self.setUpSystemInfo()
+    func testPurchaseDoesNotPostReceiptIfPurchaseFailed() async throws
 
-        self.productsManager = MockProductsManager(systemInfo: self.systemInfo,
-                                                   requestTimeout: Configuration.storeKitRequestTimeoutDefault)
-        self.purchasedProductsFetcher = .init()
-        self.operationDispatcher = MockOperationDispatcher()
-        self.receiptFetcher = MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: self.systemInfo)
-        self.mockTransactionFetcher = MockStoreKit2TransactionFetcher()
-        self.receiptParser = MockReceiptParser()
-        self.deviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo)
-        self.backend = MockBackend()
-        self.offerings = try XCTUnwrap(self.backend.offerings as? MockOfferingsAPI)
+    func testPurchaseWithInvalidPromotionalOfferSignatureFails() async throws
 
-        self.mockOfferingsManager = MockOfferingsManager(deviceCache: self.deviceCache,
-                                                         operationDispatcher: self.operationDispatcher,
-                                                         systemInfo: self.systemInfo,
-                                                         backend: self.backend,
-                                                         offeringsFactory: OfferingsFactory(),
-                                                         productsManager: self.productsManager)
-        self.setUpStoreKit1Wrapper()
+    // MARK: - Paywalls
 
-        self.customerInfoManager = MockCustomerInfoManager(
-            offlineEntitlementsManager: MockOfflineEntitlementsManager(),
-            operationDispatcher: OperationDispatcher(),
-            deviceCache: self.deviceCache,
-            backend: self.backend,
-            transactionFetcher: MockStoreKit2TransactionFetcher(),
-            transactionPoster: self.transactionPoster,
-            systemInfo: self.systemInfo
-        )
-        self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: Self.mockUserID)
-        self.transactionsManager = MockTransactionsManager(receiptParser: MockReceiptParser())
-        self.attributionFetcher = MockAttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
-                                                         systemInfo: self.systemInfo)
-        self.subscriberAttributesManager = MockSubscriberAttributesManager(
-            backend: self.backend,
-            deviceCache: self.deviceCache,
-            operationDispatcher: MockOperationDispatcher(),
-            attributionFetcher: self.attributionFetcher,
-            attributionDataMigrator: MockAttributionDataMigrator())
-        self.mockManageSubsHelper = MockManageSubscriptionsHelper(systemInfo: self.systemInfo,
-                                                                  customerInfoManager: self.customerInfoManager,
-                                                                  currentUserProvider: self.currentUserProvider)
-        self.mockBeginRefundRequestHelper = MockBeginRefundRequestHelper(systemInfo: self.systemInfo,
-                                                                         customerInfoManager: self.customerInfoManager,
-                                                                         currentUserProvider: self.currentUserProvider)
-        self.mockStoreMessagesHelper = .init()
-        self.mockTransactionFetcher = MockStoreKit2TransactionFetcher()
-        self.setUpStoreKit1Wrapper()
-        self.setUpAttribution()
-        self.setUpOrchestrator()
-        self.setUpStoreKit2Listener()
-    }
+    func testPurchaseWithPresentedPaywall() async throws
 
-    func setUpStoreKit2Listener() {
-        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
-            self.orchestrator._storeKit2TransactionListener = MockStoreKit2TransactionListener()
-        }
-    }
+    func testPurchaseFailureRemembersPresentedPaywall() async throws
 
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    var mockStoreKit2TransactionListener: MockStoreKit2TransactionListener? {
-        return self.orchestrator.storeKit2TransactionListener as? MockStoreKit2TransactionListener
-    }
+    // MARK: - AdServices and Attributes
 
-    func setUpSystemInfo(
-        finishTransactions: Bool = true,
-        storeKitVersion: StoreKitVersion = .default
-    ) {
-        let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "1.2.3")
+    func testPurchaseDoesNotPostAdServicesTokenIfNotEnabled() async throws
 
-        self.systemInfo = .init(platformInfo: platformInfo,
-                                finishTransactions: finishTransactions,
-                                storeKitVersion: storeKitVersion)
-        self.systemInfo.stubbedIsSandbox = true
-    }
+    @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    func testPurchasePostsAdServicesTokenAndSubscriberAttributes() async throws
 
-    func setUpStoreKit1Wrapper() {
-        self.storeKit1Wrapper = MockStoreKit1Wrapper(observerMode: self.systemInfo.observerMode)
-        self.storeKit1Wrapper.mockAddPaymentTransactionState = .purchased
-        self.storeKit1Wrapper.mockCallUpdatedTransactionInstantly = true
+    // MARK: - Promotional Offers
 
-        self.paymentQueueWrapper = .left(self.storeKit1Wrapper)
-    }
+    func testGetPromotionalOfferWorksIfThereIsATransaction() async throws
 
-    func setUpAttribution() {
-        let attributionPoster = AttributionPoster(deviceCache: self.deviceCache,
-                                                  currentUserProvider: self.currentUserProvider,
-                                                  backend: self.backend,
-                                                  attributionFetcher: self.attributionFetcher,
-                                                  subscriberAttributesManager: self.subscriberAttributesManager)
+    func testGetPromotionalOfferFailsWithIneligibleIfNoTransactionIsFound() async throws
 
-        self.attribution = Attribution(subscriberAttributesManager: self.subscriberAttributesManager,
-                                       currentUserProvider: MockCurrentUserProvider(mockAppUserID: Self.mockUserID),
-                                       attributionPoster: attributionPoster,
-                                       systemInfo: self.systemInfo)
-    }
+    func testGetPromotionalOfferFailsWithIneligibleIfBackendReturnsIneligible() async throws
 
-    func setUpOrchestrator() {
-        self.orchestrator = PurchasesOrchestrator(productsManager: self.productsManager,
-                                                  paymentQueueWrapper: self.paymentQueueWrapper,
-                                                  systemInfo: self.systemInfo,
-                                                  subscriberAttributes: self.attribution,
-                                                  operationDispatcher: self.operationDispatcher,
-                                                  receiptFetcher: self.receiptFetcher,
-                                                  receiptParser: self.receiptParser,
-                                                  transactionFetcher: self.mockTransactionFetcher,
-                                                  customerInfoManager: self.customerInfoManager,
-                                                  backend: self.backend,
-                                                  transactionPoster: self.transactionPoster,
-                                                  currentUserProvider: self.currentUserProvider,
-                                                  transactionsManager: self.transactionsManager,
-                                                  deviceCache: self.deviceCache,
-                                                  offeringsManager: self.mockOfferingsManager,
-                                                  manageSubscriptionsHelper: self.mockManageSubsHelper,
-                                                  beginRefundRequestHelper: self.mockBeginRefundRequestHelper,
-                                                  storeMessagesHelper: self.mockStoreMessagesHelper)
-        self.storeKit1Wrapper.delegate = self.orchestrator
-    }
+    // MARK: - Sync Purchases
 
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func setUpOrchestrator(
-        storeKit2TransactionListener: StoreKit2TransactionListenerType,
-        storeKit2StorefrontListener: StoreKit2StorefrontListener
-    ) {
-        self.orchestrator = PurchasesOrchestrator(productsManager: self.productsManager,
-                                                  paymentQueueWrapper: self.paymentQueueWrapper,
-                                                  systemInfo: self.systemInfo,
-                                                  subscriberAttributes: self.attribution,
-                                                  operationDispatcher: self.operationDispatcher,
-                                                  receiptFetcher: self.receiptFetcher,
-                                                  receiptParser: self.receiptParser,
-                                                  transactionFetcher: self.mockTransactionFetcher,
-                                                  customerInfoManager: self.customerInfoManager,
-                                                  backend: self.backend,
-                                                  transactionPoster: self.transactionPoster,
-                                                  currentUserProvider: self.currentUserProvider,
-                                                  transactionsManager: self.transactionsManager,
-                                                  deviceCache: self.deviceCache,
-                                                  offeringsManager: self.mockOfferingsManager,
-                                                  manageSubscriptionsHelper: self.mockManageSubsHelper,
-                                                  beginRefundRequestHelper: self.mockBeginRefundRequestHelper,
-                                                  storeKit2TransactionListener: storeKit2TransactionListener,
-                                                  storeKit2StorefrontListener: storeKit2StorefrontListener,
-                                                  storeMessagesHelper: self.mockStoreMessagesHelper)
-        self.storeKit1Wrapper.delegate = self.orchestrator
-    }
+    func testSyncPurchasesPostsReceipt() async throws
 
-    var transactionPoster: TransactionPoster {
-        return .init(
-            productsManager: self.productsManager,
-            receiptFetcher: self.receiptFetcher,
-            transactionFetcher: self.mockTransactionFetcher,
-            backend: self.backend,
-            paymentQueueWrapper: self.paymentQueueWrapper,
-            systemInfo: self.systemInfo,
-            operationDispatcher: self.operationDispatcher
-        )
-    }
+    func testSyncPurchasesDoesntPostReceiptAndReturnsCustomerInfoIfNoTransaction() async throws
 
-}
+    func testSyncPurchasesCallsSuccessDelegateMethod() async throws
 
-@available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 7.0, *)
-extension PurchasesOrchestratorTestCase {
-
-    func fetchSk1Product() async throws -> SK1Product {
-        return MockSK1Product(
-            mockProductIdentifier: Self.productID,
-            mockSubscriptionGroupIdentifier: "group1"
-        )
-    }
-
-    func fetchSk1StoreProduct() async throws -> SK1StoreProduct {
-        return try await SK1StoreProduct(sk1Product: fetchSk1Product())
-    }
-
-    var mockCustomerInfo: CustomerInfo { .emptyInfo }
-
-    static let testProduct = TestStoreProduct(
-        localizedTitle: "Product",
-        price: 3.99,
-        localizedPriceString: "$3.99",
-        productIdentifier: "product",
-        productType: .autoRenewableSubscription,
-        localizedDescription: "Description"
-    ).toStoreProduct()
-
-    static let paywallEventCreationData: PaywallEvent.CreationData = .init(
-        id: .init(uuidString: "72164C05-2BDC-4807-8918-A4105F727DEB")!,
-        date: .init(timeIntervalSince1970: 1694029328)
-    )
-
-    static let paywallEvent: PaywallEvent.Data = .init(
-        offeringIdentifier: "offering",
-        paywallRevision: 5,
-        sessionID: .init(),
-        displayMode: .fullScreen,
-        localeIdentifier: "en_US",
-        darkMode: true
-    )
+    func testSyncPurchasesPassesErrorOnFailure() async throws
 
 }

--- a/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
+++ b/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
@@ -38,7 +38,8 @@ extension CustomerInfo {
             "original_app_user_id": "app_user_id",
             "subscriptions": [:] as [String: Any],
             "other_purchases": [:] as [String: Any],
-            "original_application_version": "1.0"
+            "original_application_version": "1.0",
+            "original_purchase_date": "2019-07-17T00:05:54Z"
         ] as [String: Any]
     ])
 

--- a/Tests/UnitTests/Misc/StoreKitVersionTests.swift
+++ b/Tests/UnitTests/Misc/StoreKitVersionTests.swift
@@ -18,6 +18,12 @@ import XCTest
 
 class StoreKitVersionTests: TestCase {
 
+    func testDefaultIsStoreKit2() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        expect(StoreKitVersion.default) == .storeKit2
+    }
+
     func testVersionStringIsStoreKit1IfStoreKit2EnabledButNotAvailable() throws {
         try AvailabilityChecks.iOS15APINotAvailableOrSkipTest()
 

--- a/Tests/UnitTests/Mocks/MockStoreKit1Wrapper.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit1Wrapper.swift
@@ -16,6 +16,7 @@ class MockStoreKit1Wrapper: StoreKit1Wrapper {
 
     var mockAddPaymentTransactionState: SKPaymentTransactionState = .purchasing
     var mockCallUpdatedTransactionInstantly = false
+    var mockTransactionError: NSError?
 
     override func add(_ newPayment: SKPayment) {
         payment = newPayment
@@ -25,6 +26,7 @@ class MockStoreKit1Wrapper: StoreKit1Wrapper {
             let transaction = MockTransaction()
             transaction.mockPayment = newPayment
             transaction.mockState = mockAddPaymentTransactionState
+            transaction.mockError = mockTransactionError
             delegate?.storeKit1Wrapper(self, updatedTransaction: transaction)
         }
     }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testCachesCustomerGetsForSameCustomer.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerCallsBackendProperly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithFailedVerification.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetsCustomerInfo.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesGetCustomerInfoErrors.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesInvalidJSON.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
@@ -14,8 +14,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testUpdatesRequestDateFromResponseHeader.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testCachesCustomerGetsForSameCustomer.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerCallsBackendProperly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithFailedVerification.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetsCustomerInfo.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesGetCustomerInfoErrors.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesInvalidJSON.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testSendsNonceWhenEnabled.1.json
@@ -14,8 +14,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testUpdatesRequestDateFromResponseHeader.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testCachesCustomerGetsForSameCustomer.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerCallsBackendProperly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithFailedVerification.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetsCustomerInfo.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesGetCustomerInfoErrors.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesInvalidJSON.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
@@ -14,8 +14,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testUpdatesRequestDateFromResponseHeader.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testCachesCustomerGetsForSameCustomer.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerCallsBackendProperly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithFailedVerification.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetsCustomerInfo.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesGetCustomerInfoErrors.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesInvalidJSON.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testSendsNonceWhenEnabled.1.json
@@ -14,8 +14,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testUpdatesRequestDateFromResponseHeader.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testCachesCustomerGetsForSameCustomer.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerCallsBackendProperly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithFailedVerification.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetsCustomerInfo.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesGetCustomerInfoErrors.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesInvalidJSON.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testSendsNonceWhenEnabled.1.json
@@ -14,8 +14,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testUpdatesRequestDateFromResponseHeader.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testCachesCustomerGetsForSameCustomer.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerCallsBackendProperly.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoWithFailedVerification.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetsCustomerInfo.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testHandlesGetCustomerInfoErrors.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testHandlesInvalidJSON.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testSendsNonceWhenEnabled.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testUpdatesRequestDateFromResponseHeader.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfUnknownError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testPostsProductIdentifiers.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfUnknownError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testPostsProductIdentifiers.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfUnknownError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testPostsProductIdentifiers.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfUnknownError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testPostsProductIdentifiers.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfUnknownError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testPostsProductIdentifiers.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testEligibilityUnknownIfError.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testEligibilityUnknownIfUnknownError.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testPostsProductIdentifiers.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCachesForSameUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethod.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsFailSendsNil.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsNetworkErrorSendsError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsOneOffering.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCachesForSameUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethod.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsFailSendsNil.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsNetworkErrorSendsError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsOneOffering.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCachesForSameUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethod.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsFailSendsNil.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsNetworkErrorSendsError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsOneOffering.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCachesForSameUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethod.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsFailSendsNil.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsNetworkErrorSendsError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsOneOffering.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCachesForSameUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethod.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsFailSendsNil.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsNetworkErrorSendsError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsOneOffering.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCachesForSameUserID.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCallsHTTPMethod.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsFailSendsNil.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsNetworkErrorSendsError.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsOneOffering.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testRepeatedRequestsLogDebugMessage.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestIsNotAuthenticated.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithFailure.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithSuccess.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestIsNotAuthenticated.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithFailure.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithSuccess.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestIsNotAuthenticated.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithFailure.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithSuccess.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestIsNotAuthenticated.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithFailure.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithSuccess.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestIsNotAuthenticated.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithFailure.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithSuccess.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestIsNotAuthenticated.1.json
@@ -10,8 +10,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestWithFailure.1.json
@@ -10,8 +10,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestWithSuccess.1.json
@@ -10,8 +10,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCachesForSameUserIDs.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginMakesRightCalls.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCachesForSameUserIDs.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginMakesRightCalls.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithFailedVerification.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCachesForSameUserIDs.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginMakesRightCalls.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCachesForSameUserIDs.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginMakesRightCalls.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithFailedVerification.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithVerifiedResponse.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCachesForSameUserIDs.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginMakesRightCalls.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithFailedVerification.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithVerifiedResponse.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCachesForSameUserIDs.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginMakesRightCalls.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginMakesRightCalls.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginMakesRightCalls.2.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginWithFailedVerification.1.json
@@ -14,8 +14,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginWithVerifiedResponse.1.json
@@ -14,8 +14,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMapping.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMapping.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMapping.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMapping.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMapping.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/macOS-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/macOS-testGetProductEntitlementMapping.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/macOS-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/macOS-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS13-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS13-testPostAdServicesCallsHttpClient.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS14-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS14-testPostAdServicesCallsHttpClient.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS15-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS15-testPostAdServicesCallsHttpClient.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS16-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS16-testPostAdServicesCallsHttpClient.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS17-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS17-testPostAdServicesCallsHttpClient.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/macOS-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/macOS-testPostAdServicesCallsHttpClient.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS13-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS13-testPostAttributesPutsDataInDataKey.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS14-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS14-testPostAttributesPutsDataInDataKey.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS15-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS15-testPostAttributesPutsDataInDataKey.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS16-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS16-testPostAttributesPutsDataInDataKey.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS17-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS17-testPostAttributesPutsDataInDataKey.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/macOS-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/macOS-testPostAttributesPutsDataInDataKey.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningEmptyOffersResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNetworkError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningSignatureErrorResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningEmptyOffersResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNetworkError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningSignatureErrorResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningEmptyOffersResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNetworkError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningSignatureErrorResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningEmptyOffersResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNetworkError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningSignatureErrorResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningEmptyOffersResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNetworkError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningSignatureErrorResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningCorrectly.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningEmptyOffersResponse.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningNetworkError.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningSignatureErrorResponse.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testCachesRequestsForSameReceipt.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesNotPostConsentStatus.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testFreeTrialPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testIndividualParamsCanBeNil.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayAsYouGoPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayUpFrontPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testCachesRequestsForSameReceipt.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesNotPostConsentStatus.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testFreeTrialPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testIndividualParamsCanBeNil.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayAsYouGoPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayUpFrontPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testCachesRequestsForSameReceipt.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesNotPostConsentStatus.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testFreeTrialPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testIndividualParamsCanBeNil.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayAsYouGoPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayUpFrontPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testCachesRequestsForSameReceipt.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesNotPostConsentStatus.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testFreeTrialPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testIndividualParamsCanBeNil.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayAsYouGoPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayUpFrontPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testCachesRequestsForSameReceipt.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesNotPostConsentStatus.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testFreeTrialPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testIndividualParamsCanBeNil.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayAsYouGoPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayUpFrontPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testCachesRequestsForSameReceipt.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesNotPostConsentStatus.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentCurrency.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentCurrency.2.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentDiscounts.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentDiscounts.2.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOffering.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOffering.2.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOfferings.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOfferings.2.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentReceipts.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentReceipts.2.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentRestore.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentRestore.2.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testFreeTrialPostsCorrectly.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithFailedVerification.1.json
@@ -14,8 +14,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -14,8 +14,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testIndividualParamsCanBeNil.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPayAsYouGoPostsCorrectly.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPayUpFrontPostsCorrectly.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataCorrectly.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestContainsSignatureHeader.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestFailsIfSignatureVerificationFails.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestContainsSignatureHeader.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestFailsIfSignatureVerificationFails.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestContainsSignatureHeader.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestFailsIfSignatureVerificationFails.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestContainsSignatureHeader.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestFailsIfSignatureVerificationFails.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestContainsSignatureHeader.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestFailsIfSignatureVerificationFails.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/macOS-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/macOS-testRequestContainsSignatureHeader.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/macOS-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/macOS-testRequestFailsIfSignatureVerificationFails.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithMultipleEvents.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithOneEvent.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/macOS-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/macOS-testPostPaywallEventsWithMultipleEvents.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/macOS-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/macOS-testPostPaywallEventsWithOneEvent.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithAdServicesToken.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithAdServicesToken.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithAdServicesToken.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithAdServicesToken.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithAdServicesToken.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithAdServicesToken.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {


### PR DESCRIPTION
Coming from https://github.com/RevenueCat/purchases-ios/pull/3695 where we first split `PurchasesOrchestratorTests.swift` into multiple files:

`PurchasesOrchestratorSK1Tests.swift`: Tests related to StoreKit 1
`PurchasesOrchestratorSK2Tests.swift`: Tests related to StoreKit 2
`PurchasesOrchestratorCommonTests.swift`: Tests related to both versions of StoreKit

To further organize and improve PurchasesOrchestrator Tests, now that we have gotten rid of the old SK2 flag/implementation that mixed some of SK1 and SK2, we need to define a clear list of tests and have separate implementations for SK1 and SK2.

For that, I have defined the `PurchasesOrchestratorTests` protocol which includes a list of tests both `PurchasesOrchestratorSK2Tests` and `PurchasesOrchestratorSK1Tests` must implement. Furthermore, tests specific to one version of StoreKit can be implemented in its corresponding file without adding a method to the protocol.

Will be leaving inline comments as self-review and to add further context to the changes.