### PR TITLE
`Paywalls`: Update Norwegian "restore" localization

### DIFF
--- a/RevenueCatUI/Resources/no.lproj/Localizable.strings
+++ b/RevenueCatUI/Resources/no.lproj/Localizable.strings
@@ -3,7 +3,7 @@
 "Privacy" = "Personvern";
 "Privacy policy" = "Personvernerklæring";
 "Purchases restored successfully!" = "Kjøp gjenopprettet vellykket!";
-"Restore" = "Restaurere";
+"Restore" = "Gjenopprett";
 "Restore purchases" = "Gjenopprette kjøp";
 "Terms" = "Vilkår";
 "Terms and conditions" = "Vilkår og betingelser";


### PR DESCRIPTION
### Motivation

Correct word but wrong context

### Description

`Restaurere` to `Gjenopprett`
