### PR TITLE
Add option to intercept touch events in `PaywallViewController`

### DIFF
--- a/RevenueCatUI/UIKit/PaywallFooterViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallFooterViewController.swift
@@ -38,6 +38,7 @@ public final class PaywallFooterViewController: PaywallViewController {
         super.init(content: .optionalOffering(offering),
                    fonts: DefaultPaywallFontProvider(),
                    displayCloseButton: false,
+                   shouldBlockTouchEvents: false,
                    dismissRequestedHandler: dismissRequestedHandler)
     }
 
@@ -50,6 +51,7 @@ public final class PaywallFooterViewController: PaywallViewController {
         super.init(content: .offeringIdentifier(offeringIdentifier),
                    fonts: DefaultPaywallFontProvider(),
                    displayCloseButton: false,
+                   shouldBlockTouchEvents: false,
                    dismissRequestedHandler: dismissRequestedHandler)
     }
 
@@ -64,6 +66,7 @@ public final class PaywallFooterViewController: PaywallViewController {
         super.init(content: .offeringIdentifier(offeringIdentifier),
                    fonts: CustomPaywallFontProvider(fontName: fontName),
                    displayCloseButton: false,
+                   shouldBlockTouchEvents: false,
                    dismissRequestedHandler: dismissRequestedHandler)
     }
 
@@ -72,11 +75,13 @@ public final class PaywallFooterViewController: PaywallViewController {
         content: PaywallViewConfiguration.Content,
         fonts: PaywallFontProvider,
         displayCloseButton: Bool = false,
+        shouldBlockTouchEvents: Bool = false,
         dismissRequestedHandler: ((_ controller: PaywallViewController) -> Void)? = nil
     ) {
         super.init(content: content,
                    fonts: fonts,
                    displayCloseButton: false,
+                   shouldBlockTouchEvents: false,
                    dismissRequestedHandler: dismissRequestedHandler)
     }
 

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -26,6 +26,10 @@ func paywallViewControllerAPI(_ delegate: Delegate,
     let _: UIViewController = PaywallViewController(offering: offering,
                                                     displayCloseButton: true,
                                                     dismissRequestedHandler: dismissRequestedHandler)
+    let _: UIViewController = PaywallViewController(offering: offering,
+                                                    displayCloseButton: true,
+                                                    shouldBlockTouchEvents: true,
+                                                    dismissRequestedHandler: dismissRequestedHandler)
     let _: UIViewController = PaywallViewController(offering: offering, fonts: fontProvider)
     let _: UIViewController = PaywallViewController(offering: offering, fonts: fontProvider)
     let _: UIViewController = PaywallViewController(offering: offering,
@@ -35,6 +39,11 @@ func paywallViewControllerAPI(_ delegate: Delegate,
                                                     fonts: fontProvider,
                                                     displayCloseButton: true,
                                                     dismissRequestedHandler: dismissRequestedHandler)
+    let _: UIViewController = PaywallViewController(offering: offering,
+                                                    fonts: fontProvider,
+                                                    displayCloseButton: true,
+                                                    shouldBlockTouchEvents: true,
+                                                    dismissRequestedHandler: dismissRequestedHandler)
     let _: UIViewController = PaywallViewController(offeringIdentifier: "offering", displayCloseButton: true)
     let _: UIViewController = PaywallViewController(offeringIdentifier: "offering", fonts: fontProvider)
     let _: UIViewController = PaywallViewController(offeringIdentifier: "offering",
@@ -43,6 +52,11 @@ func paywallViewControllerAPI(_ delegate: Delegate,
     let _: UIViewController = PaywallViewController(offeringIdentifier: "offering",
                                                     fonts: fontProvider,
                                                     displayCloseButton: true,
+                                                    dismissRequestedHandler: dismissRequestedHandler)
+    let _: UIViewController = PaywallViewController(offeringIdentifier: "offering",
+                                                    fonts: fontProvider,
+                                                    displayCloseButton: true,
+                                                    shouldBlockTouchEvents: true,
                                                     dismissRequestedHandler: dismissRequestedHandler)
     let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering", fontName: "Papyrus")
 


### PR DESCRIPTION
### Description
This will help dealing with https://github.com/RevenueCat/purchases-flutter/issues/1023

We will conditionally not propagate touch events from the `PaywallViewController` to fix this issue.