### PR TITLE
Prevent Template 4 from wrapping Lifetime

### DIFF
--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -359,6 +359,7 @@ private struct PackageButton: View {
             }
 
             Text(secondRow)
+                .frame(maxWidth: .infinity)
                 .font(self.font(for: .title3).weight(.regular))
         }
     }

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -355,6 +355,7 @@ private struct PackageButton: View {
         VStack {
             if let firstRow {
                 Text(firstRow)
+                    .frame(maxWidth: .infinity)
                     .font(self.font(for: .title).bold())
             }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/SamplePaywalls.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/SamplePaywalls.swift
@@ -322,7 +322,7 @@ private extension SamplePaywallLoader {
         return .init(
             templateName: PaywallTemplate.template4.rawValue,
             config: .init(
-                packages: Array<PackageType>([.monthly, .sixMonth, .annual])
+                packages: Array<PackageType>([.monthly, .annual, .lifetime])
                     .map { Package.string(from: $0)! },
                 defaultPackage: Package.string(from: .sixMonth)!,
                 images: .init(background: "300883_1690710097.jpg"),


### PR DESCRIPTION
### Motivation

Prevent "Lifetime" from wrapping in Template 4

### Description

- Added `.frame(maxWidth: .infinity)` to the package button textfields
  -  They were not expanding all the way due to calculations on their parent's width

| Before | After |
|--------|--------|
| <img width="609" alt="Screenshot 2024-04-09 at 9 12 57 PM" src="https://github.com/RevenueCat/purchases-ios/assets/401294/29890622-648a-4b40-975c-66432b721873"> | <img width="609" alt="Screenshot 2024-04-09 at 9 12 16 PM" src="https://github.com/RevenueCat/purchases-ios/assets/401294/a0623580-888c-4e3f-8e8a-000223968320"> |

