### PR TITLE
Change deploy-purchase-tester to use xcode 15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1298,7 +1298,7 @@ workflows:
           xcode_version: '14.3.0'
           <<: *release-tags
       - deploy-purchase-tester:
-          xcode_version: '14.3.0'
+          xcode_version: '15.2'
           <<: *release-tags
       - notify-on-non-patch-release-branches:
           requires:


### PR DESCRIPTION
It is now required to use xcode 15 to push to the store

https://developer.apple.com/news/?id=fxu2qp7b