### PR TITLE
Add targeting to `PresentedOfferingContext`

### DIFF
--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -253,6 +253,8 @@ extension PostReceiptDataOperation.PostData: Encodable {
         case attributes
         case aadAttributionToken
         case presentedOfferingIdentifier
+        case presentedPlacementIdentifier
+        case appliedTargetingRule
         case paywall
         case testReceiptIdentifier = "test_receipt_identifier"
 
@@ -272,6 +274,8 @@ extension PostReceiptDataOperation.PostData: Encodable {
         }
 
         try container.encodeIfPresent(self.presentedOfferingIdentifier, forKey: .presentedOfferingIdentifier)
+        try container.encodeIfPresent(self.presentedPlacementIdentifier, forKey: .presentedPlacementIdentifier)
+        try container.encodeIfPresent(self.appliedTargetingRule, forKey: .appliedTargetingRule)
         try container.encodeIfPresent(self.paywall, forKey: .paywall)
 
         try container.encodeIfPresent(
@@ -298,6 +302,17 @@ extension PostReceiptDataOperation.Paywall: Codable {
         case displayMode
         case darkMode
         case localeIdentifier = "locale"
+
+    }
+
+}
+
+extension PostReceiptDataOperation.AppliedTargetingRule: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+
+        case revision
+        case ruleId
 
     }
 

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -125,6 +125,7 @@ extension PostReceiptDataOperation {
         let productData: ProductRequestData?
         let presentedOfferingIdentifier: String?
         let presentedPlacementIdentifier: String?
+        let appliedTargetingRule: AppliedTargetingRule?
         let paywall: Paywall?
         let observerMode: Bool
         let initiationSource: ProductRequestData.InitiationSource
@@ -142,6 +143,13 @@ extension PostReceiptDataOperation {
         var displayMode: PaywallViewMode
         var darkMode: Bool
         var localeIdentifier: String
+
+    }
+
+    struct AppliedTargetingRule {
+
+        var revision: Int
+        var ruleId: String
 
     }
 
@@ -163,6 +171,9 @@ extension PostReceiptDataOperation.PostData {
             productData: productData,
             presentedOfferingIdentifier: data.presentedOfferingContext?.offeringIdentifier,
             presentedPlacementIdentifier: data.presentedOfferingContext?.placementIdentifier,
+            appliedTargetingRule: data.presentedOfferingContext?.targetingContext.flatMap {
+                .init(revision: $0.revision, ruleId: $0.ruleId)
+            },
             paywall: data.paywall,
             observerMode: observerMode,
             initiationSource: data.source.initiationSource,

--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -35,14 +35,22 @@ struct OfferingsResponse {
         var metadata: [String: AnyDecodable]
 
     }
+
     struct Placements {
         let fallbackOfferingId: String?
         @DefaultDecodable.EmptyDictionary
         var offeringIdsByPlacement: [String: String?]
     }
+
+    struct Targeting {
+        let revision: Int
+        let ruleId: String
+    }
+
     let currentOfferingId: String?
     let offerings: [Offering]
     let placements: Placements?
+    let targeting: Targeting?
 }
 
 extension OfferingsResponse {
@@ -61,6 +69,7 @@ extension OfferingsResponse {
 extension OfferingsResponse.Offering.Package: Codable, Equatable {}
 extension OfferingsResponse.Offering: Codable, Equatable {}
 extension OfferingsResponse.Placements: Codable, Equatable {}
+extension OfferingsResponse.Targeting: Codable, Equatable {}
 extension OfferingsResponse: Codable, Equatable {}
 
 extension OfferingsResponse: HTTPResponseBody {}

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -28,27 +28,14 @@ import Foundation
  */
 @objc(RCOfferings) public final class Offerings: NSObject {
 
-    internal final class Placements: NSObject {
+    internal struct Placements {
         let fallbackOfferingId: String?
         let offeringIdsByPlacement: [String: String?]
-
-        init(
-            fallbackOfferingId: String?,
-            offeringIdsByPlacement: [String: String?]
-        ) {
-            self.fallbackOfferingId = fallbackOfferingId
-            self.offeringIdsByPlacement = offeringIdsByPlacement
-        }
     }
 
-    internal final class Targeting: NSObject {
+    internal struct Targeting {
         let revision: Int
         let ruleId: String
-
-        init(revision: Int, ruleId: String) {
-            self.revision = revision
-            self.ruleId = ruleId
-        }
     }
 
     /**

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -153,6 +153,10 @@ private extension Offering {
         placementIdentifier: String? = nil,
         targeting: Offerings.Targeting? = nil
     ) -> Offering {
+        if placementIdentifier == nil && targeting == nil {
+            return self
+        }
+
         let updatedPackages = self.availablePackages.map { pkg in
             let oldContext = pkg.presentedOfferingContext
 

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -135,11 +135,17 @@ public extension Offerings {
 }
 
 private extension Offering {
-    func copyWith(placementIdentifier: String?) -> Offering {
+    func copyWith(
+        placementIdentifier: String? = nil,
+        targetingContext: PresentedOfferingContext.TargetingContext? = nil
+    ) -> Offering {
         let updatedPackages = self.availablePackages.map { pkg in
+            let oldContext = pkg.presentedOfferingContext
+
             let newContext = PresentedOfferingContext(
                 offeringIdentifier: pkg.presentedOfferingContext.offeringIdentifier,
-                placementIdentifier: placementIdentifier
+                placementIdentifier: placementIdentifier ?? oldContext.placementIdentifier,
+                targetingContext: targetingContext ?? oldContext.targetingContext
             )
 
             return Package(identifier: pkg.identifier,

--- a/Sources/Purchasing/Package.swift
+++ b/Sources/Purchasing/Package.swift
@@ -24,10 +24,10 @@ import Foundation
     ///
     @objc(RCTargetingContext) public final class TargetingContext: NSObject {
         /// The revision of the targeting used to obtain this object.
-        public let revision: Int
+        @objc public let revision: Int
 
         /// The rule id from the targeting used to obtain this object.
-        public let ruleId: String
+        @objc public let ruleId: String
 
         /// Initializes a ``TargetingContext``
         @objc

--- a/Sources/Purchasing/Package.swift
+++ b/Sources/Purchasing/Package.swift
@@ -19,20 +19,43 @@ import Foundation
 ///
 @objc(RCPresentedOfferingContext) public final class PresentedOfferingContext: NSObject {
 
+    ///
+    /// Stores information a targeting rule
+    ///
+    @objc(RCTargetingContext) public final class TargetingContext: NSObject {
+        /// The revision of the targeting used to obtain this object.
+        let revision: Int
+
+        /// The rule id from the targeting used to obtain this object.
+        let ruleId: String
+
+        /// Initializes a ``TargetingContext``
+        @objc
+        public init(revision: Int, ruleId: String) {
+            self.revision = revision
+            self.ruleId = ruleId
+        }
+    }
+
     /// The identifier of the ``Offering`` containing this ``Package``.
     @objc public let offeringIdentifier: String
 
     /// The placement identifier this ``Package`` was obtained from.
     @objc public let placementIdentifier: String?
 
+    /// The targeting rule this ``Package`` was obtained from.
+    @objc public let targetingContext: TargetingContext?
+
     /// Initialize a ``PresentedOfferingContext``.
     @objc
     public init(
         offeringIdentifier: String,
-        placementIdentifier: String?
+        placementIdentifier: String?,
+        targetingContext: TargetingContext?
     ) {
         self.offeringIdentifier = offeringIdentifier
         self.placementIdentifier = placementIdentifier
+        self.targetingContext = targetingContext
         super.init()
     }
 
@@ -41,7 +64,7 @@ import Foundation
     public convenience init(
         offeringIdentifier: String
     ) {
-        self.init(offeringIdentifier: offeringIdentifier, placementIdentifier: nil)
+        self.init(offeringIdentifier: offeringIdentifier, placementIdentifier: nil, targetingContext: nil)
     }
 
     public override func isEqual(_ object: Any?) -> Bool {
@@ -104,8 +127,7 @@ import Foundation
             identifier: identifier,
             packageType: packageType,
             storeProduct: storeProduct,
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: offeringIdentifier,
-                                                               placementIdentifier: nil)
+            presentedOfferingContext: .init(offeringIdentifier: offeringIdentifier)
         )
     }
 
@@ -185,3 +207,4 @@ extension Package: Identifiable {
 
 extension Package: Sendable {}
 extension PresentedOfferingContext: Sendable {}
+extension PresentedOfferingContext.TargetingContext: Sendable {}

--- a/Sources/Purchasing/Package.swift
+++ b/Sources/Purchasing/Package.swift
@@ -24,10 +24,10 @@ import Foundation
     ///
     @objc(RCTargetingContext) public final class TargetingContext: NSObject {
         /// The revision of the targeting used to obtain this object.
-        let revision: Int
+        public let revision: Int
 
         /// The rule id from the targeting used to obtain this object.
-        let ruleId: String
+        public let ruleId: String
 
         /// Initializes a ``TargetingContext``
         @objc

--- a/Sources/Support/PaywallExtensions.swift
+++ b/Sources/Support/PaywallExtensions.swift
@@ -133,8 +133,7 @@ private extension View {
 
                 Purchases.shared.cachePresentedOfferingContext(
                     offeringContext ?? .init(
-                        offeringIdentifier: offering.identifier,
-                        placementIdentifier: nil
+                        offeringIdentifier: offering.identifier
                     ),
                     productIdentifier: product.id
                 )

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
@@ -12,9 +12,12 @@ import StoreKit
 func checkPresentedOfferingContextAPI(context: PresentedOfferingContext! = nil) {
     let _: String = context.offeringIdentifier
     let _: String? = context.placementIdentifier
+    let _: PresentedOfferingContext.TargetingContext? = context.targetingContext
 }
 
 private func checkCreatePresentedOfferingContextAPI() {
     let _: PresentedOfferingContext = .init(offeringIdentifier: "")
-    let _: PresentedOfferingContext = .init(offeringIdentifier: "", placementIdentifier: "")
+    let _: PresentedOfferingContext = .init(offeringIdentifier: "",
+                                            placementIdentifier: "",
+                                            targetingContext: .init(revision: 1, ruleId: ""))
 }

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
@@ -21,3 +21,12 @@ private func checkCreatePresentedOfferingContextAPI() {
                                             placementIdentifier: "",
                                             targetingContext: .init(revision: 1, ruleId: ""))
 }
+
+func checkTargetingContextAPI(context: PresentedOfferingContext.TargetingContext! = nil) {
+    let _: Int = context.revision
+    let _: String? = context.ruleId
+}
+
+private func checkTargetingContextAPI() {
+    let _: PresentedOfferingContext.TargetingContext = .init(revision: 1, ruleId: "")
+}

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/main.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/main.swift
@@ -43,6 +43,7 @@ func main() -> Int {
     checkPackageEnums()
 
     checkPresentedOfferingContextAPI()
+    checkTargetingContextAPI()
 
     checkReceiptParserAPI()
     checkAppleReceiptAPI()

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContextAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContextAPI.m
@@ -21,8 +21,9 @@
                                                                                                                ruleId:@""]];
     NSString *oid = poc.offeringIdentifier;
     NSString *pid = poc.placementIdentifier;
+    RCTargetingContext *pitc = poc.targetingContext;
 
-    NSLog(poc, oid, pid);
+    NSLog(poc, oid, pid, pitc);
 }
 
 @end

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContextAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContextAPI.m
@@ -14,8 +14,11 @@
 
 + (void)checkAPI {
     RCPresentedOfferingContext *poc = [[RCPresentedOfferingContext alloc] initWithOfferingIdentifier:@""];
-    poc = [[RCPresentedOfferingContext alloc] initWithOfferingIdentifier:@"" placementIdentifier:nil];
-    poc = [[RCPresentedOfferingContext alloc] initWithOfferingIdentifier:@"" placementIdentifier:@""];
+    poc = [[RCPresentedOfferingContext alloc] initWithOfferingIdentifier:@"" placementIdentifier:nil targetingContext:nil];
+    poc = [[RCPresentedOfferingContext alloc] initWithOfferingIdentifier:@"" 
+                                                     placementIdentifier:@""
+                                                        targetingContext:[[RCTargetingContext alloc] initWithRevision:1 
+                                                                                                               ruleId:@""]];
     NSString *oid = poc.offeringIdentifier;
     NSString *pid = poc.placementIdentifier;
 

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContextAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContextAPI.m
@@ -26,4 +26,12 @@
     NSLog(poc, oid, pid, pitc);
 }
 
++ (void)checkTargetContextAPI {
+    RCTargetingContext *tc = [[RCTargetingContext alloc] initWithRevision:1 ruleId:@""];
+    NSString *r = tc.revision;
+    NSString *rid = tc.ruleId;
+
+    NSLog(tc, r, rid);
+}
+
 @end

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContextAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContextAPI.m
@@ -28,7 +28,7 @@
 
 + (void)checkTargetContextAPI {
     RCTargetingContext *tc = [[RCTargetingContext alloc] initWithRevision:1 ruleId:@""];
-    NSString *r = tc.revision;
+    NSInteger r = tc.revsion;
     NSString *rid = tc.ruleId;
 
     NSLog(tc, r, rid);

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContextAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPresentedOfferingContextAPI.m
@@ -28,7 +28,7 @@
 
 + (void)checkTargetContextAPI {
     RCTargetingContext *tc = [[RCTargetingContext alloc] initWithRevision:1 ruleId:@""];
-    NSInteger r = tc.revsion;
+    NSInteger r = tc.revision;
     NSString *rid = tc.ruleId;
 
     NSLog(tc, r, rid);

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
@@ -16,5 +16,7 @@ func checkPresentedOfferingContextAPI(context: PresentedOfferingContext! = nil) 
 
 private func checkCreatePresentedOfferingContextAPI() {
     let _: PresentedOfferingContext = .init(offeringIdentifier: "")
-    let _: PresentedOfferingContext = .init(offeringIdentifier: "", placementIdentifier: "")
+    let _: PresentedOfferingContext = .init(offeringIdentifier: "",
+                                            placementIdentifier: "",
+                                            targetingContext: .init(revision: 1, ruleId: ""))
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
@@ -12,6 +12,7 @@ import StoreKit
 func checkPresentedOfferingContextAPI(context: PresentedOfferingContext! = nil) {
     let _: String = context.offeringIdentifier
     let _: String? = context.placementIdentifier
+    let _: PresentedOfferingContext.TargetingContext? = context.targetingContext
 }
 
 private func checkCreatePresentedOfferingContextAPI() {

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PresentedOfferingContextAPI.swift
@@ -21,3 +21,12 @@ private func checkCreatePresentedOfferingContextAPI() {
                                             placementIdentifier: "",
                                             targetingContext: .init(revision: 1, ruleId: ""))
 }
+
+func checkTargetingContextAPI(context: PresentedOfferingContext.TargetingContext! = nil) {
+    let _: Int = context.revision
+    let _: String? = context.ruleId
+}
+
+private func checkTargetingContextAPI() {
+    let _: PresentedOfferingContext.TargetingContext = .init(revision: 1, ruleId: "")
+}

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
@@ -45,6 +45,7 @@ func main() -> Int {
     checkPackageEnums()
 
     checkPresentedOfferingContextAPI()
+    checkTargetingContextAPI()
 
     checkReceiptParserAPI()
     checkAppleReceiptAPI()

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -96,7 +96,8 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         try self.purchases.cachePresentedOfferingContext(
             PresentedOfferingContext(
                 offeringIdentifier: package.offeringIdentifier,
-                placementIdentifier: "a_placement"
+                placementIdentifier: "a_placement",
+                targetingContext: nil
             ),
             productIdentifier: package.storeProduct.productIdentifier
         )

--- a/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
@@ -95,7 +95,7 @@ private extension OfferingsManagerStoreKitTests {
                       packages: [
                         .init(identifier: "$rc_monthly", platformProductIdentifier: StoreKitConfigTestCase.productID)
                       ])
-            ], 
+            ],
             placements: nil,
             targeting: nil
         )

--- a/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
@@ -95,7 +95,9 @@ private extension OfferingsManagerStoreKitTests {
                       packages: [
                         .init(identifier: "$rc_monthly", platformProductIdentifier: StoreKitConfigTestCase.productID)
                       ])
-            ], placements: nil
+            ], 
+            placements: nil,
+            targeting: nil
         )
     }
 

--- a/Tests/StoreKitUnitTests/Support/DebugViewSwiftUITests.swift
+++ b/Tests/StoreKitUnitTests/Support/DebugViewSwiftUITests.swift
@@ -51,7 +51,8 @@ class DebugViewSwiftUITests: TestCase {
         model.offerings = .loaded(.init(
             offerings: [:],
             currentOfferingID: nil,
-            placements: .init(fallbackOfferingId: "", offeringIdsByPlacement: [:]),
+            placements: nil,
+            targeting: nil,
             response: .mockResponse
         ))
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
@@ -20,30 +20,30 @@ struct UpsellView: View {
 
         }
         .padding()
-        .presentPaywallIfNeeded(
-            requiredEntitlementIdentifier: Configuration.entitlement,
-            purchaseStarted: {
-                print("Purchase started")
-            },
-            purchaseCompleted: { _ in
-                print("Purchase completed")
-            },
-            purchaseCancelled: {
-                print("Purchase cancelled")
-            },
-            onDismiss: {
-                print("Paywall dismissed")
-            },
-            onRestoreCompleted: { _ in
-                print("Restore completed")
-            },
-            onRestoreStarted: {
-                print("Restore started")
-            },
-            onRestoreFailure: {
-                print("Restore failed")
-            }
-        )
+//        .presentPaywallIfNeeded(
+//            requiredEntitlementIdentifier: Configuration.entitlement,
+//            purchaseStarted: {
+//                print("Purchase started")
+//            },
+//            purchaseCompleted: { _ in
+//                print("Purchase completed")
+//            },
+//            purchaseCancelled: {
+//                print("Purchase cancelled")
+//            },
+//            onDismiss: {
+//                print("Paywall dismissed")
+//            },
+//            onRestoreCompleted: { _ in
+//                print("Restore completed")
+//            },
+//            onRestoreStarted: {
+//                print("Restore started")
+//            },
+//            onRestoreFailure: {
+//                print("Restore failed")
+//            }
+//        )
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
@@ -20,30 +20,30 @@ struct UpsellView: View {
 
         }
         .padding()
-//        .presentPaywallIfNeeded(
-//            requiredEntitlementIdentifier: Configuration.entitlement,
-//            purchaseStarted: {
-//                print("Purchase started")
-//            },
-//            purchaseCompleted: { _ in
-//                print("Purchase completed")
-//            },
-//            purchaseCancelled: {
-//                print("Purchase cancelled")
-//            },
-//            onDismiss: {
-//                print("Paywall dismissed")
-//            },
-//            onRestoreCompleted: { _ in
-//                print("Restore completed")
-//            },
-//            onRestoreStarted: {
-//                print("Restore started")
-//            },
-//            onRestoreFailure: {
-//                print("Restore failed")
-//            }
-//        )
+        .presentPaywallIfNeeded(
+            requiredEntitlementIdentifier: Configuration.entitlement,
+            purchaseStarted: {
+                print("Purchase started")
+            },
+            purchaseCompleted: { _ in
+                print("Purchase completed")
+            },
+            purchaseCancelled: {
+                print("Purchase cancelled")
+            },
+            onDismiss: {
+                print("Paywall dismissed")
+            },
+            onRestoreCompleted: { _ in
+                print("Restore completed")
+            },
+            onRestoreStarted: {
+                print("Restore started")
+            },
+            onRestoreFailure: {
+                print("Restore failed")
+            }
+        )
     }
 
 }

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -497,11 +497,12 @@ private extension DeviceCacheTests {
         return Offerings(
             offerings: [offeringIdentifier: offering],
             currentOfferingID: "base",
-            placements: .init(fallbackOfferingId: "", offeringIdsByPlacement: [:]),
+            placements: nil,
             response: .init(currentOfferingId: "base",
                             offerings: [offeringsData],
-                            placements: .init(fallbackOfferingId: "", offeringIdsByPlacement: .init(wrappedValue: [:]))
-        ))
+                            placements: nil,
+                            targeting: nil)
+        )
     }
 
 }
@@ -511,11 +512,12 @@ private extension Offerings {
     static let empty: Offerings = .init(
         offerings: [:],
         currentOfferingID: "",
-        placements: .init(fallbackOfferingId: "", offeringIdsByPlacement: [:]),
+        placements: nil,
         response: .init(
             currentOfferingId: "",
             offerings: [],
-            placements: .init(fallbackOfferingId: "", offeringIdsByPlacement: .init(wrappedValue: [:]))
+            placements: nil,
+            targeting: nil
         )
     )
 

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -498,6 +498,7 @@ private extension DeviceCacheTests {
             offerings: [offeringIdentifier: offering],
             currentOfferingID: "base",
             placements: nil,
+            targeting: nil,
             response: .init(currentOfferingId: "base",
                             offerings: [offeringsData],
                             placements: nil,
@@ -513,6 +514,7 @@ private extension Offerings {
         offerings: [:],
         currentOfferingID: "",
         placements: nil,
+        targeting: nil,
         response: .init(
             currentOfferingId: "",
             offerings: [],

--- a/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
+++ b/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
@@ -38,7 +38,8 @@ class PurchasesDiagnosticsTests: TestCase {
                   placements: nil,
                   response: .init(currentOfferingId: nil,
                                   offerings: [],
-                                  placements: nil))
+                                  placements: nil,
+                                  targeting: nil))
         )
     }
 

--- a/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
+++ b/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
@@ -36,6 +36,7 @@ class PurchasesDiagnosticsTests: TestCase {
             .init(offerings: [:],
                   currentOfferingID: nil,
                   placements: nil,
+                  targeting: nil,
                   response: .init(currentOfferingId: nil,
                                   offerings: [],
                                   placements: nil,

--- a/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
@@ -18,7 +18,8 @@ class MockOfferingsFactory: OfferingsFactory {
             return Offerings(offerings: [:],
                              currentOfferingID: "base",
                              placements: nil,
-                             response: .init(currentOfferingId: "base", 
+                             targeting: nil,
+                             response: .init(currentOfferingId: "base",
                                              offerings: [],
                                              placements: nil,
                                              targeting: nil))
@@ -45,6 +46,7 @@ class MockOfferingsFactory: OfferingsFactory {
                 )],
             currentOfferingID: "base",
             placements: nil,
+            targeting: nil,
             response: .init(currentOfferingId: "base", offerings: [
                 .init(identifier: "base", description: "This is the base offering",
                       packages: [

--- a/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
@@ -18,7 +18,10 @@ class MockOfferingsFactory: OfferingsFactory {
             return Offerings(offerings: [:],
                              currentOfferingID: "base",
                              placements: nil,
-                             response: .init(currentOfferingId: "base", offerings: [], placements: nil))
+                             response: .init(currentOfferingId: "base", 
+                                             offerings: [],
+                                             placements: nil,
+                                             targeting: nil))
         }
         if nilOfferings {
             return nil
@@ -47,7 +50,7 @@ class MockOfferingsFactory: OfferingsFactory {
                       packages: [
                         .init(identifier: "", platformProductIdentifier: "$rc_monthly")
                       ])
-            ], placements: nil)
+            ], placements: nil, targeting: nil)
 
         )
     }
@@ -63,7 +66,9 @@ extension OfferingsResponse {
                   packages: [
                     .init(identifier: "$rc_monthly", platformProductIdentifier: "monthly_freetrial")
                   ])
-        ], placements: nil
+        ],
+        placements: nil,
+        targeting: nil
     )
 
 }

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -394,7 +394,8 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
 
         let context = PresentedOfferingContext(
             offeringIdentifier: offeringIdentifier,
-            placementIdentifier: placementIdentifier
+            placementIdentifier: placementIdentifier,
+            targetingContext: .init(revision: 1, ruleId: "abc123")
         )
 
         let productData: ProductRequestData = .createMockProductData(productIdentifier: productIdentifier,

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -395,7 +395,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
         let context = PresentedOfferingContext(
             offeringIdentifier: offeringIdentifier,
             placementIdentifier: placementIdentifier,
-            targetingContext: nil
+            targetingContext: .init(revision: 1, ruleId: "abc123")
         )
 
         let productData: ProductRequestData = .createMockProductData(productIdentifier: productIdentifier,

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -395,7 +395,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
         let context = PresentedOfferingContext(
             offeringIdentifier: offeringIdentifier,
             placementIdentifier: placementIdentifier,
-            targetingContext: .init(revision: 1, ruleId: "abc123")
+            targetingContext: nil
         )
 
         let productData: ProductRequestData = .createMockProductData(productIdentifier: productIdentifier,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -17,6 +17,10 @@
   "request" : {
     "body" : {
       "app_user_id" : "user",
+      "applied_targeting_rule" : {
+        "revision" : 1,
+        "rule_id" : "abc123"
+      },
       "attributes" : {
         "$attConsentStatus" : {
           "updated_at_ms" : 1678307200000,
@@ -29,6 +33,7 @@
       "is_restore" : false,
       "observer_mode" : false,
       "presented_offering_identifier" : "a_offering",
+      "presented_placement_identifier" : "a_placement",
       "price" : "10.98",
       "product_id" : "a_great_product",
       "store_country" : "ESP",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -18,6 +18,10 @@
   "request" : {
     "body" : {
       "app_user_id" : "user",
+      "applied_targeting_rule" : {
+        "revision" : 1,
+        "rule_id" : "abc123"
+      },
       "attributes" : {
         "$attConsentStatus" : {
           "updated_at_ms" : 1678307200000,
@@ -30,6 +34,7 @@
       "is_restore" : false,
       "observer_mode" : false,
       "presented_offering_identifier" : "a_offering",
+      "presented_placement_identifier" : "a_placement",
       "price" : "10.98",
       "product_id" : "a_great_product",
       "store_country" : "ESP",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -18,6 +18,10 @@
   "request" : {
     "body" : {
       "app_user_id" : "user",
+      "applied_targeting_rule" : {
+        "revision" : 1,
+        "rule_id" : "abc123"
+      },
       "attributes" : {
         "$attConsentStatus" : {
           "updated_at_ms" : 1678307200000,
@@ -30,6 +34,7 @@
       "is_restore" : false,
       "observer_mode" : false,
       "presented_offering_identifier" : "a_offering",
+      "presented_placement_identifier" : "a_placement",
       "price" : "10.98",
       "product_id" : "a_great_product",
       "store_country" : "ESP",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -18,6 +18,10 @@
   "request" : {
     "body" : {
       "app_user_id" : "user",
+      "applied_targeting_rule" : {
+        "revision" : 1,
+        "rule_id" : "abc123"
+      },
       "attributes" : {
         "$attConsentStatus" : {
           "updated_at_ms" : 1678307200000,
@@ -30,6 +34,7 @@
       "is_restore" : false,
       "observer_mode" : false,
       "presented_offering_identifier" : "a_offering",
+      "presented_placement_identifier" : "a_placement",
       "price" : "10.98",
       "product_id" : "a_great_product",
       "store_country" : "ESP",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -18,6 +18,10 @@
   "request" : {
     "body" : {
       "app_user_id" : "user",
+      "applied_targeting_rule" : {
+        "revision" : 1,
+        "rule_id" : "abc123"
+      },
       "attributes" : {
         "$attConsentStatus" : {
           "updated_at_ms" : 1678307200000,
@@ -30,6 +34,7 @@
       "is_restore" : false,
       "observer_mode" : false,
       "presented_offering_identifier" : "a_offering",
+      "presented_placement_identifier" : "a_placement",
       "price" : "10.98",
       "product_id" : "a_great_product",
       "store_country" : "ESP",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -18,6 +18,10 @@
   "request" : {
     "body" : {
       "app_user_id" : "user",
+      "applied_targeting_rule" : {
+        "revision" : 1,
+        "rule_id" : "abc123"
+      },
       "attributes" : {
         "$attConsentStatus" : {
           "updated_at_ms" : 1678307200000,
@@ -30,6 +34,7 @@
       "is_restore" : false,
       "observer_mode" : false,
       "presented_offering_identifier" : "a_offering",
+      "presented_placement_identifier" : "a_placement",
       "price" : "10.98",
       "product_id" : "a_great_product",
       "store_country" : "ESP",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -17,6 +17,10 @@
   "request" : {
     "body" : {
       "app_user_id" : "user",
+      "applied_targeting_rule" : {
+        "revision" : 1,
+        "rule_id" : "abc123"
+      },
       "attributes" : {
         "$attConsentStatus" : {
           "updated_at_ms" : 1678307200000,
@@ -29,6 +33,7 @@
       "is_restore" : false,
       "observer_mode" : false,
       "presented_offering_identifier" : "a_offering",
+      "presented_placement_identifier" : "a_placement",
       "price" : "10.98",
       "product_id" : "a_great_product",
       "store_country" : "ESP",

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -191,6 +191,7 @@ private extension PaywallCacheWarmingTests {
             offerings: Set(offerings).dictionaryWithKeys(\.identifier),
             currentOfferingID: Self.offeringIdentifier,
             placements: nil,
+            targeting: nil,
             response: offeringsResponse
         )
     }

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -509,6 +509,7 @@ private extension OfferingsManagerTests {
                 .dictionaryWithKeys(\.identifier),
             currentOfferingID: MockData.anyBackendOfferingsResponse.currentOfferingId,
             placements: nil,
+            targeting: nil,
             response: MockData.anyBackendOfferingsResponse
         )
     }

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -159,8 +159,10 @@ extension OfferingsManagerTests {
     func testOfferingsForAppUserIDReturnsConfigurationErrorIfBackendReturnsEmpty() throws {
         // given
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(
-            .init(currentOfferingId: "", offerings: [],
-                  placements: nil)
+            .init(currentOfferingId: "",
+                  offerings: [],
+                  placements: nil,
+                  targeting: nil)
         )
         self.mockOfferingsFactory.emptyOfferings = true
 
@@ -210,8 +212,10 @@ extension OfferingsManagerTests {
     func testOfferingsLogsErrorInformationIfBackendReturnsEmpty() throws {
         // given
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(
-            .init(currentOfferingId: "", offerings: [],
-                  placements: nil)
+            .init(currentOfferingId: "",
+                  offerings: [],
+                  placements: nil,
+                  targeting: nil)
         )
         self.mockOfferingsFactory.emptyOfferings = true
 
@@ -464,7 +468,8 @@ private extension OfferingsManagerTests {
                         .init(identifier: "$rc_monthly", platformProductIdentifier: "monthly_freetrial")
                       ])
             ],
-            placements: nil
+            placements: nil,
+            targeting: nil
         )
         static let backendOfferingsResponseWithUnknownProducts: OfferingsResponse = .init(
             currentOfferingId: "base",
@@ -476,7 +481,8 @@ private extension OfferingsManagerTests {
                         .init(identifier: "$rc_yearly", platformProductIdentifier: "yearly_freetrial")
                       ])
             ],
-            placements: nil
+            placements: nil,
+            targeting: nil
         )
         static let unexpectedBackendResponseError: BackendError = .unexpectedBackendResponse(
             .customerInfoNil

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -114,7 +114,8 @@ class OfferingsTests: TestCase {
                             .init(identifier: "$rc_monthly", platformProductIdentifier: "com.myproduct.monthly")
                           ])
                 ],
-                placements: nil
+                placements: nil,
+                targeting: nil
             )
         )
 
@@ -148,7 +149,8 @@ class OfferingsTests: TestCase {
                                 .init(identifier: "custom_package", platformProductIdentifier: "com.myproduct.custom")
                               ])
                     ],
-                    placements: nil
+                    placements: nil,
+                    targeting: nil
                 )
             )
         )
@@ -204,7 +206,8 @@ class OfferingsTests: TestCase {
                                       offeringIdsByPlacement: .init(wrappedValue: [
                                         "placement_name": "offering_b",
                                         "placement_name_with_nil": nil
-                                      ]))
+                                      ])),
+                    targeting: nil
                 )
             )
         )
@@ -251,7 +254,8 @@ class OfferingsTests: TestCase {
                                       offeringIdsByPlacement: .init(wrappedValue: [
                                         "placement_name": "offering_b",
                                         "placement_name_with_nil": nil
-                                      ]))
+                                      ])),
+                    targeting: nil
                 )
             )
         )
@@ -262,6 +266,43 @@ class OfferingsTests: TestCase {
         expect(offerings.currentOffering(forPlacement: "placement_name")!.identifier) == offeringB.identifier
         expect(offerings.currentOffering(forPlacement: "placement_name_with_nil")).to(beNil())
         expect(offerings.currentOffering(forPlacement: "unexisting_placement_name")).to(beNil())
+    }
+
+    func testTargeting() throws {
+        let annualProduct = MockSK1Product(mockProductIdentifier: "com.myproduct.annual")
+        let monthlyProduct = MockSK1Product(mockProductIdentifier: "com.myproduct.monthly")
+        let customProduct = MockSK1Product(mockProductIdentifier: "com.myproduct.custom")
+        let products = [
+            "com.myproduct.annual": StoreProduct(sk1Product: annualProduct),
+            "com.myproduct.monthly": StoreProduct(sk1Product: monthlyProduct),
+            "com.myproduct.custom": StoreProduct(sk1Product: customProduct)
+        ]
+        let offerings = try XCTUnwrap(
+            self.offeringsFactory.createOfferings(
+                from: products,
+                data: .init(
+                    currentOfferingId: "offering_a",
+                    offerings: [
+                        .init(identifier: "offering_a",
+                              description: "This is the base offering",
+                              packages: [
+                                .init(identifier: "$rc_six_month", platformProductIdentifier: "com.myproduct.annual")
+                              ])
+                    ],
+                    placements: nil,
+                    targeting: .init(revision: 1, ruleId: "abc123")
+                )
+            )
+        )
+
+        let offeringA = try XCTUnwrap(offerings["offering_a"])
+        expect(offerings.current) === offeringA
+        expect(
+            offerings.current!.availablePackages.first!.presentedOfferingContext.targetingContext!.revision
+        ) == 1
+        expect(
+            offerings.current!.availablePackages.first!.presentedOfferingContext.targetingContext!.ruleId
+        ) == "abc123"
     }
 
     func testOfferingsWithMetadataIsCreated() throws {
@@ -313,7 +354,8 @@ class OfferingsTests: TestCase {
                                 .init(identifier: "$rc_monthly", platformProductIdentifier: "com.myproduct.monthly")
                               ])
                     ],
-                    placements: .init(fallbackOfferingId: "", offeringIdsByPlacement: .init(wrappedValue: [:]))
+                    placements: nil,
+                    targeting: nil
                 )
             )
         )
@@ -438,7 +480,8 @@ class OfferingsTests: TestCase {
                         .init(identifier: "$rc_six_month", platformProductIdentifier: "com.myproduct.annual")
                       ])
             ],
-            placements: nil
+            placements: nil,
+            targeting: nil
         )
         let offerings = try XCTUnwrap(
             self.offeringsFactory.createOfferings(from: storeProductsByID, data: response)
@@ -478,7 +521,8 @@ private extension OfferingsTests {
                                 .init(identifier: identifier, platformProductIdentifier: productIdentifier)
                               ])
                     ],
-                    placements: nil
+                    placements: nil,
+                    targeting: nil
                 )
             )
         )

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -296,13 +296,20 @@ class OfferingsTests: TestCase {
         )
 
         let offeringA = try XCTUnwrap(offerings["offering_a"])
-        expect(offerings.current) === offeringA
+
+        // Current offering should have targeting context
+        expect(offerings.current!.identifier) == offeringA.identifier
         expect(
             offerings.current!.availablePackages.first!.presentedOfferingContext.targetingContext!.revision
         ) == 1
         expect(
             offerings.current!.availablePackages.first!.presentedOfferingContext.targetingContext!.ruleId
         ) == "abc123"
+
+        // Offering accessed directly (even if same as current) should not have targeting context
+        expect(
+            offerings.all.values.first!.availablePackages.first!.presentedOfferingContext.targetingContext
+        ).to(beNil())
     }
 
     func testOfferingsWithMetadataIsCreated() throws {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -135,6 +135,7 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
             ],
             currentOfferingID: offering.identifier,
             placements: nil,
+            targeting: nil,
             response: offeringsResponse
         )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -602,6 +602,7 @@ platform :ios do
 
   desc "Run BackendIntegrationTests"
   lane :backend_integration_tests do |options|
+    fetch_snapshots
     replace_api_key_integration_tests
     scan(
       scheme: "BackendIntegrationTests",


### PR DESCRIPTION
### Motivation

Get more context with targeting information 

### Description

- Parse targeting information into `Offerings`
- Add targeting context into `Offerings.current`
- Add targeting context into `getCurrentOffering(forPlacement: String)`
- Post targeting context in post receipts
