### PR TITLE
Add auto sync of custom attributes with `CustomAttributesManager`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */; };
 		2C7F0AD32B8EEB4600381179 /* RateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */; };
 		2C7F0AD62B8EEF7B00381179 /* RateLimiterRests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */; };
+		2C84C1512B9AC837002BF4EF /* CustomAttributesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C84C1502B9AC837002BF4EF /* CustomAttributesManager.swift */; };
 		2CB8CF9327BF538F00C34DE3 /* PlatformInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */; };
 		2CD2C544278CE0E0005D1CC2 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 2CD2C541278CE0E0005D1CC2 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit */; };
 		2CD72942268A823900BFC976 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72941268A823900BFC976 /* Data+Extensions.swift */; };
@@ -836,6 +837,7 @@
 		2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesSyncAttributesAndOfferingsIfNeededTests.swift; sourceTree = "<group>"; };
 		2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiter.swift; sourceTree = "<group>"; };
 		2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiterRests.swift; sourceTree = "<group>"; };
+		2C84C1502B9AC837002BF4EF /* CustomAttributesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAttributesManager.swift; sourceTree = "<group>"; };
 		2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfo.swift; sourceTree = "<group>"; };
 		2CD2C541278CE0E0005D1CC2 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; name = RevenueCat_IntegrationPurchaseTesterConfiguration.storekit; path = Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit; sourceTree = SOURCE_ROOT; };
 		2CD72941268A823900BFC976 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
@@ -2160,6 +2162,7 @@
 			children = (
 				35F82BB526A9B8030051DF03 /* AttributionDataMigrator.swift */,
 				354895D3267AE4B4001DC5B1 /* AttributionKey.swift */,
+				2C84C1502B9AC837002BF4EF /* CustomAttributesManager.swift */,
 				354895D5267BEDE3001DC5B1 /* ReservedSubscriberAttributes.swift */,
 				B39E811C268E887500D31189 /* SubscriberAttribute.swift */,
 				A525BF4A26C320D100C354C4 /* SubscriberAttributesManager.swift */,
@@ -3582,6 +3585,7 @@
 				574A2F4B282D7AEA00150D40 /* PostOfferResponse.swift in Sources */,
 				F575858D26C088FE00C12B97 /* OfferingsManager.swift in Sources */,
 				B34605CB279A6E380031CA74 /* PostReceiptDataOperation.swift in Sources */,
+				2C84C1512B9AC837002BF4EF /* CustomAttributesManager.swift in Sources */,
 				4FFCED882AA941D200118EF4 /* PaywallEventsRequest.swift in Sources */,
 				354895D4267AE4B4001DC5B1 /* AttributionKey.swift in Sources */,
 				F5714EA826D7A83A00635477 /* Store+Extensions.swift in Sources */,

--- a/Sources/CustomAttributes/CustomAttributesManager.swift
+++ b/Sources/CustomAttributes/CustomAttributesManager.swift
@@ -1,0 +1,129 @@
+//
+//  CustomAttributesManager.swift
+//  
+//
+//  Created by Josh Holtz on 3/7/24.
+//
+
+import Foundation
+
+class CustomAttributesManager {
+    private let manualRateLimiter = RateLimiter(maxCalls: 5, period: 60)
+    private let automaticRateLimiter = RateLimiter(maxCalls: 5, period: 60)
+
+    let offeringsManager: OfferingsManager
+
+    init(offeringsManager: OfferingsManager) {
+        self.offeringsManager = offeringsManager
+    }
+
+    func syncAttributesAndOfferingsIfNeeded(
+        appUserID: String,
+        attribution: Attribution,
+        subscriberAttributionsManager: SubscriberAttributesManager,
+        completion: @escaping (Offerings?, PublicError?) -> Void
+    ) {
+        guard manualRateLimiter.shouldProceed() else {
+            Logger.warn(
+                Strings.identity.sync_attributes_and_offerings_rate_limit_reached(
+                    maxCalls: manualRateLimiter.maxCalls,
+                    period: Int(manualRateLimiter.period)
+                )
+            )
+            self.getOfferings(appUserID: appUserID, fetchPolicy: .default, completion: completion)
+            return
+        }
+
+        self.syncSubscriberAttributes(
+            appUserID: appUserID,
+            attribution: attribution,
+            completion: {
+            self.getOfferings(appUserID: appUserID, fetchPolicy: .default, fetchCurrent: true, completion: completion)
+        })
+    }
+
+    func syncCustomAttributesAndOfferingsIfNeeded(
+        appUserID: String,
+        attribution: Attribution,
+        subscriberAttributionsManager: SubscriberAttributesManager
+    ) {
+        let hasUnsyncedCustomAttributes = self.hasUnsyncedCustomAttributes(
+            appUserID: appUserID,
+            attribution: attribution,
+            subscriberAttributionsManager: subscriberAttributionsManager
+        )
+
+        if hasUnsyncedCustomAttributes {
+            guard automaticRateLimiter.shouldProceed() else {
+                Logger.warn(
+                    Strings.identity.sync_custom_attributes_rate_limit_reached(
+                        maxCalls: manualRateLimiter.maxCalls,
+                        period: Int(manualRateLimiter.period)
+                    )
+                )
+                return
+            }
+
+            // TODO: Determine if we want to sync all or just the ones we need
+            self.syncAttributesAndOfferingsIfNeeded(
+                appUserID: appUserID,
+                attribution: attribution,
+                subscriberAttributionsManager: subscriberAttributionsManager) { offerings, error in
+                    print("here")
+                }
+        }
+    }
+
+}
+
+private extension CustomAttributesManager {
+    func hasUnsyncedCustomAttributes(
+        appUserID: String,
+        attribution: Attribution,
+        subscriberAttributionsManager: SubscriberAttributesManager
+    ) -> Bool {
+        guard let customAttributes = self.offeringsManager.cachedOfferings?.targeting?.customAttributes else {
+            return false
+        }
+
+        let unsyncedKeys = attribution.unsyncedAttributesByKey(appUserID: appUserID).keys
+        guard !unsyncedKeys.isEmpty else {
+            return false
+        }
+
+        let saltedAndHashedKeys = Set(unsyncedKeys.map { key in
+            return "\(customAttributes.salt)\(key)".asData.hashString
+        })
+
+        let intersect = saltedAndHashedKeys.intersection(Set(customAttributes.keys))
+
+        return !intersect.isEmpty
+    }
+
+    func getOfferings(
+        appUserID: String,
+        fetchPolicy: OfferingsManager.FetchPolicy,
+        fetchCurrent: Bool = false,
+        completion: @escaping (Offerings?, PublicError?) -> Void
+    ) {
+        self.offeringsManager.offerings(appUserID: appUserID,
+                                        fetchPolicy: fetchPolicy,
+                                        fetchCurrent: fetchCurrent) { @Sendable result in
+            completion(result.value, result.error?.asPublicError)
+        }
+    }
+
+    @discardableResult
+    func syncSubscriberAttributes(
+        appUserID: String,
+        attribution: Attribution,
+        syncedAttribute: (@Sendable (PublicError?) -> Void)? = nil,
+        completion: (@Sendable () -> Void)? = nil
+    ) -> Int {
+        return attribution.syncAttributesForAllUsers(
+            currentAppUserID: appUserID,
+            syncedAttribute: { @Sendable in syncedAttribute?($0?.asPublicError) },
+            completion: completion
+        )
+    }
+}

--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -42,6 +42,8 @@ enum IdentityStrings {
 
     case sync_attributes_and_offerings_rate_limit_reached(maxCalls: Int, period: Int)
 
+    case sync_custom_attributes_rate_limit_reached(maxCalls: Int, period: Int)
+
 }
 
 extension IdentityStrings: LogMessage {
@@ -80,6 +82,9 @@ extension IdentityStrings: LogMessage {
         case let .sync_attributes_and_offerings_rate_limit_reached(maxCalls, period):
             return "Sync attributes and offerings rate limit reached:\(maxCalls) per \(period) seconds. " +
             "Returning offerings from cache."
+        case let .sync_custom_attributes_rate_limit_reached(maxCalls, period):
+            return "Automatic sync of custom attributes rate limit reached:\(maxCalls) per \(period) seconds. " +
+            "Sync manually or on app backgrouned or foregrounded."
         }
     }
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -222,7 +222,7 @@ private extension HTTPClient {
             self.httpRequest = httpRequest.requestAddingNonceIfRequired(with: verificationMode)
             self.headers = self.httpRequest.headers(
                 with: authHeaders,
-                defaultHeaders: defaultHeaders,
+                defaultHeaders: defaultHeaders + httpRequest.additionalHeaders,
                 verificationMode: verificationMode,
                 internalSettings: internalSettings
             )

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -22,22 +22,24 @@ struct HTTPRequest {
     var path: HTTPRequestPath
     /// If present, this will be used by the server to compute a checksum of the response signed with a private key.
     var nonce: Data?
+    var additionalHeaders: Headers
 
-    init(method: Method, path: HTTPRequest.Path, nonce: Data? = nil) {
-        self.init(method: method, requestPath: path, nonce: nonce)
+    init(method: Method, path: HTTPRequest.Path, nonce: Data? = nil, additionalHeaders: Headers = [:]) {
+        self.init(method: method, requestPath: path, nonce: nonce, additionalHeaders: additionalHeaders)
     }
 
-    init(method: Method, path: HTTPRequest.PaywallPath, nonce: Data? = nil) {
-        self.init(method: method, requestPath: path, nonce: nonce)
+    init(method: Method, path: HTTPRequest.PaywallPath, nonce: Data? = nil, additionalHeaders: Headers = [:]) {
+        self.init(method: method, requestPath: path, nonce: nonce, additionalHeaders: additionalHeaders)
     }
 
-    private init(method: Method, requestPath: HTTPRequestPath, nonce: Data? = nil) {
+    private init(method: Method, requestPath: HTTPRequestPath, nonce: Data? = nil, additionalHeaders: Headers = [:]) {
         assert(nonce == nil || nonce?.count == Data.nonceLength,
                "Invalid nonce: \(nonce?.description ?? "")")
 
         self.method = method
         self.path = requestPath
         self.nonce = nonce
+        self.additionalHeaders = additionalHeaders
     }
 
 }

--- a/Sources/Networking/OfferingsAPI.swift
+++ b/Sources/Networking/OfferingsAPI.swift
@@ -29,11 +29,13 @@ class OfferingsAPI {
 
     func getOfferings(appUserID: String,
                       isAppBackgrounded: Bool,
+                      fetchReason: String?,
                       completion: @escaping OfferingsResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)
         let factory = GetOfferingsOperation.createFactory(
             configuration: config,
+            fetchReason: fetchReason,
             offeringsCallbackCache: self.offeringsCallbacksCache
         )
 

--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -43,8 +43,15 @@ struct OfferingsResponse {
     }
 
     struct Targeting {
+
+        struct CustomAttributes {
+            let salt: String
+            let keys: [String]
+        }
+
         let revision: Int
         let ruleId: String
+        let customAttributes: CustomAttributes?
     }
 
     let currentOfferingId: String?
@@ -69,6 +76,7 @@ extension OfferingsResponse {
 extension OfferingsResponse.Offering.Package: Codable, Equatable {}
 extension OfferingsResponse.Offering: Codable, Equatable {}
 extension OfferingsResponse.Placements: Codable, Equatable {}
+extension OfferingsResponse.Targeting.CustomAttributes: Codable, Equatable {}
 extension OfferingsResponse.Targeting: Codable, Equatable {}
 extension OfferingsResponse: Codable, Equatable {}
 

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -34,8 +34,14 @@ import Foundation
     }
 
     internal struct Targeting {
+        internal struct CustomAttributes {
+            let salt: String
+            let keys: [String]
+        }
+
         let revision: Int
         let ruleId: String
+        let customAttributes: CustomAttributes?
     }
 
     /**
@@ -59,7 +65,7 @@ import Foundation
 
     private let currentOfferingID: String?
     private let placements: Placements?
-    private let targeting: Targeting?
+    internal let targeting: Targeting?
 
     init(
         offerings: [String: Offering],

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -14,6 +14,8 @@
 
 import Foundation
 
+// swiftlint:disable nesting
+
 /**
  * This class contains all the offerings configured in RevenueCat dashboard.
  * Offerings let you control which products are shown to users without requiring an app update.
@@ -34,6 +36,7 @@ import Foundation
     }
 
     internal struct Targeting {
+
         internal struct CustomAttributes {
             let salt: String
             let keys: [String]

--- a/Sources/Purchasing/OfferingsFactory.swift
+++ b/Sources/Purchasing/OfferingsFactory.swift
@@ -29,10 +29,11 @@ class OfferingsFactory {
             return nil
         }
 
+        // TOOD: Add custom attribute logichere
         return Offerings(offerings: offerings,
                          currentOfferingID: data.currentOfferingId,
                          placements: createPlacement(with: data.placements),
-                         targeting: data.targeting.flatMap { .init(revision: $0.revision, ruleId: $0.ruleId) },
+                         targeting: createTargeting(with: data.targeting),
                          response: data)
     }
 
@@ -79,6 +80,28 @@ class OfferingsFactory {
 
         return .init(fallbackOfferingId: data.fallbackOfferingId,
                      offeringIdsByPlacement: data.offeringIdsByPlacement)
+    }
+
+    func createTargeting(
+        with targeting: OfferingsResponse.Targeting?
+    ) -> Offerings.Targeting? {
+        guard let targeting else {
+            return nil
+        }
+
+        return .init(revision: targeting.revision,
+                     ruleId: targeting.ruleId,
+                     customAttributes: createCustomAttributes(with: targeting.customAttributes))
+    }
+
+    func createCustomAttributes(
+        with customAttributes: OfferingsResponse.Targeting.CustomAttributes?
+    ) -> Offerings.Targeting.CustomAttributes? {
+        guard let customAttributes else {
+            return nil
+        }
+
+        return .init(salt: customAttributes.salt, keys: customAttributes.keys)
     }
 }
 

--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -401,10 +401,10 @@ extension Attribution: @unchecked Sendable {}
 
 extension Attribution: SubscriberAttributesManagerDelegate {
 
-    func subscriberAttributesManagerSetAttribute(
+    func subscriberAttributesManager(
         _ manager: SubscriberAttributesManager,
-        key: String,
-        value: String?,
+        didSetAttribute key: String,
+        withValue value: String?,
         forUserID userID: String
     ) {
         self.customAttributesManager.syncCustomAttributesAndOfferingsIfNeeded(
@@ -419,7 +419,6 @@ extension Attribution: SubscriberAttributesManagerDelegate {
         didFinishSyncingAttributes attributes: SubscriberAttribute.Dictionary,
         forUserID userID: String
     ) {
-        // TODO: Do stuff here
         self.delegate?.attribution(didFinishSyncingAttributes: attributes, forUserID: userID)
     }
 
@@ -469,7 +468,6 @@ extension Attribution {
     func syncAttributesForAllUsers(currentAppUserID: String,
                                    syncedAttribute: (@Sendable (PurchasesError?) -> Void)? = nil,
                                    completion: (@Sendable () -> Void)? = nil) -> Int {
-        // TODO: Add logic here to also sync custom attributes
         self.subscriberAttributesManager.syncAttributesForAllUsers(currentAppUserID: currentAppUserID,
                                                                    syncedAttribute: syncedAttribute,
                                                                    completion: completion)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -703,12 +703,12 @@ public extension Purchases {
 
     internal func getOfferings(
         fetchPolicy: OfferingsManager.FetchPolicy,
-        fetchCurrent: Bool = false,
+        fetchBehavior: OfferingsManager.FetchBehavior = .cachedOrFetched,
         completion: @escaping (Offerings?, PublicError?) -> Void
     ) {
         self.offeringsManager.offerings(appUserID: self.appUserID,
                                         fetchPolicy: fetchPolicy,
-                                        fetchCurrent: fetchCurrent) { @Sendable result in
+                                        fetchBehavior: fetchBehavior) { @Sendable result in
             completion(result.value, result.error?.asPublicError)
         }
     }
@@ -1369,11 +1369,11 @@ public extension Purchases {
     @objc(configureInCustomEntitlementsModeWithApiKey:appUserID:)
     @discardableResult static func configureInCustomEntitlementsComputationMode(apiKey: String,
                                                                                 appUserID: String) -> Purchases {
-        Self.configure(
-            with: .builder(withAPIKey: apiKey)
-                .with(appUserID: appUserID)
-                .with(dangerousSettings: DangerousSettings(customEntitlementComputation: true))
-                .build())
+Self.configure(
+    with: .builder(withAPIKey: apiKey)
+        .with(appUserID: appUserID)
+        .with(dangerousSettings: DangerousSettings(customEntitlementComputation: true))
+        .build())
     }
 
     #endif
@@ -1798,7 +1798,8 @@ private extension Purchases {
     private func updateOfferingsCache(isAppBackgrounded: Bool) {
         self.offeringsManager.updateOfferingsCache(
             appUserID: self.appUserID,
-            isAppBackgrounded: isAppBackgrounded
+            isAppBackgrounded: isAppBackgrounded,
+            fetchReason: nil
         ) { [cache = self.paywallCache] offerings in
             if #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *),
                let cache = cache, let offerings = offerings.value {

--- a/Sources/SubscriberAttributes/CustomAttributesManager.swift
+++ b/Sources/SubscriberAttributes/CustomAttributesManager.swift
@@ -64,12 +64,11 @@ class CustomAttributesManager {
                 return
             }
 
-            // TODO: Determine if we want to sync all or just the ones we need
             self.syncAttributesAndOfferingsIfNeeded(
                 appUserID: appUserID,
                 attribution: attribution,
-                subscriberAttributionsManager: subscriberAttributionsManager) { offerings, error in
-                    print("here")
+                subscriberAttributionsManager: subscriberAttributionsManager) { _, _ in
+
                 }
         }
     }

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -263,10 +263,10 @@ private extension SubscriberAttributesManager {
 
     func setAttribute(key: String, value: String?, appUserID: String) {
         storeAttributeLocallyIfNeeded(key: key, value: value, appUserID: appUserID)
-        self.delegate?.subscriberAttributesManagerSetAttribute(self, 
-                                                               key: key,
-                                                               value: value,
-                                                               forUserID: appUserID)
+        self.delegate?.subscriberAttributesManager(self,
+                                                   didSetAttribute: key,
+                                                   withValue: value,
+                                                   forUserID: appUserID)
     }
 
     func syncAttributes(attributes: SubscriberAttribute.Dictionary,
@@ -311,10 +311,10 @@ extension SubscriberAttributesManager: @unchecked Sendable {}
 
 protocol SubscriberAttributesManagerDelegate: AnyObject, Sendable {
 
-    func subscriberAttributesManagerSetAttribute(_ manager: SubscriberAttributesManager,
-                                                 key: String,
-                                                 value: String?,
-                                                 forUserID userID: String)
+    func subscriberAttributesManager(_ manager: SubscriberAttributesManager,
+                                     didSetAttribute key: String,
+                                     withValue value: String?,
+                                     forUserID userID: String)
 
     func subscriberAttributesManager(_ manager: SubscriberAttributesManager,
                                      didFinishSyncingAttributes attributes: SubscriberAttribute.Dictionary,

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -263,6 +263,10 @@ private extension SubscriberAttributesManager {
 
     func setAttribute(key: String, value: String?, appUserID: String) {
         storeAttributeLocallyIfNeeded(key: key, value: value, appUserID: appUserID)
+        self.delegate?.subscriberAttributesManagerSetAttribute(self, 
+                                                               key: key,
+                                                               value: value,
+                                                               forUserID: appUserID)
     }
 
     func syncAttributes(attributes: SubscriberAttribute.Dictionary,
@@ -306,6 +310,11 @@ extension SubscriberAttributesManager: @unchecked Sendable {}
 // MARK: -
 
 protocol SubscriberAttributesManagerDelegate: AnyObject, Sendable {
+
+    func subscriberAttributesManagerSetAttribute(_ manager: SubscriberAttributesManager,
+                                                 key: String,
+                                                 value: String?,
+                                                 forUserID userID: String)
 
     func subscriberAttributesManager(_ manager: SubscriberAttributesManager,
                                      didFinishSyncingAttributes attributes: SubscriberAttribute.Dictionary,

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -33,6 +33,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     private var customerInfoManager: MockCustomerInfoManager!
     private var paymentQueueWrapper: EitherPaymentQueueWrapper!
     private var backend: MockBackend!
+    private var customAttributesManager: CustomAttributesManager!
     private var offerings: MockOfferingsAPI!
     private var currentUserProvider: MockCurrentUserProvider!
     private var transactionsManager: MockTransactionsManager!
@@ -69,6 +70,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                          backend: self.backend,
                                                          offeringsFactory: OfferingsFactory(),
                                                          productsManager: self.productsManager)
+        self.customAttributesManager = CustomAttributesManager(offeringsManager: self.mockOfferingsManager)
         self.setUpStoreKit1Wrapper()
 
         self.customerInfoManager = MockCustomerInfoManager(
@@ -147,7 +149,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         self.attribution = Attribution(subscriberAttributesManager: self.subscriberAttributesManager,
                                        currentUserProvider: MockCurrentUserProvider(mockAppUserID: Self.mockUserID),
                                        attributionPoster: attributionPoster,
-                                       systemInfo: self.systemInfo)
+                                       systemInfo: self.systemInfo,
+                                       customAttributesManager: self.customAttributesManager)
     }
 
     fileprivate func setUpOrchestrator() {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -16,6 +16,12 @@
 		2C10F19427AC319A0078444D /* EntitlementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C10F19327AC319A0078444D /* EntitlementsView.swift */; };
 		2C10F19727AC31B80078444D /* CustomerInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C10F19627AC31B80078444D /* CustomerInfoView.swift */; };
 		2C10F19A27AC32840078444D /* SubscriberAttributesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C10F19927AC32840078444D /* SubscriberAttributesView.swift */; };
+		2C84C13F2B9A47F7002BF4EF /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 2C84C13E2B9A47F7002BF4EF /* RevenueCat */; };
+		2C84C1412B9A47FB002BF4EF /* ReceiptParser in Frameworks */ = {isa = PBXBuildFile; productRef = 2C84C1402B9A47FB002BF4EF /* ReceiptParser */; };
+		2C84C1432B9A4800002BF4EF /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 2C84C1422B9A4800002BF4EF /* RevenueCat */; };
+		2C84C1452B9A4805002BF4EF /* ReceiptParser in Frameworks */ = {isa = PBXBuildFile; productRef = 2C84C1442B9A4805002BF4EF /* ReceiptParser */; };
+		2C84C1472B9A480B002BF4EF /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 2C84C1462B9A480B002BF4EF /* RevenueCat */; };
+		2C84C1492B9A480E002BF4EF /* ReceiptParser in Frameworks */ = {isa = PBXBuildFile; productRef = 2C84C1482B9A480E002BF4EF /* ReceiptParser */; };
 		2CD2C516278C9B02005D1CC2 /* PurchaseTesterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2C4EE278C9B01005D1CC2 /* PurchaseTesterApp.swift */; };
 		2CD2C518278C9B02005D1CC2 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2C4EF278C9B01005D1CC2 /* ContentView.swift */; };
 		2CD2C51A278C9B02005D1CC2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2CD2C4F0278C9B02005D1CC2 /* Assets.xcassets */; };
@@ -32,11 +38,6 @@
 		575642A4290C7A2700719219 /* LoggerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A3290C7A2700719219 /* LoggerView.swift */; };
 		575642A6290C7D3100719219 /* Windows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A5290C7D3100719219 /* Windows.swift */; };
 		5759B472296F9B3B002472D5 /* LocalReceiptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B471296F9B3B002472D5 /* LocalReceiptView.swift */; };
-		5759B47529707153002472D5 /* ReceiptParser in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B47429707153002472D5 /* ReceiptParser */; };
-		5759B47729707153002472D5 /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B47629707153002472D5 /* RevenueCat */; };
-		5759B479297071AE002472D5 /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B478297071AE002472D5 /* RevenueCat */; };
-		5759B47D297077B1002472D5 /* ReceiptParser in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B47C297077B1002472D5 /* ReceiptParser */; };
-		5759B47F297077B1002472D5 /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B47E297077B1002472D5 /* RevenueCat */; };
 		578DAA0C2947DD21001700FD /* PurchaseTesterWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578DAA0B2947DD21001700FD /* PurchaseTesterWatchApp.swift */; };
 		578DAA0E2947DD21001700FD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578DAA0D2947DD21001700FD /* ContentView.swift */; };
 		578DAA102947DD21001700FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 578DAA0F2947DD21001700FD /* Assets.xcassets */; };
@@ -129,6 +130,7 @@
 		2C10F19327AC319A0078444D /* EntitlementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementsView.swift; sourceTree = "<group>"; };
 		2C10F19627AC31B80078444D /* CustomerInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoView.swift; sourceTree = "<group>"; };
 		2C10F19927AC32840078444D /* SubscriberAttributesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributesView.swift; sourceTree = "<group>"; };
+		2C84C13D2B9A47EC002BF4EF /* purchases-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "purchases-ios"; path = ../../..; sourceTree = "<group>"; };
 		2C8C610427C5206D00F86F21 /* RevenueCat_SwiftUIConfiguration.storekit */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RevenueCat_SwiftUIConfiguration.storekit; sourceTree = "<group>"; };
 		2C8C610D27CEBEF200F86F21 /* PurchaseTester-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "PurchaseTester-Info.plist"; sourceTree = "<group>"; };
 		2CCAF2AB286232EB0004E2CA /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -173,9 +175,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5759B47529707153002472D5 /* ReceiptParser in Frameworks */,
+				2C84C1412B9A47FB002BF4EF /* ReceiptParser in Frameworks */,
+				2C84C13F2B9A47F7002BF4EF /* RevenueCat in Frameworks */,
 				578DAA262947DD8C001700FD /* Core.framework in Frameworks */,
-				5759B47729707153002472D5 /* RevenueCat in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -183,9 +185,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5759B47D297077B1002472D5 /* ReceiptParser in Frameworks */,
+				2C84C1452B9A4805002BF4EF /* ReceiptParser in Frameworks */,
+				2C84C1432B9A4800002BF4EF /* RevenueCat in Frameworks */,
 				578DAA322947E256001700FD /* Core.framework in Frameworks */,
-				5759B47F297077B1002472D5 /* RevenueCat in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -193,7 +195,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5759B479297071AE002472D5 /* RevenueCat in Frameworks */,
+				2C84C1492B9A480E002BF4EF /* ReceiptParser in Frameworks */,
+				2C84C1472B9A480B002BF4EF /* RevenueCat in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -239,6 +242,7 @@
 		2CD2C4E8278C9B01005D1CC2 = {
 			isa = PBXGroup;
 			children = (
+				2C84C13D2B9A47EC002BF4EF /* purchases-ios */,
 				4FDA13862A33DBE300C45CFE /* PrivacyInfo.xcprivacy */,
 				57FA0F7C2908503B00E9EA1B /* PurchaseTester.entitlements */,
 				2C8C610D27CEBEF200F86F21 /* PurchaseTester-Info.plist */,
@@ -373,8 +377,8 @@
 			);
 			name = PurchaseTester;
 			packageProductDependencies = (
-				5759B47429707153002472D5 /* ReceiptParser */,
-				5759B47629707153002472D5 /* RevenueCat */,
+				2C84C13E2B9A47F7002BF4EF /* RevenueCat */,
+				2C84C1402B9A47FB002BF4EF /* ReceiptParser */,
 			);
 			productName = "PurchaseTester (iOS)";
 			productReference = 2CD2C4F5278C9B02005D1CC2 /* PurchaseTester.app */;
@@ -396,8 +400,8 @@
 			);
 			name = PurchaseTesterWatchOS;
 			packageProductDependencies = (
-				5759B47C297077B1002472D5 /* ReceiptParser */,
-				5759B47E297077B1002472D5 /* RevenueCat */,
+				2C84C1422B9A4800002BF4EF /* RevenueCat */,
+				2C84C1442B9A4805002BF4EF /* ReceiptParser */,
 			);
 			productName = "PurchaseTesterWatchOS Watch App";
 			productReference = 578DAA092947DD21001700FD /* PurchaseTesterWatchOS.app */;
@@ -418,7 +422,8 @@
 			);
 			name = Core;
 			packageProductDependencies = (
-				5759B478297071AE002472D5 /* RevenueCat */,
+				2C84C1462B9A480B002BF4EF /* RevenueCat */,
+				2C84C1482B9A480E002BF4EF /* ReceiptParser */,
 			);
 			productName = Core;
 			productReference = 578DAA202947DD8C001700FD /* Core.framework */;
@@ -455,7 +460,6 @@
 			);
 			mainGroup = 2CD2C4E8278C9B01005D1CC2;
 			packageReferences = (
-				5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */,
 			);
 			productRefGroup = 2CD2C4F6278C9B02005D1CC2 /* Products */;
 			projectDirPath = "";
@@ -978,14 +982,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/RevenueCat/purchases-ios";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
 		577E0E3B29159A8B0071E063 /* XCRemoteSwiftPackageReference "purchases-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios";
@@ -997,30 +993,29 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		5759B47429707153002472D5 /* ReceiptParser */ = {
+		2C84C13E2B9A47F7002BF4EF /* RevenueCat */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */;
+			productName = RevenueCat;
+		};
+		2C84C1402B9A47FB002BF4EF /* ReceiptParser */ = {
+			isa = XCSwiftPackageProductDependency;
 			productName = ReceiptParser;
 		};
-		5759B47629707153002472D5 /* RevenueCat */ = {
+		2C84C1422B9A4800002BF4EF /* RevenueCat */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */;
 			productName = RevenueCat;
 		};
-		5759B478297071AE002472D5 /* RevenueCat */ = {
+		2C84C1442B9A4805002BF4EF /* ReceiptParser */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */;
-			productName = RevenueCat;
-		};
-		5759B47C297077B1002472D5 /* ReceiptParser */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */;
 			productName = ReceiptParser;
 		};
-		5759B47E297077B1002472D5 /* RevenueCat */ = {
+		2C84C1462B9A480B002BF4EF /* RevenueCat */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */;
 			productName = RevenueCat;
+		};
+		2C84C1482B9A480E002BF4EF /* ReceiptParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ReceiptParser;
 		};
 		577E0E3E29159B340071E063 /* RevenueCat */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
@@ -39,17 +39,24 @@ class MockOfferingsAPI: OfferingsAPI {
 
     var invokedGetOfferingsForAppUserID = false
     var invokedGetOfferingsForAppUserIDCount = 0
-    var invokedGetOfferingsForAppUserIDParameters: (appUserID: String?, isAppBackgrounded: Bool, completion: OfferingsAPI.OfferingsResponseHandler?)?
-    var invokedGetOfferingsForAppUserIDParametersList = [(appUserID: String?, isAppBackgrounded: Bool, completion: OfferingsAPI.OfferingsResponseHandler?)]()
+    var invokedGetOfferingsForAppUserIDParameters: (appUserID: String?,
+                                                    isAppBackgrounded: Bool,
+                                                    fetchReason: String?,
+                                                    completion: OfferingsAPI.OfferingsResponseHandler?)?
+    var invokedGetOfferingsForAppUserIDParametersList = [(appUserID: String?,
+                                                          isAppBackgrounded: Bool,
+                                                          fetchReason: String?,
+                                                          completion: OfferingsAPI.OfferingsResponseHandler?)]()
     var stubbedGetOfferingsCompletionResult: Result<OfferingsResponse, BackendError>?
 
     override func getOfferings(appUserID: String,
                                isAppBackgrounded: Bool,
+                               fetchReason: String?,
                                completion: @escaping OfferingsResponseHandler) {
         self.invokedGetOfferingsForAppUserID = true
         self.invokedGetOfferingsForAppUserIDCount += 1
-        self.invokedGetOfferingsForAppUserIDParameters = (appUserID, isAppBackgrounded, completion)
-        self.invokedGetOfferingsForAppUserIDParametersList.append((appUserID, isAppBackgrounded, completion))
+        self.invokedGetOfferingsForAppUserIDParameters = (appUserID, isAppBackgrounded, fetchReason, completion)
+        self.invokedGetOfferingsForAppUserIDParametersList.append((appUserID, isAppBackgrounded, fetchReason, completion))
 
         completion(self.stubbedGetOfferingsCompletionResult!)
     }

--- a/Tests/UnitTests/Mocks/MockOfferingsManager.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsManager.swift
@@ -26,11 +26,11 @@ typealias OfferingsCompletion = @MainActor @Sendable (Result<Offerings, Error>) 
     var invokedOfferingsCount = 0
     var invokedOfferingsParameters: (appUserID: String,
                                      fetchPolicy: FetchPolicy,
-                                     fetchCurrent: Bool,
+                                     fetchBehavior: FetchBehavior,
                                      completion: OfferingsCompletion?)?
     var invokedOfferingsParametersList = [(appUserID: String,
                                            fetchPolicy: FetchPolicy,
-                                           fetchCurrent: Bool,
+                                           fetchBehavior: FetchBehavior,
                                            completion: OfferingsCompletion??)]()
     var stubbedOfferingsCompletionResult: Result<Offerings, Error> = .failure(
         .configurationError("Stub not setup", underlyingError: nil)
@@ -38,12 +38,12 @@ typealias OfferingsCompletion = @MainActor @Sendable (Result<Offerings, Error>) 
 
     override func offerings(appUserID: String,
                             fetchPolicy: FetchPolicy,
-                            fetchCurrent: Bool = false,
+                            fetchBehavior: FetchBehavior,
                             completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?) {
         self.invokedOfferings = true
         self.invokedOfferingsCount += 1
-        self.invokedOfferingsParameters = (appUserID, fetchPolicy, fetchCurrent, completion)
-        self.invokedOfferingsParametersList.append((appUserID, fetchPolicy, fetchCurrent, completion))
+        self.invokedOfferingsParameters = (appUserID, fetchPolicy, fetchBehavior, completion)
+        self.invokedOfferingsParametersList.append((appUserID, fetchPolicy, fetchBehavior, completion))
 
         OperationDispatcher.dispatchOnMainActor { [result = self.stubbedOfferingsCompletionResult] in
             completion?(result)
@@ -58,6 +58,7 @@ typealias OfferingsCompletion = @MainActor @Sendable (Result<Offerings, Error>) 
         let appUserID: String
         let isAppBackgrounded: Bool
         let fetchPolicy: OfferingsManager.FetchPolicy
+        let fetchReason: String?
     }
 
     var invokedUpdateOfferingsCache = false
@@ -72,6 +73,7 @@ typealias OfferingsCompletion = @MainActor @Sendable (Result<Offerings, Error>) 
         appUserID: String,
         isAppBackgrounded: Bool,
         fetchPolicy: OfferingsManager.FetchPolicy,
+        fetchReason: String?,
         completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
     ) {
         self.invokedUpdateOfferingsCache = true
@@ -80,7 +82,8 @@ typealias OfferingsCompletion = @MainActor @Sendable (Result<Offerings, Error>) 
         let parameters = InvokedUpdateOfferingsCacheParameters(
             appUserID: appUserID,
             isAppBackgrounded: isAppBackgrounded,
-            fetchPolicy: fetchPolicy
+            fetchPolicy: fetchPolicy,
+            fetchReason: fetchReason
         )
 
         self.invokedUpdateOfferingsCacheParameters = parameters

--- a/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
@@ -30,7 +30,10 @@ class BackendGetOfferingsTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false, completion: completed)
+            self.offerings.getOfferings(appUserID: Self.userID,
+                                        isAppBackgrounded: false,
+                                        fetchReason: nil,
+                                        completion: completed)
         }
 
         expect(result).to(beSuccess())
@@ -45,7 +48,10 @@ class BackendGetOfferingsTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: true, completion: completed)
+            self.offerings.getOfferings(appUserID: Self.userID,
+                                        isAppBackgrounded: true,
+                                        fetchReason: nil,
+                                        completion: completed)
         }
 
         expect(result).to(beSuccess())
@@ -60,8 +66,8 @@ class BackendGetOfferingsTests: BaseBackendTests {
                             response: Self.noOfferingsResponse as [String: Any],
                             delay: .milliseconds(10))
         )
-        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
-        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
+        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false, fetchReason: nil) { _ in }
+        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false, fetchReason: nil) { _ in }
 
         expect(self.httpClient.calls).toEventually(haveCount(1))
     }
@@ -73,8 +79,8 @@ class BackendGetOfferingsTests: BaseBackendTests {
                             response: Self.noOfferingsResponse as [String: Any],
                             delay: .milliseconds(10))
         )
-        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
-        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
+        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false, fetchReason: nil) { _ in }
+        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false, fetchReason: nil) { _ in }
 
         expect(self.httpClient.calls).toEventually(haveCount(1))
 
@@ -92,8 +98,14 @@ class BackendGetOfferingsTests: BaseBackendTests {
         self.httpClient.mock(requestPath: .getOfferings(appUserID: Self.userID), response: response)
         self.httpClient.mock(requestPath: .getOfferings(appUserID: userID2), response: response)
 
-        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false, completion: { _ in })
-        self.offerings.getOfferings(appUserID: userID2, isAppBackgrounded: false, completion: { _ in })
+        self.offerings.getOfferings(appUserID: Self.userID,
+                                    isAppBackgrounded: false,
+                                    fetchReason: nil,
+                                    completion: { _ in })
+        self.offerings.getOfferings(appUserID: userID2,
+                                    isAppBackgrounded: false,
+                                    fetchReason: nil,
+                                    completion: { _ in })
 
         expect(self.httpClient.calls).toEventually(haveCount(2))
     }
@@ -105,7 +117,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
         )
 
         let result: Atomic<Result<OfferingsResponse, BackendError>?> = nil
-        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) {
+        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false, fetchReason: nil) {
             result.value = $0
         }
 
@@ -135,7 +147,10 @@ class BackendGetOfferingsTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false, completion: completed)
+            self.offerings.getOfferings(appUserID: Self.userID,
+                                        isAppBackgrounded: false,
+                                        fetchReason: nil,
+                                        completion: completed)
         }
 
         expect(result).to(beFailure())
@@ -150,7 +165,10 @@ class BackendGetOfferingsTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false, completion: completed)
+            self.offerings.getOfferings(appUserID: Self.userID,
+                                        isAppBackgrounded: false,
+                                        fetchReason: nil,
+                                        completion: completed)
         }
 
         expect(result).to(beFailure())
@@ -159,7 +177,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
 
     func testGetOfferingsSkipsBackendCallIfAppUserIDIsEmpty() {
         waitUntil { completed in
-            self.offerings.getOfferings(appUserID: "", isAppBackgrounded: false) { _ in
+            self.offerings.getOfferings(appUserID: "", isAppBackgrounded: false, fetchReason: nil) { _ in
                 completed()
             }
         }
@@ -169,7 +187,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
 
     func testGetOfferingsCallsCompletionWithErrorIfAppUserIDIsEmpty() {
         let receivedError = waitUntilValue { completed in
-            self.offerings.getOfferings(appUserID: "", isAppBackgrounded: false) { result in
+            self.offerings.getOfferings(appUserID: "", isAppBackgrounded: false, fetchReason: nil) { result in
                 completed(result.error)
             }
         }

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -394,14 +394,15 @@ extension OfferingsManagerTests {
         expect(self.mockDeviceCache.cacheOfferingsCount) == 0
     }
 
-    func testOfferingsForAppUserIdForcesNetworkRequestWhenFetchCurrentIsTrue() throws {
+    func testOfferingsForAppUserIdForcesNetworkRequestWhenFetchBehaviorIsFetchCurrent() throws {
         // given
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
         self.mockDeviceCache.stubbedOfferings = MockData.sampleOfferings
 
         // when
         let result = waitUntilValue { completed in
-            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID, fetchCurrent: true) {
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID,
+                                            fetchBehavior: .fetchCurrent(reason: .manualSyncCustomAttributes)) {
                 completed($0)
             }
         }

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -207,7 +207,7 @@ class OfferingsTests: TestCase {
                                         "placement_name": "offering_b",
                                         "placement_name_with_nil": nil
                                       ])),
-                    targeting: .init(revision: 1, ruleId: "abc123")
+                    targeting: .init(revision: 1, ruleId: "abc123", customAttributes: nil)
                 )
             )
         )
@@ -314,7 +314,7 @@ class OfferingsTests: TestCase {
                               ])
                     ],
                     placements: nil,
-                    targeting: .init(revision: 1, ruleId: "abc123")
+                    targeting: .init(revision: 1, ruleId: "abc123", customAttributes: nil)
                 )
             )
         )

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -375,6 +375,7 @@ extension BasePurchasesTests {
 
         override func getOfferings(appUserID: String,
                                    isAppBackgrounded: Bool,
+                                   fetchReason: String?,
                                    completion: @escaping OfferingsAPI.OfferingsResponseHandler) {
             self.gotOfferings += 1
             if self.failOfferings {

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -95,10 +95,6 @@ class BasePurchasesTests: TestCase {
                                                    backend: self.backend,
                                                    attributionFetcher: self.attributionFetcher,
                                                    subscriberAttributesManager: self.subscriberAttributesManager)
-        self.attribution = Attribution(subscriberAttributesManager: self.subscriberAttributesManager,
-                                       currentUserProvider: self.identityManager,
-                                       attributionPoster: self.attributionPoster,
-                                       systemInfo: self.systemInfo)
         self.mockOfflineEntitlementsManager = MockOfflineEntitlementsManager()
         self.customerInfoManager = CustomerInfoManager(offlineEntitlementsManager: self.mockOfflineEntitlementsManager,
                                                        operationDispatcher: self.mockOperationDispatcher,
@@ -113,6 +109,12 @@ class BasePurchasesTests: TestCase {
                                                          backend: self.backend,
                                                          offeringsFactory: self.offeringsFactory,
                                                          productsManager: self.mockProductsManager)
+        self.customAttributesManager = CustomAttributesManager(offeringsManager: self.mockOfferingsManager)
+        self.attribution = Attribution(subscriberAttributesManager: self.subscriberAttributesManager,
+                                       currentUserProvider: self.identityManager,
+                                       attributionPoster: self.attributionPoster,
+                                       systemInfo: self.systemInfo,
+                                       customAttributesManager: self.customAttributesManager)
         self.mockManageSubsHelper = MockManageSubscriptionsHelper(systemInfo: self.systemInfo,
                                                                   customerInfoManager: self.customerInfoManager,
                                                                   currentUserProvider: self.identityManager)
@@ -152,6 +154,7 @@ class BasePurchasesTests: TestCase {
     var mockProductsManager: MockProductsManager!
     var purchasedProductsFetcher: MockPurchasedProductsFetcher!
     var backend: MockBackend!
+    var customAttributesManager: CustomAttributesManager!
     var storeKit1Wrapper: MockStoreKit1Wrapper!
     var mockPaymentQueueWrapper: MockPaymentQueueWrapper!
     var notificationCenter: MockNotificationCenter!
@@ -278,6 +281,7 @@ class BasePurchasesTests: TestCase {
                                    attributionFetcher: self.attributionFetcher,
                                    attributionPoster: self.attributionPoster,
                                    backend: self.backend,
+                                   customAttributesManager: self.customAttributesManager,
                                    paymentQueueWrapper: paymentQueueWrapper,
                                    userDefaults: self.userDefaults,
                                    notificationCenter: self.notificationCenter,

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -519,6 +519,7 @@ private extension BasePurchasesTests {
         self.mockIntroEligibilityCalculator = nil
         self.mockTransactionsManager = nil
         self.backend = nil
+        self.customAttributesManager = nil
         self.attributionFetcher = nil
         self.purchasesDelegate.makeDeferredPurchase = nil
         self.purchasesDelegate = nil

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -30,6 +30,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
     var mockIdentityManager: MockIdentityManager!
     var mockSubscriberAttributesManager: MockSubscriberAttributesManager!
     var attribution: Attribution!
+    var customAttributesManager: CustomAttributesManager!
     var subscriberAttributeHeight: SubscriberAttribute!
     var subscriberAttributeWeight: SubscriberAttribute!
     var mockAttributes: [String: SubscriberAttribute]!
@@ -109,10 +110,6 @@ class PurchasesSubscriberAttributesTests: TestCase {
                                                        backend: mockBackend,
                                                        attributionFetcher: mockAttributionFetcher,
                                                        subscriberAttributesManager: mockSubscriberAttributesManager)
-        self.attribution = Attribution(subscriberAttributesManager: self.mockSubscriberAttributesManager,
-                                       currentUserProvider: self.mockIdentityManager,
-                                       attributionPoster: self.mockAttributionPoster,
-                                       systemInfo: self.systemInfo)
         self.mockOfflineEntitlementsManager = MockOfflineEntitlementsManager()
         self.mockPurchasedProductsFetcher = MockPurchasedProductsFetcher()
         self.mockTransactionFetcher = MockStoreKit2TransactionFetcher()
@@ -144,6 +141,12 @@ class PurchasesSubscriberAttributesTests: TestCase {
                                                          backend: mockBackend,
                                                          offeringsFactory: MockOfferingsFactory(),
                                                          productsManager: mockProductsManager)
+        self.customAttributesManager = CustomAttributesManager(offeringsManager: self.mockOfferingsManager)
+        self.attribution = Attribution(subscriberAttributesManager: self.mockSubscriberAttributesManager,
+                                       currentUserProvider: self.mockIdentityManager,
+                                       attributionPoster: self.mockAttributionPoster,
+                                       systemInfo: self.systemInfo,
+                                       customAttributesManager: self.customAttributesManager)
         self.mockManageSubsHelper = MockManageSubscriptionsHelper(systemInfo: systemInfo,
                                                                   customerInfoManager: customerInfoManager,
                                                                   currentUserProvider: mockIdentityManager)
@@ -202,6 +205,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
                               attributionFetcher: mockAttributionFetcher,
                               attributionPoster: mockAttributionPoster,
                               backend: mockBackend,
+                              customAttributesManager: customAttributesManager,
                               paymentQueueWrapper: .left(self.mockStoreKit1Wrapper),
                               userDefaults: .computeDefault(),
                               notificationCenter: mockNotificationCenter,


### PR DESCRIPTION
### Motivation

Auto sync custom attributes and fetch new offerings

### Decisions (Please read 🙏)

If the attribute being set is a custom attribute, this change will sync attributes while the app is in the foreground.

This _could_ be moved to when the app is foreground/background but this current approach was decided because:
- The design of the get offerings operation doesn't allow it to be run while the app is in the background.
- This is a better experience for the developer and customer

Some potential drawbacks:
- It could result in significantly more subscriber attribute posts and offerings refreshes

Analyzing and mitigating this behavior:
- We will send headers in these requests so we can monitor the reasons for sync and refreshes and see if its a significant more amount
- We can always turn off the custom attributes from being included in the offerings response to stop this new behavior all together if needed

### Description

Use a list of subscriber attributes in the offerings response to auto sync specific attributes after they are set. This is used to provide a current offerings response that uses custom attributes in targeting. 

- Added custom attribute information into `Offerings.Targeting`
- New `CustomAttributesManager` that handles all custom attributes syncing and logic
  - Manual `startManualSync()` (called by `Purchases.shared.syncAttributesAndOfferingsIfNeeded()`)
  - Automatic `startAutomaticSync` (called when an attribute is updated)
- New delegate method on `SubscriberAttributesManager` when attributes are set
  - `Attribution` listens to this and will then call `startAutomaticSync()`
- `GetOfferingsOperation` adds additional header called `X-RC-Offerings-Refresh-Reason`
  - This will allow us to determine how often and which form of the refresh method gets called

#### HTTP Request and Client Changes
- `HTTPRequest` has new `additionalHeaders` property
- `HTTPClient` will send these on the request
  - Adds these to the `defaultHeaders` for signature signing

### Todo
- [ ] Add `X-RC-Sync-Attributes-Reason` header to post attributes (?????)
- [ ] More tests
- [ ] Verify that we need salt and/or hash
