### PR TITLE
Only update docs index on latest stable releases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 8d4d9b171b3d960556b00e21b334c53af9a64751
+  revision: 1e624200ff2ddf0d398ce072171db35d017c408b
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       rest-client
@@ -12,7 +12,7 @@ GEM
       base64
       nkf
       rexml
-    activesupport (7.1.3)
+    activesupport (7.1.3.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -30,24 +30,24 @@ GEM
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.3.0)
-    aws-partitions (1.907.0)
-    aws-sdk-core (3.191.6)
+    aws-partitions (1.914.0)
+    aws-sdk-core (3.192.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.78.0)
+    aws-sdk-kms (1.79.0)
       aws-sdk-core (~> 3, >= 3.191.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.146.1)
-      aws-sdk-core (~> 3, >= 3.191.0)
+    aws-sdk-s3 (1.147.0)
+      aws-sdk-core (~> 3, >= 3.192.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.8)
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     base64 (0.2.0)
-    bigdecimal (3.1.6)
+    bigdecimal (3.1.7)
     claide (1.1.0)
     claide-plugins (0.9.2)
       cork
@@ -116,8 +116,7 @@ GEM
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.1)
     emoji_regex (3.2.3)
     escape (0.0.4)
     ethon (0.16.0)
@@ -244,7 +243,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
     json (2.7.2)
@@ -259,7 +258,7 @@ GEM
     mime-types-data (3.2024.0305)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    minitest (5.22.1)
+    minitest (5.22.3)
     molinillo (0.8.0)
     multi_json (1.15.0)
     multipart-post (2.4.0)
@@ -275,11 +274,11 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     open4 (1.3.4)
-    optparse (0.4.0)
+    optparse (0.5.0)
     os (1.1.4)
     plist (3.7.1)
     public_suffix (4.0.7)
-    rake (13.2.0)
+    rake (13.2.1)
     rchardet (1.8.0)
     representable (3.2.0)
       declarative (< 0.1.0)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,6 @@ files_with_version_number = {
   './RevenueCatUI.podspec' => ['s.version          = "{x}"'],
   './Sources/Misc/SystemInfo.swift' => ['return "{x}"'],
   './.version' => ['{x}'],
-  './scripts/docs/index.html' => ['purchases-ios-docs/{x}/documentation/revenuecat'],
   './scripts/docs/v4_api_migration_guide.html' => ['purchases-ios-docs/{x}/documentation/revenuecat/v4_api_migration_guide']
 }
 PLIST_VERSION_PATTERNS = ["<key>CFBundleShortVersionString</key>\n\t<string>{x}</string>",]
@@ -28,6 +27,10 @@ files_with_version_number_without_prerelease_modifiers = {
   './Tests/UnitTests/Info.plist' => PLIST_VERSION_PATTERNS,
   './Tests/UnitTestsHostApp/Info.plist' => PLIST_VERSION_PATTERNS
 }
+files_to_update_on_latest_stable_releases = {
+  './scripts/docs/index.html' => ['purchases-ios-docs/{x}/documentation/revenuecat'],
+}
+
 repo_name = 'purchases-ios'
 snapshots_repo_name = 'purchases-ios-snapshots'
 changelog_latest_path = './CHANGELOG.latest.md'
@@ -51,6 +54,7 @@ platform :ios do
       changelog_path: changelog_path,
       files_to_update: files_with_version_number,
       files_to_update_without_prerelease_modifiers: files_with_version_number_without_prerelease_modifiers,
+      files_to_update_on_latest_stable_releases: files_to_update_on_latest_stable_releases,
       repo_name: repo_name,
       github_rate_limit: options[:github_rate_limit],
       editor: options[:editor],


### PR DESCRIPTION
### Description
iOS equivalent of: https://github.com/RevenueCat/purchases-android/pull/1676

We updated the plugin to support a new parameter that will only be updated on stable versions (no prereleases) and as the latest version (no bigger semver versions exist)