### PR TITLE
Change `onChangeOf` to be internal

### DIFF
--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -35,7 +35,7 @@ extension View {
     /// Wraps the 2 `onChange(of:)` implementations in iOS 17+ and below depending on what's available
     @inlinable
     @ViewBuilder
-    public func onChangeOf<V>(
+    internal func onChangeOf<V>(
         _ value: V,
         perform action: @escaping (_ newValue: V) -> Void
     ) -> some View where V: Equatable {

--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -35,7 +35,7 @@ extension View {
     /// Wraps the 2 `onChange(of:)` implementations in iOS 17+ and below depending on what's available
     @inlinable
     @ViewBuilder
-    internal func onChangeOf<V>(
+    func onChangeOf<V>(
         _ value: V,
         perform action: @escaping (_ newValue: V) -> Void
     ) -> some View where V: Equatable {

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/V5_API_Migration_guide.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/V5_API_Migration_guide.md
@@ -83,3 +83,7 @@ The minimum targets have been raised to the folllowing:
 ## Release Assets
 
 Pre-built `.frameworks` are no longer included in releases, only `.xcframeworks`: https://github.com/RevenueCat/purchases-ios/pull/3582
+
+## Breaking Changes
+
+- The scope of `onChangeOf` is changed from `public` to `internal`

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/V5_API_Migration_guide.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/V5_API_Migration_guide.md
@@ -86,4 +86,5 @@ Pre-built `.frameworks` are no longer included in releases, only `.xcframeworks`
 
 ## Breaking Changes
 
-- The scope of `onChangeOf` is changed from `public` to `internal`
+- The scope of the View extension `onChangeOf` is changed from `public` to `internal`
+  - This was never intended to be made public and to be used outside of the RevenueCat SDK


### PR DESCRIPTION
### Motivation

`onChangeOf` was accidentally made public in #3517 

### Description

- Change scope of `onChangeOf` from `public` to `internal`
- Added breaking change in v5 migration doc
