### PR TITLE
[PoC]: disallow sharing anonymous app store account

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,41 +1,43 @@
 {
-  "pins" : [
-    {
-      "identity" : "cwlcatchexception",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
-      "state" : {
-        "revision" : "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
-        "version" : "2.1.2"
+  "object": {
+    "pins": [
+      {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "a23ded2c91df9156628a6996ab4f347526f17b6b",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "git@github.com:Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
+          "version": "10.0.0"
+        }
+      },
+      {
+        "package": "swift-snapshot-testing",
+        "repositoryURL": "git@github.com:pointfreeco/swift-snapshot-testing.git",
+        "state": {
+          "branch": null,
+          "revision": "dc46eeb3928a75390651fac6c1ef7f93ad59a73b",
+          "version": "1.11.1"
+        }
       }
-    },
-    {
-      "identity" : "cwlpreconditiontesting",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-      "state" : {
-        "revision" : "a23ded2c91df9156628a6996ab4f347526f17b6b",
-        "version" : "2.1.2"
-      }
-    },
-    {
-      "identity" : "nimble",
-      "kind" : "remoteSourceControl",
-      "location" : "git@github.com:Quick/Nimble.git",
-      "state" : {
-        "revision" : "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
-        "version" : "10.0.0"
-      }
-    },
-    {
-      "identity" : "swift-snapshot-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "git@github.com:pointfreeco/swift-snapshot-testing.git",
-      "state" : {
-        "revision" : "26ed3a2b4a2df47917ca9b790a57f91285b923fb",
-        "version" : "1.12.0"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,43 +1,41 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "CwlCatchException",
-        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
-        "state": {
-          "branch": null,
-          "revision": "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
-          "version": "2.1.2"
-        }
-      },
-      {
-        "package": "CwlPreconditionTesting",
-        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-        "state": {
-          "branch": null,
-          "revision": "a23ded2c91df9156628a6996ab4f347526f17b6b",
-          "version": "2.1.2"
-        }
-      },
-      {
-        "package": "Nimble",
-        "repositoryURL": "git@github.com:Quick/Nimble.git",
-        "state": {
-          "branch": null,
-          "revision": "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
-          "version": "10.0.0"
-        }
-      },
-      {
-        "package": "swift-snapshot-testing",
-        "repositoryURL": "git@github.com:pointfreeco/swift-snapshot-testing.git",
-        "state": {
-          "branch": null,
-          "revision": "dc46eeb3928a75390651fac6c1ef7f93ad59a73b",
-          "version": "1.11.1"
-        }
+  "pins" : [
+    {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
+        "version" : "2.1.2"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "a23ded2c91df9156628a6996ab4f347526f17b6b",
+        "version" : "2.1.2"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "git@github.com:Quick/Nimble.git",
+      "state" : {
+        "revision" : "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
+        "version" : "10.0.0"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "git@github.com:pointfreeco/swift-snapshot-testing.git",
+      "state" : {
+        "revision" : "26ed3a2b4a2df47917ca9b790a57f91285b923fb",
+        "version" : "1.12.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -23,7 +23,7 @@ class CustomerInfoManager {
     private let operationDispatcher: OperationDispatcher
     private let backend: Backend
     private let systemInfo: SystemInfo
-    private let transactionFetcher: StoreKit2TransactionFetcherType
+    let transactionFetcher: StoreKit2TransactionFetcherType
     private let transactionPoster: TransactionPosterType
 
     /// Underlying synchronized data.

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -23,6 +23,7 @@ class CustomerInfoManager {
     private let operationDispatcher: OperationDispatcher
     private let backend: Backend
     private let systemInfo: SystemInfo
+    // todo: move to Purchases class
     let transactionFetcher: StoreKit2TransactionFetcherType
     private let transactionPoster: TransactionPosterType
 

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -158,8 +158,9 @@ private extension IdentityManager {
             return
         }
 
-        self.resetCacheAndSave(newUserID: Self.generateRandomID())
-        Logger.info(Strings.identity.log_out_success)
+        let newAppUserID = Self.generateRandomID()
+        self.resetCacheAndSave(newUserID: newAppUserID)
+        Logger.info(Strings.identity.log_out_success(newAppUserID: newAppUserID))
         completion(nil)
     }
 }

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -31,6 +31,7 @@ class IdentityManager: CurrentUserProvider {
     private let backend: Backend
     private let customerInfoManager: CustomerInfoManager
     private let attributeSyncing: AttributeSyncing
+    private let systemInfo: SystemInfo
 
     private static let anonymousRegex = #"\$RCAnonymousID:([a-z0-9]{32})$"#
 
@@ -39,12 +40,14 @@ class IdentityManager: CurrentUserProvider {
         backend: Backend,
         customerInfoManager: CustomerInfoManager,
         attributeSyncing: AttributeSyncing,
-        appUserID: String?
+        appUserID: String?,
+        systemInfo: SystemInfo
     ) {
         self.deviceCache = deviceCache
         self.backend = backend
         self.customerInfoManager = customerInfoManager
         self.attributeSyncing = attributeSyncing
+        self.systemInfo = systemInfo
 
         if appUserID?.isEmpty == true {
             Logger.warn(Strings.identity.logging_in_with_empty_appuserid)
@@ -149,7 +152,8 @@ private extension IdentityManager {
     func performLogOut(completion: (PurchasesError?) -> Void) {
         Logger.info(Strings.identity.log_out_called_for_user)
 
-        if self.currentUserIsAnonymous {
+        if self.currentUserIsAnonymous
+            && !systemInfo.dangerousSettings.disallowSharingAppStoreAccountsForAnonymousIDs {
             completion(ErrorUtils.logOutAnonymousUserError())
             return
         }

--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -42,6 +42,8 @@ enum IdentityStrings {
 
     case sync_attributes_and_offerings_rate_limit_reached(maxCalls: Int, period: Int)
 
+    case app_store_logout_detected_anonymous_id_not_sharing
+
 }
 
 extension IdentityStrings: LogMessage {
@@ -80,6 +82,12 @@ extension IdentityStrings: LogMessage {
         case let .sync_attributes_and_offerings_rate_limit_reached(maxCalls, period):
             return "Sync attributes and offerings rate limit reached:\(maxCalls) per \(period) seconds. " +
             "Returning offerings from cache."
+
+        case .app_store_logout_detected_anonymous_id_not_sharing:
+            return "The current user doesn't have transactions in their App Store Account, " +
+            "but their corresponding CustomerInfo does. \n " +
+            "The user will be reset under assumption that they've logged out of their App Store Account " +
+            "\n becuase of the disallowSharingAppStoreAccountsForAnonymousIDs dangerousSetting"
         }
     }
 

--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -26,7 +26,7 @@ enum IdentityStrings {
 
     case log_out_called_for_user
 
-    case log_out_success
+    case log_out_success(newAppUserID: String)
 
     case identifying_app_user_id
 
@@ -64,8 +64,8 @@ extension IdentityStrings: LogMessage {
             return "Log in successful"
         case .log_out_called_for_user:
             return "Log out called for user"
-        case .log_out_success:
-            return "Log out successful"
+        case let .log_out_success(newAppUserID):
+            return "Log out successful, new appUserID: \(newAppUserID)"
         case .identifying_app_user_id:
             return "Identifying App User ID"
         case .null_currentappuserid:

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -77,6 +77,8 @@ import Foundation
      */
     @objc public let customEntitlementComputation: Bool
 
+    public let disallowSharingAppStoreAccountsForAnonymousIDs: Bool
+
     internal let internalSettings: InternalDangerousSettingsType
 
     @objc public override convenience init() {
@@ -109,10 +111,12 @@ import Foundation
     /// Designated initializer
     internal init(autoSyncPurchases: Bool,
                   customEntitlementComputation: Bool = false,
-                  internalSettings: InternalDangerousSettingsType) {
+                  internalSettings: InternalDangerousSettingsType,
+                  disallowSharingAppStoreAccountsForAnonymousIDs: Bool = false) {
         self.autoSyncPurchases = autoSyncPurchases
         self.internalSettings = internalSettings
         self.customEntitlementComputation = customEntitlementComputation
+        self.disallowSharingAppStoreAccountsForAnonymousIDs = disallowSharingAppStoreAccountsForAnonymousIDs
     }
 
 }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -362,7 +362,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                               backend: backend,
                                               customerInfoManager: customerInfoManager,
                                               attributeSyncing: subscriberAttributesManager,
-                                              appUserID: appUserID)
+                                              appUserID: appUserID,
+                                              systemInfo: systemInfo)
 
         let paywallEventsManager: PaywallEventsManagerType?
         do {
@@ -848,9 +849,6 @@ private extension Purchases {
 
         _ = Task<Void, Never> {
 
-            let hasTransactions = await self.customerInfoManager.transactionFetcher.firstVerifiedTransaction != nil
-            guard !hasTransactions else { return }
-
             // if there are no transactions in StoreKit, but the user has transactions in RevenueCat,
             // we assume that they've logged out of the account, and we logOut correspondingly.
             guard let cachedCustomerInfo = customerInfoManager
@@ -861,6 +859,9 @@ private extension Purchases {
             guard !cachedCustomerInfo.allPurchasedProductIdentifiers.isEmpty else {
                 return
             }
+
+            let hasTransactions = await self.customerInfoManager.transactionFetcher.firstVerifiedTransaction != nil
+            guard !hasTransactions else { return }
 
             Logger.warn(Strings.identity.app_store_logout_detected_anonymous_id_not_sharing)
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -842,6 +842,7 @@ public extension Purchases {
 private extension Purchases {
 
     func resetUserIfPurchaseHistoryIsEmptyIfNeeded() {
+        guard self.isAnonymous else { return }
         guard self.systemInfo.dangerousSettings.disallowSharingAppStoreAccountsForAnonymousIDs,
         self.systemInfo.dangerousSettings.internalSettings.usesStoreKit2JWS else { return }
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
@@ -49,7 +49,9 @@ public final class ConfiguredPurchases {
                 .with(observerMode: observerMode)
                 .with(entitlementVerificationMode: entitlementVerificationMode)
                 #if DEBUG
-                .with(dangerousSettings: .init(autoSyncPurchases: true, internalSettings: DangerousSettings.Internal(usesStoreKit2JWS: useStoreKit2)))
+                .with(dangerousSettings: .init(autoSyncPurchases: true,
+                                               internalSettings: DangerousSettings.Internal(usesStoreKit2JWS: useStoreKit2),
+                                               disallowSharingAppStoreAccountsForAnonymousIDs: true))
                 #endif
                 .build()
         )


### PR DESCRIPTION
This adds a new `dangerousSetting` that allows the SDK to detect when the user has logged out of their App Store account on an anonymous ID, and reset the user cache in order to revoke access.

This is very much a draft, but I tested this locally by: 
- enabling the setting
- making a purchase as anonymous user 1
- deleting transactions through StoreKit Test to simulate an app store logout
- foregrounding the SDK
- access revoked

Notes: 
- This is a `dangerousSetting`, and will likely not be a behavior most developers would want to have enabled. But it might be useful for some developers, as a way to prevent account sharing as an exploit. 
- This is *only* compatible with StoreKit 2, as we need a single system to check purchasing history, and StoreKit 1 is fairly unreliable for it given receipt refresh & throttle issues. 
- This could be similarly implemented for Android
- Tests are broken, I need to add the systemInfo param in a couple of places
- No new tests added yet, but this should be coverable by BackendIntegrationTests using StoreKit Test. 