### PR TITLE
[PoC] cloud synced anonymous ids

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		2D4D6AF624F7193700B656BE /* verifyReceiptSample1.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2DDE559A24C8B5E300DCB087 /* verifyReceiptSample1.txt */; };
 		2D4D6AF724F7193700B656BE /* base64encodedreceiptsample1.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2DDE559B24C8B5E300DCB087 /* base64encodedreceiptsample1.txt */; };
 		2D4E926526990AB1000E10B0 /* StoreKit1Wrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4E926426990AB1000E10B0 /* StoreKit1Wrapper.swift */; };
+		2D69DAEF2BC73920008FD893 /* CloudSyncedAnonymousIDProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D69DAEE2BC73920008FD893 /* CloudSyncedAnonymousIDProvider.swift */; };
 		2D735F7E26EFF198004E82A7 /* UnitTestsConfiguration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 2D43017726EBFD7100BAB891 /* UnitTestsConfiguration.storekit */; };
 		2D803F6326F144830069D717 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 2D803F6226F144830069D717 /* Nimble */; };
 		2D803F6626F144BF0069D717 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 2D803F6526F144BF0069D717 /* Nimble */; };
@@ -860,6 +861,7 @@
 		2D4E926426990AB1000E10B0 /* StoreKit1Wrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit1Wrapper.swift; sourceTree = "<group>"; };
 		2D5BB46A24C8E8ED00E27537 /* PurchasesReceiptParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesReceiptParser.swift; sourceTree = "<group>"; };
 		2D69384426DFF93300FCDBC0 /* StoreProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductTests.swift; sourceTree = "<group>"; };
+		2D69DAEE2BC73920008FD893 /* CloudSyncedAnonymousIDProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudSyncedAnonymousIDProvider.swift; sourceTree = "<group>"; };
 		2D84458826B9CD270033B5A3 /* ReceiptFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcherTests.swift; sourceTree = "<group>"; };
 		2D8D03B42799A2B90044C2ED /* DocCDocumentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = DocCDocumentation.docc; sourceTree = "<group>"; };
 		2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriberAttributeTests.swift; sourceTree = "<group>"; };
@@ -2849,6 +2851,7 @@
 				4F15B4A02A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift */,
 				B3A36AAD26BC76340059EDEA /* CustomerInfoManager.swift */,
 				B3852F9F26C1ED1F005384F8 /* IdentityManager.swift */,
+				2D69DAEE2BC73920008FD893 /* CloudSyncedAnonymousIDProvider.swift */,
 			);
 			path = Identity;
 			sourceTree = "<group>";
@@ -3453,6 +3456,7 @@
 				A55D5D66282ECCC100FA7623 /* PostAdServicesTokenOperation.swift in Sources */,
 				B3B5FBB4269CED4B00104A0C /* BackendErrorCode.swift in Sources */,
 				2DDF41B624F6F387005BC22D /* ASN1ObjectIdentifierBuilder.swift in Sources */,
+				2D69DAEF2BC73920008FD893 /* CloudSyncedAnonymousIDProvider.swift in Sources */,
 				35D832D2262E56DB00E60AC5 /* HTTPStatusCode.swift in Sources */,
 				5740FCD32996CE5E00E049F9 /* VerificationResult.swift in Sources */,
 				572247D127BEC28E00C524A7 /* Array+Extensions.swift in Sources */,

--- a/Sources/Identity/CloudSyncedAnonymousIDProvider.swift
+++ b/Sources/Identity/CloudSyncedAnonymousIDProvider.swift
@@ -54,4 +54,8 @@ class CloudSyncedAnonymousIDProvider {
         return appUserID.starts(with: Constants.appUserIDPrefix)
     }
 
+    func forceSyncWithICloud() -> Bool {
+        return self.store.synchronize()
+    }
+
 }

--- a/Sources/Identity/CloudSyncedAnonymousIDProvider.swift
+++ b/Sources/Identity/CloudSyncedAnonymousIDProvider.swift
@@ -36,6 +36,7 @@ class CloudSyncedAnonymousIDProvider {
         }
     }
 
+    // todo: add checks for this
     func isKeyValueStoreAvailable() -> Bool {
         let token = FileManager.default.ubiquityIdentityToken
         return token != nil

--- a/Sources/Identity/CloudSyncedAnonymousIDProvider.swift
+++ b/Sources/Identity/CloudSyncedAnonymousIDProvider.swift
@@ -1,0 +1,56 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CloudSyncedAnonymousIDProvider.swift
+//
+//  Created by Andrés Boedo on 4/10/24.
+
+import Foundation
+
+class CloudSyncedAnonymousIDProvider {
+
+    // todo: inject store
+    private let store = NSUbiquitousKeyValueStore.default
+    private enum Constants {
+        static let keyValueStoreKey: String = "appUserID"
+        static let appUserIDPrefix: String = "$RCCloudAnonymousID:"
+    }
+
+    var appUserID: String {
+        get {
+            if let id = self.store.string(forKey: Constants.keyValueStoreKey) {
+                return id
+            } else {
+                return self.resetAppUserID()
+            }
+        }
+        set {
+            self.store.set(newValue, forKey: Constants.keyValueStoreKey)
+            self.store.synchronize()
+        }
+    }
+
+    func isKeyValueStoreAvailable() -> Bool {
+        let token = FileManager.default.ubiquityIdentityToken
+        return token != nil
+    }
+
+    func resetAppUserID() -> String {
+        let uuid = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
+        let newID = Constants.appUserIDPrefix + uuid
+        store.set(newID, forKey: Constants.keyValueStoreKey)
+        store.synchronize()
+        return newID
+    }
+
+    func isCloudSyncedAnonymousID(appUserID: String) -> Bool {
+        return appUserID.starts(with: Constants.appUserIDPrefix)
+    }
+
+}

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -143,11 +143,9 @@ extension IdentityManager {
 private extension IdentityManager {
 
     func performLogIn(appUserID: String, completion: @escaping IdentityAPI.LogInResponseHandler) {
-        // todo: update warning message, we want to warn that you're logging in in this mode,
-        // which maybe is an accident, and that you should check that you're using the right
-        // tranfer behavior
         if cloudSyncedAnonymousIDMode {
-            Logger.warn(Strings.identity.deleting_attributes_none_found)
+            Logger.warn(Strings.identity.login_called_in_cloud_synced_appuserid_mode(oldUserID: currentAppUserID,
+                                                                                     newUserID: appUserID))
         }
 
         let oldAppUserID = self.currentAppUserID
@@ -191,9 +189,9 @@ private extension IdentityManager {
         let newAppUserID: String
         if self.cloudSyncedAnonymousIDMode &&
                 self.cloudSyncedAnonymousIDProvider.isCloudSyncedAnonymousID(appUserID: self.currentAppUserID) {
-            // todo: update with message about how we're switching to a new cloud synced ID.
-            Logger.info(Strings.identity.deleting_attributes_none_found)
             newAppUserID = self.cloudSyncedAnonymousIDProvider.resetAppUserID()
+            Logger.info(Strings.identity.logout_called_in_cloud_synced_appuserid_mode(oldUserID: self.currentAppUserID,
+                                                                                      newUserID: newAppUserID))
         } else {
             newAppUserID = Self.generateRandomID()
         }

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -118,13 +118,18 @@ class IdentityManager: CurrentUserProvider {
 extension IdentityManager {
     
     @objc private func ubiquitousKeyValueStoreDidChange(notification: Notification) {
-        logOut { error in
-            if let error {
-                // todo: add delegate call here informing of the issue.
-            } else {
-                // todo: add delegate call here informing that we've detected an account logout
-                // and that we're automatically logging out the user.
+        guard let userInfo = notification.userInfo else { return }
+
+        if let reason = userInfo[NSUbiquitousKeyValueStoreChangeReasonKey] as? NSNumber {
+            if reason.intValue == NSUbiquitousKeyValueStoreAccountChange {
+                // todo: log
+                // app store account change detected
             }
+        }
+
+        let newAppUserID = cloudSyncedAnonymousIDProvider.appUserID
+        logIn(appUserID: newAppUserID) { response in
+            // todo
         }
     }
 
@@ -200,6 +205,7 @@ private extension IdentityManager {
         Logger.info(Strings.identity.log_out_success)
         completion(nil)
     }
+
 }
 
 // @unchecked because:

--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -42,6 +42,10 @@ enum IdentityStrings {
 
     case sync_attributes_and_offerings_rate_limit_reached(maxCalls: Int, period: Int)
 
+    case login_called_in_cloud_synced_appuserid_mode(oldUserID: String, newUserID: String)
+
+    case logout_called_in_cloud_synced_appuserid_mode(oldUserID: String, newUserID: String)
+
 }
 
 extension IdentityStrings: LogMessage {
@@ -80,7 +84,25 @@ extension IdentityStrings: LogMessage {
         case let .sync_attributes_and_offerings_rate_limit_reached(maxCalls, period):
             return "Sync attributes and offerings rate limit reached:\(maxCalls) per \(period) seconds. " +
             "Returning offerings from cache."
+        case let .login_called_in_cloud_synced_appuserid_mode(oldUserID, newUserID):
+            return """
+            logIn() called with cloud synced appUserIDs enabled. This shouldn't be an issue, but the purchases
+            for the user will be transferred or blocked depending on the configuration in RevenueCat Dashboard.
+            Old user ID: \(oldUserID)
+            New user ID: \(newUserID)
+            More info: https://rev.cat/auth
+            """
+        case let .logout_called_in_cloud_synced_appuserid_mode(oldUserID, newUserID):
+            return """
+            logOut() called with cloud synced appUserIDs enabled. The current user will be logged out, and
+            a new appUserID will be generated.
+            Old user ID: \(oldUserID)
+            New user ID: \(newUserID)
+            """
+
         }
+
+
     }
 
     var category: String { return "identity" }

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -77,6 +77,12 @@ import Foundation
      */
     @objc public let customEntitlementComputation: Bool
 
+    /**
+     * Experimental. A property meant for apps that don't have an accounts system and want to keep
+     * the appUserID synced across devices through NSUbiquituousKeyValueStorage.
+     */
+    public let cloudSyncedAnonymousIDs: Bool
+
     internal let internalSettings: InternalDangerousSettingsType
 
     @objc public override convenience init() {
@@ -109,10 +115,12 @@ import Foundation
     /// Designated initializer
     internal init(autoSyncPurchases: Bool,
                   customEntitlementComputation: Bool = false,
-                  internalSettings: InternalDangerousSettingsType) {
+                  internalSettings: InternalDangerousSettingsType,
+                  cloudSyncedAnonymousIDs: Bool = false) {
         self.autoSyncPurchases = autoSyncPurchases
         self.internalSettings = internalSettings
         self.customEntitlementComputation = customEntitlementComputation
+        self.cloudSyncedAnonymousIDs = cloudSyncedAnonymousIDs
     }
 
 }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -362,7 +362,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                               backend: backend,
                                               customerInfoManager: customerInfoManager,
                                               attributeSyncing: subscriberAttributesManager,
-                                              appUserID: appUserID)
+                                              appUserID: appUserID,
+                                              cloudSyncedAnonymousIDMode: systemInfo.dangerousSettings.cloudSyncedAnonymousIDs)
 
         let paywallEventsManager: PaywallEventsManagerType?
         do {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
@@ -49,7 +49,9 @@ public final class ConfiguredPurchases {
                 .with(observerMode: observerMode)
                 .with(entitlementVerificationMode: entitlementVerificationMode)
                 #if DEBUG
-                .with(dangerousSettings: .init(autoSyncPurchases: true, internalSettings: DangerousSettings.Internal(usesStoreKit2JWS: useStoreKit2)))
+                .with(dangerousSettings: .init(autoSyncPurchases: true,
+                                               internalSettings: DangerousSettings.Internal(usesStoreKit2JWS: useStoreKit2),
+                                               cloudSyncedAnonymousIDs: true))
                 #endif
                 .build()
         )


### PR DESCRIPTION
This allows an app that doesn't have an account system to automatically sync anonymous IDs. 

This is helpful in a few ways: 
- it allows automatic restores on different devices under the same iCloud account
- it prevents sharing app store accounts to attach them to anonymous user IDs and share purchases

This is achieved by using `NSUbiquituousKeyValueStorage`, which syncs data through iCloud. Each app only gets 1mb worth of data, but we're only storing a single string. 

Missing: 
- tests (tested on device and it works as expected though)
- watchOS compatibility (watchOS only supports key value storage starting on watchOS 9.0)
- a delegate to inform developer when an app store account change is detected and the user is logged out as a result
