### PR TITLE
Make `PaywallViewController` open

### DIFF
--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -22,7 +22,7 @@ import UIKit
 /// - Seealso: ``PaywallView`` for `SwiftUI`.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 @objc(RCPaywallViewController)
-public class PaywallViewController: UIViewController {
+open class PaywallViewController: UIViewController {
 
     /// See ``PaywallViewControllerDelegate`` for receiving purchase events.
     @objc public final weak var delegate: PaywallViewControllerDelegate?

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -70,6 +70,9 @@ func paywallFooterViewControllerAPI(_ delegate: Delegate,
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+final class PaywallViewControllerNoImplementation: PaywallViewController {}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 final class Delegate: PaywallViewControllerDelegate {
 
     func paywallViewControllerDidStartPurchase(_ controller: PaywallViewController) {}


### PR DESCRIPTION
### Description
Following a different approach to #3797. We want to move some logic to the hybrids and we need to make the `PaywallViewController` open for that.