### PR TITLE
Paywalls: Allow closed button color to be configured

### DIFF
--- a/RevenueCatUI/Helpers/ColorInformation+MultiScheme.swift
+++ b/RevenueCatUI/Helpers/ColorInformation+MultiScheme.swift
@@ -47,7 +47,8 @@ extension PaywallData.Configuration.Colors {
                                                    dark: dark.callToActionSecondaryBackground),
             accent1: .init(light: light.accent1, dark: dark.accent1),
             accent2: .init(light: light.accent2, dark: dark.accent2),
-            accent3: .init(light: light.accent3, dark: dark.accent3)
+            accent3: .init(light: light.accent3, dark: dark.accent3),
+            closeButton: .init(light: light.closeButton, dark: dark.closeButton)
         )
     }
 
@@ -118,6 +119,7 @@ extension PaywallData.Configuration.Colors {
     var accent1Color: Color { self.accent1?.underlyingColor ?? self.callToActionForegroundColor }
     var accent2Color: Color { self.accent2?.underlyingColor ?? self.accent1Color }
     var accent3Color: Color { self.accent3?.underlyingColor ?? self.accent2Color }
+    var closeButtonColor: Color? { self.closeButton?.underlyingColor }
 
 }
 

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -80,7 +80,6 @@ private extension PaywallTemplate {
 extension PaywallData {
 
     @ViewBuilder
-    // swiftlint:disable:next function_parameter_count
     func createView(for offering: Offering,
                     template: PaywallTemplate,
                     configuration: Result<TemplateViewConfiguration, Error>,

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -82,18 +82,10 @@ extension PaywallData {
     @ViewBuilder
     // swiftlint:disable:next function_parameter_count
     func createView(for offering: Offering,
-                    activelySubscribedProductIdentifiers: Set<String>,
                     template: PaywallTemplate,
-                    mode: PaywallViewMode,
-                    fonts: PaywallFontProvider,
-                    introEligibility: IntroEligibilityViewModel,
-                    locale: Locale) -> some View {
-        switch self.configuration(for: offering,
-                                  activelySubscribedProductIdentifiers: activelySubscribedProductIdentifiers,
-                                  template: template,
-                                  mode: mode,
-                                  fonts: fonts,
-                                  locale: locale) {
+                    configuration: Result<TemplateViewConfiguration, Error>,
+                    introEligibility: IntroEligibilityViewModel) -> some View {
+        switch configuration {
         case let .success(configuration):
             Self.createView(template: template, configuration: configuration)
                 .adaptTemplateView(with: configuration)

--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -361,6 +361,8 @@ extension PaywallData.Configuration {
         public var accent2: PaywallColor?
         /// Tertiary accent color
         public var accent3: PaywallColor?
+        /// Color for the close button of the paywall.
+        public var closeButton: PaywallColor?
 
         // swiftlint:disable:next missing_docs
         public init(
@@ -373,7 +375,8 @@ extension PaywallData.Configuration {
             callToActionSecondaryBackground: PaywallColor? = nil,
             accent1: PaywallColor? = nil,
             accent2: PaywallColor? = nil,
-            accent3: PaywallColor? = nil
+            accent3: PaywallColor? = nil,
+            closeButton: PaywallColor? = nil
         ) {
             self.background = background
             self.text1 = text1
@@ -385,6 +388,7 @@ extension PaywallData.Configuration {
             self.accent1 = accent1
             self.accent2 = accent2
             self.accent3 = accent3
+            self.closeButton = closeButton
         }
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -33,7 +33,7 @@ final class Configuration: ObservableObject {
     #warning("Configure API key if you want to test paywalls from your dashboard")
     // Note: you can leave this empty to use the production server, or point to your own instance.
     private static let proxyURL = ""
-    private static let apiKey = "appl_TFIZqBlauHeMhnqfNlWWFBjZwkf"
+    private static let apiKey = ""
 
     // This is modified by CI:
     private static let apiKeyFromCIForTesting = ""

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -33,7 +33,7 @@ final class Configuration: ObservableObject {
     #warning("Configure API key if you want to test paywalls from your dashboard")
     // Note: you can leave this empty to use the production server, or point to your own instance.
     private static let proxyURL = ""
-    private static let apiKey = ""
+    private static let apiKey = "appl_TFIZqBlauHeMhnqfNlWWFBjZwkf"
 
     // This is modified by CI:
     private static let apiKeyFromCIForTesting = ""

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/SamplePaywalls.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/SamplePaywalls.swift
@@ -283,7 +283,8 @@ private extension SamplePaywallLoader {
                         callToActionBackground: "#222222",
                         callToActionForeground: "#FFFFFF",
                         accent1: "#F4E971",
-                        accent2: "#121212"
+                        accent2: "#121212",
+                        closeButton: "#00FF00"
                     ),
                     dark: .init(
                         background: "#272727",
@@ -292,7 +293,8 @@ private extension SamplePaywallLoader {
                         callToActionBackground: "#FFFFFF",
                         callToActionForeground: "#000000",
                         accent1: "#F4E971",
-                        accent2: "#4A4A4A"
+                        accent2: "#4A4A4A",
+                        closeButton: "#00FF00"
                     )
                 ),
                 termsOfServiceURL: Self.tosURL


### PR DESCRIPTION
### Motivation

Allow presented paywall view to have a custom close button color from the dashboard

### Description

- New `close_button` color
