### PR TITLE
Use SK2 in Traditional Configure SDK Functions

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1325,7 +1325,7 @@ public extension Purchases {
             with: Configuration
                 .builder(withAPIKey: apiKey)
                 .with(appUserID: appUserID)
-                .with(observerMode: observerMode, storeKitVersion: .storeKit1)
+                .with(observerMode: observerMode, storeKitVersion: .default)
                 .build()
         )
     }
@@ -1344,7 +1344,7 @@ public extension Purchases {
             with: Configuration
                 .builder(withAPIKey: apiKey)
                 .with(appUserID: "\(appUserID)")
-                .with(observerMode: observerMode, storeKitVersion: .storeKit1)
+                .with(observerMode: observerMode, storeKitVersion: .default)
                 .build()
         )
     }


### PR DESCRIPTION
### Motivation
The `Purchases.configure()` functions that don't use the builder patter weren't yet using StoreKit2. This PR updates them to use the default StoreKit version (in this case, StoreKit 2).

### Testing
TODO: Test locally through the purchase tester app and in my own apps.

