### PR TITLE
Track `MaxEventsStoredLimitReached` diagnostics event

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -32,6 +32,7 @@ extension DiagnosticsEvent {
 
         case httpRequestPerformed
         case customerInfoVerificationResult
+        case maxEventsStoredLimitReached
 
     }
 

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -14,9 +14,11 @@
 import Foundation
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-protocol DiagnosticsTrackerType {
+protocol DiagnosticsTrackerType : Sendable {
 
     func track(_ event: DiagnosticsEvent) async
+
+    func trackMaxEventsStoredLimitReached() async
 
 }
 
@@ -24,12 +26,21 @@ protocol DiagnosticsTrackerType {
 final class DiagnosticsTracker: DiagnosticsTrackerType {
 
     private let diagnosticsFileHandler: DiagnosticsFileHandler
+    private let dateProvider: DateProvider
 
-    init(diagnosticsFileHandler: DiagnosticsFileHandler) {
+    init(diagnosticsFileHandler: DiagnosticsFileHandler,
+         dateProvider: DateProvider = .init()) {
         self.diagnosticsFileHandler = diagnosticsFileHandler
+        self.dateProvider = dateProvider
     }
 
     func track(_ event: DiagnosticsEvent) async {
         await diagnosticsFileHandler.appendEvent(diagnosticsEvent: event)
+    }
+
+    func trackMaxEventsStoredLimitReached() async {
+        await self.track(.init(eventType: .maxEventsStoredLimitReached,
+                               properties: [:],
+                               timestamp: self.dateProvider.now()))
     }
 }

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-protocol DiagnosticsTrackerType : Sendable {
+protocol DiagnosticsTrackerType: Sendable {
 
     func track(_ event: DiagnosticsEvent) async
 

--- a/Sources/Diagnostics/FileHandler.swift
+++ b/Sources/Diagnostics/FileHandler.swift
@@ -30,6 +30,8 @@ protocol FileHandlerType: Sendable {
     /// Deletes the first N lines from the file, without loading the entire file in memory.
     func removeFirstLines(_ count: Int) async throws
 
+    func fileSizeInKB() async throws -> Double
+
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
@@ -127,6 +129,14 @@ actor FileHandler: FileHandlerType {
         try self.replaceHandler(with: tempURL)
     }
 
+    func fileSizeInKB() async throws -> Double {
+        let resources = try self.url.resourceValues(forKeys: [.fileSizeKey])
+        guard let fileSizeInBytes = resources.fileSize else {
+            throw Error.failedGettingFileSize(self.url)
+        }
+        return Double(fileSizeInBytes) / 1024
+    }
+
     // MARK: -
 
     private static let fileManager: FileManager = .default
@@ -150,6 +160,7 @@ extension FileHandler {
         case failedSeeking(Swift.Error)
         case failedEmptyingFile(Swift.Error)
         case failedMovingNewFile(from: URL, toURL: URL, Swift.Error)
+        case failedGettingFileSize(URL)
 
     }
 

--- a/Sources/Diagnostics/Networking/DiagnosticsEventsRequest.swift
+++ b/Sources/Diagnostics/Networking/DiagnosticsEventsRequest.swift
@@ -63,6 +63,7 @@ private extension DiagnosticsEvent.EventType {
         switch self {
         case .httpRequestPerformed: return "http_request_performed"
         case .customerInfoVerificationResult: return "customer_info_verification_result"
+        case .maxEventsStoredLimitReached: return "max_events_stored_limit_reached"
         }
 
     }

--- a/Sources/Diagnostics/Networking/DiagnosticsSynchronizer.swift
+++ b/Sources/Diagnostics/Networking/DiagnosticsSynchronizer.swift
@@ -18,6 +18,8 @@ protocol DiagnosticsSynchronizerType {
 
     func syncDiagnosticsIfNeeded() async throws
 
+    func clearDiagnosticsFileIfTooBig() async
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -34,6 +36,12 @@ actor DiagnosticsSynchronizer: DiagnosticsSynchronizerType {
     ) {
         self.internalAPI = internalAPI
         self.handler = handler
+    }
+
+    func clearDiagnosticsFileIfTooBig() async {
+        if await self.handler.isDiagnosticsFileTooBig() {
+            await self.handler.emptyDiagnosticsFile()
+        }
     }
 
     func syncDiagnosticsIfNeeded() async throws {

--- a/Sources/Diagnostics/Networking/DiagnosticsSynchronizer.swift
+++ b/Sources/Diagnostics/Networking/DiagnosticsSynchronizer.swift
@@ -27,20 +27,24 @@ actor DiagnosticsSynchronizer: DiagnosticsSynchronizerType {
 
     private let internalAPI: InternalAPI
     private let handler: DiagnosticsFileHandlerType
+    private let diagnosticsTracker: DiagnosticsTrackerType
 
     private var syncInProgress = false
 
     init(
         internalAPI: InternalAPI,
-        handler: DiagnosticsFileHandlerType
+        handler: DiagnosticsFileHandlerType,
+        diagnosticsTracker: DiagnosticsTrackerType
     ) {
         self.internalAPI = internalAPI
         self.handler = handler
+        self.diagnosticsTracker = diagnosticsTracker
     }
 
     func clearDiagnosticsFileIfTooBig() async {
         if await self.handler.isDiagnosticsFileTooBig() {
             await self.handler.emptyDiagnosticsFile()
+            await self.diagnosticsTracker.trackMaxEventsStoredLimitReached()
         }
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -425,8 +425,10 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                 var diagnosticsSynchronizer: DiagnosticsSynchronizer?
                 if diagnosticsEnabled {
                     if let diagnosticsFileHandler = DiagnosticsFileHandler() {
+                        let diagnosticsTracker = DiagnosticsTracker(diagnosticsFileHandler: diagnosticsFileHandler)
                         diagnosticsSynchronizer = DiagnosticsSynchronizer(internalAPI: backend.internalAPI,
-                                                                          handler: diagnosticsFileHandler)
+                                                                          handler: diagnosticsFileHandler,
+                                                                          diagnosticsTracker: diagnosticsTracker)
                     } else {
                         Logger.error(Strings.diagnostics.could_not_create_diagnostics_tracker)
                     }

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -165,6 +165,7 @@ final class PurchasesOrchestrator {
         }
 
         Task {
+            await diagnosticsSynchronizer?.clearDiagnosticsFileIfTooBig()
             await syncDiagnosticsIfNeeded()
         }
     }

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -1735,6 +1735,18 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(self.orchestrator.diagnosticsSynchronizer).toNot(beNil())
         expect(mockDiagnosticsSynchronizer.invokedSyncDiagnosticsIfNeeded).toEventually(beTrue())
     }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testClearDiagnosticsFileIfTooBigOnInitialization() throws {
+        let mockDiagnosticsSynchronizer = MockDiagnosticsSynchronizer()
+        let transactionListener = MockStoreKit2TransactionListener()
+
+        self.setUpOrchestrator(storeKit2TransactionListener: transactionListener,
+                               storeKit2StorefrontListener: StoreKit2StorefrontListener(delegate: nil),
+                               diagnosticsSynchronizer: mockDiagnosticsSynchronizer)
+        expect(self.orchestrator.diagnosticsSynchronizer).toNot(beNil())
+        expect(mockDiagnosticsSynchronizer.invokedClearDiagnosticsFileIfTooBig).toEventually(beTrue())
+    }
 }
 
 @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 7.0, *)

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -143,6 +143,61 @@ class DiagnosticsFileHandlerTests: TestCase {
         expect(data).to(beEmpty())
     }
 
+    // MARK: - isDiagnosticsFileTooBig
+
+    func testDiagnosticsFileIsNotTooBigIfEmpty() async {
+        let result = await self.handler.isDiagnosticsFileTooBig()
+        expect(result).to(beFalse())
+    }
+
+    func testDiagnosticsFileIsNotTooBigWithAFewEvents() async throws {
+        let line1 = """
+        {
+          "properties": {"key": "value"},
+          "timestamp": "2024-04-04T12:55:59Z",
+          "event_type": "httpRequestPerformed",
+          "version": 1
+        }
+        """.trimmingWhitespacesAndNewLines
+        let line2 = """
+        {
+          "properties": {"key": "value"},
+          "timestamp": "2024-04-04T13:55:59Z",
+          "event_type": "httpRequestPerformed",
+          "version": 1
+        }
+        """.trimmingWhitespacesAndNewLines
+
+        await self.fileHandler.append(line: line1)
+        await self.fileHandler.append(line: line2)
+
+        let data = try await self.fileHandler.readFile()
+        expect(data).toNot(beEmpty())
+
+        let result = await self.handler.isDiagnosticsFileTooBig()
+        expect(result).to(beFalse())
+    }
+
+    func testDiagnosticsFileIsTooBigWithALotOfEvents() async throws {
+        for iterator in 0...8000 {
+            let line = """
+            {
+              "properties": {"key\(iterator)": "value\(iterator)"},
+              "timestamp": "2024-04-04T12:55:59Z",
+              "event_type": "httpRequestPerformed",
+              "version": \(iterator)
+            }
+            """.trimmingWhitespacesAndNewLines
+            await self.fileHandler.append(line: line)
+        }
+
+        let data = try await self.fileHandler.readFile()
+        expect(data).toNot(beEmpty())
+
+        let result = await self.handler.isDiagnosticsFileTooBig()
+        expect(result).to(beTrue())
+    }
+
 }
 
 // MARK: - Private

--- a/Tests/UnitTests/Diagnostics/DiagnosticsSynchronizerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsSynchronizerTests.swift
@@ -130,6 +130,35 @@ class DiagnosticsSynchronizerTests: TestCase {
                                            level: .debug,
                                            expectedCount: 1)
     }
+
+    // MARK: - clearDiagnosticsFileIfTooBig
+
+    func testClearDiagnosticsFileIfTooBigDoesNotClearFileIfNotBig() async throws {
+        _ = await self.storeEvent()
+        _ = await self.storeEvent(timestamp: Self.eventTimestamp2)
+
+        let data = try await self.fileHandler.readFile()
+        expect(data).toNot(beEmpty())
+
+        await self.synchronizer!.clearDiagnosticsFileIfTooBig()
+
+        let data2 = try await self.fileHandler.readFile()
+        expect(data2).to(equal(data))
+    }
+
+    func testClearDiagnosticsFileIfTooBigDoesClearFileIfBig() async throws {
+        for _ in 0...8000 {
+            _ = await self.storeEvent()
+        }
+
+        let data = try await self.fileHandler.readFile()
+        expect(data).toNot(beEmpty())
+
+        await self.synchronizer!.clearDiagnosticsFileIfTooBig()
+
+        let data2 = try await self.fileHandler.readFile()
+        expect(data2).to(beEmpty())
+    }
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/UnitTests/Diagnostics/FileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/FileHandlerTests.swift
@@ -181,6 +181,22 @@ class FileHandlerTests: BaseFileHandlerTests {
         expect(data).to(beEmpty())
     }
 
+    // MARK: - fileSizeInKB
+
+    func testFileSizeInKBForEmptyFile() async throws {
+        let result = try await self.handler.fileSizeInKB()
+        expect(result) == 0
+    }
+
+    func testFileSizeInKBForFileWithSomeData() async throws {
+        let content = Self.sampleLine()
+
+        await self.handler.append(line: content)
+
+        let result = try await self.handler.fileSizeInKB()
+        expect(result) > 0
+    }
+
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/Tests/UnitTests/Mocks/MockDiagnosticsSynchronizer.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsSynchronizer.swift
@@ -17,7 +17,12 @@ import Foundation
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 class MockDiagnosticsSynchronizer: DiagnosticsSynchronizerType {
 
+    private(set) var invokedClearDiagnosticsFileIfTooBig = false
     private(set) var invokedSyncDiagnosticsIfNeeded = false
+
+    func clearDiagnosticsFileIfTooBig() async {
+        invokedClearDiagnosticsFileIfTooBig = true
+    }
 
     func syncDiagnosticsIfNeeded() async throws {
         invokedSyncDiagnosticsIfNeeded = true

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -19,8 +19,17 @@ class MockDiagnosticsTracker: DiagnosticsTrackerType {
 
     private(set) var trackedEvents: [DiagnosticsEvent] = []
 
+    private(set) var invokedTrackMaxEventsStoredLimitReached = false
+
     func track(_ event: DiagnosticsEvent) async {
         trackedEvents.append(event)
     }
 
+    func trackMaxEventsStoredLimitReached() async {
+        invokedTrackMaxEventsStoredLimitReached = true
+    }
+
 }
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+extension MockDiagnosticsTracker: @unchecked Sendable {}

--- a/Tests/UnitTests/Mocks/MockFileHandler.swift
+++ b/Tests/UnitTests/Mocks/MockFileHandler.swift
@@ -42,6 +42,10 @@ actor MockFileHandler: FileHandlerType {
         self.file.removeAll(keepingCapacity: false)
     }
 
+    func fileSizeInKB() async throws -> Double {
+        return Double(self.file.count)
+    }
+
     private var removeFirstLineError: Error?
     func setRemoveFirstLineError(_ error: Error) { self.removeFirstLineError = error }
 


### PR DESCRIPTION
### Description
Adds a new event to track when we reach the diagnostics file size limit as implemented in #3824 