### PR TITLE
New `syncAttributesAndOfferingsIfNeeded` method

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1E568B512ACC6A8300D3C12F /* StoreMessageTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E568B502ACC6A8300D3C12F /* StoreMessageTypeTests.swift */; };
 		1E99F81F2AC5917F0023E26E /* StoreMessagesHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E99F81D2AC5917F0023E26E /* StoreMessagesHelperTests.swift */; };
 		2C0B98CD2797070B00C5874F /* PromotionalOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */; };
+		2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */; };
 		2CB8CF9327BF538F00C34DE3 /* PlatformInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */; };
 		2CD2C544278CE0E0005D1CC2 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 2CD2C541278CE0E0005D1CC2 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit */; };
 		2CD72942268A823900BFC976 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72941268A823900BFC976 /* Data+Extensions.swift */; };
@@ -830,6 +831,7 @@
 		1E99F81D2AC5917F0023E26E /* StoreMessagesHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessagesHelperTests.swift; sourceTree = "<group>"; };
 		2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOffer.swift; sourceTree = "<group>"; };
 		2C646C282A0EBD0300E5936E /* CI-Snapshots.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = "CI-Snapshots.xctestplan"; path = "Tests/TestPlans/CI-Snapshots.xctestplan"; sourceTree = "<group>"; };
+		2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesSyncAttributesAndOfferingsIfNeededTests.swift; sourceTree = "<group>"; };
 		2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfo.swift; sourceTree = "<group>"; };
 		2CD2C541278CE0E0005D1CC2 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; name = RevenueCat_IntegrationPurchaseTesterConfiguration.storekit; path = Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit; sourceTree = SOURCE_ROOT; };
 		2CD72941268A823900BFC976 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
@@ -2547,6 +2549,7 @@
 				57FDAA952846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift */,
 				57FDAA992846C2BD009A48F1 /* PurchasesDelegateTests.swift */,
 				57DBFA5C28AADA43002D18CA /* PurchasesLogInTests.swift */,
+				2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */,
 				4F0CE2BC2A215CE600561895 /* TransactionPosterTests.swift */,
 			);
 			path = Purchases;
@@ -3833,6 +3836,7 @@
 				2DDF41DF24F6F527005BC22D /* MockProductsManager.swift in Sources */,
 				351B514F26D44ACE00BD2BD7 /* PurchasesSubscriberAttributesTests.swift in Sources */,
 				57DBFA5D28AADA43002D18CA /* PurchasesLogInTests.swift in Sources */,
+				2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */,
 				4F6ABC7C2A81673F00250E63 /* PaywallCacheWarmingTests.swift in Sources */,
 				57D04BB827D947C6006DAC06 /* HTTPResponseTests.swift in Sources */,
 				5796A38127D6B78500653165 /* BaseBackendTest.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		1E99F81F2AC5917F0023E26E /* StoreMessagesHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E99F81D2AC5917F0023E26E /* StoreMessagesHelperTests.swift */; };
 		2C0B98CD2797070B00C5874F /* PromotionalOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */; };
 		2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */; };
+		2C7F0AD32B8EEB4600381179 /* RateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */; };
+		2C7F0AD62B8EEF7B00381179 /* RateLimiterRests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */; };
 		2CB8CF9327BF538F00C34DE3 /* PlatformInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */; };
 		2CD2C544278CE0E0005D1CC2 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 2CD2C541278CE0E0005D1CC2 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit */; };
 		2CD72942268A823900BFC976 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72941268A823900BFC976 /* Data+Extensions.swift */; };
@@ -832,6 +834,8 @@
 		2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOffer.swift; sourceTree = "<group>"; };
 		2C646C282A0EBD0300E5936E /* CI-Snapshots.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = "CI-Snapshots.xctestplan"; path = "Tests/TestPlans/CI-Snapshots.xctestplan"; sourceTree = "<group>"; };
 		2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesSyncAttributesAndOfferingsIfNeededTests.swift; sourceTree = "<group>"; };
+		2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiter.swift; sourceTree = "<group>"; };
+		2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiterRests.swift; sourceTree = "<group>"; };
 		2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfo.swift; sourceTree = "<group>"; };
 		2CD2C541278CE0E0005D1CC2 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; name = RevenueCat_IntegrationPurchaseTesterConfiguration.storekit; path = Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit; sourceTree = SOURCE_ROOT; };
 		2CD72941268A823900BFC976 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
@@ -1806,6 +1810,7 @@
 				57EAE52A274332830060EB74 /* Obsoletions.swift */,
 				2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */,
 				F5FCD3E927DA0D0B003BDC04 /* PriceFormatterProvider.swift */,
+				2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */,
 				57FDAAB9284937A0009A48F1 /* SandboxEnvironmentDetector.swift */,
 				57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */,
 				B3AA6237268B926F00894871 /* SystemInfo.swift */,
@@ -2059,6 +2064,7 @@
 				5712BE9129241F7900A83F15 /* TimingUtilTests.swift */,
 				4F8DDB682AAA9189000188F2 /* OperationDispatcherTests.swift */,
 				4FEF41AC2B4F301800CD699F /* MacAppStoreDetectorTests.swift */,
+				2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -3493,6 +3499,7 @@
 				57ABA76D28F08DDA003D9181 /* Either.swift in Sources */,
 				35F82BB426A9A74D0051DF03 /* HTTPClient.swift in Sources */,
 				57488BD429CB7E2D0000EE7E /* OfflineEntitlementsManager.swift in Sources */,
+				2C7F0AD32B8EEB4600381179 /* RateLimiter.swift in Sources */,
 				B3A55B7D26C452A7007EFC56 /* AttributionPoster.swift in Sources */,
 				4F8452682A5756CC00084550 /* HTTPRequestBody+Signing.swift in Sources */,
 				5791FE4A2994453500F1FEDA /* Signing+ResponseVerification.swift in Sources */,
@@ -3864,6 +3871,7 @@
 				574A2F4F282D7B9E00150D40 /* PostOfferDecodingTests.swift in Sources */,
 				2DDF41CE24F6F4C3005BC22D /* InAppPurchaseBuilderTests.swift in Sources */,
 				573A10DB2800AF4700F976E5 /* PurchaseErrorTests.swift in Sources */,
+				2C7F0AD62B8EEF7B00381179 /* RateLimiterRests.swift in Sources */,
 				351B513F26D4496000BD2BD7 /* MockIdentityManager.swift in Sources */,
 				B319514926C19856002CA9AC /* DataExtensionsTests.swift in Sources */,
 				5733B1A427FF9F8300EC2045 /* NetworkErrorTests.swift in Sources */,

--- a/Sources/Error Handling/ErrorCode.swift
+++ b/Sources/Error Handling/ErrorCode.swift
@@ -60,6 +60,7 @@ import Foundation
     @objc(RCFeatureNotAvailableInCustomEntitlementsComputationMode)
     case featureNotAvailableInCustomEntitlementsComputationMode = 36
     @objc(RCSignatureVerificationFailed) case signatureVerificationFailed = 37
+    @objc(RCSyncingAttributesRateLimitReached) case syncingAttributesRateLimitReached = 38
 
     // swiftlint:enable missing_docs
 

--- a/Sources/Error Handling/ErrorCode.swift
+++ b/Sources/Error Handling/ErrorCode.swift
@@ -60,7 +60,6 @@ import Foundation
     @objc(RCFeatureNotAvailableInCustomEntitlementsComputationMode)
     case featureNotAvailableInCustomEntitlementsComputationMode = 36
     @objc(RCSignatureVerificationFailed) case signatureVerificationFailed = 37
-    @objc(RCSyncingAttributesRateLimitReached) case syncingAttributesRateLimitReached = 38
 
     // swiftlint:enable missing_docs
 

--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -40,6 +40,8 @@ enum IdentityStrings {
 
     case switching_user_same_app_user_id(newUserID: String)
 
+    case sync_attributes_and_offerings_rate_limit_reached(maxCalls: Int, period: Int)
+
 }
 
 extension IdentityStrings: LogMessage {
@@ -75,6 +77,9 @@ extension IdentityStrings: LogMessage {
         case let .switching_user_same_app_user_id(newUserID):
             return "switchUser(to:) called with the same appUserID as the current user (\(newUserID)). " +
             "This has no effect."
+        case let .sync_attributes_and_offerings_rate_limit_reached(maxCalls, period):
+            return "Sync attributes and offerings rate limit reached:\(maxCalls) per \(period) seconds. " +
+            "Returning offerings from cache."
         }
     }
 

--- a/Sources/Misc/RateLimiter.swift
+++ b/Sources/Misc/RateLimiter.swift
@@ -1,0 +1,38 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RateLimiter.swift
+//
+//  Created by Josh Holtz on 2/27/24.
+
+import Foundation
+
+internal class RateLimiter {
+    private var timestamps: [Date] = []
+
+    let maxCalls: Int
+    let period: TimeInterval // Period in seconds
+
+    init(maxCalls: Int, period: TimeInterval) {
+        self.maxCalls = maxCalls
+        self.period = period
+    }
+
+    func shouldProceed() -> Bool {
+        let now = Date()
+        timestamps = timestamps.filter { now.timeIntervalSince($0) <= period }
+
+        if timestamps.count < maxCalls {
+            timestamps.append(now)
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -37,20 +37,33 @@ class OfferingsManager {
         self.productsManager = productsManager
     }
 
-    func offerings(
+    private func fetchFromNetwork(
         appUserID: String,
         fetchPolicy: FetchPolicy = .default,
         completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
     ) {
-        guard let memoryCachedOfferings = self.cachedOfferings else {
-            Logger.debug(Strings.offering.no_cached_offerings_fetching_from_network)
+        Logger.debug(Strings.offering.no_cached_offerings_fetching_from_network)
 
-            self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
-                self.updateOfferingsCache(appUserID: appUserID,
-                                          isAppBackgrounded: isAppBackgrounded,
-                                          fetchPolicy: fetchPolicy,
-                                          completion: completion)
-            }
+        self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
+            self.updateOfferingsCache(appUserID: appUserID,
+                                      isAppBackgrounded: isAppBackgrounded,
+                                      fetchPolicy: fetchPolicy,
+                                      completion: completion)
+        }
+    }
+
+    func offerings(
+        appUserID: String,
+        fetchPolicy: FetchPolicy = .default,
+        fetchCurrent: Bool = false,
+        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
+    ) {
+        guard !fetchCurrent else {
+            self.fetchFromNetwork(appUserID: appUserID, fetchPolicy: fetchPolicy, completion: completion)
+            return
+        }
+        guard let memoryCachedOfferings = self.cachedOfferings else {
+            self.fetchFromNetwork(appUserID: appUserID, fetchPolicy: fetchPolicy, completion: completion)
             return
         }
 

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -37,20 +37,6 @@ class OfferingsManager {
         self.productsManager = productsManager
     }
 
-    private func fetchFromNetwork(
-        appUserID: String,
-        fetchPolicy: FetchPolicy = .default,
-        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
-    ) {
-        Logger.debug(Strings.offering.no_cached_offerings_fetching_from_network)
-
-        self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
-            self.updateOfferingsCache(appUserID: appUserID,
-                                      isAppBackgrounded: isAppBackgrounded,
-                                      fetchPolicy: fetchPolicy,
-                                      completion: completion)
-        }
-    }
 
     func offerings(
         appUserID: String,
@@ -62,6 +48,7 @@ class OfferingsManager {
             self.fetchFromNetwork(appUserID: appUserID, fetchPolicy: fetchPolicy, completion: completion)
             return
         }
+
         guard let memoryCachedOfferings = self.cachedOfferings else {
             self.fetchFromNetwork(appUserID: appUserID, fetchPolicy: fetchPolicy, completion: completion)
             return
@@ -143,6 +130,21 @@ class OfferingsManager {
 }
 
 private extension OfferingsManager {
+
+    func fetchFromNetwork(
+        appUserID: String,
+        fetchPolicy: FetchPolicy = .default,
+        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
+    ) {
+        Logger.debug(Strings.offering.no_cached_offerings_fetching_from_network)
+
+        self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
+            self.updateOfferingsCache(appUserID: appUserID,
+                                      isAppBackgrounded: isAppBackgrounded,
+                                      fetchPolicy: fetchPolicy,
+                                      completion: completion)
+        }
+    }
 
     func fetchCachedOfferingsFromDisk(
         appUserID: String,

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -14,6 +14,8 @@
 import Foundation
 import StoreKit
 
+// swiftlint:disable file_length
+
 class OfferingsManager {
 
     private let deviceCache: DeviceCache
@@ -36,7 +38,6 @@ class OfferingsManager {
         self.offeringsFactory = offeringsFactory
         self.productsManager = productsManager
     }
-
 
     func offerings(
         appUserID: String,

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -721,18 +721,6 @@ public extension Purchases {
         return try await self.offeringsAsync(fetchPolicy: fetchPolicy)
     }
 
-    @objc func syncAttributesAndOfferingsIfNeeded(completion: @escaping (Offerings?, PublicError?) -> Void) {
-        if let lastSync = self.lastSyncAttributesAndRefreshOfferingsTimestamp, Date().timeIntervalSince(lastSync) < 60 {
-            self.getOfferings(fetchPolicy: .default, completion: completion)
-            return
-
-        }
-        self.syncSubscriberAttributes(completion: {
-            self.getOfferings(fetchPolicy: .default, fetchCurrent: true, completion: completion)
-            self.lastSyncAttributesAndRefreshOfferingsTimestamp = Date()
-        })
-    }
-
 }
 
 #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
@@ -807,6 +795,18 @@ public extension Purchases {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func logOut() async throws -> CustomerInfo {
         return try await logOutAsync()
+    }
+
+    @objc func syncAttributesAndOfferingsIfNeeded(completion: @escaping (Offerings?, PublicError?) -> Void) {
+        if let lastSync = self.lastSyncAttributesAndRefreshOfferingsTimestamp, Date().timeIntervalSince(lastSync) < 60 {
+            self.getOfferings(fetchPolicy: .default, completion: completion)
+            return
+
+        }
+        self.syncSubscriberAttributes(completion: {
+            self.getOfferings(fetchPolicy: .default, fetchCurrent: true, completion: completion)
+            self.lastSyncAttributesAndRefreshOfferingsTimestamp = Date()
+        })
     }
 
 }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -721,9 +721,9 @@ public extension Purchases {
 
     @objc func syncAttributesAndOfferingsIfNeeded(completion: @escaping (Offerings?, PublicError?) -> Void) {
         if let lastSync = self.lastSyncAttributesAndRefreshOfferingsTimestamp, Date().timeIntervalSince(lastSync) < 60 {
-            let userInfo: [NSError.UserInfoKey: Any] = [:]
-            completion(nil, PurchasesError.init(error: .syncingAttributesRateLimitReached, userInfo: userInfo).asPublicError)
+            self.getOfferings(fetchPolicy: .default, completion: completion)
             return
+
         }
         self.syncSubscriberAttributes(completion: {
             self.getOfferings(fetchPolicy: .default, fetchCurrent: true, completion: completion)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -700,7 +700,9 @@ public extension Purchases {
         fetchCurrent: Bool = false,
         completion: @escaping (Offerings?, PublicError?) -> Void
     ) {
-        self.offeringsManager.offerings(appUserID: self.appUserID, fetchPolicy: fetchPolicy, fetchCurrent: fetchCurrent) { @Sendable result in
+        self.offeringsManager.offerings(appUserID: self.appUserID,
+                                        fetchPolicy: fetchPolicy,
+                                        fetchCurrent: fetchCurrent) { @Sendable result in
             completion(result.value, result.error?.asPublicError)
         }
     }

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -849,6 +849,21 @@ public protocol PurchasesType: AnyObject {
      */
     var attribution: Attribution { get }
 
+    /**
+     * Syncs subscriber attributes and then fetches the configured offerings for this user. This method is intended to
+     * be called when using Targeting Rules with Custom Attributes. Any subscriber attributes should be set before
+     * calling this method to ensure the returned offerings are applied with the latest subscriber attributes.
+     *
+     * This method is rate limited to 5 calls per minute. It will log a warning and return offerings cache when reached.
+     *
+     * - Parameter completion: A completion block called when attributes are synced and offerings are available.
+     * Called immediately with cached offerings if rate limit reached. ``Offerings`` will be `nil` if an error occurred.
+     *
+     * #### Related Articles
+     * -  [Targeting](https://docs.revenuecat.com/docs/targeting)
+     */
+    @objc func syncAttributesAndOfferingsIfNeeded(completion: @escaping (Offerings?, PublicError?) -> Void)
+
     // MARK: - Deprecated
 
     // swiftlint:disable missing_docs

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -141,6 +141,19 @@ struct HomeView: View {
                         Text("Begin Refund For Active Entitlement")
                     }
                     #endif
+
+                    Button {
+                        Purchases.shared.syncAttributesAndOfferingsIfNeeded { offerings, error in
+                            if let error {
+                                print("🚀 Info 💁‍♂️ - Error: \(error)")
+                                self.error = error
+                            } else if let offerings {
+                                setOfferings(offerings: offerings)
+                            }
+                        }
+                    } label: {
+                        Text("Sync Attributes and Fetch Offerings")
+                    }
                 }
             }
             .task {
@@ -212,12 +225,21 @@ struct HomeView: View {
         #endif
     }
     
+    private func setOfferings(offerings: Offerings) {
+        self.offerings = Array(offerings.all.values).sorted(by: { a, b in
+            return b.identifier > a.identifier
+        }).sorted(by: { a, b in
+            guard let identifier = offerings.current?.identifier else {
+                return false
+            }
+            return a.identifier == identifier
+        })
+    }
+
     private func fetchData() async {
         do {
             let offerings = try await Purchases.shared.offerings()
-            self.offerings = Array(offerings.all.values).sorted(by: { a, b in
-                return b.identifier > a.identifier
-            })
+            setOfferings(offerings: offerings)
         } catch {
             print("🚀 Info 💁‍♂️ - Error: \(error)")
             self.error = error

--- a/Tests/UnitTests/Misc/RateLimiterRests.swift
+++ b/Tests/UnitTests/Misc/RateLimiterRests.swift
@@ -1,0 +1,43 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RateLimiterRests.swift
+//
+//  Created by Josh Holtz on 2/27/24.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class RateLimiterTests: TestCase {
+
+    func testAllowsCorrectNumberOfCalls() {
+        let rateLimiter = RateLimiter(maxCalls: 2, period: 1)
+
+        expect(rateLimiter.shouldProceed()) == true
+        expect(rateLimiter.shouldProceed()) == true
+    }
+
+    func testBlocksExcessCalls() {
+        let rateLimiter = RateLimiter(maxCalls: 1, period: 2)
+
+        expect(rateLimiter.shouldProceed()) == true
+        expect(rateLimiter.shouldProceed()) == false
+    }
+
+    func testResetsAfterPeriod() {
+        let rateLimiter = RateLimiter(maxCalls: 1, period: 2)
+
+        expect(rateLimiter.shouldProceed()) == true
+        sleep(2)
+        expect(rateLimiter.shouldProceed()) == true
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockOfferingsManager.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsManager.swift
@@ -26,9 +26,11 @@ typealias OfferingsCompletion = @MainActor @Sendable (Result<Offerings, Error>) 
     var invokedOfferingsCount = 0
     var invokedOfferingsParameters: (appUserID: String,
                                      fetchPolicy: FetchPolicy,
+                                     fetchCurrent: Bool,
                                      completion: OfferingsCompletion?)?
     var invokedOfferingsParametersList = [(appUserID: String,
                                            fetchPolicy: FetchPolicy,
+                                           fetchCurrent: Bool,
                                            completion: OfferingsCompletion??)]()
     var stubbedOfferingsCompletionResult: Result<Offerings, Error> = .failure(
         .configurationError("Stub not setup", underlyingError: nil)
@@ -36,11 +38,12 @@ typealias OfferingsCompletion = @MainActor @Sendable (Result<Offerings, Error>) 
 
     override func offerings(appUserID: String,
                             fetchPolicy: FetchPolicy,
+                            fetchCurrent: Bool = false,
                             completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?) {
         self.invokedOfferings = true
         self.invokedOfferingsCount += 1
-        self.invokedOfferingsParameters = (appUserID, fetchPolicy, completion)
-        self.invokedOfferingsParametersList.append((appUserID, fetchPolicy, completion))
+        self.invokedOfferingsParameters = (appUserID, fetchPolicy, fetchCurrent, completion)
+        self.invokedOfferingsParametersList.append((appUserID, fetchPolicy, fetchCurrent, completion))
 
         OperationDispatcher.dispatchOnMainActor { [result = self.stubbedOfferingsCompletionResult] in
             completion?(result)

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -163,6 +163,12 @@ extension MockPurchases: PurchasesType {
         self.unimplemented()
     }
 
+    func syncAttributesAndOfferingsIfNeeded(
+        completion: @escaping (RevenueCat.Offerings?, RevenueCat.PublicError?) -> Void
+    ) {
+        self.unimplemented()
+    }
+
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func customerInfo(fetchPolicy: CacheFetchPolicy) async throws -> CustomerInfo {
         self.unimplemented()

--- a/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
@@ -314,6 +314,7 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
         invokedSyncAttributesForAllUsersCount += 1
         invokedSyncAttributesForAllUsersParameters = (currentAppUserID, ())
         invokedSyncAttributesForAllUsersParametersList.append((currentAppUserID, ()))
+        completion?()
 
         return -1
     }

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -390,6 +390,29 @@ extension OfferingsManagerTests {
         expect(self.mockDeviceCache.cacheOfferingsCount) == 0
     }
 
+    func testOfferingsForAppUserIdForcesNetworkRequestWhenFetchCurrentIsTrue() throws {
+        // given
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
+        self.mockDeviceCache.stubbedOfferings = MockData.sampleOfferings
+
+        // when
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID, fetchCurrent: true) {
+                completed($0)
+            }
+        }
+
+        // then
+        expect(result).to(beSuccess())
+        expect(result?.value) !== MockData.sampleOfferings
+        expect(result?.value?["base"]).toNot(beNil())
+        expect(result?.value?["base"]!.monthly).toNot(beNil())
+        expect(result?.value?["base"]!.monthly?.storeProduct).toNot(beNil())
+
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserID) == true
+        expect(self.mockDeviceCache.cacheOfferingsCount) == 1
+    }
+
     func testReturnsOfferingsFromDiskCacheIfNetworkRequestWithServerDown() throws {
         self.mockDeviceCache.stubbedOfferings = nil
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .failure(.networkError(.serverDown()))

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
@@ -1,0 +1,64 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
+//
+//  Created by Lauren Burdock on 2/26/24.
+
+import Nimble
+import StoreKit
+import XCTest
+
+@testable import RevenueCat
+
+class PurchasesSyncAttributesAndOfferingsIfNeededTests: BasePurchasesTests {
+
+    func testAttributesSyncedAndOfferingsFetched() throws {
+
+        self.setupPurchases()
+        let userID1 = "userID1"
+        let userID2 = "userID2"
+        let userID3 = "userID3"
+
+        let userID1Attributes = [
+            "band": SubscriberAttribute(withKey: "band", value: "The Doors"),
+            "song": SubscriberAttribute(withKey: "song", value: "Riders on the storm"),
+            "album": SubscriberAttribute(withKey: "album", value: "L.A. Woman")
+        ]
+        let userID2Attributes = [
+            "instrument": SubscriberAttribute(withKey: "instrument", value: "Guitar"),
+            "name": SubscriberAttribute(withKey: "name", value: "Robert Krieger")
+        ]
+        let userID3Attributes = [
+            "band": SubscriberAttribute(withKey: "band", value: "Dire Straits"),
+            "song": SubscriberAttribute(withKey: "song", value: "Sultans of Swing"),
+            "album": SubscriberAttribute(withKey: "album", value: "Dire Straits")
+        ]
+        let allAttributes: [String: [String: SubscriberAttribute]] = [
+            userID1: userID1Attributes,
+            userID2: userID2Attributes,
+            userID3: userID3Attributes
+        ]
+
+        self.deviceCache.stubbedUnsyncedAttributesForAllUsersResult = allAttributes
+
+        self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(
+            try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:], data: .mockResponse))
+        )
+
+        let result: Offerings? = waitUntilValue { completed in
+            self.purchases.syncAttributesAndOfferingsIfNeeded(completion: { offerings, error in
+                completed(offerings)
+            })
+        }
+        expect(result).toNot(beNil())
+        expect(self.subscriberAttributesManager.invokedSetAttributesCount) == 1
+        expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
+    }
+}

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
@@ -20,33 +20,7 @@ import XCTest
 class PurchasesSyncAttributesAndOfferingsIfNeededTests: BasePurchasesTests {
 
     func testAttributesSyncedAndOfferingsFetched() throws {
-
         self.setupPurchases()
-        let userID1 = "userID1"
-        let userID2 = "userID2"
-        let userID3 = "userID3"
-
-        let userID1Attributes = [
-            "band": SubscriberAttribute(withKey: "band", value: "The Doors"),
-            "song": SubscriberAttribute(withKey: "song", value: "Riders on the storm"),
-            "album": SubscriberAttribute(withKey: "album", value: "L.A. Woman")
-        ]
-        let userID2Attributes = [
-            "instrument": SubscriberAttribute(withKey: "instrument", value: "Guitar"),
-            "name": SubscriberAttribute(withKey: "name", value: "Robert Krieger")
-        ]
-        let userID3Attributes = [
-            "band": SubscriberAttribute(withKey: "band", value: "Dire Straits"),
-            "song": SubscriberAttribute(withKey: "song", value: "Sultans of Swing"),
-            "album": SubscriberAttribute(withKey: "album", value: "Dire Straits")
-        ]
-        let allAttributes: [String: [String: SubscriberAttribute]] = [
-            userID1: userID1Attributes,
-            userID2: userID2Attributes,
-            userID3: userID3Attributes
-        ]
-
-        self.deviceCache.stubbedUnsyncedAttributesForAllUsersResult = allAttributes
 
         self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(
             try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:], data: .mockResponse))
@@ -58,7 +32,7 @@ class PurchasesSyncAttributesAndOfferingsIfNeededTests: BasePurchasesTests {
             })
         }
         expect(result).toNot(beNil())
-        expect(self.subscriberAttributesManager.invokedSetAttributesCount) == 1
+        expect(self.subscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 1
         expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
     }
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class PurchasesSyncAttributesAndOfferingsIfNeededTests: BasePurchasesTests {
+class PurchasesSyncAttributesAndOfferingsTests: BasePurchasesTests {
 
     func testAttributesSyncedAndOfferingsFetched() throws {
         self.setupPurchases()
@@ -27,7 +27,7 @@ class PurchasesSyncAttributesAndOfferingsIfNeededTests: BasePurchasesTests {
         )
 
         let result: Offerings? = waitUntilValue { completed in
-            self.purchases.syncAttributesAndOfferingsIfNeeded(completion: { offerings, error in
+            self.purchases.syncAttributesAndOfferingsIfNeeded(completion: { offerings, _ in
                 completed(offerings)
             })
         }


### PR DESCRIPTION
### Motivation

Adding new method to manually sync attributes and fetch fresh offerings 

### Description

- New `Purchases.shared.syncAttributesAndOfferingsIfNeeded()` method
    - Syncs subscriber attributes and then fetches fresh offerings from network
    - This is designed to be a blocking call since developer will want fresh offerings after syncing subscriber attributes
    - The method is rate limited to 5 calls per minute (new `RateLimiter` class()
