### PR TITLE
Add async `syncAttributesAndOfferingsIfNeeded()`

### DIFF
--- a/Sources/Misc/Concurrency/Purchases+async.swift
+++ b/Sources/Misc/Concurrency/Purchases+async.swift
@@ -36,6 +36,14 @@ extension Purchases {
         }
     }
 
+    func syncAttributesAndOfferingsIfNeededAsync() async throws -> Offerings? {
+        return try await withCheckedThrowingContinuation { continuation in
+            syncAttributesAndOfferingsIfNeeded { offerings, error in
+                continuation.resume(with: Result(offerings, error))
+            }
+        }
+    }
+
     #endif
 
     func offeringsAsync(fetchPolicy: OfferingsManager.FetchPolicy) async throws -> Offerings {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -825,6 +825,11 @@ public extension Purchases {
         })
     }
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func syncAttributesAndOfferingsIfNeeded() async throws -> Offerings? {
+        return try await syncAttributesAndOfferingsIfNeededAsync()
+    }
+
 }
 
 #endif

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -864,6 +864,19 @@ public protocol PurchasesType: AnyObject {
      */
     @objc func syncAttributesAndOfferingsIfNeeded(completion: @escaping (Offerings?, PublicError?) -> Void)
 
+    /**
+     * Syncs subscriber attributes and then fetches the configured offerings for this user. This method is intended to
+     * be called when using Targeting Rules with Custom Attributes. Any subscriber attributes should be set before
+     * calling this method to ensure the returned offerings are applied with the latest subscriber attributes.
+     *
+     * This method is rate limited to 5 calls per minute. It will log a warning and return offerings cache when reached.
+     *
+     * #### Related Articles
+     * -  [Targeting](https://docs.revenuecat.com/docs/targeting)
+     */
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func syncAttributesAndOfferingsIfNeeded() async throws -> Offerings?
+
     // MARK: - Deprecated
 
     // swiftlint:disable missing_docs

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -130,6 +130,8 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.getOfferings { (_: Offerings?, _: Error?) in }
     let _: Offerings? = purchases.cachedOfferings
 
+    purchases.syncAttributesAndOfferingsIfNeeded { (_: Offerings?, _: Error?) in }
+
     purchases.getProducts([String]()) { (_: [StoreProduct]) in }
 
     let storeProduct: StoreProduct! = nil
@@ -248,6 +250,8 @@ private func checkAsyncMethods(purchases: Purchases) async {
         )
         let _: CustomerInfo = try await purchases.logOut()
         let _: Offerings = try await purchases.offerings()
+
+        let _: Offerings? = try await purchases.syncAttributesAndOfferingsIfNeeded()
 
         let _: [StoreProduct] = await purchases.products([])
         let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(package: pack)

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -169,6 +169,10 @@ extension MockPurchases: PurchasesType {
         self.unimplemented()
     }
 
+    func syncAttributesAndOfferingsIfNeeded() async throws -> Offerings? {
+        self.unimplemented()
+    }
+
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func customerInfo(fetchPolicy: CacheFetchPolicy) async throws -> CustomerInfo {
         self.unimplemented()

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -169,6 +169,7 @@ extension MockPurchases: PurchasesType {
         self.unimplemented()
     }
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func syncAttributesAndOfferingsIfNeeded() async throws -> Offerings? {
         self.unimplemented()
     }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
@@ -35,14 +35,11 @@ class PurchasesSyncAttributesAndOfferingsTests: BasePurchasesTests {
         expect(self.subscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 1
         expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
     }
-}
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-class PurchasesSyncAttributesAndOfferingsAsyncTests: BasePurchasesTests {
-
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func testAttributesSyncedAndOfferingsFetchedAsync() async throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
-        
+
         self.setupPurchases()
 
         self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(
@@ -55,5 +52,4 @@ class PurchasesSyncAttributesAndOfferingsAsyncTests: BasePurchasesTests {
         expect(self.subscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 1
         expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
     }
-
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
@@ -36,20 +36,21 @@ class PurchasesSyncAttributesAndOfferingsTests: BasePurchasesTests {
         expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func testAttributesSyncedAndOfferingsFetchedAsync() async throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
-        self.setupPurchases()
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+            self.setupPurchases()
 
-        self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(
-            try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:], data: .mockResponse))
-        )
+            self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(
+                try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:], data: .mockResponse))
+            )
 
-        let result: Offerings? = try await self.purchases.syncAttributesAndOfferingsIfNeeded()
+            let result: Offerings? = try await self.purchases.syncAttributesAndOfferingsIfNeeded()
 
-        expect(result).toNot(beNil())
-        expect(self.subscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 1
-        expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
+            expect(result).toNot(beNil())
+            expect(self.subscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 1
+            expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
+        }
     }
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
@@ -35,4 +35,21 @@ class PurchasesSyncAttributesAndOfferingsTests: BasePurchasesTests {
         expect(self.subscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 1
         expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
     }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func testAttributesSyncedAndOfferingsFetchedAsync() async throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        self.setupPurchases()
+
+        self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(
+            try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:], data: .mockResponse))
+        )
+
+        let result: Offerings? = try await self.purchases.syncAttributesAndOfferingsIfNeeded()
+
+        expect(result).toNot(beNil())
+        expect(self.subscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 1
+        expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
+    }
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
@@ -35,22 +35,23 @@ class PurchasesSyncAttributesAndOfferingsTests: BasePurchasesTests {
         expect(self.subscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 1
         expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
     }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+extension PurchasesSyncAttributesAndOfferingsTests {
 
     func testAttributesSyncedAndOfferingsFetchedAsync() async throws {
-        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+        self.setupPurchases()
 
-        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-            self.setupPurchases()
+        self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(
+            try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:], data: .mockResponse))
+        )
 
-            self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(
-                try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:], data: .mockResponse))
-            )
+        let result: Offerings? = try await self.purchases.syncAttributesAndOfferingsIfNeeded()
 
-            let result: Offerings? = try await self.purchases.syncAttributesAndOfferingsIfNeeded()
-
-            expect(result).toNot(beNil())
-            expect(self.subscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 1
-            expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
-        }
+        expect(result).toNot(beNil())
+        expect(self.subscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 1
+        expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
     }
+
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
@@ -41,6 +41,8 @@ class PurchasesSyncAttributesAndOfferingsTests: BasePurchasesTests {
 class PurchasesSyncAttributesAndOfferingsAsyncTests: BasePurchasesTests {
 
     func testAttributesSyncedAndOfferingsFetchedAsync() async throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+        
         self.setupPurchases()
 
         self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
@@ -38,7 +38,7 @@ class PurchasesSyncAttributesAndOfferingsTests: BasePurchasesTests {
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-extension PurchasesSyncAttributesAndOfferingsTests {
+class PurchasesSyncAttributesAndOfferingsAsyncTests: BasePurchasesTests {
 
     func testAttributesSyncedAndOfferingsFetchedAsync() async throws {
         self.setupPurchases()


### PR DESCRIPTION
### Motivation

Added async version of `syncAttributesAndOfferingsIfNeeded()`

### Description

- New async version of `syncAttributesAndOfferingsIfNeeded()` on `PurchasesType`
- Added both async and non-async (oops) versions to API Testers