### PR TITLE
Sync repo in an SPM-friendly way

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1007,6 +1007,7 @@ jobs:
       - run:
           name: Create automatic PR
           command: bundle exec fastlane automatic_bump github_rate_limit:10
+      - push-to-spm
 
   push-to-spm:
     docker:
@@ -1234,10 +1235,6 @@ workflows:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
-
-  deploy-spm:
-    jobs:
-      - push-to-spm
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,9 +340,6 @@ commands:
           destination: scan-test-output
 
   push-to-spm:
-    docker:
-      - image: cimg/base:stable
-    resource_class: small
     steps:
       - checkout
       - setup-git-credentials
@@ -1026,6 +1023,13 @@ jobs:
           command: bundle exec fastlane automatic_bump github_rate_limit:10
       - push-to-spm
 
+  push-to-spm-job:
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - push-to-spm
+
   integration-tests-all:
     <<: *base-job
     steps:
@@ -1236,10 +1240,6 @@ workflows:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
-
-  deploy-spm:
-    jobs:
-      - push-to-spm
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1016,13 +1016,6 @@ jobs:
       - checkout
       - revenuecat/setup-git-credentials
       - run:
-          name: Trust GitHub key
-          command: |
-              for ip in $(dig @8.8.8.8 github.com +short); \
-              do ssh-keyscan github.com,$ip; \
-              ssh-keyscan $ip; \
-              done 2>/dev/null >> ~/.ssh/known_hosts
-      - run:
           name: Clone and Push purchases-ios
           command: |
             git clone https://github.com/RevenueCat/purchases-ios.git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1010,7 +1010,6 @@ jobs:
           command: bundle exec fastlane automatic_bump github_rate_limit:10
 
   push-to-spm:
-    <<: *base-job
     steps:
       - checkout
       - revenuecat/setup-git-credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,7 +349,7 @@ commands:
             git clone https://github.com/RevenueCat/purchases-ios.git
             cd purchases-ios
             git fetch --tags
-            git remote set-url origin https://github.com/RevenueCat/purchases-ios-spm4.git
+            git remote set-url origin https://github.com/RevenueCat/purchases-ios-spm.git
             git push origin
             git push --tags
 
@@ -1240,10 +1240,6 @@ workflows:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
-
-  deploy-spm:
-    jobs:
-      - push-to-spm-job
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1027,6 +1027,8 @@ jobs:
           command: |
             git clone https://github.com/RevenueCat/purchases-ios.git
             cd purchases-ios
+            echo "0000"
+            git checkout HEAD~3
             echo "AAAA"
             git fetch --tags
             echo "BBBB"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,4 @@
 orbs:
-  revenuecat: revenuecat/sdks-common-config@3.0.0
   macos: circleci/macos@2.0.1
   slack: circleci/slack@4.10.1
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
@@ -1014,22 +1013,16 @@ jobs:
       - image: cimg/base:stable
     steps:
       - checkout
-      - revenuecat/setup-git-credentials
+      - setup-git-credentials
       - run:
-          name: Clone and Push purchases-ios
+          name: Clone purchases-ios and push to purchases-ios-spm
           command: |
             git clone https://github.com/RevenueCat/purchases-ios.git
             cd purchases-ios
-            echo "AAAA"
             git fetch --tags
-            echo "BBBB"
             git remote set-url origin https://github.com/RevenueCat/purchases-ios-spm4.git
-            echo "CCCC"
             git push origin
-            echo "DDDD"
             git push --tags
-            echo "EEEE"
-
 
   integration-tests-all:
     <<: *base-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1007,7 +1007,6 @@ jobs:
       - run:
           name: Create automatic PR
           command: bundle exec fastlane automatic_bump github_rate_limit:10
-      - push-to-spm
 
   push-to-spm:
     docker:
@@ -1235,6 +1234,10 @@ workflows:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
+
+  deploy-spm:
+    jobs:
+      - push-to-spm
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,23 @@ commands:
           path: fastlane/test_output/xctest
           destination: scan-test-output
 
+  push-to-spm:
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - checkout
+      - setup-git-credentials
+      - run:
+          name: Clone purchases-ios and push to purchases-ios-spm
+          command: |
+            git clone https://github.com/RevenueCat/purchases-ios.git
+            cd purchases-ios
+            git fetch --tags
+            git remote set-url origin https://github.com/RevenueCat/purchases-ios-spm4.git
+            git push origin
+            git push --tags
+
 jobs:
   spm-release-build-xcode-14:
     <<: *base-job
@@ -996,23 +1013,6 @@ jobs:
       - run:
           name: Tag branch
           command: bundle exec fastlane tag_current_branch
-
-  push-to-spm:
-    docker:
-      - image: cimg/base:stable
-    resource_class: small
-    steps:
-      - checkout
-      - setup-git-credentials
-      - run:
-          name: Clone purchases-ios and push to purchases-ios-spm
-          command: |
-            git clone https://github.com/RevenueCat/purchases-ios.git
-            cd purchases-ios
-            git fetch --tags
-            git remote set-url origin https://github.com/RevenueCat/purchases-ios-spm4.git
-            git push origin
-            git push --tags
 
   release-train:
     <<: *base-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1023,13 +1023,6 @@ jobs:
           command: bundle exec fastlane automatic_bump github_rate_limit:10
       - push-to-spm
 
-  push-to-spm-job:
-    docker:
-      - image: cimg/base:stable
-    resource_class: small
-    steps:
-      - push-to-spm
-
   integration-tests-all:
     <<: *base-job
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,10 +346,10 @@ commands:
       - run:
           name: Clone purchases-ios and push to purchases-ios-spm
           command: |
-            git clone https://github.com/RevenueCat/purchases-ios.git
-            cd purchases-ios
+            git clone https://github.com/RevenueCat/purchases-test.git
+            cd purchases-test
             git fetch --tags
-            git remote set-url origin https://github.com/RevenueCat/purchases-ios-spm.git
+            git remote set-url origin https://github.com/RevenueCat/purchases-test-spm.git
             git push origin
             git push --tags
 
@@ -1023,6 +1023,13 @@ jobs:
           command: bundle exec fastlane automatic_bump github_rate_limit:10
       - push-to-spm
 
+  push-to-spm-job:
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - push-to-spm
+
   integration-tests-all:
     <<: *base-job
     steps:
@@ -1234,6 +1241,10 @@ workflows:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
 
+  deploy-spm:
+    jobs:
+      - push-to-spm-job
+      
   deploy:
     when:
       not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1010,6 +1010,7 @@ jobs:
           command: bundle exec fastlane automatic_bump github_rate_limit:10
 
   push-to-spm:
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - revenuecat/setup-git-credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1017,10 +1017,10 @@ jobs:
       - run:
           name: Clone purchases-ios and push to purchases-ios-spm
           command: |
-            git clone https://github.com/RevenueCat/purchases-ios.git
-            cd purchases-ios
+            git clone https://github.com/RevenueCat/purchases-test.git
+            cd purchases-test
             git fetch --tags
-            git remote set-url origin https://github.com/RevenueCat/purchases-ios-spm4.git
+            git remote set-url origin https://github.com/RevenueCat/purchases-test-spm.git
             git push origin
             git push --tags
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1243,7 +1243,7 @@ workflows:
 
   deploy-spm:
     jobs:
-      - push-to-spm
+      - push-to-spm-job
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1010,7 +1010,8 @@ jobs:
           command: bundle exec fastlane automatic_bump github_rate_limit:10
 
   push-to-spm:
-    resource_class: macos.m1.medium.gen1
+    docker:
+      - image: cimg/base:stable
     steps:
       - checkout
       - revenuecat/setup-git-credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,8 +350,8 @@ commands:
             cd purchases-test
             git fetch --tags
             git remote set-url origin https://github.com/RevenueCat/purchases-test-spm.git
-            git push origin
-            git push --tags
+            git push origin --force
+            git push --tags --force
 
 jobs:
   spm-release-build-xcode-14:
@@ -1244,7 +1244,7 @@ workflows:
   deploy-spm:
     jobs:
       - push-to-spm-job
-      
+
   deploy:
     when:
       not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 orbs:
+  revenuecat: revenuecat/sdks-common-config@3.0.0
   macos: circleci/macos@2.0.1
   slack: circleci/slack@4.10.1
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
@@ -1008,6 +1009,34 @@ jobs:
           name: Create automatic PR
           command: bundle exec fastlane automatic_bump github_rate_limit:10
 
+  push-to-spm:
+    <<: *base-job
+    steps:
+      - checkout
+      - revenuecat/setup-git-credentials
+      - run:
+          name: Trust GitHub key
+          command: |
+              for ip in $(dig @8.8.8.8 github.com +short); \
+              do ssh-keyscan github.com,$ip; \
+              ssh-keyscan $ip; \
+              done 2>/dev/null >> ~/.ssh/known_hosts
+      - run:
+          name: Clone and Push purchases-ios
+          command: |
+            git clone https://github.com/RevenueCat/purchases-ios.git
+            cd purchases-ios
+            echo "AAAA"
+            git fetch --tags
+            echo "BBBB"
+            git remote set-url origin https://github.com/RevenueCat/purchases-ios-spm4.git
+            echo "CCCC"
+            git push origin
+            echo "DDDD"
+            git push --tags
+            echo "EEEE"
+
+
   integration-tests-all:
     <<: *base-job
     steps:
@@ -1218,6 +1247,10 @@ workflows:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
+
+  deploy-spm:
+    jobs:
+      - push-to-spm
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1027,8 +1027,6 @@ jobs:
           command: |
             git clone https://github.com/RevenueCat/purchases-ios.git
             cd purchases-ios
-            echo "0000"
-            git checkout HEAD~3
             echo "AAAA"
             git fetch --tags
             echo "BBBB"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,8 +350,8 @@ commands:
             cd purchases-test
             git fetch --tags
             git remote set-url origin https://github.com/RevenueCat/purchases-test-spm.git
-            git push origin --force
-            git push --tags --force
+            git push origin
+            git push --tags
 
 jobs:
   spm-release-build-xcode-14:
@@ -1244,7 +1244,7 @@ workflows:
   deploy-spm:
     jobs:
       - push-to-spm-job
-
+      
   deploy:
     when:
       not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1011,6 +1011,7 @@ jobs:
   push-to-spm:
     docker:
       - image: cimg/base:stable
+    resource_class: small
     steps:
       - checkout
       - setup-git-credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1017,10 +1017,10 @@ jobs:
       - run:
           name: Clone purchases-ios and push to purchases-ios-spm
           command: |
-            git clone https://github.com/RevenueCat/purchases-test.git
-            cd purchases-test
+            git clone https://github.com/RevenueCat/purchases-ios.git
+            cd purchases-ios
             git fetch --tags
-            git remote set-url origin https://github.com/RevenueCat/purchases-test-spm.git
+            git remote set-url origin https://github.com/RevenueCat/purchases-ios-spm4.git
             git push origin
             git push --tags
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1241,6 +1241,10 @@ workflows:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
 
+  deploy-spm:
+    jobs:
+      - push-to-spm
+
   deploy:
     when:
       not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,10 +346,10 @@ commands:
       - run:
           name: Clone purchases-ios and push to purchases-ios-spm
           command: |
-            git clone https://github.com/RevenueCat/purchases-test.git
-            cd purchases-test
+            git clone https://github.com/RevenueCat/purchases-ios.git
+            cd purchases-ios
             git fetch --tags
-            git remote set-url origin https://github.com/RevenueCat/purchases-test-spm.git
+            git remote set-url origin https://github.com/RevenueCat/purchases-ios-spm.git
             git push origin
             git push --tags
 
@@ -1023,13 +1023,6 @@ jobs:
           command: bundle exec fastlane automatic_bump github_rate_limit:10
       - push-to-spm
 
-  push-to-spm-job:
-    docker:
-      - image: cimg/base:stable
-    resource_class: small
-    steps:
-      - push-to-spm
-
   integration-tests-all:
     <<: *base-job
     steps:
@@ -1241,10 +1234,6 @@ workflows:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
 
-  deploy-spm:
-    jobs:
-      - push-to-spm-job
-      
   deploy:
     when:
       not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -997,17 +997,6 @@ jobs:
           name: Tag branch
           command: bundle exec fastlane tag_current_branch
 
-  release-train:
-    <<: *base-job
-    steps:
-      - checkout
-      - setup-git-credentials
-      - trust-github-key
-      - install-dependencies
-      - run:
-          name: Create automatic PR
-          command: bundle exec fastlane automatic_bump github_rate_limit:10
-
   push-to-spm:
     docker:
       - image: cimg/base:stable
@@ -1024,6 +1013,18 @@ jobs:
             git remote set-url origin https://github.com/RevenueCat/purchases-ios-spm4.git
             git push origin
             git push --tags
+
+  release-train:
+    <<: *base-job
+    steps:
+      - checkout
+      - setup-git-credentials
+      - trust-github-key
+      - install-dependencies
+      - run:
+          name: Create automatic PR
+          command: bundle exec fastlane automatic_bump github_rate_limit:10
+      - push-to-spm
 
   integration-tests-all:
     <<: *base-job


### PR DESCRIPTION
Creates a copy of this repo at `/RevenueCat/purchases-ios-spm` that is much faster for integrating RC via SPM.

Before merge:

- [x] Delete and recreate purchases-ios-spm repo
- [x] Set up branch restrictions to require a PR for everyone except the RCGitBot Team
- [x] Assign purchases-ios-spm an owner in Vanta

Before or after merge:
- [x] Manually run the script once to populate the spm repo