### PR TITLE
Retry flaky tests

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -214,7 +214,9 @@ platform :ios do
         report_formats: [:junit],
         report_path: 'fastlane/test_output/revenuecatui/tests.xml',
         test: true,
-        xcargs: generate_snapshots ? "-testPlan CI-Snapshots" : "-testPlan CI-RevenueCatUI"
+        xcargs: generate_snapshots ? "-testPlan CI-Snapshots" : "-testPlan CI-RevenueCatUI",
+        test_iterations: 2,
+        retry_tests_on_failure: true
       )
     rescue => e
       # Equivalent to `fail_build: !generate_snapshots`

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -614,7 +614,8 @@ platform :ios do
       result_bundle: true,
       testplan: options[:test_plan],
       configuration: 'Debug',
-      output_directory: "fastlane/test_output/xctest/ios"
+      output_directory: "fastlane/test_output/xctest/ios",
+      number_of_retries: 2
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -214,7 +214,7 @@ platform :ios do
         report_formats: [:junit],
         report_path: 'fastlane/test_output/revenuecatui/tests.xml',
         test: true,
-        xcargs: "-retry-tests-on-failure -test_iterations 2 " + (generate_snapshots ? "-testPlan CI-Snapshots" : "-testPlan CI-RevenueCatUI")
+        xcargs: "-retry-tests-on-failure -test-iterations 2 " + (generate_snapshots ? "-testPlan CI-Snapshots" : "-testPlan CI-RevenueCatUI")
       )
     rescue => e
       # Equivalent to `fail_build: !generate_snapshots`
@@ -613,7 +613,7 @@ platform :ios do
       testplan: options[:test_plan],
       configuration: 'Debug',
       output_directory: "fastlane/test_output/xctest/ios",
-      xcargs: "-retry-tests-on-failure -test_iterations 2"
+      xcargs: "-retry-tests-on-failure -test-iterations 2"
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -214,9 +214,7 @@ platform :ios do
         report_formats: [:junit],
         report_path: 'fastlane/test_output/revenuecatui/tests.xml',
         test: true,
-        xcargs: generate_snapshots ? "-testPlan CI-Snapshots" : "-testPlan CI-RevenueCatUI",
-        test_iterations: 2,
-        retry_tests_on_failure: true
+        xcargs: "-retry-tests-on-failure -test_iterations 2 " + (generate_snapshots ? "-testPlan CI-Snapshots" : "-testPlan CI-RevenueCatUI")
       )
     rescue => e
       # Equivalent to `fail_build: !generate_snapshots`
@@ -615,7 +613,7 @@ platform :ios do
       testplan: options[:test_plan],
       configuration: 'Debug',
       output_directory: "fastlane/test_output/xctest/ios",
-      number_of_retries: 2
+      xcargs: "-retry-tests-on-failure -test_iterations 2"
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -612,8 +612,7 @@ platform :ios do
       result_bundle: true,
       testplan: options[:test_plan],
       configuration: 'Debug',
-      output_directory: "fastlane/test_output/xctest/ios",
-      xcargs: "-retry-tests-on-failure -test-iterations 2"
+      output_directory: "fastlane/test_output/xctest/ios"
     )
   end
 


### PR DESCRIPTION
I've noticed we have a bunch of flaky tests, and it's making merging PRs very time consuming. I added a retry to failing tests, hoping it reduces the amount of times we have to retry in CircleCI