### PR TITLE
Override PaywallViewController touch events to avoid propagating them

### DIFF
--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -158,6 +158,12 @@ public class PaywallViewController: UIViewController {
         self.configuration.fonts = CustomPaywallFontProvider(fontName: fontName)
     }
 
+    // Override touch events to deal with: https://github.com/RevenueCat/purchases-flutter/issues/1023
+    public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {}
+    public override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {}
+    public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {}
+    public override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {}
+
     // MARK: - Internal
 
     class var mode: PaywallViewMode {


### PR DESCRIPTION
### Description
There was an issue reporting with paywalls in flutter: https://github.com/RevenueCat/purchases-flutter/issues/1023

From investigating, it was related to this issue: https://github.com/flutter/flutter/issues/14720

This is a possible solution as suggested in this comment: https://github.com/flutter/flutter/issues/35784#issuecomment-516243057
