### PR TITLE
New `Package.presentedOfferingContext`

### DIFF
--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -142,14 +142,14 @@ extension OfferingStrings: LogMessage {
             return "Empty Product titles are not supported. Found in product with identifier: \(identifier)"
 
         case let .unknown_package_type(package):
-            return "Package '\(package.identifier)' in offering '\(package.offeringIdentifier)' " +
-            "has an unknown duration." +
+            return "Package '\(package.identifier)' in offering " +
+            "'\(package.presentedOfferingContext.offeringIdentifier)' has an unknown duration." +
             "\nYou can reference this package by its identifier ('\(package.identifier)') directly." +
             "\nMore information: https://rev.cat/displaying-products"
 
         case let .custom_package_type(package):
-            return "Package '\(package.identifier)' in offering '\(package.offeringIdentifier)' " +
-            "has a custom duration." +
+            return "Package '\(package.identifier)' in offering " +
+            "'\(package.presentedOfferingContext.offeringIdentifier)' has a custom duration." +
             "\nYou can reference this package by its identifier ('\(package.identifier)') directly." +
             "\nMore information: https://rev.cat/displaying-products"
 

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -205,14 +205,14 @@ extension PurchaseStrings: LogMessage {
 
         case let .purchasing_product_from_package(product, package):
             return "Purchasing Product '\(product.productIdentifier)' from package " +
-            "in Offering '\(package.offeringIdentifier)'"
+            "in Offering '\(package.presentedOfferingContext.offeringIdentifier)'"
 
         case let .purchasing_product_with_offer(product, discount):
             return "Purchasing Product '\(product.productIdentifier)' with Offer '\(discount.identifier)'"
 
         case let .purchasing_product_from_package_with_offer(product, package, discount):
             return "Purchasing Product '\(product.productIdentifier)' from package in Offering " +
-            "'\(package.offeringIdentifier)' with Offer '\(discount.identifier)'"
+            "'\(package.presentedOfferingContext.offeringIdentifier)' with Offer '\(discount.identifier)'"
 
         case let .purchased_product(productIdentifier):
             return "Purchased product - '\(productIdentifier)'"

--- a/Sources/Purchasing/Package.swift
+++ b/Sources/Purchasing/Package.swift
@@ -15,6 +15,39 @@
 import Foundation
 
 ///
+/// Stores information about how a ``Package`` was presented.
+///
+@objc(RCPresentedOfferingContext) public final class PresentedOfferingContext: NSObject {
+
+    /// The identifier of the ``Offering`` containing this Package.
+    @objc public let offeringIdentifier: String
+
+    /// Initialize a ``PresentedOfferingContext``.
+    @objc
+    public init(
+        offeringIdentifier: String
+    ) {
+        self.offeringIdentifier = offeringIdentifier
+        super.init()
+    }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? PresentedOfferingContext else { return false }
+
+        return (
+            self.offeringIdentifier == other.offeringIdentifier
+        )
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(self.offeringIdentifier)
+
+        return hasher.finalize()
+    }
+}
+
+///
 /// Packages help abstract platform-specific products by grouping equivalent products across iOS, Android, and web.
 /// A package is made up of three parts: ``identifier``, ``packageType``, and underlying ``StoreProduct``.
 ///
@@ -31,8 +64,9 @@ import Foundation
     @objc public let packageType: PackageType
     /// The underlying ``storeProduct``
     @objc public let storeProduct: StoreProduct
-    /// The identifier of the ``Offering`` containing this Package.
-    @objc public let offeringIdentifier: String
+
+    ////  The information about the ``Offering`` containing this Package
+    @objc public let presentedOfferingContext: PresentedOfferingContext
 
     /// The price of this product using ``StoreProduct/priceFormatter``.
     @objc public var localizedPriceString: String {
@@ -47,16 +81,32 @@ import Foundation
 
     /// Initialize a ``Package``.
     @objc
-    public init(
+    public convenience init(
         identifier: String,
         packageType: PackageType,
         storeProduct: StoreProduct,
         offeringIdentifier: String
     ) {
+        self.init(
+            identifier: identifier,
+            packageType: packageType,
+            storeProduct: storeProduct,
+            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: offeringIdentifier)
+        )
+    }
+
+    /// Initialize a ``Package``.
+    @objc
+    public init(
+        identifier: String,
+        packageType: PackageType,
+        storeProduct: StoreProduct,
+        presentedOfferingContext: PresentedOfferingContext
+    ) {
         self.identifier = identifier
         self.packageType = packageType
         self.storeProduct = storeProduct
-        self.offeringIdentifier = offeringIdentifier
+        self.presentedOfferingContext = presentedOfferingContext
 
         super.init()
     }
@@ -68,7 +118,7 @@ import Foundation
             self.identifier == other.identifier &&
             self.packageType == other.packageType &&
             self.storeProduct == other.storeProduct &&
-            self.offeringIdentifier == other.offeringIdentifier
+            self.presentedOfferingContext == other.presentedOfferingContext
         )
     }
 
@@ -77,7 +127,7 @@ import Foundation
         hasher.combine(self.identifier)
         hasher.combine(self.packageType)
         hasher.combine(self.storeProduct)
-        hasher.combine(self.offeringIdentifier)
+        hasher.combine(self.presentedOfferingContext)
 
         return hasher.finalize()
     }
@@ -106,6 +156,10 @@ import Foundation
         return string.hasPrefix("$rc_") ? .unknown : .custom
     }
 
+    /// - Returns: the identifier of the ``Offering`` containing this Package.
+    var offeringIdentifier: String {
+        return self.presentedOfferingContext.offeringIdentifier
+    }
 }
 
 extension Package: Identifiable {
@@ -116,3 +170,4 @@ extension Package: Identifiable {
 }
 
 extension Package: Sendable {}
+extension PresentedOfferingContext: Sendable {}

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1467,12 +1467,14 @@ extension Purchases: @unchecked Sendable {}
 extension Purchases {
 
     /// Used when purchasing through `SwiftUI` paywalls.
-    func cachePresentedOfferingIdentifier(_ identifier: String, productIdentifier: String) {
-        Logger.debug(Strings.purchase.caching_presented_offering_identifier(offeringID: identifier,
-                                                                            productID: productIdentifier))
+    func cachePresentedOfferingContext(_ context: PresentedOfferingContext, productIdentifier: String) {
+        Logger.debug(Strings.purchase.caching_presented_offering_identifier(
+            offeringID: context.offeringIdentifier,
+            productID: productIdentifier
+        ))
 
-        self.purchasesOrchestrator.cachePresentedOfferingIdentifier(
-            identifier,
+        self.purchasesOrchestrator.cachePresentedOfferingContext(
+            context,
             productIdentifier: productIdentifier
         )
     }

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -42,7 +42,7 @@ final class PurchasesOrchestrator {
     @objc weak var delegate: PurchasesOrchestratorDelegate?
 
     private let _allowSharingAppStoreAccount: Atomic<Bool?> = nil
-    private let presentedOfferingIDsByProductID: Atomic<[String: String]> = .init([:])
+    private let presentedOfferingContextsByProductID: Atomic<[String: PresentedOfferingContext]> = .init([:])
     private let presentedPaywall: Atomic<PaywallEvent?> = nil
     private let purchaseCompleteCallbacksByProductID: Atomic<[String: PurchaseCompletedBlock]> = .init([:])
 
@@ -384,7 +384,7 @@ final class PurchasesOrchestrator {
 
         payment.applicationUsername = self.appUserID
 
-        self.cachePresentedOfferingIdentifier(package: package, productIdentifier: productIdentifier)
+        self.cachePresentedOfferingContext(package: package, productIdentifier: productIdentifier)
 
         self.productsManager.cache(StoreProduct(sk1Product: sk1Product))
 
@@ -472,7 +472,7 @@ final class PurchasesOrchestrator {
                 options.insert(try signedData.sk2PurchaseOption)
             }
 
-            self.cachePresentedOfferingIdentifier(package: package, productIdentifier: sk2Product.id)
+            self.cachePresentedOfferingContext(package: package, productIdentifier: sk2Product.id)
 
             result = try await self.purchase(sk2Product, options)
         } catch StoreKitError.userCancelled {
@@ -541,8 +541,8 @@ final class PurchasesOrchestrator {
         }
     }
 
-    func cachePresentedOfferingIdentifier(_ identifier: String, productIdentifier: String) {
-        self.presentedOfferingIDsByProductID.modify { $0[productIdentifier] = identifier }
+    func cachePresentedOfferingContext(_ context: PresentedOfferingContext, productIdentifier: String) {
+        self.presentedOfferingContextsByProductID.modify { $0[productIdentifier] = context }
     }
 
     func track(paywallEvent: PaywallEvent) {
@@ -1170,13 +1170,13 @@ private extension PurchasesOrchestrator {
     func handlePurchasedTransaction(_ purchasedTransaction: StoreTransaction,
                                     storefront: StorefrontType?,
                                     restored: Bool) {
-        let offeringID = self.getAndRemovePresentedOfferingIdentifier(for: purchasedTransaction)
+        let offeringContext = self.getAndRemovePresentedOfferingIdentifier(for: purchasedTransaction)
         let paywall = self.getAndRemovePresentedPaywall()
         let unsyncedAttributes = self.unsyncedAttributes
         self.attribution.unsyncedAdServicesToken { adServicesToken in
             let transactionData: PurchasedTransactionData = .init(
                 appUserID: self.appUserID,
-                presentedOfferingID: offeringID,
+                presentedOfferingID: offeringContext?.offeringIdentifier,
                 presentedPaywall: paywall,
                 unsyncedAttributes: unsyncedAttributes,
                 aadAttributionToken: adServicesToken,
@@ -1226,9 +1226,10 @@ private extension PurchasesOrchestrator {
         self.offeringsManager.invalidateAndReFetchCachedOfferingsIfAppropiate(appUserID: self.appUserID)
     }
 
-    func cachePresentedOfferingIdentifier(package: Package?, productIdentifier: String) {
+    func cachePresentedOfferingContext(package: Package?, productIdentifier: String) {
         if let package = package {
-            self.cachePresentedOfferingIdentifier(package.offeringIdentifier, productIdentifier: productIdentifier)
+            self.cachePresentedOfferingContext(package.presentedOfferingContext,
+                                               productIdentifier: productIdentifier)
         }
     }
 
@@ -1242,13 +1243,13 @@ private extension PurchasesOrchestrator {
         self.presentedPaywall.value = nil
     }
 
-    func getAndRemovePresentedOfferingIdentifier(for productIdentifier: String) -> String? {
-        return self.presentedOfferingIDsByProductID.modify {
+    func getAndRemovePresentedOfferingIdentifier(for productIdentifier: String) -> PresentedOfferingContext? {
+        return self.presentedOfferingContextsByProductID.modify {
             $0.removeValue(forKey: productIdentifier)
         }
     }
 
-    func getAndRemovePresentedOfferingIdentifier(for transaction: StoreTransaction) -> String? {
+    func getAndRemovePresentedOfferingIdentifier(for transaction: StoreTransaction) -> PresentedOfferingContext? {
         return self.getAndRemovePresentedOfferingIdentifier(for: transaction.productIdentifier)
     }
 
@@ -1426,13 +1427,13 @@ extension PurchasesOrchestrator {
         _ initiationSource: ProductRequestData.InitiationSource
     ) async throws -> CustomerInfo {
         let storefront = await Storefront.currentStorefront
-        let offeringID = self.getAndRemovePresentedOfferingIdentifier(for: transaction)
+        let offeringData = self.getAndRemovePresentedOfferingIdentifier(for: transaction)
         let paywall = self.getAndRemovePresentedPaywall()
         let unsyncedAttributes = self.unsyncedAttributes
         let adServicesToken = await self.attribution.unsyncedAdServicesToken
         let transactionData: PurchasedTransactionData = .init(
             appUserID: self.appUserID,
-            presentedOfferingID: offeringID,
+            presentedOfferingID: offeringData?.offeringIdentifier,
             presentedPaywall: paywall,
             unsyncedAttributes: unsyncedAttributes,
             aadAttributionToken: adServicesToken,

--- a/Sources/Support/PaywallExtensions.swift
+++ b/Sources/Support/PaywallExtensions.swift
@@ -124,8 +124,8 @@ private extension View {
                     Logger.appleWarning(Strings.configure.sk2_required_for_swiftui_paywalls)
                 }
 
-                Purchases.shared.cachePresentedOfferingIdentifier(
-                    offering.identifier,
+                Purchases.shared.cachePresentedOfferingContext(
+                    .init(offeringIdentifier: offering.identifier),
                     productIdentifier: product.id
                 )
             }

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/CustomEntitlementComputationSwiftAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/CustomEntitlementComputationSwiftAPITester.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2C396F5C281C64AF00669657 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C396F5B281C64AF00669657 /* AdServices.framework */; platformFilters = (ios, maccatalyst, macos, ); };
+		2CA538462B7D60F20037D96F /* PresentedOfferingContextAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA538452B7D60F20037D96F /* PresentedOfferingContextAPI.swift */; };
 		2DD778E5270E23460079CBD4 /* IntroEligibilityAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614CD26EBE7EA007DDB75 /* IntroEligibilityAPI.swift */; };
 		2DD778E6270E23460079CBD4 /* PurchasesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614CE26EBE7EA007DDB75 /* PurchasesAPI.swift */; };
 		2DD778E8270E23460079CBD4 /* PackageAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C926EBE7EA007DDB75 /* PackageAPI.swift */; };
@@ -50,6 +51,7 @@
 
 /* Begin PBXFileReference section */
 		2C396F5B281C64AF00669657 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
+		2CA538452B7D60F20037D96F /* PresentedOfferingContextAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentedOfferingContextAPI.swift; sourceTree = "<group>"; };
 		2DD778D0270E233F0079CBD4 /* SwiftAPITester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftAPITester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F592A4F2A1FDC6F00851F36 /* AttributionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionAPI.swift; sourceTree = "<group>"; };
 		570FAF552864EE1D00D3C769 /* NonSubscriptionTransactionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonSubscriptionTransactionAPI.swift; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 				A5D614C726EBE7EA007DDB75 /* OfferingAPI.swift */,
 				A5D614C326EBE7EA007DDB75 /* OfferingsAPI.swift */,
 				A5D614C926EBE7EA007DDB75 /* PackageAPI.swift */,
+				2CA538452B7D60F20037D96F /* PresentedOfferingContextAPI.swift */,
 				B3A4C833280DE72600D4AE17 /* PromotionalOfferAPI.swift */,
 				A5D614CE26EBE7EA007DDB75 /* PurchasesAPI.swift */,
 				A513AD33272B4C0100E0C1BA /* RefundRequestStatusAPI.swift */,
@@ -236,6 +239,7 @@
 				2DD778ED270E23460079CBD4 /* OfferingAPI.swift in Sources */,
 				2DD778EE270E23460079CBD4 /* EntitlementInfosAPI.swift in Sources */,
 				2DD778E5270E23460079CBD4 /* IntroEligibilityAPI.swift in Sources */,
+				2CA538462B7D60F20037D96F /* PresentedOfferingContextAPI.swift in Sources */,
 				2DD778EB270E23460079CBD4 /* ErrorCodesAPI.swift in Sources */,
 				2DD778EC270E23460079CBD4 /* TransactionAPI.swift in Sources */,
 				B32554422825E5EA00DA62EA /* ConfigurationAPI.swift in Sources */,

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PackageAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PackageAPI.swift
@@ -15,19 +15,26 @@ import Foundation
 import RevenueCat_CustomEntitlementComputation
 import StoreKit
 
-var pack: Package!
-func checkPackageAPI() {
-    let ident: String = pack.identifier
-    let pType: PackageType = pack.packageType
-    let prod: StoreProduct = pack.storeProduct
-    let lps: String = pack.localizedPriceString
-    let lips: String? = pack.localizedIntroductoryPriceString
-
-    print(pack!, ident, pType, prod, lps, lips!)
+func checkPackageAPI(pack: Package! = nil) {
+    let _: String = pack.identifier
+    let _: PackageType = pack.packageType
+    let _: StoreProduct = pack.storeProduct
+    let _: String = pack.offeringIdentifier
+    let _: PresentedOfferingContext = pack.presentedOfferingContext
+    let _: String = pack.localizedPriceString
+    let _: String? = pack.localizedIntroductoryPriceString
 }
 
-var packageType: PackageType!
-func checkPackageEnums() {
+private func checkCreatePackageAPI(product: StoreProduct) {
+    _ = Package(
+        identifier: "",
+        packageType: PackageType.annual,
+        storeProduct: product,
+        offeringIdentifier: ""
+    )
+}
+
+func checkPackageEnums(packageType: PackageType! = nil) {
     switch packageType! {
     case .custom,
          .lifetime,

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
@@ -1,0 +1,18 @@
+//
+//  PresentedOfferingContextAPI.swift
+//  SwiftAPITester
+//
+//  Created by Josh Holtz on 2/14/24.
+//
+
+import Foundation
+import RevenueCat_CustomEntitlementComputation
+import StoreKit
+
+func checkPresentedOfferingContextAPI(context: PresentedOfferingContext! = nil) {
+    let _: String = context.offeringIdentifier
+}
+
+private func checkCreatePresentedOfferingContextAPI() {
+    let _: PresentedOfferingContext = .init(offeringIdentifier: "")
+}

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/main.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/main.swift
@@ -42,6 +42,8 @@ func main() -> Int {
     checkPackageAPI()
     checkPackageEnums()
 
+    checkPresentedOfferingContextAPI()
+
     checkReceiptParserAPI()
     checkAppleReceiptAPI()
 

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2C396F5E281C64B700669657 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C396F5D281C64B700669657 /* AdServices.framework */; platformFilters = (ios, maccatalyst, macos, ); };
+		2CA5383C2B7D44610037D96F /* RCPresentedOfferingContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CA5383B2B7D44610037D96F /* RCPresentedOfferingContext.m */; };
 		2DD77909270E23870079CBD4 /* RCAttributionNetworkAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614EC26EBE84F007DDB75 /* RCAttributionNetworkAPI.m */; };
 		2DD7790B270E23870079CBD4 /* RCCustomerInfoAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614F026EBE84F007DDB75 /* RCCustomerInfoAPI.m */; };
 		2DD7790C270E23870079CBD4 /* RCPurchasesErrorCodeAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614EE26EBE84F007DDB75 /* RCPurchasesErrorCodeAPI.m */; };
@@ -53,6 +54,8 @@
 
 /* Begin PBXFileReference section */
 		2C396F5D281C64B700669657 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
+		2CA5383B2B7D44610037D96F /* RCPresentedOfferingContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCPresentedOfferingContext.m; sourceTree = "<group>"; };
+		2CA5383E2B7D44A20037D96F /* RCPresentedOfferingContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCPresentedOfferingContext.h; sourceTree = "<group>"; };
 		2DD778F5270E235B0079CBD4 /* ObjCAPITester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ObjCAPITester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F3409392A37E5930050EA0E /* RCOtherAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCOtherAPI.h; sourceTree = "<group>"; };
 		4F34093A2A37E5930050EA0E /* RCOtherAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCOtherAPI.m; sourceTree = "<group>"; };
@@ -167,6 +170,8 @@
 				4F34093A2A37E5930050EA0E /* RCOtherAPI.m */,
 				A5D614E126EBE84F007DDB75 /* RCPackageAPI.h */,
 				A5D614DE26EBE84F007DDB75 /* RCPackageAPI.m */,
+				2CA5383E2B7D44A20037D96F /* RCPresentedOfferingContext.h */,
+				2CA5383B2B7D44610037D96F /* RCPresentedOfferingContext.m */,
 				B3A4C835280DE95000D4AE17 /* RCPromotionalOfferAPI.h */,
 				B3A4C836280DE95000D4AE17 /* RCPromotionalOfferAPI.m */,
 				A5D614E526EBE84F007DDB75 /* RCPurchasesAPI.h */,
@@ -300,6 +305,7 @@
 				2DD7790F270E23870079CBD4 /* RCPurchasesAPI.m in Sources */,
 				B378153D2857A750000A7B93 /* RCAttributionAPI.m in Sources */,
 				5740FCD82996DB3300E049F9 /* RCVerificationResultAPI.m in Sources */,
+				2CA5383C2B7D44610037D96F /* RCPresentedOfferingContext.m in Sources */,
 				5758EE5227864A8500B3B703 /* RCStoreProductAPI.m in Sources */,
 				2DD77911270E23870079CBD4 /* RCEntitlementInfoAPI.m in Sources */,
 				2DD77912270E23870079CBD4 /* RCOfferingsAPI.m in Sources */,

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPackageAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPackageAPI.m
@@ -24,10 +24,11 @@
     NSString *i = p.identifier;
     RCPackageType t = p.packageType;
     NSString *oid = p.offeringIdentifier;
+    RCPresentedOfferingContext *poc = p.presentedOfferingContext;
     NSString *lps = p.localizedPriceString;
     NSString *lips = p.localizedIntroductoryPriceString;
 
-    NSLog(p, storeProduct, i, t, lps, lips);
+    NSLog(p, storeProduct, i, t, oid, poc, lps, lips);
 
     RCPackage *package __unused = [[RCPackage alloc] initWithIdentifier:i
                                                             packageType:RCPackageTypeAnnual

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContext.h
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContext.h
@@ -1,0 +1,18 @@
+//
+//  RCPresentedOfferingContext.h
+//  ObjCAPITester
+//
+//  Created by Josh Holtz on 2/14/24.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCPresentOfferingContextAPI : NSObject
+
++ (void)checkAPI;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContext.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContext.m
@@ -1,0 +1,22 @@
+//
+//  RCPresentedOfferingContext.m
+//  ObjCAPITester
+//
+//  Created by Josh Holtz on 2/14/24.
+//
+
+#import "RCPresentedOfferingContext.h"
+
+@import StoreKit;
+@import RevenueCat;
+
+@implementation RCPresentOfferingContextAPI
+
++ (void)checkAPI {
+    RCPresentedOfferingContext *poc = [[RCPresentedOfferingContext alloc] initWithOfferingIdentifier:@""];
+    NSString *oid = poc.offeringIdentifier;
+
+    NSLog(poc, oid);
+}
+
+@end

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/main.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/main.m
@@ -17,6 +17,7 @@
 #import "RCOfferingAPI.h"
 #import "RCOfferingsAPI.h"
 #import "RCPackageAPI.h"
+#import "RCPresentedOfferingContext.h"
 #import "RCPromotionalOfferAPI.h"
 #import "RCPurchasesAPI.h"
 #import "RCPurchasesErrorCodeAPI.h"
@@ -52,6 +53,8 @@ int main(int argc, const char * argv[]) {
 
         [RCPackageAPI checkAPI];
         [RCPackageAPI checkEnums];
+
+        [RCPresentOfferingContextAPI checkAPI];
 
         [RCPromotionalOfferAPI checkAPI];
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2C396F5C281C64AF00669657 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C396F5B281C64AF00669657 /* AdServices.framework */; platformFilters = (ios, maccatalyst, macos, ); };
+		2CA5383A2B7D42100037D96F /* PresentedOfferingContextAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA538392B7D42100037D96F /* PresentedOfferingContextAPI.swift */; };
 		2DD778E4270E23460079CBD4 /* AttributionNetworkAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614CA26EBE7EA007DDB75 /* AttributionNetworkAPI.swift */; };
 		2DD778E5270E23460079CBD4 /* IntroEligibilityAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614CD26EBE7EA007DDB75 /* IntroEligibilityAPI.swift */; };
 		2DD778E6270E23460079CBD4 /* PurchasesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614CE26EBE7EA007DDB75 /* PurchasesAPI.swift */; };
@@ -57,6 +58,7 @@
 
 /* Begin PBXFileReference section */
 		2C396F5B281C64AF00669657 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
+		2CA538392B7D42100037D96F /* PresentedOfferingContextAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentedOfferingContextAPI.swift; sourceTree = "<group>"; };
 		2DD778D0270E233F0079CBD4 /* SwiftAPITester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftAPITester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F1428A12A4A11D7006CD196 /* TestStoreProductAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStoreProductAPI.swift; sourceTree = "<group>"; };
 		4F1428A62A4A16C0006CD196 /* TestStoreProductDiscountAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStoreProductDiscountAPI.swift; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 				4F6BEE742A27C77C00CD9322 /* OtherAPI.swift */,
 				A5D614C926EBE7EA007DDB75 /* PackageAPI.swift */,
 				4FF58AD12A5DDA5B00451B28 /* PaywallAPI.swift */,
+				2CA538392B7D42100037D96F /* PresentedOfferingContextAPI.swift */,
 				B3A4C833280DE72600D4AE17 /* PromotionalOfferAPI.swift */,
 				A5D614CE26EBE7EA007DDB75 /* PurchasesAPI.swift */,
 				A513AD33272B4C0100E0C1BA /* RefundRequestStatusAPI.swift */,
@@ -262,6 +265,7 @@
 				2DD778E5270E23460079CBD4 /* IntroEligibilityAPI.swift in Sources */,
 				2DD778EB270E23460079CBD4 /* ErrorCodesAPI.swift in Sources */,
 				2DD778E4270E23460079CBD4 /* AttributionNetworkAPI.swift in Sources */,
+				2CA5383A2B7D42100037D96F /* PresentedOfferingContextAPI.swift in Sources */,
 				2DD778EC270E23460079CBD4 /* TransactionAPI.swift in Sources */,
 				B32554422825E5EA00DA62EA /* ConfigurationAPI.swift in Sources */,
 				5738F40C27866DD00096D623 /* StoreProductDiscountAPI.swift in Sources */,

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PackageAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PackageAPI.swift
@@ -15,16 +15,14 @@ import Foundation
 import RevenueCat
 import StoreKit
 
-var pack: Package!
-func checkPackageAPI() {
-    let ident: String = pack.identifier
-    let pType: PackageType = pack.packageType
-    let prod: StoreProduct = pack.storeProduct
-    let oID: String = pack.offeringIdentifier
-    let lps: String = pack.localizedPriceString
-    let lips: String? = pack.localizedIntroductoryPriceString
-
-    print(pack!, ident, pType, prod, oID, lps, lips!)
+func checkPackageAPI(pack: Package! = nil) {
+    let _: String = pack.identifier
+    let _: PackageType = pack.packageType
+    let _: StoreProduct = pack.storeProduct
+    let _: String = pack.offeringIdentifier
+    let _: PresentedOfferingContext = pack.presentedOfferingContext
+    let _: String = pack.localizedPriceString
+    let _: String? = pack.localizedIntroductoryPriceString
 }
 
 private func checkCreatePackageAPI(product: StoreProduct) {
@@ -36,8 +34,7 @@ private func checkCreatePackageAPI(product: StoreProduct) {
     )
 }
 
-var packageType: PackageType!
-func checkPackageEnums() {
+func checkPackageEnums(packageType: PackageType! = nil) {
     switch packageType! {
     case .custom,
          .lifetime,

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
@@ -1,0 +1,18 @@
+//
+//  PresentedOfferingContextAPI.swift
+//  SwiftAPITester
+//
+//  Created by Josh Holtz on 2/14/24.
+//
+
+import Foundation
+import RevenueCat
+import StoreKit
+
+func checkPresentedOfferingContextAPI(context: PresentedOfferingContext! = nil) {
+    let _: String = context.offeringIdentifier
+}
+
+private func checkCreatePresentedOfferingContextAPI() {
+    let _: PresentedOfferingContext = .init(offeringIdentifier: "")
+}

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
@@ -44,6 +44,8 @@ func main() -> Int {
     checkPackageAPI()
     checkPackageEnums()
 
+    checkPresentedOfferingContextAPI()
+
     checkReceiptParserAPI()
     checkAppleReceiptAPI()
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -89,11 +89,11 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         await verifyNoUnfinishedTransactions()
     }
 
-    func testPurchasingPackageWithPresentedOfferingIdentifier() async throws {
+    func testPurchasingPackageWithPresentedOfferingContext() async throws {
         let package = try await self.monthlyPackage
 
-        try self.purchases.cachePresentedOfferingIdentifier(
-            package.offeringIdentifier,
+        try self.purchases.cachePresentedOfferingContext(
+            PresentedOfferingContext(offeringIdentifier: package.offeringIdentifier),
             productIdentifier: package.storeProduct.productIdentifier
         )
 


### PR DESCRIPTION
### Motivation

Allow for storing of other presented offering context on a `Package`

### Description

- Replaced `offeringIdentifier: String` on `Package` with new
`presentedOfferingContext: PresentedOfferingContext`
  - Currently it only has a `offeringIdentifier: String`
- Eventually this will add new optional properties for targeting and
placements
