### PR TITLE
RevenueCatUI: fade in Loading view

### DIFF
--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -22,6 +22,7 @@ import SwiftUI
 @available(tvOS, unavailable)
 @MainActor
 struct LoadingPaywallView: View {
+    @State private var opacity = 1.0
 
     var mode: PaywallViewMode
     var displayCloseButton: Bool
@@ -55,6 +56,13 @@ struct LoadingPaywallView: View {
                 blurred: true,
                 ignoreSafeArea: self.mode.shouldDisplayBackground
             )
+        }
+        // fade in when loading for the first time
+        .overlay(Self.defaultPaywall.config.colors.multiScheme.backgroundColor.opacity(opacity))
+        .onAppear {
+            withAnimation(.easeOut(duration: 1)) {
+                opacity = 0
+            }
         }
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
@@ -22,7 +22,7 @@ struct UpsellView: View {
         .padding()
         .presentPaywallIfNeeded(
             requiredEntitlementIdentifier: Configuration.entitlement,
-            purchaseStarted: {
+            purchaseStarted: { _ in
                 print("Purchase started")
             },
             purchaseCompleted: { _ in
@@ -31,17 +31,17 @@ struct UpsellView: View {
             purchaseCancelled: {
                 print("Purchase cancelled")
             },
-            onDismiss: {
-                print("Paywall dismissed")
-            },
-            onRestoreCompleted: { _ in
-                print("Restore completed")
-            },
-            onRestoreStarted: {
+            restoreStarted: {
                 print("Restore started")
             },
-            onRestoreFailure: {
+            restoreCompleted: { _ in
+                print("Restore completed")
+            },
+            restoreFailure: { _ in
                 print("Restore failed")
+            },
+            onDismiss: {
+                print("Paywall dismissed")
             }
         )
     }


### PR DESCRIPTION
This is a proposal, just adding a fade-in effect when first showing the loading view. 

I'll get a screen recording of it, but the idea is that since the placeholder view still won't match the actual paywall, and it can lead to perceived "flicker" when it's too fast to really see the placeholder but too slow for it not to show up, maybe the fade makes things a bit smoother. 

Still need to try it out more though. 