### PR TITLE
PurchaseTester menubar app: debugging tools improvements

### DIFF
--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -141,4 +141,9 @@ extension AppleReceipt: CustomDebugStringConvertible {
         return (try? self.encodedJSON) ?? "<null>"
     }
 
+    /// swiftlint:disable:next missing_docs
+    public var prettyPrinted: String {
+        return (try? self.prettyPrintedJSON) ?? "<null>"
+    }
+
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
@@ -90,7 +90,7 @@ struct PurchaseTesterApp: App {
             }
         }
         .menuBarExtraStyle(.window)
-        .defaultSize(width: 800, height: 1000)
+        .defaultSize(width: 1200, height: 1000)
         #endif
 
     }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
@@ -5,6 +5,7 @@
 //  Created by Andrés Boedo on 1/25/23.
 //
 
+import Foundation
 import SwiftUI
 import ReceiptParser
 
@@ -13,8 +14,8 @@ import ReceiptParser
 struct ReceiptInspectorView: View {
 
     @State private var encodedReceipt: String = ""
-    @State private var parsedReceipt: String = ""
-    @State private var verifyReceiptResult: String = ""
+    @State private var parsedReceipt: String = "A JSON version of the parsed receipt will show up here."
+    @State private var verifyReceiptResult: String = "Results of calling /verifyReceipt will show up here."
     @State private var sharedSecret: String = ""
 
     var body: some View {
@@ -24,50 +25,37 @@ struct ReceiptInspectorView: View {
                 .padding()
 
             TextField("Enter receipt text here (base64 encoded)", text: $encodedReceipt, onEditingChanged: { isEditing in
-                    if !isEditing {
-                        Task {
-                            await inspectReceipt()
-                        }
+                if !isEditing {
+                    Task {
+                        await inspectReceipt()
                     }
-                })
-                    .textFieldStyle(.roundedBorder)
-                    .padding()
+                }
+            })
+            .textFieldStyle(.roundedBorder)
+            .padding()
 
             TextField("Enter shared secret here", text: $sharedSecret, onEditingChanged: { isEditing in
-                    if !isEditing {
-                        Task {
-                            await inspectReceipt()
-                        }
+                if !isEditing {
+                    Task {
+                        await inspectReceipt()
                     }
-                })
-                    .textFieldStyle(.roundedBorder)
-                    .padding()
-
-            Divider()
-            Text("Parsed Receipt")
-                .font(.title2)
-                .padding()
-
-            ScrollView {
-                Text(parsedReceipt)
-                    .padding()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .textSelection(.enabled)
-            }.frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            })
+            .textFieldStyle(.roundedBorder)
+            .padding()
 
             Divider()
 
-            Text("Verify Receipt")
-                .font(.title2)
-                .padding()
-            
-            ScrollView {
-                Text(verifyReceiptResult)
-                    .padding()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .textSelection(.enabled)
-            }.frame(maxWidth: .infinity, maxHeight: .infinity)
-        }.frame(minWidth: 800, maxWidth: .infinity, minHeight: 1000, maxHeight: .infinity, alignment: .center)
+            ReceiptInformationView(title: "Parsed Receipt", informationText: parsedReceipt)
+
+            Divider()
+
+            ReceiptInformationView(title: "SK1 Verify Receipt", informationText: verifyReceiptResult)
+
+        }
+        .frame(minWidth: 800, maxWidth: .infinity, minHeight: 1000, maxHeight: .infinity, alignment: .center)
+        .background(Color(red: 0.1, green: 0.1, blue: 0.1))
+
     }
 
     func inspectReceipt() async {
@@ -87,10 +75,57 @@ struct ReceiptInspectorView: View {
     }
 }
 
+struct ReceiptInformationView: View {
+
+    var title: String
+    var informationText: String
+
+    var body: some View {
+        VStack {
+            Text(title)
+                .font(.title2)
+                .padding()
+
+            ScrollView {
+                Text(informationText)
+                    .font(.system(.body, design: .monospaced))
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.black)
+                    .foregroundColor(.white)
+                    .textSelection(.enabled)
+            }.frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            CopyButton(textToCopy: informationText)
+        }
+    }
+
+}
+
+struct CopyButton: View {
+    
+    var textToCopy: String
+
+    var body: some View {
+        Button(action: {
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(textToCopy, forType: .string)
+        }) {
+            Image(systemName: "doc.on.doc")
+                .imageScale(.large)
+        }
+        .padding()
+    }
+
+}
+
 struct ReceiptInspectorView_Previews: PreviewProvider {
+
     static var previews: some View {
         ReceiptInspectorView()
     }
+
 }
 
 #endif

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
@@ -17,48 +17,72 @@ struct ReceiptInspectorView: View {
     @State private var parsedReceipt: String = "A JSON version of the parsed receipt will show up here."
     @State private var verifyReceiptResult: String = "Results of calling /verifyReceipt will show up here."
     @State private var sharedSecret: String = ""
+    
+    @State private var sk2AuthToken: String = ""
+    @State private var sk2AppConfigID: String = ""
+    @State private var sk2TransactionID: String = ""
+    @State private var sk2ReceiptResult: String = "Results of calling StoreKit 2 diagnostics will show up here."
 
     var body: some View {
         VStack {
-            Text("Receipt Parser")
-                .font(.title)
-                .padding()
+            HStack {
 
-            TextField("Enter receipt text here (base64 encoded)", text: $encodedReceipt, onEditingChanged: { isEditing in
-                if !isEditing {
-                    Task {
-                        await inspectReceipt()
+                VStack {
+                    Text("StoreKit 1 Receipt")
+                        .font(.title)
+                        .padding()
+
+                    InputTextField(placeholder: "Enter receipt text here (base64 encoded)", text: $encodedReceipt) {
+                        await processSK1Receipt()
+                    }
+
+                    InputTextField(placeholder: "Enter shared secret here", text: $sharedSecret) {
+                        await processSK1Receipt()
                     }
                 }
-            })
-            .textFieldStyle(.roundedBorder)
-            .padding()
 
-            TextField("Enter shared secret here", text: $sharedSecret, onEditingChanged: { isEditing in
-                if !isEditing {
-                    Task {
-                        await inspectReceipt()
+                Divider()
+                
+                VStack {
+                    Text("StoreKit 2 Receipt")
+                        .font(.title)
+                        .padding()
+
+                    InputTextField(placeholder: "Enter auth token here", text: $sk2AuthToken) {
+                        await processSK2Receipt()
+                    }
+
+                    InputTextField(placeholder: "Enter transaction ID here", text: $sk2TransactionID) {
+                        await processSK2Receipt()
+                    }
+                    
+                    InputTextField(placeholder: "Enter app config ID here", text: $sk2AppConfigID) {
+                        await processSK2Receipt()
                     }
                 }
-            })
-            .textFieldStyle(.roundedBorder)
-            .padding()
+            }
+
 
             Divider()
 
             ReceiptInformationView(title: "Parsed Receipt", informationText: parsedReceipt)
 
             Divider()
+            HStack {
+                ReceiptInformationView(title: "SK1 Verify Receipt", informationText: verifyReceiptResult)
 
-            ReceiptInformationView(title: "SK1 Verify Receipt", informationText: verifyReceiptResult)
+                Divider()
+                
+                ReceiptInformationView(title: "SK2 Transaction details", informationText: sk2ReceiptResult)
+            }
 
         }
-        .frame(minWidth: 800, maxWidth: .infinity, minHeight: 1000, maxHeight: .infinity, alignment: .center)
+        .frame(minWidth: 1200, maxWidth: .infinity, minHeight: 1000, maxHeight: .infinity, alignment: .center)
         .background(Color(red: 0.1, green: 0.1, blue: 0.1))
 
     }
 
-    func inspectReceipt() async {
+    func processSK1Receipt() async {
         do {
             guard !encodedReceipt.isEmpty else { return }
             // in kibana, receipts get encoded with extra `\`s
@@ -66,12 +90,36 @@ struct ReceiptInspectorView: View {
             // just in case you accidentally copied with extra double-quotations
             let receiptWithoutQuotations = receiptWithoutForwardSlashes.replacingOccurrences(of: "\"", with: "")
             parsedReceipt = try PurchasesReceiptParser.default.parse(base64String: receiptWithoutQuotations).prettyPrinted
-            verifyReceiptResult = await ReceiptVerifier().verifyReceipt(base64Encoded: receiptWithoutQuotations,
-                                                                        sharedSecret: sharedSecret)
+            verifyReceiptResult = await StoreKit1ReceiptVerifier().verifyReceipt(base64Encoded: receiptWithoutQuotations,
+                                                                                 sharedSecret: sharedSecret)
         } catch {
             parsedReceipt = "Couldn't decode receipt. Error:\n\(error)"
             verifyReceiptResult = ""
         }
+    }
+
+    func processSK2Receipt() async {
+        sk2ReceiptResult = await StoreKit2ReceiptVerifier().fetchSK2Diagnostics(appConfigID: sk2AppConfigID,
+                                                                                transactionID: sk2TransactionID,
+                                                                                token: sk2AuthToken)
+    }
+}
+
+struct InputTextField: View {
+    var placeholder: String
+    @Binding var text: String
+    let onEditingChanged: () async -> Void
+
+    var body: some View {
+        TextField(placeholder, text: $text, onEditingChanged: { isEditing in
+            if !isEditing {
+                Task {
+                    await onEditingChanged()
+                }
+            }
+        })
+        .textFieldStyle(.roundedBorder)
+        .padding()
     }
 }
 
@@ -103,7 +151,7 @@ struct ReceiptInformationView: View {
 }
 
 struct CopyButton: View {
-    
+
     var textToCopy: String
 
     var body: some View {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
@@ -77,11 +77,12 @@ struct ReceiptInspectorView: View {
             let receiptWithoutForwardSlashes = encodedReceipt.replacingOccurrences(of: "\\", with: "")
             // just in case you accidentally copied with extra double-quotations
             let receiptWithoutQuotations = receiptWithoutForwardSlashes.replacingOccurrences(of: "\"", with: "")
-            parsedReceipt = try PurchasesReceiptParser.default.parse(base64String: receiptWithoutQuotations).debugDescription
+            parsedReceipt = try PurchasesReceiptParser.default.parse(base64String: receiptWithoutQuotations).prettyPrinted
             verifyReceiptResult = await ReceiptVerifier().verifyReceipt(base64Encoded: receiptWithoutQuotations,
                                                                         sharedSecret: sharedSecret)
         } catch {
             parsedReceipt = "Couldn't decode receipt. Error:\n\(error)"
+            verifyReceiptResult = ""
         }
     }
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/StoreKit1ReceiptVerifier.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/StoreKit1ReceiptVerifier.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ReceiptVerifier {
+struct StoreKit1ReceiptVerifier {
 
     private static let errorMessagesByCode = [
         21000: "The App Store could not read the JSON object you provided.",

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/StoreKit2ReceiptVerifier.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/StoreKit2ReceiptVerifier.swift
@@ -1,0 +1,31 @@
+//
+//  StoreKit2ReceiptInspector.swift
+//  PurchaseTester
+//
+//  Created by Andrés Boedo on 3/6/24.
+//
+
+import Foundation
+
+struct StoreKit2ReceiptVerifier {
+
+    func fetchSK2Diagnostics(appConfigID: String, transactionID: String, token: String) async -> String {
+        guard let url = URL(string: "https://api.revenuecat.com/toolkit/v1/app_configs/\(appConfigID)/sk2_diagnostics/\(transactionID)") else {
+            return "Malformed URL!"
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        do {
+            let (data, _) = try await URLSession.shared.data(for: request)
+            let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
+            let prettyData = try JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted)
+            return String(data: prettyData, encoding: .utf8) ?? "Error when decoding data into json. Data: \(data)"
+        } catch {
+            return "Fetching receipt information failed for transaction \(transactionID).\nError: \(error.localizedDescription)"
+        }
+    }
+
+}


### PR DESCRIPTION
Made a few improvements to the menubar app while debugging an issue today, namely: 

- Added a button to copy the output to clipboard
- Cleaned up the UI
- Added a section for SK2 so we can pass in an app config id, token and transaction id and easily debug the contents. 