### PR TITLE
Fix offerings integration test

### DIFF
--- a/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
@@ -89,5 +89,11 @@
       ],
       "paywall" : null
     }
-  ]
+  ],
+  "placements" : {
+    "fallback_offering_id" : "default",
+    "offering_ids_by_placement" : {
+
+    }
+  }
 }


### PR DESCRIPTION
### Motivation

Fix integration tests

### Description

Integration test snapshot was missing `placements` key with the default offering the the placements fallback. This will always happen now to make sure that `getCurrentOffering(forPlacement:)` has a fallback even when placements isn't enabled.
