### PR TITLE
iOS append events to JSONL file and get diagnostics events

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -185,6 +185,8 @@
 		354895D6267BEDE3001DC5B1 /* ReservedSubscriberAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 354895D5267BEDE3001DC5B1 /* ReservedSubscriberAttributes.swift */; };
 		35549323269E298B005F9AE9 /* OfferingsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35549322269E298B005F9AE9 /* OfferingsFactory.swift */; };
 		359E8E3F26DEBEEB00B869F9 /* TrialOrIntroPriceEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359E8E3E26DEBEEB00B869F9 /* TrialOrIntroPriceEligibilityChecker.swift */; };
+		35AAEB452BBB14D000A12548 /* DiagnosticsFileHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AAEB442BBB14D000A12548 /* DiagnosticsFileHandler.swift */; };
+		35AAEB492BBB17B500A12548 /* DiagnosticsEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AAEB482BBB17B500A12548 /* DiagnosticsEntry.swift */; };
 		35B745A82711001A00458D46 /* MockManageSubscriptionsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E840CD2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift */; };
 		35D0E5D026A5886C0099EAD8 /* ErrorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D0E5CF26A5886C0099EAD8 /* ErrorUtils.swift */; };
 		35D832CD262A5B7500E60AC5 /* ETagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D832CC262A5B7500E60AC5 /* ETagManager.swift */; };
@@ -948,6 +950,8 @@
 		3597020F24BF6A710010506E /* TransactionsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsFactory.swift; sourceTree = "<group>"; };
 		3597021124BF6AAC0010506E /* TransactionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsFactoryTests.swift; sourceTree = "<group>"; };
 		359E8E3E26DEBEEB00B869F9 /* TrialOrIntroPriceEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrialOrIntroPriceEligibilityChecker.swift; sourceTree = "<group>"; };
+		35AAEB442BBB14D000A12548 /* DiagnosticsFileHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsFileHandler.swift; sourceTree = "<group>"; };
+		35AAEB482BBB17B500A12548 /* DiagnosticsEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsEntry.swift; sourceTree = "<group>"; };
 		35D0E5CF26A5886C0099EAD8 /* ErrorUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorUtils.swift; sourceTree = "<group>"; };
 		35D832CC262A5B7500E60AC5 /* ETagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETagManager.swift; sourceTree = "<group>"; };
 		35D832D1262E56DB00E60AC5 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
@@ -2323,6 +2327,8 @@
 			isa = PBXGroup;
 			children = (
 				4F2F2EFE2A3CDAA800652B24 /* FileHandler.swift */,
+				35AAEB442BBB14D000A12548 /* DiagnosticsFileHandler.swift */,
+				35AAEB482BBB17B500A12548 /* DiagnosticsEntry.swift */,
 			);
 			path = Diagnostics;
 			sourceTree = "<group>";
@@ -3480,6 +3486,7 @@
 				2D00A41D2767C08300FC3DD8 /* ManageSubscriptionsStrings.swift in Sources */,
 				2DD9F4BE274EADC20031AE2C /* Purchases+async.swift in Sources */,
 				B3C4AAD526B8911300E1B3C8 /* Backend.swift in Sources */,
+				35AAEB452BBB14D000A12548 /* DiagnosticsFileHandler.swift in Sources */,
 				B34D2AA626976FC700D88C3A /* ErrorCode.swift in Sources */,
 				4F15B4A12A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift in Sources */,
 				B39E811D268E887500D31189 /* SubscriberAttribute.swift in Sources */,
@@ -3493,6 +3500,7 @@
 				35D832F4262E606500E60AC5 /* HTTPResponse.swift in Sources */,
 				352B7D7927BD919B002A47DD /* DangerousSettings.swift in Sources */,
 				A56F9AB126990E9200AFC48F /* CustomerInfo.swift in Sources */,
+				35AAEB492BBB17B500A12548 /* DiagnosticsEntry.swift in Sources */,
 				4F6EEBD92A38ED76007FD783 /* FakeSigning.swift in Sources */,
 				2DDF41AE24F6F37C005BC22D /* InAppPurchase.swift in Sources */,
 				B32B750126868C1D005647BF /* EntitlementInfo.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		359E8E3F26DEBEEB00B869F9 /* TrialOrIntroPriceEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359E8E3E26DEBEEB00B869F9 /* TrialOrIntroPriceEligibilityChecker.swift */; };
 		35AAEB452BBB14D000A12548 /* DiagnosticsFileHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AAEB442BBB14D000A12548 /* DiagnosticsFileHandler.swift */; };
 		35AAEB492BBB17B500A12548 /* DiagnosticsEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AAEB482BBB17B500A12548 /* DiagnosticsEntry.swift */; };
+		35AAEB4C2BBC39D100A12548 /* DiagnosticsFileHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AAEB4A2BBC380600A12548 /* DiagnosticsFileHandlerTests.swift */; };
 		35B745A82711001A00458D46 /* MockManageSubscriptionsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E840CD2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift */; };
 		35D0E5D026A5886C0099EAD8 /* ErrorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D0E5CF26A5886C0099EAD8 /* ErrorUtils.swift */; };
 		35D832CD262A5B7500E60AC5 /* ETagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D832CC262A5B7500E60AC5 /* ETagManager.swift */; };
@@ -952,6 +953,7 @@
 		359E8E3E26DEBEEB00B869F9 /* TrialOrIntroPriceEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrialOrIntroPriceEligibilityChecker.swift; sourceTree = "<group>"; };
 		35AAEB442BBB14D000A12548 /* DiagnosticsFileHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsFileHandler.swift; sourceTree = "<group>"; };
 		35AAEB482BBB17B500A12548 /* DiagnosticsEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsEntry.swift; sourceTree = "<group>"; };
+		35AAEB4A2BBC380600A12548 /* DiagnosticsFileHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsFileHandlerTests.swift; sourceTree = "<group>"; };
 		35D0E5CF26A5886C0099EAD8 /* ErrorUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorUtils.swift; sourceTree = "<group>"; };
 		35D832CC262A5B7500E60AC5 /* ETagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETagManager.swift; sourceTree = "<group>"; };
 		35D832D1262E56DB00E60AC5 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
@@ -2337,6 +2339,7 @@
 			isa = PBXGroup;
 			children = (
 				4F2F2F132A3CEAB500652B24 /* FileHandlerTests.swift */,
+				35AAEB4A2BBC380600A12548 /* DiagnosticsFileHandlerTests.swift */,
 			);
 			path = Diagnostics;
 			sourceTree = "<group>";
@@ -3782,6 +3785,7 @@
 				5733D01128D00354008638D8 /* PromotionalOfferTests.swift in Sources */,
 				57544C28285FA94B004E54D5 /* MockAttributeSyncing.swift in Sources */,
 				4F34AEEC2A5DCCBA00F4BCB0 /* VerificationResultTests.swift in Sources */,
+				35AAEB4C2BBC39D100A12548 /* DiagnosticsFileHandlerTests.swift in Sources */,
 				57DE80802807529F008D6C6F /* MockStorefront.swift in Sources */,
 				5759B464296E1A4B002472D5 /* MockBundle.swift in Sources */,
 				35D83312262FBD4200E60AC5 /* MockETagManager.swift in Sources */,

--- a/Sources/Diagnostics/DiagnosticsEntry.swift
+++ b/Sources/Diagnostics/DiagnosticsEntry.swift
@@ -14,8 +14,10 @@
 import Foundation
 
 protocol DiagnosticsEntry: Codable, Equatable {
+
     var diagnosticType: String { get }
     var version: Int { get }
+
 }
 
 extension DiagnosticsEntry {
@@ -32,6 +34,7 @@ extension DiagnosticsEntry {
 }
 
 struct DiagnosticsEvent: DiagnosticsEntry {
+    
     var diagnosticType: String = "event"
     let name: String
     let properties: [String: AnyEncodable]
@@ -41,18 +44,22 @@ struct DiagnosticsEvent: DiagnosticsEntry {
         case diagnosticType = "type"
         case name, properties, timestamp
     }
+    
 }
 
 extension DiagnosticsEvent {
+
     static func == (lhs: DiagnosticsEvent, rhs: DiagnosticsEvent) -> Bool {
         return lhs.diagnosticType == rhs.diagnosticType &&
                lhs.name == rhs.name &&
                lhs.properties == rhs.properties &&
                lhs.timestamp == rhs.timestamp
     }
+
 }
 
 struct Counter: DiagnosticsEntry {
+
     var diagnosticType: String = "counter"
     let name: String
     let tags: [String: String]
@@ -62,9 +69,11 @@ struct Counter: DiagnosticsEntry {
         case diagnosticType = "type"
         case name, tags, value
     }
+
 }
 
 struct Histogram: DiagnosticsEntry {
+
     var diagnosticType: String = "histogram"
     let name: String
     let tags: [String: String]
@@ -74,4 +83,5 @@ struct Histogram: DiagnosticsEntry {
         case diagnosticType = "type"
         case name, tags, values
     }
+    
 }

--- a/Sources/Diagnostics/DiagnosticsEntry.swift
+++ b/Sources/Diagnostics/DiagnosticsEntry.swift
@@ -13,24 +13,15 @@
 
 import Foundation
 
-protocol DiagnosticsEntry: Codable, Equatable {
-
-    var diagnosticType: String { get }
-    var version: Int { get }
-
-}
-
-struct DiagnosticsEvent: DiagnosticsEntry {
+struct DiagnosticsEvent: Codable, Equatable {
 
     let version: Int = 1
-    let diagnosticType: String = "event"
     let name: String
     let properties: [String: AnyEncodable]
     let timestamp: Date
 
     enum CodingKeys: String, CodingKey {
-        case diagnosticType = "type"
-        case name, properties, timestamp, version
+        case version, name, properties, timestamp
     }
 
 }
@@ -38,7 +29,7 @@ struct DiagnosticsEvent: DiagnosticsEntry {
 extension DiagnosticsEvent {
 
     static func == (lhs: DiagnosticsEvent, rhs: DiagnosticsEvent) -> Bool {
-        return lhs.diagnosticType == rhs.diagnosticType &&
+        return lhs.version == rhs.version &&
                lhs.name == rhs.name &&
                lhs.properties == rhs.properties &&
                lhs.timestamp == rhs.timestamp

--- a/Sources/Diagnostics/DiagnosticsEntry.swift
+++ b/Sources/Diagnostics/DiagnosticsEntry.swift
@@ -24,7 +24,7 @@ extension DiagnosticsEntry {
     func toJSONString() -> String? {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
-        encoder.dateEncodingStrategy = .millisecondsSince1970 // Example date encoding strategy
+        encoder.dateEncodingStrategy = .iso8601
 
         guard let jsonData = try? encoder.encode(self) else { return nil }
         return String(data: jsonData, encoding: .utf8)

--- a/Sources/Diagnostics/DiagnosticsEntry.swift
+++ b/Sources/Diagnostics/DiagnosticsEntry.swift
@@ -21,16 +21,9 @@ protocol DiagnosticsEntry: Codable, Equatable {
 }
 
 extension DiagnosticsEntry {
+
     var version: Int { 1 }
 
-    func toJSONString() -> String? {
-        let encoder = JSONEncoder()
-        encoder.keyEncodingStrategy = .convertToSnakeCase
-        encoder.dateEncodingStrategy = .iso8601
-
-        guard let jsonData = try? encoder.encode(self) else { return nil }
-        return String(data: jsonData, encoding: .utf8)
-    }
 }
 
 struct DiagnosticsEvent: DiagnosticsEntry {

--- a/Sources/Diagnostics/DiagnosticsEntry.swift
+++ b/Sources/Diagnostics/DiagnosticsEntry.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-protocol DiagnosticsEntry: Codable {
+protocol DiagnosticsEntry: Codable, Equatable {
     var diagnosticType: String { get }
     var version: Int { get }
 }
@@ -40,6 +40,15 @@ struct DiagnosticsEvent: DiagnosticsEntry {
     enum CodingKeys: String, CodingKey {
         case diagnosticType = "type"
         case name, properties, timestamp
+    }
+}
+
+extension DiagnosticsEvent {
+    static func == (lhs: DiagnosticsEvent, rhs: DiagnosticsEvent) -> Bool {
+        return lhs.diagnosticType == rhs.diagnosticType &&
+               lhs.name == rhs.name &&
+               lhs.properties == rhs.properties &&
+               lhs.timestamp == rhs.timestamp
     }
 }
 

--- a/Sources/Diagnostics/DiagnosticsEntry.swift
+++ b/Sources/Diagnostics/DiagnosticsEntry.swift
@@ -27,7 +27,7 @@ extension DiagnosticsEntry {
 }
 
 struct DiagnosticsEvent: DiagnosticsEntry {
-    
+
     var diagnosticType: String = "event"
     let name: String
     let properties: [String: AnyEncodable]
@@ -37,7 +37,7 @@ struct DiagnosticsEvent: DiagnosticsEntry {
         case diagnosticType = "type"
         case name, properties, timestamp
     }
-    
+
 }
 
 extension DiagnosticsEvent {
@@ -76,5 +76,5 @@ struct Histogram: DiagnosticsEntry {
         case diagnosticType = "type"
         case name, tags, values
     }
-    
+
 }

--- a/Sources/Diagnostics/DiagnosticsEntry.swift
+++ b/Sources/Diagnostics/DiagnosticsEntry.swift
@@ -45,33 +45,3 @@ extension DiagnosticsEvent {
     }
 
 }
-
-struct Counter: DiagnosticsEntry {
-
-    let version: Int = 1
-    let diagnosticType: String = "counter"
-    let name: String
-    let tags: [String: String]
-    let value: Int
-
-    enum CodingKeys: String, CodingKey {
-        case diagnosticType = "type"
-        case name, tags, value, version
-    }
-
-}
-
-struct Histogram: DiagnosticsEntry {
-
-    let version: Int = 1
-    let diagnosticType: String = "histogram"
-    let name: String
-    let tags: [String: String]
-    let values: [Double]
-
-    enum CodingKeys: String, CodingKey {
-        case diagnosticType = "type"
-        case name, tags, values, version
-    }
-
-}

--- a/Sources/Diagnostics/DiagnosticsEntry.swift
+++ b/Sources/Diagnostics/DiagnosticsEntry.swift
@@ -20,22 +20,17 @@ protocol DiagnosticsEntry: Codable, Equatable {
 
 }
 
-extension DiagnosticsEntry {
-
-    var version: Int { 1 }
-
-}
-
 struct DiagnosticsEvent: DiagnosticsEntry {
 
-    var diagnosticType: String = "event"
+    let version: Int = 1
+    let diagnosticType: String = "event"
     let name: String
     let properties: [String: AnyEncodable]
     let timestamp: Date
 
     enum CodingKeys: String, CodingKey {
         case diagnosticType = "type"
-        case name, properties, timestamp
+        case name, properties, timestamp, version
     }
 
 }
@@ -53,28 +48,30 @@ extension DiagnosticsEvent {
 
 struct Counter: DiagnosticsEntry {
 
-    var diagnosticType: String = "counter"
+    let version: Int = 1
+    let diagnosticType: String = "counter"
     let name: String
     let tags: [String: String]
     let value: Int
 
     enum CodingKeys: String, CodingKey {
         case diagnosticType = "type"
-        case name, tags, value
+        case name, tags, value, version
     }
 
 }
 
 struct Histogram: DiagnosticsEntry {
 
-    var diagnosticType: String = "histogram"
+    let version: Int = 1
+    let diagnosticType: String = "histogram"
     let name: String
     let tags: [String: String]
     let values: [Double]
 
     enum CodingKeys: String, CodingKey {
         case diagnosticType = "type"
-        case name, tags, values
+        case name, tags, values, version
     }
 
 }

--- a/Sources/Diagnostics/DiagnosticsEntry.swift
+++ b/Sources/Diagnostics/DiagnosticsEntry.swift
@@ -1,0 +1,70 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DiagnosticsEntry.swift
+//
+//  Created by Cesar de la Vega on 1/4/24.
+
+import Foundation
+
+typealias DiagnosticsEntries = [String]
+
+protocol DiagnosticsEntry: Codable {
+    var diagnosticType: String { get }
+    var version: Int { get }
+}
+
+extension DiagnosticsEntry {
+    var version: Int { 1 }
+
+    func toJSONString() -> String? {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.dateEncodingStrategy = .millisecondsSince1970 // Example date encoding strategy
+
+        guard let jsonData = try? encoder.encode(self) else { return nil }
+        return String(data: jsonData, encoding: .utf8)
+    }
+}
+
+struct DiagnosticsEvent: DiagnosticsEntry {
+    var diagnosticType: String = "event"
+    let name: String
+    let properties: [String: AnyEncodable]
+    let timestamp: Date
+
+    enum CodingKeys: String, CodingKey {
+        case diagnosticType = "type"
+        case name, properties, timestamp
+    }
+}
+
+struct Counter: DiagnosticsEntry {
+    var diagnosticType: String = "counter"
+    let name: String
+    let tags: [String: String]
+    let value: Int
+
+    enum CodingKeys: String, CodingKey {
+        case diagnosticType = "type"
+        case name, tags, value
+    }
+}
+
+struct Histogram: DiagnosticsEntry {
+    var diagnosticType: String = "histogram"
+    let name: String
+    let tags: [String: String]
+    let values: [Double]
+
+    enum CodingKeys: String, CodingKey {
+        case diagnosticType = "type"
+        case name, tags, values
+    }
+}

--- a/Sources/Diagnostics/DiagnosticsEntry.swift
+++ b/Sources/Diagnostics/DiagnosticsEntry.swift
@@ -13,8 +13,6 @@
 
 import Foundation
 
-typealias DiagnosticsEntries = [String]
-
 protocol DiagnosticsEntry: Codable {
     var diagnosticType: String { get }
     var version: Int { get }

--- a/Sources/Diagnostics/DiagnosticsFileHandler.swift
+++ b/Sources/Diagnostics/DiagnosticsFileHandler.swift
@@ -13,6 +13,7 @@
 
 import Foundation
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 protocol DiagnosticsFileHandlerType: AnyObject {
 
     func getEntries() async -> [DiagnosticsEvent]

--- a/Sources/Diagnostics/DiagnosticsFileHandler.swift
+++ b/Sources/Diagnostics/DiagnosticsFileHandler.swift
@@ -17,8 +17,11 @@ import Foundation
 protocol DiagnosticsFileHandlerType: AnyObject {
 
     func getEntries() async -> [DiagnosticsEvent]
+
     func appendEvent(diagnosticsEvent: DiagnosticsEvent) async
+
     func cleanSentDiagnostics(diagnosticsSentCount: Int) async
+
     func deleteDiagnosticsFile() async
 
 }
@@ -134,4 +137,5 @@ private extension DiagnosticsFileHandler {
             return nil
         }
     }
+
 }

--- a/Sources/Diagnostics/DiagnosticsFileHandler.swift
+++ b/Sources/Diagnostics/DiagnosticsFileHandler.swift
@@ -19,7 +19,7 @@ protocol DiagnosticsFileHandlerType: AnyObject {
     func appendEvent(diagnosticsEvent: DiagnosticsEvent) async
     func cleanSentDiagnostics(diagnosticsSentCount: Int) async
     func deleteDiagnosticsFile() async
-    
+
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
@@ -34,6 +34,10 @@ actor DiagnosticsFileHandler: DiagnosticsFileHandlerType {
             Logger.error("Initialization error: \(error.localizedDescription)")
             return nil
         }
+    }
+
+    init(_ fileHandler: FileHandler) {
+        self.fileHandler = fileHandler
     }
 
     func appendEvent(diagnosticsEvent: DiagnosticsEvent) async {
@@ -89,7 +93,6 @@ actor DiagnosticsFileHandler: DiagnosticsFileHandlerType {
     }
 
     func deleteDiagnosticsFile() async {
-        // TODO
     }
 
 }
@@ -119,7 +122,17 @@ private extension DiagnosticsFileHandler {
     }
 
     private func decodeDiagnosticsEvent(from line: String) -> DiagnosticsEvent? {
-        guard let data = line.data(using: .utf8) else { return nil }
-        return try? JSONDecoder().decode(DiagnosticsEvent.self, from: data)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+
+        do {
+            guard let data = line.data(using: .utf8) else { return nil }
+            let event = try decoder.decode(DiagnosticsEvent.self, from: data)
+            print("Decoded Timestamp: \(event.timestamp)")
+            return event
+        } catch {
+            print("Decoding error: \(error)")
+            return nil
+        }
     }
 }

--- a/Sources/Diagnostics/DiagnosticsFileHandler.swift
+++ b/Sources/Diagnostics/DiagnosticsFileHandler.swift
@@ -123,15 +123,13 @@ private extension DiagnosticsFileHandler {
 
     private func decodeDiagnosticsEvent(from line: String) -> DiagnosticsEvent? {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .millisecondsSince1970
+        decoder.dateDecodingStrategy = .iso8601
 
         do {
             guard let data = line.data(using: .utf8) else { return nil }
             let event = try decoder.decode(DiagnosticsEvent.self, from: data)
-            print("Decoded Timestamp: \(event.timestamp)")
             return event
         } catch {
-            print("Decoding error: \(error)")
             return nil
         }
     }

--- a/Sources/Diagnostics/DiagnosticsFileHandler.swift
+++ b/Sources/Diagnostics/DiagnosticsFileHandler.swift
@@ -45,7 +45,7 @@ actor DiagnosticsFileHandler: DiagnosticsFileHandlerType {
     }
 
     func appendEvent(diagnosticsEvent: DiagnosticsEvent) async {
-        guard let jsonString = diagnosticsEvent.toJSONString() else {
+        guard let jsonString = try? diagnosticsEvent.encodedJSON else {
             Logger.error("Failed to serialize diagnostics event to JSON")
             return
         }

--- a/Sources/Diagnostics/DiagnosticsFileHandler.swift
+++ b/Sources/Diagnostics/DiagnosticsFileHandler.swift
@@ -1,0 +1,125 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DiagnosticsFileHandler.swift
+//
+//  Created by Nacho Soto on 6/16/23.
+
+import Foundation
+
+protocol DiagnosticsFileHandlerType: AnyObject {
+
+    func getEntries() async -> [DiagnosticsEvent]
+    func appendEvent(diagnosticsEvent: DiagnosticsEvent) async
+    func cleanSentDiagnostics(diagnosticsSentCount: Int) async
+    func deleteDiagnosticsFile() async
+    
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+actor DiagnosticsFileHandler: DiagnosticsFileHandlerType {
+
+    private let fileHandler: FileHandler
+
+    init?() {
+        do {
+            self.fileHandler = try .init(Self.diagnosticsFile)
+        } catch {
+            Logger.error("Initialization error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func appendEvent(diagnosticsEvent: DiagnosticsEvent) async {
+        guard let jsonString = diagnosticsEvent.toJSONString() else {
+            Logger.error("Failed to serialize diagnostics event to JSON")
+            return
+        }
+
+        await fileHandler.append(line: jsonString)
+    }
+
+    func getEntries() async -> [DiagnosticsEvent] {
+        var entries: [DiagnosticsEvent] = []
+
+        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+            do {
+                for try await line in try await fileHandler.readLines() {
+                    if let event = decodeDiagnosticsEvent(from: line) {
+                        entries.append(event)
+                    }
+                }
+            } catch {
+                Logger.error("Failed to read lines from file: \(error.localizedDescription)")
+            }
+        } else {
+            do {
+                let data = try await fileHandler.readFile()
+                let content = String(decoding: data, as: UTF8.self)
+                content.split(separator: "\n").forEach { line in
+                    if let event = decodeDiagnosticsEvent(from: String(line)) {
+                        entries.append(event)
+                    }
+                }
+            } catch {
+                Logger.error("Failed to read file content: \(error.localizedDescription)")
+            }
+        }
+
+        return entries
+    }
+
+    func cleanSentDiagnostics(diagnosticsSentCount: Int) async {
+        guard diagnosticsSentCount > 0 else {
+            Logger.error("Invalid sent diagnostics count: \(diagnosticsSentCount)")
+            return
+        }
+
+        do {
+            try await fileHandler.removeFirstLines(diagnosticsSentCount)
+        } catch {
+            Logger.error("Failed to clean sent diagnostics: \(error.localizedDescription)")
+        }
+    }
+
+    func deleteDiagnosticsFile() async {
+        // TODO
+    }
+
+}
+
+// MARK: - Private
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+private extension DiagnosticsFileHandler {
+
+    static var diagnosticsFile: URL {
+        return Self.documentsDirectory
+            .appendingPathComponent("com.revenuecat")
+            .appendingPathComponent("diagnostics")
+            .appendingPathExtension("jsonl")
+    }
+
+    private static var documentsDirectory: URL {
+        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+            return URL.documentsDirectory
+        } else {
+            return FileManager.default.urls(
+                for: .documentDirectory,
+                in: .userDomainMask
+            )[0]
+        }
+
+    }
+
+    private func decodeDiagnosticsEvent(from line: String) -> DiagnosticsEvent? {
+        guard let data = line.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(DiagnosticsEvent.self, from: data)
+    }
+}

--- a/Sources/Diagnostics/DiagnosticsFileHandler.swift
+++ b/Sources/Diagnostics/DiagnosticsFileHandler.swift
@@ -126,13 +126,9 @@ private extension DiagnosticsFileHandler {
     }
 
     private func decodeDiagnosticsEvent(from line: String) -> DiagnosticsEvent? {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-
         do {
             guard let data = line.data(using: .utf8) else { return nil }
-            let event = try decoder.decode(DiagnosticsEvent.self, from: data)
-            return event
+            return try JSONDecoder.default.decode(DiagnosticsEvent.self, from: data)
         } catch {
             return nil
         }

--- a/Sources/Diagnostics/DiagnosticsFileHandler.swift
+++ b/Sources/Diagnostics/DiagnosticsFileHandler.swift
@@ -22,7 +22,7 @@ protocol DiagnosticsFileHandlerType: AnyObject {
 
     func cleanSentDiagnostics(diagnosticsSentCount: Int) async
 
-    func deleteDiagnosticsFile() async
+    func emptyDiagnosticsFile() async
 
 }
 
@@ -96,7 +96,12 @@ actor DiagnosticsFileHandler: DiagnosticsFileHandlerType {
         }
     }
 
-    func deleteDiagnosticsFile() async {
+    func emptyDiagnosticsFile() async {
+        do {
+            try await fileHandler.emptyFile()
+        } catch {
+            Logger.error("Failed to empty diagnostics file: \(error.localizedDescription)")
+        }
     }
 
 }

--- a/Sources/Diagnostics/DiagnosticsFileHandler.swift
+++ b/Sources/Diagnostics/DiagnosticsFileHandler.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 protocol DiagnosticsFileHandlerType: AnyObject {
 
     func getEntries() async -> [DiagnosticsEvent]
@@ -26,7 +26,7 @@ protocol DiagnosticsFileHandlerType: AnyObject {
 
 }
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 actor DiagnosticsFileHandler: DiagnosticsFileHandlerType {
 
     private let fileHandler: FileHandler
@@ -56,28 +56,14 @@ actor DiagnosticsFileHandler: DiagnosticsFileHandlerType {
     func getEntries() async -> [DiagnosticsEvent] {
         var entries: [DiagnosticsEvent] = []
 
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-            do {
-                for try await line in try await fileHandler.readLines() {
-                    if let event = decodeDiagnosticsEvent(from: line) {
-                        entries.append(event)
-                    }
+        do {
+            for try await line in try await fileHandler.readLines() {
+                if let event = decodeDiagnosticsEvent(from: line) {
+                    entries.append(event)
                 }
-            } catch {
-                Logger.error("Failed to read lines from file: \(error.localizedDescription)")
             }
-        } else {
-            do {
-                let data = try await fileHandler.readFile()
-                let content = String(decoding: data, as: UTF8.self)
-                content.split(separator: "\n").forEach { line in
-                    if let event = decodeDiagnosticsEvent(from: String(line)) {
-                        entries.append(event)
-                    }
-                }
-            } catch {
-                Logger.error("Failed to read file content: \(error.localizedDescription)")
-            }
+        } catch {
+            Logger.error("Failed to read lines from file: \(error.localizedDescription)")
         }
 
         return entries
@@ -108,7 +94,7 @@ actor DiagnosticsFileHandler: DiagnosticsFileHandlerType {
 
 // MARK: - Private
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension DiagnosticsFileHandler {
 
     static var diagnosticsFile: URL {

--- a/Sources/Misc/Codable/AnyEncodable.swift
+++ b/Sources/Misc/Codable/AnyEncodable.swift
@@ -113,7 +113,7 @@ extension AnyEncodable: Equatable {
     static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool {
         let lhsEncoder = JSONEncoder()
         let rhsEncoder = JSONEncoder()
-        
+
         lhsEncoder.dateEncodingStrategy = .iso8601
         rhsEncoder.dateEncodingStrategy = .iso8601
 

--- a/Sources/Misc/Codable/AnyEncodable.swift
+++ b/Sources/Misc/Codable/AnyEncodable.swift
@@ -109,4 +109,19 @@ extension AnyEncodable: Decodable {
 
 }
 
+extension AnyEncodable: Equatable {
+    static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool {
+        let lhsEncoder = JSONEncoder()
+        let rhsEncoder = JSONEncoder()
+
+        do {
+            let lhsData = try lhsEncoder.encode(lhs)
+            let rhsData = try rhsEncoder.encode(rhs)
+            return lhsData == rhsData
+        } catch {
+            return false
+        }
+    }
+}
+
 // swiftlint:enable cyclomatic_complexity

--- a/Sources/Misc/Codable/AnyEncodable.swift
+++ b/Sources/Misc/Codable/AnyEncodable.swift
@@ -113,6 +113,9 @@ extension AnyEncodable: Equatable {
     static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool {
         let lhsEncoder = JSONEncoder()
         let rhsEncoder = JSONEncoder()
+        
+        lhsEncoder.dateEncodingStrategy = .iso8601
+        rhsEncoder.dateEncodingStrategy = .iso8601
 
         do {
             let lhsData = try lhsEncoder.encode(lhs)

--- a/Sources/Misc/Codable/AnyEncodable.swift
+++ b/Sources/Misc/Codable/AnyEncodable.swift
@@ -110,21 +110,17 @@ extension AnyEncodable: Decodable {
 }
 
 extension AnyEncodable: Equatable {
+
     static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool {
-        let lhsEncoder = JSONEncoder()
-        let rhsEncoder = JSONEncoder()
-
-        lhsEncoder.dateEncodingStrategy = .iso8601
-        rhsEncoder.dateEncodingStrategy = .iso8601
-
         do {
-            let lhsData = try lhsEncoder.encode(lhs)
-            let rhsData = try rhsEncoder.encode(rhs)
+            let lhsData = try lhs.encodedJSON
+            let rhsData = try rhs.encodedJSON
             return lhsData == rhsData
         } catch {
             return false
         }
     }
+
 }
 
 // swiftlint:enable cyclomatic_complexity

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -55,6 +55,32 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
         expect(entries[0]).to(equal(content))
     }
 
+    // MARK: - getEntries
+
+    func testGetEntries() async throws {
+        let line1 = """
+        {\"version\": 1, \"type\": \"event\", \"name\": \"event_name\", \"properties\": {}, \"timestamp\": 1712140712}
+        """
+        let line2 = """
+        {\"version\": 1, \"type\": \"event\", \"name\": \"event_name_2\", \"properties\": {}, \"timestamp\": 1712140714}
+        """
+
+        await self.fileHandler.append(line: line1)
+        await self.fileHandler.append(line: line2)
+
+        let content1 = DiagnosticsEvent(name: "event_name",
+                                        properties: [:],
+                                        timestamp: Date(millisecondsSince1970: 1712140712))
+
+        let content2 = DiagnosticsEvent(name: "event_name_2",
+                                        properties: [:],
+                                        timestamp: Date(millisecondsSince1970: 1712140714))
+
+        let entries = await self.handler.getEntries()
+        expect(entries[0]).to(equal(content1))
+        expect(entries[1]).to(equal(content2))
+    }
+
 }
 
 // MARK: - Private

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -88,7 +88,6 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
           "properties": {"key": "value"},
           "timestamp": "2024-04-04T12:55:59Z",
           "name": "HTTP_REQUEST_PERFORMED",
-          "type": "event",
           "version": 1
         }
         """.trimmingWhitespacesAndNewLines
@@ -97,7 +96,6 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
           "properties": {"key": "value"},
           "timestamp": "2024-04-04T13:55:59Z",
           "name": "HTTP_REQUEST_PERFORMED",
-          "type": "event",
           "version": 1
         }
         """.trimmingWhitespacesAndNewLines

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -44,16 +44,17 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
 
     // MARK: - append
 
-//    func testAppendEventWithProperties() async throws {
-//        let content = DiagnosticsEvent(name: "HTTP_REQUEST_PERFORMED",
-//                                       properties: ["key": AnyEncodable("value")],
-//                                       timestamp: Date())
-//
-//        await self.handler.appendEvent(diagnosticsEvent: content)
-//
-//        let entries = await self.handler.getEntries()
-//        expect(entries[0]).to(equal(content))
-//    }
+    func testAppendEventWithProperties() async throws {
+        let content = DiagnosticsEvent(name: "HTTP_REQUEST_PERFORMED",
+                                       properties: ["key": AnyEncodable("value")],
+                                       timestamp: Date())
+
+        await self.handler.appendEvent(diagnosticsEvent: content)
+
+        let entries = await self.handler.getEntries()
+        let encodedContent = try content.encodeAndDecode()
+        expect(entries[0]).to(equal(encodedContent))
+    }
 
     // MARK: - cleanSentDiagnostics
 

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -16,8 +16,8 @@ import Nimble
 @testable import RevenueCat
 import XCTest
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-class BaseDiagnosticsFileHandlerTests: TestCase {
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+class DiagnosticsFileHandlerTests: TestCase {
 
     fileprivate var fileHandler: FileHandler!
     fileprivate var handler: DiagnosticsFileHandler!
@@ -25,7 +25,7 @@ class BaseDiagnosticsFileHandlerTests: TestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         self.fileHandler = try Self.createWithTemporaryFile()
         self.handler = .init(self.fileHandler)
@@ -36,11 +36,6 @@ class BaseDiagnosticsFileHandlerTests: TestCase {
 
         try await super.tearDown()
     }
-
-}
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
 
     // MARK: - append
 
@@ -152,51 +147,10 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
 
 }
 
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-class IOS15DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
-
-    override func setUp() async throws {
-        try await super.setUp()
-
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-    }
-
-    func testGetEntries() async throws {
-        let line1 =
-            "{\"properties\":{\"key\":\"value\"}," +
-            "\"timestamp\":\"2024-04-04T12:55:59Z\"," +
-            "\"name\":\"HTTP_REQUEST_PERFORMED\"," +
-            "\"type\":\"event\"," +
-            "\"version\":1}"
-        let line2 =
-            "{\"properties\":{\"key\":\"value\"}," +
-            "\"timestamp\":\"2024-04-04T13:55:59Z\"," +
-            "\"name\":\"HTTP_REQUEST_PERFORMED\"," +
-            "\"type\":\"event\"," +
-            "\"version\":1}"
-
-        await self.fileHandler.append(line: line1)
-        await self.fileHandler.append(line: line2)
-
-        let content1 = DiagnosticsEvent(name: "HTTP_REQUEST_PERFORMED",
-                                        properties: ["key": AnyEncodable("value")],
-                                        timestamp: Date(millisecondsSince1970: 1712235359000))
-
-        let content2 = DiagnosticsEvent(name: "HTTP_REQUEST_PERFORMED",
-                                        properties: ["key": AnyEncodable("value")],
-                                        timestamp: Date(millisecondsSince1970: 1712238959000))
-
-        let entries = await self.handler.getEntries()
-        expect(entries[0]).to(equal(content1))
-        expect(entries[1]).to(equal(content2))
-    }
-
-}
-
 // MARK: - Private
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-private extension BaseDiagnosticsFileHandlerTests {
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension DiagnosticsFileHandlerTests {
 
     func reCreateHandler() async throws {
         self.fileHandler = try FileHandler(await self.fileHandler.url)

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -59,10 +59,10 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
 
     func testGetEntries() async throws {
         let line1 = """
-        {\"version\": 1, \"type\": \"event\", \"name\": \"event_name\", \"properties\": {}, \"timestamp\": 1712140712}
+        {\"type\": \"event\", \"name\": \"event_name\", \"properties\": {}, \"timestamp\": \"2024-04-03T12:17:36Z\"}
         """
         let line2 = """
-        {\"version\": 1, \"type\": \"event\", \"name\": \"event_name_2\", \"properties\": {}, \"timestamp\": 1712140714}
+        {\"type\": \"event\", \"name\": \"event_name_2\", \"properties\": {}, \"timestamp\": \"2024-04-03T12:18:36Z\"}
         """
 
         await self.fileHandler.append(line: line1)
@@ -70,11 +70,11 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
 
         let content1 = DiagnosticsEvent(name: "event_name",
                                         properties: [:],
-                                        timestamp: Date(millisecondsSince1970: 1712140712))
+                                        timestamp: Date(millisecondsSince1970: 1712146656000))
 
         let content2 = DiagnosticsEvent(name: "event_name_2",
                                         properties: [:],
-                                        timestamp: Date(millisecondsSince1970: 1712140714))
+                                        timestamp: Date(millisecondsSince1970: 1712146716000))
 
         let entries = await self.handler.getEntries()
         expect(entries[0]).to(equal(content1))

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -49,10 +49,14 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
                                        properties: ["key": AnyEncodable("value")],
                                        timestamp: Date())
 
+        var entries = await self.handler.getEntries()
+        expect(entries.count).to(equal(0))
+
         await self.handler.appendEvent(diagnosticsEvent: content)
 
-        let entries = await self.handler.getEntries()
+        entries = await self.handler.getEntries()
         let encodedContent = try content.encodeAndDecode()
+        expect(entries.count).to(equal(1))
         expect(entries[0]).to(equal(encodedContent))
     }
 

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -155,7 +155,7 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-class ModernDiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
+class IOS15DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
 
     override func setUp() async throws {
         try await super.setUp()
@@ -232,4 +232,3 @@ private extension String {
     }
 
 }
-

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -1,0 +1,84 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DiagnosticsFileHandlerTests.swift
+//
+//  Created by Cesar de la Vega on 2/4/24.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+class BaseDiagnosticsFileHandlerTests: TestCase {
+
+    fileprivate var fileHandler: FileHandler!
+    fileprivate var handler: DiagnosticsFileHandler!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        self.fileHandler = try Self.createWithTemporaryFile()
+        self.handler = .init(self.fileHandler)
+    }
+
+    override func tearDown() async throws {
+        self.handler = nil
+
+        try await super.tearDown()
+    }
+
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
+
+    // MARK: - append
+
+    func testAppendEvent() async throws {
+        let content = DiagnosticsEvent(name: "HTTP_REQUEST_PERFORMED", properties: [:], timestamp: Date())
+
+        await self.handler.appendEvent(diagnosticsEvent: content)
+
+        let entries = await self.handler.getEntries()
+        expect(entries[0]).to(equal(content))
+    }
+
+}
+
+// MARK: - Private
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+private extension BaseDiagnosticsFileHandlerTests {
+
+    func reCreateHandler() async throws {
+        self.fileHandler = try FileHandler(await self.fileHandler.url)
+        self.handler = .init(self.fileHandler)
+    }
+
+    static func temporaryFileURL() -> URL {
+        return FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("file_handler_tests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: false)
+            .appendingPathExtension("jsonl")
+    }
+
+    static func createWithTemporaryFile() throws -> FileHandler {
+        return try FileHandler(Self.temporaryFileURL())
+    }
+
+    static func sampleLine() -> String {
+        return UUID().uuidString
+    }
+
+}

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -83,18 +83,24 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
     // MARK: - getEntries
 
     func testGetEntries() async throws {
-        let line1 =
-            "{\"properties\":{\"key\":\"value\"}," +
-            "\"timestamp\":\"2024-04-04T12:55:59Z\"," +
-            "\"name\":\"HTTP_REQUEST_PERFORMED\"," +
-            "\"type\":\"event\"," +
-            "\"version\":1}"
-        let line2 =
-            "{\"properties\":{\"key\":\"value\"}," +
-            "\"timestamp\":\"2024-04-04T13:55:59Z\"," +
-            "\"name\":\"HTTP_REQUEST_PERFORMED\"," +
-            "\"type\":\"event\"," +
-            "\"version\":1}"
+        let line1 = """
+        {
+          "properties": {"key": "value"},
+          "timestamp": "2024-04-04T12:55:59Z",
+          "name": "HTTP_REQUEST_PERFORMED",
+          "type": "event",
+          "version": 1
+        }
+        """.trimmingWhitespacesAndNewLines
+        let line2 = """
+        {
+          "properties": {"key": "value"},
+          "timestamp": "2024-04-04T13:55:59Z",
+          "name": "HTTP_REQUEST_PERFORMED",
+          "type": "event",
+          "version": 1
+        }
+        """.trimmingWhitespacesAndNewLines
 
         await self.fileHandler.append(line: line1)
         await self.fileHandler.append(line: line2)
@@ -115,18 +121,24 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
     // MARK: - emptyFile
 
     func testEmptyFile() async throws {
-        let line1 =
-            "{\"properties\":{\"key\":\"value\"}," +
-            "\"timestamp\":\"2024-04-04T12:55:59Z\"," +
-            "\"name\":\"HTTP_REQUEST_PERFORMED\"," +
-            "\"type\":\"event\"," +
-            "\"version\":1}"
-        let line2 =
-            "{\"properties\":{\"key\":\"value\"}," +
-            "\"timestamp\":\"2024-04-04T13:55:59Z\"," +
-            "\"name\":\"HTTP_REQUEST_PERFORMED\"," +
-            "\"type\":\"event\"," +
-            "\"version\":1}"
+        let line1 = """
+        {
+          "properties": {"key": "value"},
+          "timestamp": "2024-04-04T12:55:59Z",
+          "name": "HTTP_REQUEST_PERFORMED",
+          "type": "event",
+          "version": 1
+        }
+        """.trimmingWhitespacesAndNewLines
+        let line2 = """
+        {
+          "properties": {"key": "value"},
+          "timestamp": "2024-04-04T13:55:59Z",
+          "name": "HTTP_REQUEST_PERFORMED",
+          "type": "event",
+          "version": 1
+        }
+        """.trimmingWhitespacesAndNewLines
 
         await self.fileHandler.append(line: line1)
         await self.fileHandler.append(line: line2)
@@ -212,3 +224,12 @@ private extension BaseDiagnosticsFileHandlerTests {
     }
 
 }
+
+private extension String {
+
+    var trimmingWhitespacesAndNewLines: String {
+        return self.replacingOccurrences(of: "[\\s\\n]+", with: "", options: .regularExpression, range: nil)
+    }
+
+}
+

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -45,7 +45,9 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
     // MARK: - append
 
     func testAppendEvent() async throws {
-        let content = DiagnosticsEvent(name: "HTTP_REQUEST_PERFORMED", properties: [:], timestamp: Date())
+        let content = DiagnosticsEvent(name: "HTTP_REQUEST_PERFORMED",
+                                       properties: ["key": AnyEncodable("value")],
+                                       timestamp: Date())
 
         await self.handler.appendEvent(diagnosticsEvent: content)
 

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -55,6 +55,26 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
         expect(entries[0]).to(equal(content))
     }
 
+    // MARK: - cleanSentDiagnostics
+
+    func testCleanSentDiagnostics() async throws {
+        await self.handler.appendEvent(diagnosticsEvent: Self.sampleEvent())
+        await self.handler.appendEvent(diagnosticsEvent: Self.sampleEvent())
+        await self.handler.appendEvent(diagnosticsEvent: Self.sampleEvent())
+        await self.handler.appendEvent(diagnosticsEvent: Self.sampleEvent())
+
+        var entries = await self.handler.getEntries()
+        expect(entries.count).to(equal(4))
+
+        await self.handler.cleanSentDiagnostics(diagnosticsSentCount: 2)
+        entries = await self.handler.getEntries()
+        expect(entries.count).to(equal(2))
+
+        await self.handler.cleanSentDiagnostics(diagnosticsSentCount: 2)
+        entries = await self.handler.getEntries()
+        expect(entries.count).to(equal(0))
+    }
+
     // MARK: - getEntries
 
     func testGetEntries() async throws {
@@ -105,8 +125,10 @@ private extension BaseDiagnosticsFileHandlerTests {
         return try FileHandler(Self.temporaryFileURL())
     }
 
-    static func sampleLine() -> String {
-        return UUID().uuidString
+    static func sampleEvent() -> DiagnosticsEvent {
+        return DiagnosticsEvent(name: "HTTP_REQUEST_PERFORMED",
+                                properties: ["key": AnyEncodable("value")],
+                                timestamp: Date())
     }
 
 }

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -44,16 +44,16 @@ class DiagnosticsFileHandlerTests: BaseDiagnosticsFileHandlerTests {
 
     // MARK: - append
 
-    func testAppendEvent() async throws {
-        let content = DiagnosticsEvent(name: "HTTP_REQUEST_PERFORMED",
-                                       properties: ["key": AnyEncodable("value")],
-                                       timestamp: Date())
-
-        await self.handler.appendEvent(diagnosticsEvent: content)
-
-        let entries = await self.handler.getEntries()
-        expect(entries[0]).to(equal(content))
-    }
+//    func testAppendEventWithProperties() async throws {
+//        let content = DiagnosticsEvent(name: "HTTP_REQUEST_PERFORMED",
+//                                       properties: ["key": AnyEncodable("value")],
+//                                       timestamp: Date())
+//
+//        await self.handler.appendEvent(diagnosticsEvent: content)
+//
+//        let entries = await self.handler.getEntries()
+//        expect(entries[0]).to(equal(content))
+//    }
 
     // MARK: - cleanSentDiagnostics
 

--- a/Tests/UnitTests/Diagnostics/FileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/FileHandlerTests.swift
@@ -184,7 +184,7 @@ class FileHandlerTests: BaseFileHandlerTests {
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-class ModernFileHandlerTests: BaseFileHandlerTests {
+class IOS15FileHandlerTests: BaseFileHandlerTests {
 
     override func setUp() async throws {
         try await super.setUp()


### PR DESCRIPTION
Based off https://github.com/RevenueCat/purchases-ios/pull/2672/

Equivalent to https://github.com/RevenueCat/purchases-android/pull/784/

Adds DiagnosticsEntry classes and implements adding an entry to the file, getting all entries, and deleting X first entries