### PR TITLE
Update SDK docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Or view our iOS sample apps:
 | visionOS | 1.0+ |
 
 ## SDK Reference
-Our full SDK reference [can be found here](https://revenuecat.github.io/purchases-ios-docs).
+Our full SDK reference [can be found here](https://www.revenuecat.com/docs/getting-started/installation/ios).
 
 ## Contributing
 Contributions are always welcome! To learn how you can contribute, please see the [Contributing Guide](./Contributing/CONTRIBUTING.md).


### PR DESCRIPTION
This is in reference to https://revenuecat.slack.com/archives/C03HPN9UE80/p1713915105266199

I'm unsure if the updated link is the correct one (what did this used to point to)?

This outdated link show up in a number of places - two others in this repo and in a number of other repos - once I get confirmation the new link is the correct one, I can update them too.