### PR TITLE
[EXTERNAL] Cocoapods support for privacy manifest (#3772) via @sdurban

### DIFF
--- a/RevenueCat.podspec
+++ b/RevenueCat.podspec
@@ -31,5 +31,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/**/*.swift'
   s.exclude_files = 'Sources/LocalReceiptParsing/ReceiptParser-only-files/**'
   
-  
+  s.resource_bundles = {'RevenueCat' => ['Sources/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
### Motivation
The library already includes Privacy.xcprivacy in SPM, but when used with CocoaPods (mandatory in Flutter), these files are not exported as the podspec does not include that file as a resource bundle.

### Description
Listing the PrivacyInfo.xcprivacy file inside the resource_bundles specification in the podspec allows to distribute the file correctly. Ref.
https://github.com/CocoaPods/CocoaPods/issues/10325#issuecomment-1718723762

This GitHub issue contains the entire discussion on how to add these xcprivacy files and is referenced in multiple places; many libraries already follow this approach:


https://github.com/firebase/firebase-ios-sdk/blob/main/FirebaseCrashlytics.podspec https://github.com/SDWebImage/SDWebImage/pull/3649 https://github.com/flutter/packages/pull/5846
https://github.com/Baseflow/flutter-permission-handler/pull/1291 https://github.com/Baseflow/flutter-geolocator/pull/1462

