### PR TITLE
Revert "`Xcode 15.3`: fix warnings on Integration Tests"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ aliases:
       branches:
         only: main
   non-patch-release-branches: &non-patch-release-branches
-    filters:
+    filters: 
       tags:
         ignore: /.*/
       branches:
@@ -99,7 +99,7 @@ commands:
           key: v2-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
           paths:
             - vendor/bundle
-
+  
   install-dependencies:
     parameters:
       directory:
@@ -122,7 +122,7 @@ commands:
             - /usr/local/Cellar/swiftlint/
             - /usr/local/Cellar/xcbeautify/
             - /Users/$USER/Library/Caches/Homebrew/
-
+  
   install-brew-dependency:
     parameters:
       dependency_name:
@@ -308,7 +308,7 @@ commands:
           command: bundle exec fastlane backend_integration_tests test_plan:"<< parameters.test_plan >>"
           no_output_timeout: 5m
           environment:
-            SCAN_DEVICE: iPhone 14 (17.4.0)
+            SCAN_DEVICE: iPhone 14 (17.2.0)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: BackendIntegrationTests
@@ -359,7 +359,7 @@ jobs:
           name: SPM Receipt Parser
           command: swift build -c release --target ReceiptParser
           no_output_timeout: 30m
-
+  
   spm-xcode-14-1:
     <<: *base-job
     steps:
@@ -427,7 +427,7 @@ jobs:
           path: fastlane/test_output
           destination: scan-test-output
       - run:
-          condition:
+          condition: 
             - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
           name: RevenueCatUI API Tests
           command: bundle exec fastlane build_revenuecatui_api_tester
@@ -447,7 +447,7 @@ jobs:
           command: bundle exec fastlane test_revenuecatui
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 15 Pro,OS=17.4
+            SCAN_DEVICE: iPhone 15 Pro,OS=17.2
       - create-snapshot-pr-if-needed:
           condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
           job: "create_snapshots_repo_pr"
@@ -460,7 +460,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-
+          
   spm-revenuecat-ui-watchos:
     <<: *base-job
     steps:
@@ -483,7 +483,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-
+  
   run-test-macos:
     <<: *base-job
     steps:
@@ -505,7 +505,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-
+          
   run-test-ios-17:
     <<: *base-job
     steps:
@@ -516,7 +516,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 15 (17.4.0)
+            SCAN_DEVICE: iPhone 15 (17.2.0)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: RevenueCat
@@ -992,7 +992,7 @@ jobs:
           command: bundle exec fastlane backend_integration_tests test_plan:"BackendIntegrationTests-All-CI"
           no_output_timeout: 5m
           environment:
-            SCAN_DEVICE: iPhone 14 (17.4.0)
+            SCAN_DEVICE: iPhone 14 (17.2.0)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: BackendIntegrationTests
@@ -1016,7 +1016,7 @@ jobs:
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: v3LoadShedderIntegration
-
+  
   deploy-purchase-tester:
     <<: *base-job
     steps:
@@ -1083,7 +1083,7 @@ workflows:
     when: << pipeline.parameters.generate_snapshots >>
     jobs:
       - run-test-ios-17:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
       - run-test-ios-16:
           xcode_version: '14.3.0'
       - run-test-ios-15:
@@ -1095,7 +1095,7 @@ workflows:
       - run-test-ios-12:
           xcode_version: '14.2.0'
       - run-test-macos:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
 
   generate_revenuecatui_snapshots:
     when: << pipeline.parameters.generate_revenuecatui_snapshots >>
@@ -1105,8 +1105,8 @@ workflows:
       - spm-revenuecat-ui-ios-16:
           xcode_version: '14.3.0'
       - spm-revenuecat-ui-ios-17:
-          xcode_version: '15.3'
-
+          xcode_version: '15.2'
+  
   build-test:
     when:
       and:
@@ -1120,7 +1120,7 @@ workflows:
       - spm-release-build-xcode-14:
           xcode_version: '14.3.0'
       - spm-release-build-xcode-15:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
       - spm-xcode-14-1:
           xcode_version: '14.1.0'
       - spm-custom-entitlement-computation-build:
@@ -1132,13 +1132,13 @@ workflows:
       - spm-revenuecat-ui-ios-16:
           xcode_version: '14.3.0'
       - spm-revenuecat-ui-ios-17:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
       - spm-revenuecat-ui-watchos:
           xcode_version: '14.3.0'
       - run-test-macos:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
       - run-test-ios-17:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
       - run-test-ios-16:
           xcode_version: '14.3.0'
       - run-test-ios-15:
@@ -1160,31 +1160,31 @@ workflows:
       - build-tv-watch-and-macos:
           xcode_version: '14.3.0'
       - build-visionos:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
       - backend-integration-tests-SK1:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
           filters:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
       - backend-integration-tests-SK2:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
           filters:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
       - backend-integration-tests-other:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
           filters:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
       - backend-integration-tests-offline:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
           # These tests are flaky due to FB13133387 so we don't want the noise in every PR
           <<: *release-branches-and-main
       - backend-integration-tests-custom-entitlements:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
           filters:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
@@ -1235,12 +1235,12 @@ workflows:
           xcode_version: '14.3.0'
           <<: *release-tags
       - push-revenuecat-pod:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
           requires:
             - make-release
           <<: *release-tags
       - push-revenuecatui-pod:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
           requires:
             - make-release
             - push-revenuecat-pod
@@ -1283,10 +1283,10 @@ workflows:
         - equal: [ "load_shedder_integration_tests", << pipeline.schedule.name >> ]
     jobs:
       - loadshedder-integration-tests-v3:
-          xcode_version: '15.3'
+          xcode_version: '15.2'
       - integration-tests-all:
-          xcode_version: '15.3'
-
+          xcode_version: '15.2'
+  
   manual-trigger-bump:
     when:
       equal: [ bump, << pipeline.parameters.action >> ]

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,4 @@ gem 'cocoapods'
 gem 'cocoapods-trunk'
 gem 'danger'
 gem 'rest-client'
-gem 'readline-ext'
 eval_gemfile("fastlane/Pluginfile")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,7 +277,6 @@ GEM
     public_suffix (4.0.7)
     rake (13.1.0)
     rchardet (1.8.0)
-    readline-ext (0.2.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -347,7 +346,6 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-create_xcframework
   fastlane-plugin-revenuecat_internal!
-  readline-ext
   rest-client
 
 BUNDLED WITH

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "tr
 var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:Quick/Nimble.git", from: "10.0.0"),
     // SST requires iOS 13 starting from version 1.13.0
-    .package(url: "git@github.com:revenuecat/swift-snapshot-testing.git", branch: "1.12.0-fix-test-observer")
+    .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", .upToNextMinor(from: "1.12.0"))
 ]
 if shouldIncludeDocCPlugin {
     dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -11,7 +11,7 @@ let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "tr
 
 var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:Quick/Nimble.git", from: "10.0.0"),
-    .package(url: "git@github.com:revenuecat/swift-snapshot-testing.git", branch: "1.12.0-fix-test-observer")
+    .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", from: "1.11.0")
 ]
 if shouldIncludeDocCPlugin {
     dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -11,7 +11,7 @@ let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "tr
 
 var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:Quick/Nimble.git", from: "10.0.0"),
-    .package(url: "git@github.com:revenuecat/swift-snapshot-testing.git", branch: "1.12.0-fix-test-observer")
+    .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", from: "1.11.0")
 ]
 if shouldIncludeDocCPlugin {
     dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -212,9 +212,6 @@
 		4DBF1F362B4D572400D52354 /* LocalReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBF1F352B4D572400D52354 /* LocalReceiptFetcher.swift */; };
 		4DBF1F372B4D572400D52354 /* LocalReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBF1F352B4D572400D52354 /* LocalReceiptFetcher.swift */; };
 		4DC546272AD44BBE005CDB35 /* EncodedAppleReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC546262AD44BBE005CDB35 /* EncodedAppleReceipt.swift */; };
-		4DCF76642B91E22E004F03B5 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 4DCF76632B91E22E004F03B5 /* SnapshotTesting */; };
-		4DCF76662B91E235004F03B5 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 4DCF76652B91E235004F03B5 /* SnapshotTesting */; };
-		4DCF766A2B91E241004F03B5 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 4DCF76692B91E241004F03B5 /* SnapshotTesting */; };
 		4F0201C42A13C85500091612 /* Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0201C32A13C85500091612 /* Assertions.swift */; };
 		4F05876F2A5DE03F00E9A834 /* PaywallDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F05876E2A5DE03F00E9A834 /* PaywallDataTests.swift */; };
 		4F062D322A85A11600A8A613 /* PaywallData+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F062D312A85A11600A8A613 /* PaywallData+Localization.swift */; };
@@ -316,6 +313,7 @@
 		4FC883822AA7A2BD00A3DE03 /* ProcessInfo+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC883802AA7A2BD00A3DE03 /* ProcessInfo+Extensions.swift */; };
 		4FC972172A712DCC008593DE /* CachingProductsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC972162A712DCC008593DE /* CachingProductsManagerTests.swift */; };
 		4FCBA84F2A15391B004134BD /* SnapshotTesting+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */; };
+		4FCBA8512A153940004134BD /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 4FCBA8502A153940004134BD /* SnapshotTesting */; };
 		4FCEEA5E2A379B80002C2112 /* DebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCEEA5D2A379B80002C2112 /* DebugViewController.swift */; };
 		4FD291BE2A1E9A2E0098D1B9 /* StoreKit2TransactionFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD291BD2A1E9A2E0098D1B9 /* StoreKit2TransactionFetcherTests.swift */; };
 		4FD3688B2AA7C12600F63354 /* PaywallEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD3688A2AA7C12600F63354 /* PaywallEvent.swift */; };
@@ -460,6 +458,7 @@
 		576C8A9227D27DDD0058FA6E /* SnapshotTesting+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */; };
 		576C8AB927D2996C0058FA6E /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
 		576C8ABC27D2997C0058FA6E /* SnapshotTesting+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */; };
+		576C8ABE27D299860058FA6E /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 576C8ABD27D299860058FA6E /* SnapshotTesting */; };
 		576C8AD927D2BCB90058FA6E /* HTTPRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8AD827D2BCB90058FA6E /* HTTPRequestTests.swift */; };
 		5774F9B62805E6CC00997128 /* CustomerInfoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5774F9B52805E6CC00997128 /* CustomerInfoResponse.swift */; };
 		5774F9BE2805E71100997128 /* Fixtures in Resources */ = {isa = PBXBuildFile; fileRef = 5774F9BD2805E71100997128 /* Fixtures */; };
@@ -573,6 +572,7 @@
 		57DE80AF28075D77008D6C6F /* OSVersionEquivalent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DE80AD28075D77008D6C6F /* OSVersionEquivalent.swift */; };
 		57DE80BE28077010008D6C6F /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D22BF6626F3CBFB001AE2F9 /* XCTestCase+Extensions.swift */; };
 		57DE80BF2807705F008D6C6F /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D22BF6626F3CBFB001AE2F9 /* XCTestCase+Extensions.swift */; };
+		57E0473B277260DE0082FE91 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 57E0473A277260DE0082FE91 /* SnapshotTesting */; };
 		57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E2230627500BB1002DB06E /* AtomicTests.swift */; };
 		57E415EB2846962500EA5460 /* PurchasesSyncPurchasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E415EA2846962500EA5460 /* PurchasesSyncPurchasesTests.swift */; };
 		57E415EF284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E415EE284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift */; };
@@ -1456,7 +1456,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4DCF766A2B91E241004F03B5 /* SnapshotTesting in Frameworks */,
+				576C8ABE27D299860058FA6E /* SnapshotTesting in Frameworks */,
 				2D803F6926F149E70069D717 /* RevenueCat.framework in Frameworks */,
 				2D9C5ED726F281750057FC45 /* OHHTTPStubsSwift in Frameworks */,
 				2D9C5ED526F281750057FC45 /* OHHTTPStubs in Frameworks */,
@@ -1477,7 +1477,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4DCF76642B91E22E004F03B5 /* SnapshotTesting in Frameworks */,
+				57E0473B277260DE0082FE91 /* SnapshotTesting in Frameworks */,
 				B36824BE268FBC5B00957E4C /* XCTest.framework in Frameworks */,
 				2D9C5ED326F2816F0057FC45 /* OHHTTPStubsSwift in Frameworks */,
 				2D9C5ED126F2816F0057FC45 /* OHHTTPStubs in Frameworks */,
@@ -1490,7 +1490,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2D803F6626F144BF0069D717 /* Nimble in Frameworks */,
-				4DCF76662B91E235004F03B5 /* SnapshotTesting in Frameworks */,
+				4FCBA8512A153940004134BD /* SnapshotTesting in Frameworks */,
 				2DA85A8C26DEA7FB00F1136D /* RevenueCat.framework in Frameworks */,
 				2DE20B7626408807004C597D /* StoreKitTest.framework in Frameworks */,
 			);
@@ -2911,7 +2911,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				4DFF0D772B90A84700BBBE71 /* PBXTargetDependency */,
 				2DAC5F7726F13C9800C5258F /* PBXTargetDependency */,
 				2D803F6B26F150190069D717 /* PBXTargetDependency */,
 			);
@@ -2920,7 +2919,7 @@
 				2D803F6726F144C40069D717 /* Nimble */,
 				2D9C5ED426F281750057FC45 /* OHHTTPStubs */,
 				2D9C5ED626F281750057FC45 /* OHHTTPStubsSwift */,
-				4DCF76692B91E241004F03B5 /* SnapshotTesting */,
+				576C8ABD27D299860058FA6E /* SnapshotTesting */,
 			);
 			productName = StoreKitUnitTests;
 			productReference = 2DAC5F7226F13C9800C5258F /* StoreKitUnitTests.xctest */;
@@ -2958,7 +2957,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				4DFF0D712B90A83200BBBE71 /* PBXTargetDependency */,
 				2DC5622124EC63430031F69B /* PBXTargetDependency */,
 				2DFF6C55270CA11400ECAFAB /* PBXTargetDependency */,
 			);
@@ -2967,7 +2965,7 @@
 				2D803F6226F144830069D717 /* Nimble */,
 				2D9C5ED026F2816F0057FC45 /* OHHTTPStubs */,
 				2D9C5ED226F2816F0057FC45 /* OHHTTPStubsSwift */,
-				4DCF76632B91E22E004F03B5 /* SnapshotTesting */,
+				57E0473A277260DE0082FE91 /* SnapshotTesting */,
 			);
 			productName = PurchasesTests;
 			productReference = 2DC5621E24EC63430031F69B /* UnitTests.xctest */;
@@ -2984,14 +2982,13 @@
 			buildRules = (
 			);
 			dependencies = (
-				4DFF0D522B90A4F300BBBE71 /* PBXTargetDependency */,
 				2D803F6D26F150200069D717 /* PBXTargetDependency */,
 				2DE20B8F26409EC0004C597D /* PBXTargetDependency */,
 			);
 			name = BackendIntegrationTests;
 			packageProductDependencies = (
 				2D803F6526F144BF0069D717 /* Nimble */,
-				4DCF76652B91E235004F03B5 /* SnapshotTesting */,
+				4FCBA8502A153940004134BD /* SnapshotTesting */,
 			);
 			productName = BackendIntegrationTests;
 			productReference = 2DE20B6C264087FB004C597D /* BackendIntegrationTests.xctest */;
@@ -3041,7 +3038,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				4DCF76682B91E23B004F03B5 /* PBXTargetDependency */,
 				4F6BEE072A27B02400CD9322 /* PBXTargetDependency */,
 			);
 			name = BackendCustomEntitlementsIntegrationTests;
@@ -3149,7 +3145,7 @@
 			packageReferences = (
 				2D803F6126F144830069D717 /* XCRemoteSwiftPackageReference "nimble" */,
 				2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */,
-				4DCF76622B91E21F004F03B5 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
+				57E04739277260DE0082FE91 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 			);
 			productRefGroup = 352629FF1F7C4B9100C04F2C /* Products */;
 			projectDirPath = "";
@@ -4075,22 +4071,6 @@
 			target = 2DEAC2D926EFE46E006914ED /* UnitTestsHostApp */;
 			targetProxy = 2DFF6C54270CA11400ECAFAB /* PBXContainerItemProxy */;
 		};
-		4DCF76682B91E23B004F03B5 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = 4DCF76672B91E23B004F03B5 /* SnapshotTesting */;
-		};
-		4DFF0D522B90A4F300BBBE71 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = 4DFF0D512B90A4F300BBBE71 /* SnapshotTesting */;
-		};
-		4DFF0D712B90A83200BBBE71 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = 4DFF0D702B90A83200BBBE71 /* SnapshotTesting */;
-		};
-		4DFF0D772B90A84700BBBE71 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = 4DFF0D762B90A84700BBBE71 /* SnapshotTesting */;
-		};
 		4F6BEE072A27B02400CD9322 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 2DE20B7E26409EB7004C597D /* BackendIntegrationTestsHostApp */;
@@ -4913,30 +4893,6 @@
 				minimumVersion = 9.0.0;
 			};
 		};
-		4DCF76622B91E21F004F03B5 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/RevenueCat/swift-snapshot-testing";
-			requirement = {
-				branch = "1.12.0-fix-test-observer";
-				kind = branch;
-			};
-		};
-		4DFF0D4E2B90A4D200BBBE71 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/MarkVillacampa/swift-snapshot-testing";
-			requirement = {
-				branch = "1.12.0-fix-test-observer";
-				kind = branch;
-			};
-		};
-		4DFF0D6F2B90A82900BBBE71 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/MarkVillacampa/swift-snapshot-testing";
-			requirement = {
-				branch = "1.12.0-fix-test-observer";
-				kind = branch;
-			};
-		};
 		4F6BEE0A2A27B02400CD9322 /* XCRemoteSwiftPackageReference "nimble" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/quick/nimble";
@@ -4967,6 +4923,14 @@
 			requirement = {
 				kind = upToNextMinorVersion;
 				minimumVersion = 10.0.0;
+			};
+		};
+		57E04739277260DE0082FE91 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.11.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -5007,41 +4971,6 @@
 			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
 			productName = OHHTTPStubsSwift;
 		};
-		4DCF76632B91E22E004F03B5 /* SnapshotTesting */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4DCF76622B91E21F004F03B5 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
-			productName = SnapshotTesting;
-		};
-		4DCF76652B91E235004F03B5 /* SnapshotTesting */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4DCF76622B91E21F004F03B5 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
-			productName = SnapshotTesting;
-		};
-		4DCF76672B91E23B004F03B5 /* SnapshotTesting */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4DCF76622B91E21F004F03B5 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
-			productName = SnapshotTesting;
-		};
-		4DCF76692B91E241004F03B5 /* SnapshotTesting */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4DCF76622B91E21F004F03B5 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
-			productName = SnapshotTesting;
-		};
-		4DFF0D512B90A4F300BBBE71 /* SnapshotTesting */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4DFF0D4E2B90A4D200BBBE71 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
-			productName = SnapshotTesting;
-		};
-		4DFF0D702B90A83200BBBE71 /* SnapshotTesting */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4DFF0D6F2B90A82900BBBE71 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
-			productName = SnapshotTesting;
-		};
-		4DFF0D762B90A84700BBBE71 /* SnapshotTesting */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4DFF0D6F2B90A82900BBBE71 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
-			productName = SnapshotTesting;
-		};
 		4F6BEE092A27B02400CD9322 /* Nimble */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 4F6BEE0A2A27B02400CD9322 /* XCRemoteSwiftPackageReference "nimble" */;
@@ -5057,10 +4986,25 @@
 			package = 4F6BEE0E2A27B02400CD9322 /* XCRemoteSwiftPackageReference "purchases-ios" */;
 			productName = RevenueCat_CustomEntitlementComputation;
 		};
+		4FCBA8502A153940004134BD /* SnapshotTesting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 57E04739277260DE0082FE91 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
+			productName = SnapshotTesting;
+		};
 		5759B335296DF65D002472D5 /* Nimble */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5759B336296DF65D002472D5 /* XCRemoteSwiftPackageReference "nimble" */;
 			productName = Nimble;
+		};
+		576C8ABD27D299860058FA6E /* SnapshotTesting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 57E04739277260DE0082FE91 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
+			productName = SnapshotTesting;
+		};
+		57E0473A277260DE0082FE91 /* SnapshotTesting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 57E04739277260DE0082FE91 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
+			productName = SnapshotTesting;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/RevenueCat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RevenueCat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -39,10 +39,10 @@
     {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/RevenueCat/swift-snapshot-testing",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "branch" : "1.12.0-fix-test-observer",
-        "revision" : "e789e15dae01529a40bcc20f727bd73b285ead1c"
+        "revision" : "26ed3a2b4a2df47917ca9b790a57f91285b923fb",
+        "version" : "1.12.0"
       }
     }
   ],

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -35,6 +35,7 @@ final class TestPurchaseDelegate: NSObject, PurchasesDelegate, Sendable {
 
 }
 
+@MainActor
 class BaseBackendIntegrationTests: TestCase {
 
     private var userDefaults: UserDefaults!
@@ -86,6 +87,7 @@ class BaseBackendIntegrationTests: TestCase {
 
     // MARK: -
 
+    @MainActor
     override func setUp() async throws {
         try await super.setUp()
 
@@ -245,6 +247,3 @@ extension BaseBackendIntegrationTests: InternalDangerousSettingsType {
     final func serverUp() { self.serverIsDown = false }
 
 }
-
-// `InternalDangerousSettingsType` requires this type to be Sendable
-extension BaseBackendIntegrationTests: @unchecked Sendable {}

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -23,6 +23,7 @@ import XCTest
 @testable import RevenueCat
 #endif
 
+@MainActor
 class BaseStoreKitIntegrationTests: BaseBackendIntegrationTests {
 
     private(set) var testSession: SKTestSession!

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -58,7 +58,7 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTes
             timeout: .seconds(5),
             pollInterval: .milliseconds(500)
         ) {
-            let entitlement = self.purchasesDelegate
+            let entitlement = await self.purchasesDelegate
                 .customerInfo?
                 .entitlements[Self.entitlementIdentifier]
 
@@ -108,7 +108,7 @@ class StoreKit1ObserverModeIntegrationTests: BaseStoreKitObserverModeIntegration
             timeout: .seconds(4),
             pollInterval: .milliseconds(100)
         ) {
-            self.purchasesDelegate.customerInfo?.entitlements.active.isEmpty == false
+            await self.purchasesDelegate.customerInfo?.entitlements.active.isEmpty == false
         }
 
         let customerInfo = try XCTUnwrap(self.purchasesDelegate.customerInfo)
@@ -142,7 +142,11 @@ class StoreKit1ObserverModeWithExistingPurchasesTests: BaseStoreKitObserverModeI
         super.setUp()
 
         Self.transactionsObservation?.cancel()
-        Self.transactionsObservation = Self.listenToTransactionUpdates()
+        Self.transactionsObservation = Task {
+            // Silence warning in tests:
+            // "Making a purchase without listening for transaction updates risks missing successful purchases.
+            for await _ in Transaction.updates {}
+        }
     }
 
     override class func tearDown() {
@@ -151,18 +155,6 @@ class StoreKit1ObserverModeWithExistingPurchasesTests: BaseStoreKitObserverModeI
 
         super.tearDown()
     }
-
-    // `nonisolated` required to work around Swift 5.10 issue.
-    // See https://github.com/RevenueCat/purchases-ios/pull/3599
-    private nonisolated static func listenToTransactionUpdates() -> Task<Void, Never> {
-        return Task {
-            // Silence warning in tests:
-            // "Making a purchase without listening for transaction updates risks missing successful purchases.
-            for await _ in Transaction.updates {}
-        }
-    }
-
-    // MARK: -
 
     override func setUp() async throws {
         // Not calling `super.setUp` so each test can

--- a/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
@@ -42,8 +42,7 @@ class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
 
     @MainActor
     func testReceiptParserParsesEmptyReceipt() async throws {
-        let receiptData = await self.receiptFetcher.receiptData(refreshPolicy: .always)
-        let data = try XCTUnwrap(receiptData)
+        let data = try await XCTAsyncUnwrap(await self.receiptFetcher.receiptData(refreshPolicy: .always))
 
         let receipt = try self.parser.parse(from: data)
 

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -70,8 +70,9 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
                         "com.revenuecat.annual_39.99.2_week_intro": IntroEligibilityStatus.eligible,
                         "lifetime": IntroEligibilityStatus.noIntroOfferExists]
 
-        let elegibilityResult = try await trialOrIntroPriceEligibilityChecker.sk2CheckEligibility(products)
-        let eligibilities = try XCTUnwrap(elegibilityResult)
+        let eligibilities = try await XCTAsyncUnwrap(
+            try await trialOrIntroPriceEligibilityChecker.sk2CheckEligibility(products)
+        )
         expect(eligibilities.count) == expected.count
 
         for (product, receivedEligibility) in eligibilities {

--- a/Tests/UnitTests/Misc/XCTestCase+Extensions.swift
+++ b/Tests/UnitTests/Misc/XCTestCase+Extensions.swift
@@ -25,8 +25,8 @@ import XCTest
 @MainActor
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 func XCTAsyncUnwrap<T: Sendable>(
-    _ expression: @autoclosure @Sendable () async throws -> T?,
-    _ message: @autoclosure @Sendable () -> String = "",
+    _ expression: @autoclosure () async throws -> T?,
+    _ message: @autoclosure () -> String = "",
     file: StaticString = #filePath,
     line: UInt = #line
 ) async throws -> T {


### PR DESCRIPTION
Reverts RevenueCat/purchases-ios#3603

I _think_ this is causing a bunch of failures in SK2 tests