### PR TITLE
PaywallsTester: Improves OfferingList UI  (#2 in queue)

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		4FCA01FB2A3A1CBD00B262C0 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FCA01FA2A3A1CBD00B262C0 /* StoreKit.framework */; };
 		4FDF11202A7270F3004F3680 /* SamplePaywallsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF111F2A7270F3004F3680 /* SamplePaywallsList.swift */; };
 		4FDF11222A72714C004F3680 /* SamplePaywalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF11212A72714C004F3680 /* SamplePaywalls.swift */; };
+		88B2F9882BE1943C00B43E0B /* ManagePaywallButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B2F9872BE1943C00B43E0B /* ManagePaywallButton.swift */; };
 		88B4378C2BD0972B000AF27C /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B4378B2BD0972B000AF27C /* Logging.swift */; };
 		88B438082BDB0089000AF27C /* OfferingsPaywallsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B438072BDB0089000AF27C /* OfferingsPaywallsViewModel.swift */; };
 		88B4380A2BDB0A28000AF27C /* PaywallForID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B438092BDB0A28000AF27C /* PaywallForID.swift */; };
@@ -92,6 +93,7 @@
 		4FDF111F2A7270F3004F3680 /* SamplePaywallsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplePaywallsList.swift; sourceTree = "<group>"; };
 		4FDF11212A72714C004F3680 /* SamplePaywalls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplePaywalls.swift; sourceTree = "<group>"; };
 		4FFD2A602AA154B4001F4B0C /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
+		88B2F9872BE1943C00B43E0B /* ManagePaywallButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagePaywallButton.swift; sourceTree = "<group>"; };
 		88B4378B2BD0972B000AF27C /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		88B438072BDB0089000AF27C /* OfferingsPaywallsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OfferingsPaywallsViewModel.swift; path = PaywallsTester/Data/OfferingsPaywallsViewModel.swift; sourceTree = SOURCE_ROOT; };
 		88B438092BDB0A28000AF27C /* PaywallForID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallForID.swift; sourceTree = "<group>"; };
@@ -209,6 +211,15 @@
 			name = Config;
 			sourceTree = "<group>";
 		};
+		88B2F9892BE1944200B43E0B /* OfferingList */ = {
+			isa = PBXGroup;
+			children = (
+				4FC6F8B12A7403D3002139B2 /* OfferingsList.swift */,
+				88B2F9872BE1943C00B43E0B /* ManagePaywallButton.swift */,
+			);
+			path = OfferingList;
+			sourceTree = "<group>";
+		};
 		88B4378D2BD09735000AF27C /* Logging */ = {
 			isa = PBXGroup;
 			children = (
@@ -225,7 +236,7 @@
 				88B438092BDB0A28000AF27C /* PaywallForID.swift */,
 				4F34FF622A60AD9A00AADF11 /* AppContentView.swift */,
 				4FC046C32A572E3700A28BCF /* DebugView.swift */,
-				4FC6F8B12A7403D3002139B2 /* OfferingsList.swift */,
+				88B2F9892BE1944200B43E0B /* OfferingList */,
 				88B4380B2BDB0FCB000AF27C /* PaywallPresenter.swift */,
 				4FDF111F2A7270F3004F3680 /* SamplePaywallsList.swift */,
 				4F102E262A840ECC0059EED6 /* CustomPaywall.swift */,
@@ -405,6 +416,7 @@
 				88DFC1322BC7385B00273B6D /* AuthenticationActor.swift in Sources */,
 				4F4EE7CF2A572F5D00D7EAE1 /* DebugView.swift in Sources */,
 				88B4378C2BD0972B000AF27C /* Logging.swift in Sources */,
+				88B2F9882BE1943C00B43E0B /* ManagePaywallButton.swift in Sources */,
 				88B438082BDB0089000AF27C /* OfferingsPaywallsViewModel.swift in Sources */,
 				88DFC1332BC7385B00273B6D /* ApplicationManager.swift in Sources */,
 				4FDF11222A72714C004F3680 /* SamplePaywalls.swift in Sources */,

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		4FDF11202A7270F3004F3680 /* SamplePaywallsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF111F2A7270F3004F3680 /* SamplePaywallsList.swift */; };
 		4FDF11222A72714C004F3680 /* SamplePaywalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF11212A72714C004F3680 /* SamplePaywalls.swift */; };
 		88B2F9882BE1943C00B43E0B /* ManagePaywallButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B2F9872BE1943C00B43E0B /* ManagePaywallButton.swift */; };
+		88B2F98B2BE19B1200B43E0B /* OfferingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B2F98A2BE19B1200B43E0B /* OfferingButton.swift */; };
 		88B4378C2BD0972B000AF27C /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B4378B2BD0972B000AF27C /* Logging.swift */; };
 		88B438082BDB0089000AF27C /* OfferingsPaywallsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B438072BDB0089000AF27C /* OfferingsPaywallsViewModel.swift */; };
 		88B4380A2BDB0A28000AF27C /* PaywallForID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B438092BDB0A28000AF27C /* PaywallForID.swift */; };
@@ -94,6 +95,7 @@
 		4FDF11212A72714C004F3680 /* SamplePaywalls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplePaywalls.swift; sourceTree = "<group>"; };
 		4FFD2A602AA154B4001F4B0C /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
 		88B2F9872BE1943C00B43E0B /* ManagePaywallButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagePaywallButton.swift; sourceTree = "<group>"; };
+		88B2F98A2BE19B1200B43E0B /* OfferingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingButton.swift; sourceTree = "<group>"; };
 		88B4378B2BD0972B000AF27C /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		88B438072BDB0089000AF27C /* OfferingsPaywallsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OfferingsPaywallsViewModel.swift; path = PaywallsTester/Data/OfferingsPaywallsViewModel.swift; sourceTree = SOURCE_ROOT; };
 		88B438092BDB0A28000AF27C /* PaywallForID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallForID.swift; sourceTree = "<group>"; };
@@ -216,6 +218,7 @@
 			children = (
 				4FC6F8B12A7403D3002139B2 /* OfferingsList.swift */,
 				88B2F9872BE1943C00B43E0B /* ManagePaywallButton.swift */,
+				88B2F98A2BE19B1200B43E0B /* OfferingButton.swift */,
 			);
 			path = OfferingList;
 			sourceTree = "<group>";
@@ -429,6 +432,7 @@
 				2D708C7F2AC6050000336AC8 /* UpsellView.swift in Sources */,
 				2DBCEDFD2AC4BC060064C274 /* PaywallViewMode+Extensions.swift in Sources */,
 				4F102E272A840ECC0059EED6 /* CustomPaywall.swift in Sources */,
+				88B2F98B2BE19B1200B43E0B /* OfferingButton.swift in Sources */,
 				88B4380A2BDB0A28000AF27C /* PaywallForID.swift in Sources */,
 				4FDF11202A7270F3004F3680 /* SamplePaywallsList.swift in Sources */,
 				88DFC13F2BC73D9D00273B6D /* HTTPMethod.swift in Sources */,

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -2,8 +2,13 @@
   "colors" : [
     {
       "color" : {
-        "platform" : "universal",
-        "reference" : "systemOrangeColor"
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "91",
+          "green" : "84",
+          "red" : "242"
+        }
       },
       "idiom" : "universal"
     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -68,8 +68,10 @@ final class OfferingsPaywallsViewModel {
             let paywalls = try await appPaywalls
 
             let offeringPaywallData = OfferingPaywallData(offerings: offerings, paywalls: paywalls)
-            let listData = PaywallsData(offeringsAndPaywalls: offeringPaywallData.paywallsByOffering(), offeringsWithoutPaywalls: offeringPaywallData.offeringsWithoutPaywalls())
-            self.hasMultipleTemplates = Set(listData.offeringsAndPaywalls.map { $0.paywall.data.templateName }).count > 1
+            let listData = PaywallsData(offeringsAndPaywalls: offeringPaywallData.paywallsByOffering(),
+                                        offeringsWithoutPaywalls: offeringPaywallData.offeringsWithoutPaywalls())
+            let templateNames = listData.offeringsAndPaywalls.map { $0.paywall.data.templateName }
+            self.hasMultipleTemplates = Set(templateNames).count > 1
             self.hasMultipleOfferingsWithPaywalls = listData.offeringsAndPaywalls.count > 1
             self.listData = listData
             self.state = .success

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -61,9 +61,6 @@ final class OfferingsPaywallsViewModel {
             let listData = PaywallsListData(offeringsAndPaywalls: offeringPaywallData.paywallsByOffering(), offeringsWithoutPaywalls: offeringPaywallData.offeringsWithoutPaywalls())
 
             self.listData = .success(listData)
-
-
-
         } catch let error as NSError {
             self.listData = .failure(error)
             Self.logger.log(level: .error, "Could not fetch offerings/paywalls: \(error)")

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -71,14 +71,14 @@ final class OfferingsPaywallsViewModel {
     }
     
     @MainActor
-    func getAndShowPaywallForID(id: String) async {
+    func getAndShowPaywallForID(id: String, mode: PaywallViewMode = .default) async {
 
-        showPaywallForID(id)
+        showPaywallForID(id, mode: mode)
 
         // in case data has changed since last fetch
         await updateOfferingsAndPaywalls()
 
-        showPaywallForID(id)
+        showPaywallForID(id, mode: mode)
     }
 
     private static var logger = Logging.shared.logger(category: "Paywalls Tester")
@@ -117,13 +117,13 @@ extension OfferingsPaywallsViewModel {
     }
 
     @MainActor
-    private func showPaywallForID(_ id: String) {
+    private func showPaywallForID(_ id: String, mode: PaywallViewMode = .default) {
         switch self.listData {
         case let .success(data):
             if let dataForRequestedID = data.offeringsAndPaywalls.first(where: { $0.offering.id == id }) {
                 let newRCOffering = dataForRequestedID.paywall.convertToRevenueCatPaywall(with: dataForRequestedID.offering)
                 if self.presentedPaywall == nil || self.presentedPaywall?.offering.paywall != newRCOffering.paywall {
-                    self.presentedPaywall = .init(offering: newRCOffering, mode: .default, responseOfferingID: id)
+                    self.presentedPaywall = .init(offering: newRCOffering, mode: mode, responseOfferingID: id)
                 }
             }
         default:

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -44,6 +44,8 @@ final class OfferingsPaywallsViewModel {
         }
     }
 
+    private(set) var hasMultipleTemplates = false
+
     var presentedPaywall: PresentedPaywall?
 
     @MainActor
@@ -61,6 +63,7 @@ final class OfferingsPaywallsViewModel {
             let listData = PaywallsListData(offeringsAndPaywalls: offeringPaywallData.paywallsByOffering(), offeringsWithoutPaywalls: offeringPaywallData.offeringsWithoutPaywalls())
 
             self.listData = .success(listData)
+            self.hasMultipleTemplates = Set(listData.offeringsAndPaywalls.map { $0.paywall.data.templateName }).count > 1
         } catch let error as NSError {
             self.listData = .failure(error)
             Self.logger.log(level: .error, "Could not fetch offerings/paywalls: \(error)")

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -45,6 +45,7 @@ final class OfferingsPaywallsViewModel {
     }
 
     private(set) var hasMultipleTemplates = false
+    private(set) var hasMultipleOfferingsWithPaywalls = false
 
     var presentedPaywall: PresentedPaywall?
 
@@ -64,6 +65,7 @@ final class OfferingsPaywallsViewModel {
 
             self.listData = .success(listData)
             self.hasMultipleTemplates = Set(listData.offeringsAndPaywalls.map { $0.paywall.data.templateName }).count > 1
+            self.hasMultipleOfferingsWithPaywalls = listData.offeringsAndPaywalls.count > 1
         } catch let error as NSError {
             self.listData = .failure(error)
             Self.logger.log(level: .error, "Could not fetch offerings/paywalls: \(error)")

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -16,6 +16,7 @@ struct PaywallsListData: Hashable {
 struct OfferingPaywall: Hashable {
     let offering: OfferingsResponse.Offering
     let paywall: PaywallsResponse.Paywall
+    let rcOffering: Offering
 }
 
 struct PresentedPaywall: Hashable {
@@ -108,7 +109,8 @@ extension OfferingsPaywallsViewModel {
             var offeringPaywall = [OfferingPaywall]()
             for offering in self.offerings {
                 if let paywall = paywallsByOfferingID[offering.id] {
-                    offeringPaywall.append(OfferingPaywall(offering: offering, paywall: paywall))
+                    let rcOffering = paywall.convertToRevenueCatPaywall(with: offering)
+                    offeringPaywall.append(OfferingPaywall(offering: offering, paywall: paywall, rcOffering: rcOffering))
                 }
             }
 
@@ -127,8 +129,7 @@ extension OfferingsPaywallsViewModel {
     private func showPaywallForID(_ id: String, mode: PaywallViewMode = .default) {
         switch self.listData {
         case let .success(data):
-            if let dataForRequestedID = data.offeringsAndPaywalls.first(where: { $0.offering.id == id }) {
-                let newRCOffering = dataForRequestedID.paywall.convertToRevenueCatPaywall(with: dataForRequestedID.offering)
+            if let newRCOffering = data.offeringsAndPaywalls.first(where: { $0.offering.id == id })?.rcOffering {
                 if self.presentedPaywall == nil || self.presentedPaywall?.offering.paywall != newRCOffering.paywall {
                     self.presentedPaywall = .init(offering: newRCOffering, mode: mode, responseOfferingID: id)
                 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -29,7 +29,7 @@ struct PresentedPaywall: Hashable {
 final class OfferingsPaywallsViewModel {
 
     enum State {
-        case unloaded
+        case notloaded
         case success
         case error(NSError)
     }
@@ -54,7 +54,7 @@ final class OfferingsPaywallsViewModel {
 
     init(apps: [DeveloperResponse.App]) {
         self.apps = apps
-        state = .unloaded
+        state = .notloaded
     }
 
     @MainActor
@@ -134,7 +134,7 @@ extension OfferingsPaywallsViewModel {
     @MainActor
     private func showPaywallForID(_ id: String, mode: PaywallViewMode = .default) {
         switch self.state {
-        case .unloaded:
+        case .notloaded:
             Self.logger.log(level: .info, "Could not show paywall for id \(id), data not loaded.")
             self.presentedPaywall = nil
         case .success:

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -81,6 +81,11 @@ final class OfferingsPaywallsViewModel {
         showPaywallForID(id, mode: mode)
     }
 
+    @MainActor
+    func dismissPaywall() {
+        self.presentedPaywall = nil
+    }
+
     private static var logger = Logging.shared.logger(category: "Paywalls Tester")
 
     private var apps: [DeveloperResponse.App]

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -84,7 +84,7 @@ extension OfferingsPaywallsViewModel {
         var paywalls: [PaywallsResponse.Paywall]
 
         func paywallsByOffering() -> [OfferingPaywall] {
-            let paywallsByOfferingID = Set(self.paywalls).dictionaryWithKeys { $0.offeringID }
+            let paywallsByOfferingID = self.paywalls.dictionaryWithKeys { $0.offeringID }
 
             var offeringPaywall = [OfferingPaywall]()
             for offering in self.offerings {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
@@ -101,14 +101,6 @@ struct AppContentView: View {
             Text("Currently configured for \(self.descriptionForCurrentMode())")
                 .font(.footnote)
 
-            ConfigurationButton(title: "Configure for demos", mode: .demos, configuration: configuration) {
-                self.configuration.currentMode = .demos
-            }
-
-            ConfigurationButton(title: "Configure for testing", mode: .testing, configuration: configuration) {
-                self.configuration.currentMode = .testing
-            }
-
             ProminentButton(title: "Present default paywall") {
                 self.showingDefaultPaywall.toggle()
             }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
@@ -48,7 +48,7 @@ struct AppContentView: View {
 
             AppList()
                 .tabItem {
-                    Label("My paywalls", systemImage: "network")
+                    Label("My Apps", systemImage: "network")
                 }
 
             if Purchases.isConfigured {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
@@ -23,18 +23,9 @@ struct ManagePaywallButton: View {
         }
     }
 
-    let kind: Kind
-    let appID: String
-    let offeringID: String
-    let buttonName: String?
-
     var body: some View {
         Button {
-            let urlString = urlString(appID: appID, offeringID: offeringID)
-            guard let url = URL(string: urlString) else {
-                Self.logger.log(level: .error, "Could not create URL for \(urlString)")
-                return
-            }
+            guard let url = dashboardPaywallURL else { return }
             openURL(url)
         } label: {
             switch kind {
@@ -60,14 +51,21 @@ struct ManagePaywallButton: View {
 
     init(kind: Kind, appID: String, offeringID: String, buttonName: String? = nil) {
         self.kind = kind
-        self.appID = appID
-        self.offeringID = offeringID
         self.buttonName = buttonName
+        self.dashboardPaywallURL = {
+            let urlString = "https://app.revenuecat.com/projects/\(appID)/paywalls/\(offeringID)/\(kind.rawValue)"
+            guard let url = URL(string: urlString) else {
+                Self.logger.log(level: .error, "Could not create URL for \(urlString)")
+                return nil
+            }
+
+            return url
+        }()
     }
 
-    private func urlString(appID: String, offeringID: String) -> String {
-        "https://app.revenuecat.com/projects/\(appID)/paywalls/\(offeringID)/\(kind.rawValue)"
-    }
+    private let kind: Kind
+    private let buttonName: String?
+    private let dashboardPaywallURL: URL?
 
     private func openURL(_ url: URL) {
         guard UIApplication.shared.canOpenURL(url) else {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
@@ -51,21 +51,26 @@ struct ManagePaywallButton: View {
 
     init(kind: Kind, appID: String, offeringID: String, buttonName: String? = nil) {
         self.kind = kind
+        self.appID = appID
+        self.offeringID = offeringID
         self.buttonName = buttonName
-        self.dashboardPaywallURL = {
-            let urlString = "https://app.revenuecat.com/projects/\(appID)/paywalls/\(offeringID)/\(kind.rawValue)"
-            guard let url = URL(string: urlString) else {
-                Self.logger.log(level: .error, "Could not create URL for \(urlString)")
-                return nil
-            }
-
-            return url
-        }()
     }
 
     private let kind: Kind
+    private let appID: String
+    private let offeringID: String
     private let buttonName: String?
-    private let dashboardPaywallURL: URL?
+
+    private var dashboardPaywallURL: URL? {
+        let urlString = "https://app.revenuecat.com/projects/\(appID)/paywalls/\(offeringID)/\(kind.rawValue)"
+
+        guard let url = URL(string: urlString) else {
+            Self.logger.log(level: .error, "Could not create URL for \(urlString)")
+            return nil
+        }
+
+        return url
+    }
 
     private func openURL(_ url: URL) {
         guard UIApplication.shared.canOpenURL(url) else {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
@@ -30,8 +30,9 @@ struct ManagePaywallButton: View {
 
     var body: some View {
         Button {
-            guard let url = URL(string: urlString(appID: appID, offeringID: offeringID)) else {
-                print("Invalid URL")
+            let urlString = urlString(appID: appID, offeringID: offeringID)
+            guard let url = URL(string: urlString) else {
+                Self.logger.log(level: .error, "Could not create URL for \(urlString)")
                 return
             }
             openURL(url)
@@ -39,7 +40,7 @@ struct ManagePaywallButton: View {
             switch kind {
             case .edit:
                 HStack {
-                    Text("Edit Paywall")
+                    Text(buttonName ?? "Edit Paywall")
                         .font(.headline)
                     Spacer()
                     Image(systemName: kind.systemImageName)
@@ -70,11 +71,13 @@ struct ManagePaywallButton: View {
 
     private func openURL(_ url: URL) {
         guard UIApplication.shared.canOpenURL(url) else {
-            print("Cannot open URL")
+            Self.logger.log(level: .error, "Could not open URL for \(url)")
             return
         }
-        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        UIApplication.shared.open(url)
     }
+
+    private static var logger = Logging.shared.logger(category: "Paywalls Tester")
 }
 
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
@@ -21,6 +21,15 @@ struct ManagePaywallButton: View {
                 return "plus.square.on.square"
             }
         }
+
+        var defaultName: String {
+            switch self {
+            case .edit:
+                "Edit Paywall"
+            case .new:
+                "New Paywall"
+            }
+        }
     }
 
     var body: some View {
@@ -31,14 +40,14 @@ struct ManagePaywallButton: View {
             switch kind {
             case .edit:
                 HStack {
-                    Text(buttonName ?? "Edit Paywall")
+                    Text(buttonName ?? kind.defaultName)
                         .font(.headline)
                     Spacer()
                     Image(systemName: kind.systemImageName)
                 }
             case .new:
                 HStack {
-                    Text(buttonName ?? "New Paywall")
+                    Text(buttonName ?? kind.defaultName)
                         .font(.headline)
                     Spacer()
                     Image(systemName: "escape")

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
@@ -13,12 +13,15 @@ struct ManagePaywallButton: View {
         case edit
         case new
 
-        var systemImageName: String {
-            switch self {
-            case .edit:
-                return "slider.horizontal.2.square.on.square"
-            case .new:
-                return "plus.square.on.square"
+        var image: some View {
+            Group {
+                switch self {
+                case .edit:
+                    Image(systemName: "slider.horizontal.2.square.on.square")
+                case .new:
+                    Image(systemName: "escape")
+                        .rotationEffect(Angle(degrees: 90))
+                }
             }
         }
 
@@ -37,24 +40,12 @@ struct ManagePaywallButton: View {
             guard let url = dashboardPaywallURL else { return }
             openURL(url)
         } label: {
-            switch kind {
-            case .edit:
-                HStack {
-                    Text(buttonName ?? kind.defaultName)
-                        .font(.headline)
-                    Spacer()
-                    Image(systemName: kind.systemImageName)
-                }
-            case .new:
-                HStack {
-                    Text(buttonName ?? kind.defaultName)
-                        .font(.headline)
-                    Spacer()
-                    Image(systemName: "escape")
-                        .rotationEffect(Angle(degrees: 90))
-                }
+            HStack {
+                Text(buttonName ?? kind.defaultName)
+                    .font(.headline)
+                Spacer()
+                kind.image
             }
-
         }
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
@@ -1,0 +1,86 @@
+//
+//  ManagePaywallButton.swift
+//  PaywallsTester
+//
+//  Created by James Borthwick on 2024-04-30.
+//
+
+import SwiftUI
+
+struct ManagePaywallButton: View {
+
+    enum Kind: String {
+        case edit
+        case new
+
+        var systemImageName: String {
+            switch self {
+            case .edit:
+                return "slider.horizontal.2.square.on.square"
+            case .new:
+                return "plus.square.on.square"
+            }
+        }
+    }
+
+    let kind: Kind
+    let appID: String
+    let offeringID: String
+    let buttonName: String?
+
+    var body: some View {
+        Button {
+            guard let url = URL(string: urlString(appID: appID, offeringID: offeringID)) else {
+                print("Invalid URL")
+                return
+            }
+            openURL(url)
+        } label: {
+            switch kind {
+            case .edit:
+                HStack {
+                    Text("Edit Paywall")
+                        .font(.headline)
+                    Spacer()
+                    Image(systemName: kind.systemImageName)
+                }
+            case .new:
+                HStack {
+                    Text(buttonName ?? "New Paywall")
+                        .font(.headline)
+                    Spacer()
+                    Image(systemName: "escape")
+                        .rotationEffect(Angle(degrees: 90))
+                }
+            }
+
+        }
+    }
+
+    init(kind: Kind, appID: String, offeringID: String, buttonName: String? = nil) {
+        self.kind = kind
+        self.appID = appID
+        self.offeringID = offeringID
+        self.buttonName = buttonName
+    }
+
+    private func urlString(appID: String, offeringID: String) -> String {
+        "https://app.revenuecat.com/projects/\(appID)/paywalls/\(offeringID)/\(kind.rawValue)"
+    }
+
+    private func openURL(_ url: URL) {
+        guard UIApplication.shared.canOpenURL(url) else {
+            print("Cannot open URL")
+            return
+        }
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
+}
+
+
+#Preview {
+    List {
+        ManagePaywallButton(kind: .new, appID: "abc", offeringID: "efg")
+        ManagePaywallButton(kind: .edit, appID: "abc", offeringID: "efg")
+    }
+}

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
@@ -24,19 +24,16 @@ struct OfferingButton: View {
     }
 
     init(offeringPaywall: OfferingPaywall,
-         multipleOfferings: Bool,
          viewModel: OfferingsPaywallsViewModel,
          selectedItemID: Binding<String?>) {
         self.responseOffering = offeringPaywall.offering
         self.rcOffering = offeringPaywall.paywall.convertToRevenueCatPaywall(with: responseOffering)
-        self.multipleOfferings = multipleOfferings
         self.viewModel = viewModel
         self._selectedItemID = selectedItemID
     }
 
     private let responseOffering: OfferingsResponse.Offering
     private let rcOffering: Offering
-    private let multipleOfferings: Bool
     private let viewModel: OfferingsPaywallsViewModel
     @Binding private var selectedItemID: String?
 }
@@ -56,7 +53,7 @@ private extension OfferingButton {
     private func label() -> some View {
         let templateName = rcOffering.paywall?.templateName
         let paywallTitle = rcOffering.paywall?.localizedConfiguration.title
-        let decorator = multipleOfferings && self.selectedItemID == responseOffering.id ? "▶ " : ""
+        let decorator = viewModel.hasMultipleOfferingsWithPaywalls && self.selectedItemID == responseOffering.id ? "▶ " : ""
         HStack {
             VStack(alignment:.leading, spacing: 5) {
                 Text(decorator + responseOffering.displayName)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
@@ -27,7 +27,7 @@ struct OfferingButton: View {
          viewModel: OfferingsPaywallsViewModel,
          selectedItemID: Binding<String?>) {
         self.responseOffering = offeringPaywall.offering
-        self.rcOffering = offeringPaywall.paywall.convertToRevenueCatPaywall(with: responseOffering)
+        self.rcOffering = offeringPaywall.rcOffering
         self.viewModel = viewModel
         self._selectedItemID = selectedItemID
     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
@@ -1,0 +1,106 @@
+//
+//  OfferingButton.swift
+//  PaywallsTester
+//
+//  Created by James Borthwick on 2024-04-30.
+//
+
+import SwiftUI
+import RevenueCat
+
+struct OfferingButton: View {
+
+    let responseOffering: OfferingsResponse.Offering
+    let responsePaywall: PaywallsResponse.Paywall
+    let rcOffering: Offering
+    let multipleOfferings: Bool
+    let hasMultipleTemplates: Bool
+    let viewModel: OfferingsPaywallsViewModel
+    @Binding var selectedItemID: String?
+
+    init(offeringPaywall: OfferingPaywall,
+         multipleOfferings: Bool,
+         hasMultipleTemplates: Bool,
+         viewModel: OfferingsPaywallsViewModel,
+         selectedItemID: Binding<String?>) {
+        self.responseOffering = offeringPaywall.offering
+        self.responsePaywall = offeringPaywall.paywall
+        self.rcOffering = responsePaywall.convertToRevenueCatPaywall(with: responseOffering)
+        self.multipleOfferings = multipleOfferings
+        self.hasMultipleTemplates = hasMultipleTemplates
+        self.viewModel = viewModel
+        self._selectedItemID = selectedItemID
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Button {
+                Task {
+                    await viewModel.getAndShowPaywallForID(id: responseOffering.id)
+                    selectedItemID = responseOffering.identifier
+                }
+            } label: {
+                let templateName = rcOffering.paywall?.templateName
+                let paywallTitle = rcOffering.paywall?.localizedConfiguration.title
+                let decorator = multipleOfferings && self.selectedItemID == responseOffering.identifier ? "▶ " : ""
+                HStack {
+                    VStack(alignment:.leading, spacing: 5) {
+                        Text(decorator + responseOffering.displayName)
+                            .font(.headline)
+                        if let title = paywallTitle, let name = templateName {
+                            let text = hasMultipleTemplates ? "Style \(name): \(title)" : title
+                            Text(text)
+                                .font(.footnote)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    Spacer()
+                    offeringButtonMenu(offeringID: responseOffering.id)
+                    .padding(.all, 0)
+                }
+            }
+        }
+        #if !os(watchOS)
+        .contextMenu {
+            contextMenuItems(offeringID: responseOffering.id)
+        }
+        #endif
+    }
+
+    private func offeringButtonMenu(offeringID: String) -> some View {
+        return Menu {
+            contextMenuItems(offeringID: offeringID)
+        } label: {
+            Image(systemName: "ellipsis")
+                .padding([.leading, .vertical])
+        }
+    }
+
+
+    @ViewBuilder
+    func contextMenuItems(offeringID: String) -> some View {
+        ForEach(PaywallViewMode.allCases, id: \.self) { mode in
+            self.showPaywallButton(for: mode, offeringID: offeringID)
+        }
+        if let appID = viewModel.singleApp?.id {
+            Divider()
+            ManagePaywallButton(kind: .edit, appID: appID, offeringID: offeringID)
+        }
+    }
+
+    private func showPaywallButton(for selectedMode: PaywallViewMode, offeringID: String) -> some View {
+        Button {
+            Task { @MainActor in
+                await viewModel.getAndShowPaywallForID(id: offeringID, mode: selectedMode)
+                selectedItemID = offeringID
+            }
+        } label: {
+            Text(selectedMode.name)
+            Image(systemName: selectedMode.icon)
+        }
+    }
+}
+
+//#Preview {
+//    OfferingButton()
+//}

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
@@ -25,13 +25,11 @@ struct OfferingButton: View {
 
     init(offeringPaywall: OfferingPaywall,
          multipleOfferings: Bool,
-         hasMultipleTemplates: Bool,
          viewModel: OfferingsPaywallsViewModel,
          selectedItemID: Binding<String?>) {
         self.responseOffering = offeringPaywall.offering
         self.rcOffering = offeringPaywall.paywall.convertToRevenueCatPaywall(with: responseOffering)
         self.multipleOfferings = multipleOfferings
-        self.hasMultipleTemplates = hasMultipleTemplates
         self.viewModel = viewModel
         self._selectedItemID = selectedItemID
     }
@@ -39,7 +37,6 @@ struct OfferingButton: View {
     private let responseOffering: OfferingsResponse.Offering
     private let rcOffering: Offering
     private let multipleOfferings: Bool
-    private let hasMultipleTemplates: Bool
     private let viewModel: OfferingsPaywallsViewModel
     @Binding private var selectedItemID: String?
 }
@@ -65,7 +62,7 @@ private extension OfferingButton {
                 Text(decorator + responseOffering.displayName)
                     .font(.headline)
                 if let title = paywallTitle, let name = templateName {
-                    let text = hasMultipleTemplates ? "Style \(name): \(title)" : title
+                    let text = viewModel.hasMultipleTemplates ? "Style \(name): \(title)" : title
                     Text(text)
                         .font(.footnote)
                         .foregroundColor(.secondary)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
@@ -78,7 +78,7 @@ struct OfferingButton: View {
 
 
     @ViewBuilder
-    func contextMenuItems(offeringID: String) -> some View {
+    private func contextMenuItems(offeringID: String) -> some View {
         ForEach(PaywallViewMode.allCases, id: \.self) { mode in
             self.showPaywallButton(for: mode, offeringID: offeringID)
         }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
@@ -11,7 +11,6 @@ import RevenueCat
 struct OfferingButton: View {
 
     let responseOffering: OfferingsResponse.Offering
-    let responsePaywall: PaywallsResponse.Paywall
     let rcOffering: Offering
     let multipleOfferings: Bool
     let hasMultipleTemplates: Bool
@@ -24,8 +23,7 @@ struct OfferingButton: View {
          viewModel: OfferingsPaywallsViewModel,
          selectedItemID: Binding<String?>) {
         self.responseOffering = offeringPaywall.offering
-        self.responsePaywall = offeringPaywall.paywall
-        self.rcOffering = responsePaywall.convertToRevenueCatPaywall(with: responseOffering)
+        self.rcOffering = offeringPaywall.paywall.convertToRevenueCatPaywall(with: responseOffering)
         self.multipleOfferings = multipleOfferings
         self.hasMultipleTemplates = hasMultipleTemplates
         self.viewModel = viewModel
@@ -37,12 +35,12 @@ struct OfferingButton: View {
             Button {
                 Task {
                     await viewModel.getAndShowPaywallForID(id: responseOffering.id)
-                    selectedItemID = responseOffering.identifier
+                    selectedItemID = responseOffering.id
                 }
             } label: {
                 let templateName = rcOffering.paywall?.templateName
                 let paywallTitle = rcOffering.paywall?.localizedConfiguration.title
-                let decorator = multipleOfferings && self.selectedItemID == responseOffering.identifier ? "▶ " : ""
+                let decorator = multipleOfferings && self.selectedItemID == responseOffering.id ? "▶ " : ""
                 HStack {
                     VStack(alignment:.leading, spacing: 5) {
                         Text(decorator + responseOffering.displayName)
@@ -56,7 +54,6 @@ struct OfferingButton: View {
                     }
                     Spacer()
                     offeringButtonMenu(offeringID: responseOffering.id)
-                    .padding(.all, 0)
                 }
             }
         }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
@@ -54,11 +54,13 @@ private extension OfferingButton {
 }
 
 private extension OfferingButton {
+
+    @ViewBuilder
     private func label() -> some View {
         let templateName = rcOffering.paywall?.templateName
         let paywallTitle = rcOffering.paywall?.localizedConfiguration.title
         let decorator = multipleOfferings && self.selectedItemID == responseOffering.id ? "▶ " : ""
-        return HStack {
+        HStack {
             VStack(alignment:.leading, spacing: 5) {
                 Text(decorator + responseOffering.displayName)
                     .font(.headline)
@@ -75,7 +77,7 @@ private extension OfferingButton {
     }
 
     private func moreActionsMenu() -> some View {
-        return Menu {
+        Menu {
             contextMenuItems()
         } label: {
             Image(systemName: "ellipsis")

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
@@ -10,12 +10,21 @@ import RevenueCat
 
 struct OfferingButton: View {
 
-    let responseOffering: OfferingsResponse.Offering
-    let rcOffering: Offering
-    let multipleOfferings: Bool
-    let hasMultipleTemplates: Bool
-    let viewModel: OfferingsPaywallsViewModel
-    @Binding var selectedItemID: String?
+    var body: some View {
+        Button {
+            Task {
+                await viewModel.getAndShowPaywallForID(id: responseOffering.id)
+                selectedItemID = responseOffering.id
+            }
+        } label: {
+            offeringButtonLabel()
+        }
+        #if !os(watchOS)
+        .contextMenu {
+            contextMenuItems(offeringID: responseOffering.id)
+        }
+        #endif
+    }
 
     init(offeringPaywall: OfferingPaywall,
          multipleOfferings: Bool,
@@ -30,38 +39,34 @@ struct OfferingButton: View {
         self._selectedItemID = selectedItemID
     }
 
-    var body: some View {
-        VStack(alignment: .leading) {
-            Button {
-                Task {
-                    await viewModel.getAndShowPaywallForID(id: responseOffering.id)
-                    selectedItemID = responseOffering.id
-                }
-            } label: {
-                let templateName = rcOffering.paywall?.templateName
-                let paywallTitle = rcOffering.paywall?.localizedConfiguration.title
-                let decorator = multipleOfferings && self.selectedItemID == responseOffering.id ? "▶ " : ""
-                HStack {
-                    VStack(alignment:.leading, spacing: 5) {
-                        Text(decorator + responseOffering.displayName)
-                            .font(.headline)
-                        if let title = paywallTitle, let name = templateName {
-                            let text = hasMultipleTemplates ? "Style \(name): \(title)" : title
-                            Text(text)
-                                .font(.footnote)
-                                .foregroundColor(.secondary)
-                        }
-                    }
-                    Spacer()
-                    offeringButtonMenu(offeringID: responseOffering.id)
+    private let responseOffering: OfferingsResponse.Offering
+    private let rcOffering: Offering
+    private let multipleOfferings: Bool
+    private let hasMultipleTemplates: Bool
+    private let viewModel: OfferingsPaywallsViewModel
+    @Binding private var selectedItemID: String?
+}
+
+
+private extension OfferingButton {
+    private func offeringButtonLabel() -> some View {
+        let templateName = rcOffering.paywall?.templateName
+        let paywallTitle = rcOffering.paywall?.localizedConfiguration.title
+        let decorator = multipleOfferings && self.selectedItemID == responseOffering.id ? "▶ " : ""
+        return HStack {
+            VStack(alignment:.leading, spacing: 5) {
+                Text(decorator + responseOffering.displayName)
+                    .font(.headline)
+                if let title = paywallTitle, let name = templateName {
+                    let text = hasMultipleTemplates ? "Style \(name): \(title)" : title
+                    Text(text)
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
                 }
             }
+            Spacer()
+            offeringButtonMenu(offeringID: responseOffering.id)
         }
-        #if !os(watchOS)
-        .contextMenu {
-            contextMenuItems(offeringID: responseOffering.id)
-        }
-        #endif
     }
 
     private func offeringButtonMenu(offeringID: String) -> some View {
@@ -72,7 +77,6 @@ struct OfferingButton: View {
                 .padding([.leading, .vertical])
         }
     }
-
 
     @ViewBuilder
     private func contextMenuItems(offeringID: String) -> some View {
@@ -97,7 +101,3 @@ struct OfferingButton: View {
         }
     }
 }
-
-//#Preview {
-//    OfferingButton()
-//}

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -62,7 +62,6 @@ struct OfferingsList: View {
                 if !data.offeringsAndPaywalls.isEmpty {
                     ForEach(data.offeringsAndPaywalls, id: \.self) { offeringPaywall in
                         OfferingButton(offeringPaywall: offeringPaywall,
-                                       multipleOfferings: data.offeringsAndPaywalls.count > 1,
                                        viewModel: viewModel,
                                        selectedItemID: $selectedItemId)
                     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -89,10 +89,8 @@ struct OfferingsList: View {
 
                     VStack(alignment: .leading) {
                         Button {
-                            viewModel.presentedPaywall = .init(offering: rcOffering, mode: .default, responseOfferingID: responseOffering.id)
-                            Task { @MainActor in
-                                // The paywall data may have changed, reload
-                                await viewModel.updateOfferingsAndPaywalls()
+                            Task {
+                                await viewModel.getAndShowPaywallForID(id: responseOffering.id)
                                 selectedItemId = offeringPaywall.offering.id
                             }
                         } label: {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -45,18 +45,22 @@ struct OfferingsList: View {
 
     @ViewBuilder
     private var content: some View {
-        switch viewModel.listData {
-        case let .success(data):
-            self.list(with: data)
-        case let .failure(error):
-            Text(error.description)
-        case .none:
+        switch viewModel.state {
+        case .unloaded:
             SwiftUI.ProgressView()
+        case .success:
+            if let listData = viewModel.listData {
+                self.list(with:listData)
+            } else {
+                Text("No data available.")
+            }
+        case .error(let error):
+            Text(error.description)
         }
     }
 
     @ViewBuilder
-    private func list(with data: PaywallsListData) -> some View {
+    private func list(with data: PaywallsData) -> some View {
         List {
             Section {
                 if !data.offeringsAndPaywalls.isEmpty {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -55,8 +55,7 @@ struct OfferingsList: View {
             SwiftUI.ProgressView()
         }
     }
-    
-    @ViewBuilder
+
     private func list(with data: PaywallsListData) -> some View {
         List {
             Section {
@@ -70,14 +69,7 @@ struct OfferingsList: View {
                                        selectedItemID: $selectedItemId)
                     }
                 } else {
-                    VStack {
-                        ContentUnavailableView("No paywalls configured", systemImage: "exclamationmark.triangle.fill")
-                        Text(Self.pullToRefresh)
-                            .font(.footnote)
-                        Text("Use the RevenueCat [web dashboard](https://app.revenuecat.com/) to configure a new paywall for one of this app's offerings.")
-                            .font(.footnote)
-                            .padding()
-                    }
+                    noPaywallsListItem()
                 }
             } header: {
                 Text("Offerings With Paywalls")
@@ -106,6 +98,17 @@ struct OfferingsList: View {
                     viewModel.presentedPaywall = nil
                 }
                 .id(viewModel.presentedPaywall?.hashValue) //FIXME: This should not be required, issue is in Paywallview
+        }
+    }
+
+    private func noPaywallsListItem() -> some View {
+        return VStack {
+            ContentUnavailableView("No configured paywalls", systemImage: "exclamationmark.triangle.fill")
+            Text(Self.pullToRefresh)
+                .font(.footnote)
+            Text("Use the RevenueCat [web dashboard](https://app.revenuecat.com/) to configure a new paywall for one of this app's offerings.")
+                .font(.footnote)
+                .padding()
         }
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -15,14 +15,6 @@ import SwiftUI
 
 struct OfferingsList: View {
 
-    @Environment(\.scenePhase) var scenePhase
-
-    @State
-    private var viewModel: OfferingsPaywallsViewModel
-
-    @State
-    private var selectedItemId: String?
-
     init(app: DeveloperResponse.App) {
 
         self._viewModel = State(initialValue: OfferingsPaywallsViewModel(apps: [app]))
@@ -42,6 +34,15 @@ struct OfferingsList: View {
             }
     }
 
+    @Environment(\.scenePhase) private var scenePhase
+
+    @State
+    private var viewModel: OfferingsPaywallsViewModel
+
+    @State
+    private var selectedItemId: String?
+
+
     @ViewBuilder
     private var content: some View {
         switch viewModel.listData {
@@ -54,15 +55,14 @@ struct OfferingsList: View {
         }
     }
 
+    @ViewBuilder
     private func list(with data: PaywallsListData) -> some View {
         List {
             Section {
                 if !data.offeringsAndPaywalls.isEmpty {
-                    let hasMultipleTemplates = Set(data.offeringsAndPaywalls.map { $0.paywall.data.templateName }).count > 1
                     ForEach(data.offeringsAndPaywalls, id: \.self) { offeringPaywall in
                         OfferingButton(offeringPaywall: offeringPaywall,
                                        multipleOfferings: data.offeringsAndPaywalls.count > 1,
-                                       hasMultipleTemplates: hasMultipleTemplates,
                                        viewModel: viewModel,
                                        selectedItemID: $selectedItemId)
                     }
@@ -100,7 +100,7 @@ struct OfferingsList: View {
     }
 
     private func noPaywallsListItem() -> some View {
-        return VStack {
+        VStack {
             ContentUnavailableView("No configured paywalls", systemImage: "exclamationmark.triangle.fill")
             Text(Self.pullToRefresh)
                 .font(.footnote)
@@ -117,8 +117,6 @@ struct OfferingsList: View {
 #endif
 
 }
-
-
 
 extension PresentedPaywall: Identifiable {
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -13,8 +13,6 @@ import RevenueCatUI
 #endif
 import SwiftUI
 
-
-// TODO: Ask Barbara about how to present
 struct OfferingsList: View {
 
     @Environment(\.scenePhase) var scenePhase

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -91,8 +91,8 @@ struct OfferingsList: View {
     @ViewBuilder
     private func offeringsWithPaywallsListItems(with data: PaywallsData) -> some View {
         if !data.offeringsAndPaywalls.isEmpty {
-            ForEach(data.offeringsAndPaywalls, id: \.self) { offeringPaywall in
-                OfferingButton(offeringPaywall: offeringPaywall,
+            ForEach(data.offeringsAndPaywalls, id: \.self) { offeringWithPaywall in
+                OfferingButton(offeringPaywall: offeringWithPaywall,
                                viewModel: viewModel,
                                selectedItemID: $selectedItemId)
             }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -76,7 +76,7 @@ struct OfferingsList: View {
             SwiftUI.ProgressView()
         }
     }
-
+    
     @ViewBuilder
     private func list(with data: PaywallsListData) -> some View {
         List {
@@ -118,25 +118,7 @@ struct OfferingsList: View {
                                     }
                                     if let appID = viewModel.singleApp?.id {
                                         Divider()
-                                        Button {
-                                            let urlString = "https://app.revenuecat.com/projects/" + appID + "/paywalls/" + responseOffering.id + "/edit"
-                                            if let url = URL(string: urlString) {
-                                                if UIApplication.shared.canOpenURL(url) {
-                                                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
-                                                } else {
-                                                    print("Cannot open URL")
-                                                }
-                                            } else {
-                                                print("Invalid URL")
-                                            }
-                                        } label: {
-                                            HStack {
-                                                Text("Edit Paywall")
-                                                    .font(.headline)
-                                                Spacer()
-                                                Image(systemName: "slider.horizontal.2.square.on.square")
-                                            }
-                                        }
+                                        ManagePaywallButton(kind: .edit, appID: appID, offeringID: responseOffering.id)
                                     }
                                 } label: {
                                     Image(systemName: "ellipsis")
@@ -157,26 +139,10 @@ struct OfferingsList: View {
             if let appID = viewModel.singleApp?.id, !data.offeringsWithoutPaywalls.isEmpty {
                 Section(header: Text("Offerings Without Paywalls")) {
                     ForEach(data.offeringsWithoutPaywalls, id: \.self) { offeringWithoutPaywall in
-                        Button {
-                            let urlString = "https://app.revenuecat.com/projects/" + appID + "/paywalls/" + offeringWithoutPaywall.id + "/new"
-                            if let url = URL(string: urlString) {
-                                if UIApplication.shared.canOpenURL(url) {
-                                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
-                                } else {
-                                    print("Cannot open URL")
-                                }
-                            } else {
-                                print("Invalid URL")
-                            }
-                        } label: {
-                            HStack {
-                                Text(offeringWithoutPaywall.displayName)
-                                    .font(.headline)
-                                Spacer()
-                                Image(systemName: "escape")
-                                    .rotationEffect(Angle(degrees: 90))
-                            }
-                        }
+                        ManagePaywallButton(kind: .new, 
+                                            appID: appID,
+                                            offeringID: offeringWithoutPaywall.id,
+                                            buttonName: offeringWithoutPaywall.displayName)
                     }
                 }
             }
@@ -226,6 +192,8 @@ struct OfferingsList: View {
 #endif
 
 }
+
+
 
 extension PresentedPaywall: Identifiable {
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -15,11 +15,6 @@ import SwiftUI
 
 struct OfferingsList: View {
 
-    init(app: DeveloperResponse.App) {
-
-        self._viewModel = State(initialValue: OfferingsPaywallsViewModel(apps: [app]))
-    }
-
     var body: some View {
         self.content
             .task {
@@ -34,6 +29,11 @@ struct OfferingsList: View {
             }
     }
 
+    init(app: DeveloperResponse.App) {
+
+        self._viewModel = State(initialValue: OfferingsPaywallsViewModel(apps: [app]))
+    }
+
     @Environment(\.scenePhase) private var scenePhase
 
     @State
@@ -42,7 +42,6 @@ struct OfferingsList: View {
     @State
     private var selectedItemId: String?
 
-
     @ViewBuilder
     private var content: some View {
         switch viewModel.state {
@@ -50,7 +49,7 @@ struct OfferingsList: View {
             SwiftUI.ProgressView()
         case .success:
             if let listData = viewModel.listData {
-                self.list(with:listData)
+                self.offeringsList(with:listData)
             } else {
                 Text("No data available.")
             }
@@ -58,31 +57,18 @@ struct OfferingsList: View {
             Text(error.description)
         }
     }
-
+    
     @ViewBuilder
-    private func list(with data: PaywallsData) -> some View {
+    private func offeringsList(with data: PaywallsData) -> some View {
         List {
             Section {
-                if !data.offeringsAndPaywalls.isEmpty {
-                    ForEach(data.offeringsAndPaywalls, id: \.self) { offeringPaywall in
-                        OfferingButton(offeringPaywall: offeringPaywall,
-                                       viewModel: viewModel,
-                                       selectedItemID: $selectedItemId)
-                    }
-                } else {
-                    noPaywallsListItem()
-                }
+                offeringsWithPaywallsListItems(with: data)
             } header: {
                 Text("Offerings With Paywalls")
             }
             if let appID = viewModel.singleApp?.id, !data.offeringsWithoutPaywalls.isEmpty {
                 Section{
-                    ForEach(data.offeringsWithoutPaywalls, id: \.self) { offeringWithoutPaywall in
-                        ManagePaywallButton(kind: .new, 
-                                            appID: appID,
-                                            offeringID: offeringWithoutPaywall.id,
-                                            buttonName: offeringWithoutPaywall.displayName)
-                    }
+                    offeringsWithoutPaywallsListItems(with: data, appID: appID)
                 } header: {
                     Text("Offerings Without Paywalls")
                 }
@@ -99,6 +85,29 @@ struct OfferingsList: View {
                     viewModel.dismissPaywall()
                 }
                 .id(viewModel.presentedPaywall?.hashValue) //FIXME: This should not be required, issue is in Paywallview
+        }
+    }
+
+    @ViewBuilder
+    private func offeringsWithPaywallsListItems(with data: PaywallsData) -> some View {
+        if !data.offeringsAndPaywalls.isEmpty {
+            ForEach(data.offeringsAndPaywalls, id: \.self) { offeringPaywall in
+                OfferingButton(offeringPaywall: offeringPaywall,
+                               viewModel: viewModel,
+                               selectedItemID: $selectedItemId)
+            }
+        } else {
+            noPaywallsListItem()
+        }
+    }
+
+    @ViewBuilder
+    private func offeringsWithoutPaywallsListItems(with data: PaywallsData, appID: String) -> some View {
+        ForEach(data.offeringsWithoutPaywalls, id: \.self) { offeringWithoutPaywall in
+            ManagePaywallButton(kind: .new,
+                                appID: appID,
+                                offeringID: offeringWithoutPaywall.id,
+                                buttonName: offeringWithoutPaywall.displayName)
         }
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -46,7 +46,7 @@ struct OfferingsList: View {
     @ViewBuilder
     private var content: some View {
         switch viewModel.state {
-        case .unloaded:
+        case .notloaded:
             SwiftUI.ProgressView()
         case .success:
             if let listData = viewModel.listData {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -93,7 +93,7 @@ struct OfferingsList: View {
         .sheet(item: $viewModel.presentedPaywall) { paywall in
             PaywallPresenter(offering: paywall.offering, mode: paywall.mode)
                 .onRestoreCompleted { _ in
-                    viewModel.presentedPaywall = nil
+                    viewModel.dismissPaywall()
                 }
                 .id(viewModel.presentedPaywall?.hashValue) //FIXME: This should not be required, issue is in Paywallview
         }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingsList.swift
@@ -107,6 +107,29 @@ struct OfferingsList: View {
                                     ForEach(PaywallViewMode.allCases, id: \.self) { mode in
                                         self.button(for: mode, offering: rcOffering, responseOfferingID: responseOffering.id)
                                     }
+                                    if let appID = viewModel.singleApp?.id {
+                                        Divider()
+                                        Button {
+                                            let urlString = "https://app.revenuecat.com/projects/" + appID + "/paywalls/" + responseOffering.id + "/edit"
+                                            if let url = URL(string: urlString) {
+                                                if UIApplication.shared.canOpenURL(url) {
+                                                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                                                } else {
+                                                    print("Cannot open URL")
+                                                }
+                                            } else {
+                                                print("Invalid URL")
+                                            }
+                                        } label: {
+                                            HStack {
+                                                Text("Edit Paywall")
+                                                    .font(.headline)
+                                                Spacer()
+                                                Image(systemName: "slider.horizontal.2.square.on.square")
+                                            }
+                                        }
+                                    }
+
                                 } label: {
                                     Image(systemName: "ellipsis")
                                         .padding([.leading, .vertical])

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingsList.swift
@@ -70,6 +70,8 @@ struct OfferingsList: View {
 
     @ViewBuilder
     private func list(with data: [OfferingPaywall]) -> some View {
+        let heterogenousTemplates = Set(data.map { $0.paywall.data.templateName }).count > 1
+
         List {
             ForEach(data, id: \.self) { offeringPaywall in
                 let responseOffering = offeringPaywall.offering
@@ -85,16 +87,20 @@ struct OfferingsList: View {
                             selectedItemId = offeringPaywall.offering.id
                         }
                     } label: {
-                        let name = responsePaywall.data.templateName
-                        let humanTemplateName = PaywallTemplate(rawValue: name)?.name ?? name
+                        let templateName = rcOffering.paywall?.templateName
+                        let paywallTitle = rcOffering.paywall?.localizedConfiguration.title
+
                         let decorator = data.count > 1 && self.selectedItemId == offeringPaywall.offering.id ? "▶ " : ""
                         HStack {
-                            VStack(alignment:.leading) {
+                            VStack(alignment:.leading, spacing: 5) {
                                 Text(decorator + responseOffering.displayName)
                                     .font(.headline)
-                                Text("\(humanTemplateName)")
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
+                                if let title = paywallTitle, let name = templateName {
+                                    let text = heterogenousTemplates ? "Style \(name): \(title)" : title
+                                    Text(text)
+                                        .font(.footnote)
+                                        .foregroundColor(.secondary)
+                                }
                             }
                             Spacer()
                             Menu {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingsList.swift
@@ -70,7 +70,7 @@ struct OfferingsList: View {
 
     @ViewBuilder
     private func list(with data: [OfferingPaywall]) -> some View {
-        let heterogenousTemplates = Set(data.map { $0.paywall.data.templateName }).count > 1
+        let hasMultipleTemplates = Set(data.map { $0.paywall.data.templateName }).count > 1
 
         List {
             ForEach(data, id: \.self) { offeringPaywall in
@@ -96,7 +96,7 @@ struct OfferingsList: View {
                                 Text(decorator + responseOffering.displayName)
                                     .font(.headline)
                                 if let title = paywallTitle, let name = templateName {
-                                    let text = heterogenousTemplates ? "Style \(name): \(title)" : title
+                                    let text = hasMultipleTemplates ? "Style \(name): \(title)" : title
                                     Text(text)
                                         .font(.footnote)
                                         .foregroundColor(.secondary)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingsList.swift
@@ -17,6 +17,8 @@ import SwiftUI
 // TODO: Ask Barbara about how to present
 struct OfferingsList: View {
 
+    @Environment(\.scenePhase) var scenePhase
+
     @State
     private var viewModel: OfferingsPaywallsViewModel
 
@@ -32,6 +34,13 @@ struct OfferingsList: View {
         self.content
             .task {
                 await viewModel.updateOfferingsAndPaywalls()
+            }
+            .onChange(of: scenePhase) { oldPhase, newPhase in
+                if newPhase == .active {
+                    Task {
+                        await viewModel.updateOfferingsAndPaywalls()
+                    }
+                }
             }
     }
 
@@ -129,13 +138,11 @@ struct OfferingsList: View {
                                             }
                                         }
                                     }
-
                                 } label: {
                                     Image(systemName: "ellipsis")
                                         .padding([.leading, .vertical])
                                 }
                                 .padding(.all, 0)
-
                             }
 #if !os(watchOS)
                             .contextMenu {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingsList.swift
@@ -181,7 +181,7 @@ struct OfferingsList: View {
                 }
             }
 
-    }
+        }
         .refreshable {
             Task { @MainActor in
                 await viewModel.updateOfferingsAndPaywalls()
@@ -194,35 +194,35 @@ struct OfferingsList: View {
                 }
                 .id(viewModel.presentedPaywall?.hashValue) //FIXME: This should not be required, issue is in Paywallview
         }
-}
+    }
 
 #if !os(watchOS)
-@ViewBuilder
-private func contextMenu(for offering: Offering, responseOfferingID: String) -> some View {
-    ForEach(PaywallViewMode.allCases, id: \.self) { mode in
-        self.button(for: mode, offering: offering, responseOfferingID: responseOfferingID)
+    @ViewBuilder
+    private func contextMenu(for offering: Offering, responseOfferingID: String) -> some View {
+        ForEach(PaywallViewMode.allCases, id: \.self) { mode in
+            self.button(for: mode, offering: offering, responseOfferingID: responseOfferingID)
+        }
     }
-}
 #endif
 
-@ViewBuilder
-private func button(for selectedMode: PaywallViewMode, offering: Offering, responseOfferingID: String) -> some View {
-    Button {
-        viewModel.presentedPaywall = .init(offering: offering, mode: selectedMode, responseOfferingID: responseOfferingID)
-        Task { @MainActor in
-            await viewModel.updateOfferingsAndPaywalls()
-            selectedItemId = responseOfferingID
+    @ViewBuilder
+    private func button(for selectedMode: PaywallViewMode, offering: Offering, responseOfferingID: String) -> some View {
+        Button {
+            viewModel.presentedPaywall = .init(offering: offering, mode: selectedMode, responseOfferingID: responseOfferingID)
+            Task { @MainActor in
+                await viewModel.updateOfferingsAndPaywalls()
+                selectedItemId = responseOfferingID
+            }
+        } label: {
+            Text(selectedMode.name)
+            Image(systemName: selectedMode.icon)
         }
-    } label: {
-        Text(selectedMode.name)
-        Image(systemName: selectedMode.icon)
     }
-}
 
 #if targetEnvironment(macCatalyst)
-private static let pullToRefresh = ""
+    private static let pullToRefresh = ""
 #else
-private static let pullToRefresh = "Pull to refresh"
+    private static let pullToRefresh = "Pull to refresh"
 #endif
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -19,7 +19,7 @@ struct SamplePaywallsList: View {
     var body: some View {
         NavigationView {
             self.list(with: Self.loader)
-                .navigationTitle("Test Paywalls")
+                .navigationTitle("Example Paywalls")
         }
             .sheet(item: self.$display) { display in
                 self.view(for: display)


### PR DESCRIPTION
Base branch is https://github.com/RevenueCat/purchases-ios/pull/3850

This improves the Offerings list UI:

- Offerings with paywalls are grouped into a single section
- Offering paywall buttons are named by their offering, with the sub-title containing the template number and main content.
- Paywall buttons get a ••• menu that is the same as the long-press context menu, but easier to discover
- If there are offerings without configured paywalls, they are listed in a separate section.
- Offerings have links out to the revenue cat dashboard for quick edits (or even to create a new one), which may be handy for use on the phone or for sending the URL to a desktop.

The PR also contain quite a bit of refactoring - view decomposition, simplification in places as well as better data organization and flow.


Before:


https://github.com/RevenueCat/purchases-ios/assets/109382862/fc4abf5c-b779-41fa-be61-bcd885b74fc9



After:


https://github.com/RevenueCat/purchases-ios/assets/109382862/7f7a3c77-08e5-4b89-9cc0-309ea9841bb5


