### PR TITLE
Pin xcbeautify version for xcode 14 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ commands:
     steps:
       - run:
           name: Install xcbeautify using Mint
-          command: mint install cpisciotta/xcbeautify@0.16.0
+          command: mint install cpisciotta/xcbeautify@1.17.0
 
   install-rubydocker-dependencies:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ commands:
         default: true
       install_mint:
         type: boolean
-        default: true
+        default: false
     steps:
       - install-bundle-dependencies:
           directory: << parameters.directory >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ aliases:
       branches:
         only: main
   non-patch-release-branches: &non-patch-release-branches
-    filters: 
+    filters:
       tags:
         ignore: /.*/
       branches:
@@ -99,22 +99,36 @@ commands:
           key: v2-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
           paths:
             - vendor/bundle
-  
+
   install-dependencies:
     parameters:
       directory:
         type: string
         default: .
+      install_xcbeautify:
+        type: boolean
+        default: true
+      install_mint:
+        type: boolean
+        default: true
     steps:
       - install-bundle-dependencies:
           directory: << parameters.directory >>
       - restore_cache:
           keys:
             - homebrew-cache-{{ checksum "Brewfile.lock.json" }}-{{ arch }}
-      - install-brew-dependency:
-          dependency_name: 'xcbeautify'
+      - when:
+          condition: << parameters.install_xcbeautify >>
+          steps:
+            - install-brew-dependency:
+                dependency_name: 'xcbeautify'
       - install-brew-dependency:
           dependency_name: 'swiftlint'
+      - when:
+          condition: << parameters.install_mint >>
+          steps:
+            - install-brew-dependency:
+                dependency_name: 'mint'
       - run: brew tap robotsandpencils/made
       - save_cache:
           key: homebrew-cache-{{ checksum "Brewfile.lock.json" }}-{{ arch }}
@@ -122,7 +136,7 @@ commands:
             - /usr/local/Cellar/swiftlint/
             - /usr/local/Cellar/xcbeautify/
             - /Users/$USER/Library/Caches/Homebrew/
-  
+
   install-brew-dependency:
     parameters:
       dependency_name:
@@ -141,6 +155,13 @@ commands:
             brew install << parameters.dependency_name >>
           environment:
             HOMEBREW_NO_INSTALL_CLEANUP: 1
+
+  install-xcbeautify-for-xcode14:
+    description: "Installs xcbeautify using Mint"
+    steps:
+      - run:
+          name: Install xcbeautify using Mint
+          command: mint install cpisciotta/xcbeautify@0.16.0
 
   install-rubydocker-dependencies:
     steps:
@@ -359,7 +380,7 @@ jobs:
           name: SPM Receipt Parser
           command: swift build -c release --target ReceiptParser
           no_output_timeout: 30m
-  
+
   spm-xcode-14-1:
     <<: *base-job
     steps:
@@ -427,7 +448,7 @@ jobs:
           path: fastlane/test_output
           destination: scan-test-output
       - run:
-          condition: 
+          condition:
             - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
           name: RevenueCatUI API Tests
           command: bundle exec fastlane build_revenuecatui_api_tester
@@ -460,7 +481,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-          
+
   spm-revenuecat-ui-watchos:
     <<: *base-job
     steps:
@@ -483,7 +504,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-  
+
   run-test-macos:
     <<: *base-job
     steps:
@@ -505,7 +526,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-          
+
   run-test-ios-17:
     <<: *base-job
     steps:
@@ -625,7 +646,10 @@ jobs:
     <<: *base-job
     steps:
       - checkout
-      - install-dependencies
+      - install-dependencies:
+          install_xcbeautify: false
+          install_mint: true
+      - install-xcbeautify-for-xcode14
       - update-spm-installation-commit
       - install-runtime:
           runtime-name: iOS 14.5
@@ -1021,7 +1045,7 @@ jobs:
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: v3LoadShedderIntegration
-  
+
   deploy-purchase-tester:
     <<: *base-job
     steps:
@@ -1111,7 +1135,7 @@ workflows:
           xcode_version: '14.3.0'
       - spm-revenuecat-ui-ios-17:
           xcode_version: '15.2'
-  
+
   build-test:
     when:
       and:
@@ -1291,7 +1315,7 @@ workflows:
           xcode_version: '15.2'
       - integration-tests-all:
           xcode_version: '15.2'
-  
+
   manual-trigger-bump:
     when:
       equal: [ bump, << pipeline.parameters.action >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ commands:
     steps:
       - run:
           name: Install xcbeautify using Mint
-          command: mint install cpisciotta/xcbeautify@1.17.0
+          command: mint install cpisciotta/xcbeautify@1.6.0
 
   install-rubydocker-dependencies:
     steps:


### PR DESCRIPTION
Xcode 14 tests broke with xcbeautify 2.0.0, which needs xcode 15. Earlier versions of xcbeautify are not available in homebrew, so we need to install it using mint