### PR TITLE
`[SK2]`: Fix syncPurchases

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1094,7 +1094,7 @@ private extension PurchasesOrchestrator {
 
         self.attribution.unsyncedAdServicesToken { adServicesToken in
             _ = Task<Void, Never> {
-                let transaction = await self.transactionFetcher.firstVerifiedAutoRenewableTransaction
+                let transaction = await self.transactionFetcher.firstVerifiedTransaction
                 guard let transaction = transaction, let jwsRepresentation = transaction.jwsRepresentation  else {
                     self.customerInfoManager.customerInfo(appUserID: currentAppUserID,
                                                           fetchPolicy: .cachedOrFetched) { result in

--- a/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionFetcherTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionFetcherTests.swift
@@ -43,7 +43,7 @@ class StoreKit2TransactionFetcherTests: StoreKitConfigTestCase {
     }
 
     func testOneUnfinishedConsumablePurchase() async throws {
-        let transaction = try await self.createTransaction(productID: Self.consumable,
+        let transaction = try await self.createTransaction(productID: Self.consumableProductId,
                                                            finished: false)
         let result = await self.fetcher.unfinishedVerifiedTransactions
 
@@ -82,14 +82,14 @@ class StoreKit2TransactionFetcherTests: StoreKitConfigTestCase {
     }
 
     func testHasNoPendingConsumablePurchaseWithFinishedConsumable() async throws {
-        _ = try await self.createTransaction(productID: Self.consumable, finished: true)
+        _ = try await self.createTransaction(productID: Self.consumableProductId, finished: true)
 
         let result = await self.fetcher.hasPendingConsumablePurchase
         expect(result) == false
     }
 
     func testHasPendingConsumablePurchase() async throws {
-        _ = try await self.createTransaction(productID: Self.consumable, finished: false)
+        _ = try await self.createTransaction(productID: Self.consumableProductId, finished: false)
 
         let result = await self.fetcher.hasPendingConsumablePurchase
         expect(result) == true
@@ -109,13 +109,13 @@ class StoreKit2TransactionFetcherTests: StoreKitConfigTestCase {
     }
 
     func testFirstVerifiedAutoRenewableTransactionDoesNotIncludeFinishedConsumableTransaction() async throws {
-        _ = try await self.createTransaction(productID: Self.consumable, finished: true)
+        _ = try await self.createTransaction(productID: Self.consumableProductId, finished: true)
         let result = await self.fetcher.firstVerifiedAutoRenewableTransaction
         expect(result) == nil
     }
 
     func testHasVerifiedAutoRenewableTransactionDoesNotIncludeUnfinishedConsumableTransaction() async throws {
-        _ = try await self.createTransaction(productID: Self.consumable, finished: false)
+        _ = try await self.createTransaction(productID: Self.consumableProductId, finished: false)
         let result = await self.fetcher.firstVerifiedAutoRenewableTransaction
         expect(result) == nil
     }
@@ -134,13 +134,13 @@ class StoreKit2TransactionFetcherTests: StoreKitConfigTestCase {
     }
 
     func testFirstVerifiedTransactionDoesNotIncludeFinishedConsumableTransaction() async throws {
-        _ = try await self.createTransaction(productID: Self.consumable, finished: true)
+        _ = try await self.createTransaction(productID: Self.consumableProductId, finished: true)
         let result = await self.fetcher.firstVerifiedTransaction
         expect(result) == nil
     }
 
     func testHasVerifiedTransactionIncludesUnfinishedConsumableTransaction() async throws {
-        let transaction = try await self.createTransaction(productID: Self.consumable,
+        let transaction = try await self.createTransaction(productID: Self.consumableProductId,
                                                            finished: false)
         let result = await self.fetcher.firstVerifiedTransaction
         expect(result) == transaction
@@ -226,6 +226,5 @@ private extension StoreKit2TransactionFetcherTests {
 
     static let product1 = "com.revenuecat.monthly_4.99.1_week_intro"
     static let product2 = "com.revenuecat.annual_39.99_no_trial"
-    static let consumable = "com.revenuecat.consumable"
 
 }

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -336,7 +336,7 @@ class StoreProductTests: StoreKitConfigTestCase {
 
     func testSK1ProductCategory() async throws {
         let subscription = try await self.sk1Fetcher.product(withIdentifier: Self.productID)
-        let nonSubscription = try await self.sk1Fetcher.product(withIdentifier: Self.lifetimeProductID)
+        let nonSubscription = try await self.sk1Fetcher.product(withIdentifier: Self.nonConsumableProductId)
 
         expect(subscription.productCategory) == .subscription
         expect(nonSubscription.productCategory) == .nonSubscription
@@ -348,10 +348,10 @@ class StoreProductTests: StoreKitConfigTestCase {
 
         let fetcher = ProductsFetcherSK2()
 
-        let consumable = try await fetcher.product(withIdentifier: "com.revenuecat.consumable")
-        let nonConsumable = try await fetcher.product(withIdentifier: Self.lifetimeProductID)
-        let nonRenewable = try await fetcher.product(withIdentifier: "com.revenuecat.non_renewable")
         let autoRenewable = try await fetcher.product(withIdentifier: Self.productID)
+        let consumable = try await fetcher.product(withIdentifier: Self.consumableProductId)
+        let nonConsumable = try await fetcher.product(withIdentifier: Self.nonConsumableProductId)
+        let nonRenewable = try await fetcher.product(withIdentifier: Self.nonRenewableProductId)
 
         expect(consumable.productType) == .consumable
         expect(nonConsumable.productType) == .nonConsumable
@@ -366,7 +366,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         let fetcher = ProductsFetcherSK2()
 
         let subscription = try await fetcher.product(withIdentifier: Self.productID)
-        let nonSubscription = try await fetcher.product(withIdentifier: Self.lifetimeProductID)
+        let nonSubscription = try await fetcher.product(withIdentifier: Self.nonConsumableProductId)
 
         expect(subscription.productCategory) == .subscription
         expect(nonSubscription.productCategory) == .nonSubscription

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitConfigTestCase+Extensions.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitConfigTestCase+Extensions.swift
@@ -127,7 +127,9 @@ extension StoreKitConfigTestCase {
 extension StoreKitConfigTestCase {
 
     static let productID = "com.revenuecat.monthly_4.99.1_week_intro"
-    static let lifetimeProductID = "lifetime"
+    static let consumableProductId = "com.revenuecat.consumable"
+    static let nonConsumableProductId = "lifetime"
+    static let nonRenewableProductId = "com.revenuecat.non_renewable"
 
 }
 


### PR DESCRIPTION
We can use any transaction token available, not only auto-renewable ones