### PR TITLE
WIP: support workflow

### DIFF
--- a/RevenueCatUI/Support/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/Support/ManageSubscriptionsView.swift
@@ -1,0 +1,20 @@
+//
+//  ManageSubscriptionsView.swift
+//
+//
+//  Created by Andrés Boedo on 5/3/24.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+public struct ManageSubscriptionsView: View {
+    public var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+@available(iOS 13.0, *)
+#Preview {
+    ManageSubscriptionsView()
+}

--- a/RevenueCatUI/Support/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/Support/ManageSubscriptionsView.swift
@@ -6,15 +6,108 @@
 //
 
 import SwiftUI
+import RevenueCat
 
-@available(iOS 13.0, *)
+@available(iOS 15.0, *)
 public struct ManageSubscriptionsView: View {
+    @State private var subscriptionInformation: SubscriptionInformation? = nil
+    @State private var showRestoreAlert: Bool = false
+    @Environment(\.openURL) var openURL
+
     public var body: some View {
-        Text("Hello, World!")
+        VStack {
+            Text("How can we help?")
+                .font(.title)
+                .padding()
+
+            if let subscriptionInformation = subscriptionInformation {
+                Text("\(subscriptionInformation.title) - \(subscriptionInformation.duration)")
+                    .font(.subheadline)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+                    .padding(.top)
+
+                Text("\(subscriptionInformation.price)")
+                    .font(.caption)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .foregroundColor(Color.gray)
+                    .padding(.horizontal)
+
+                Text("\(subscriptionInformation.willRenew ? "Renews" : "Expires"): \(subscriptionInformation.nextRenewal)")
+                    .font(.caption)
+                    .foregroundColor(Color.gray)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+                    .padding(.bottom)
+            }
+
+            Spacer()
+
+            Button("Didn't receive purchase") {
+                self.showRestoreAlert = true
+            }
+            .restorePurchasesAlert(isPresented: self.$showRestoreAlert)
+            .padding()
+            .frame(width: 300)
+            .background(Color.blue)
+            .foregroundColor(.white)
+            .cornerRadius(10)
+
+            Button("Change plans") {
+                Task {
+                    try await Purchases.shared.showManageSubscriptions()
+                }
+            }
+            .padding()
+            .frame(width: 300)
+            .background(Color.blue)
+            .foregroundColor(.white)
+            .cornerRadius(10)
+
+            Button("Contact support") {
+                Task {
+                    openURL(self.createMailURL()!)
+                }
+            }
+            .padding()
+
+
+        }
+        .task {
+            try! await loadSubscriptionInformation()
+        }
     }
+
+    private struct SubscriptionInformation {
+        let title: String
+        let duration: String
+        let price: String
+        let nextRenewal: String
+        let willRenew: Bool
+    }
+
+    private func loadSubscriptionInformation() async throws {
+        self.subscriptionInformation = SubscriptionInformation(
+            title: "Basic",
+            duration: "Monthly",
+            price: "4.99/month",
+            nextRenewal: "June 1st, 2024",
+            willRenew: false)
+    }
+
+    func createMailURL() -> URL? {
+        let subject = "Support Request"
+        let body = "Please describe your issue or question."
+        let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let encodedBody = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+
+        let urlString = "mailto:support@revenuecat.com?subject=\(encodedSubject)&body=\(encodedBody)"
+        return URL(string: urlString)
+    }
+
 }
 
-@available(iOS 13.0, *)
+@available(iOS 15.0, *)
 #Preview {
     ManageSubscriptionsView()
 }

--- a/RevenueCatUI/Support/NoSubscriptionsView.swift
+++ b/RevenueCatUI/Support/NoSubscriptionsView.swift
@@ -1,0 +1,33 @@
+//
+//  NoSubscriptionsView.swift
+//
+//
+//  Created by Andrés Boedo on 5/3/24.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+public struct NoSubscriptionsView: View {
+    public var body: some View {
+        VStack {
+            Text("No Subscriptions found")
+                .font(.title)
+                .padding()
+            Text("We can try checking your Apple account for any previously purchased products")
+                .font(.body)
+                .padding()
+
+            Spacer()
+
+            
+        }
+
+
+    }
+}
+
+@available(iOS 13.0, *)
+#Preview {
+    NoSubscriptionsView()
+}

--- a/RevenueCatUI/Support/NoSubscriptionsView.swift
+++ b/RevenueCatUI/Support/NoSubscriptionsView.swift
@@ -6,9 +6,15 @@
 //
 
 import SwiftUI
+import RevenueCat
 
-@available(iOS 13.0, *)
+@available(iOS 15.0, *)
 public struct NoSubscriptionsView: View {
+
+    @Environment(\.dismiss) var dismiss
+    @State private var showRestoreAlert: Bool = false
+
+
     public var body: some View {
         VStack {
             Text("No Subscriptions found")
@@ -20,14 +26,28 @@ public struct NoSubscriptionsView: View {
 
             Spacer()
 
-            
+            Button("Restore purchases") {
+                showRestoreAlert = true
+            }
+            .restorePurchasesAlert(isPresented: $showRestoreAlert)
+
+            .padding()
+            .background(Color.blue)
+            .foregroundColor(.white)
+            .cornerRadius(10)
+
+            Button("Cancel") {
+                dismiss()
+            }
+
         }
 
 
     }
+
 }
 
-@available(iOS 13.0, *)
+@available(iOS 15.0, *)
 #Preview {
     NoSubscriptionsView()
 }

--- a/RevenueCatUI/Support/NoSubscriptionsView.swift
+++ b/RevenueCatUI/Support/NoSubscriptionsView.swift
@@ -32,6 +32,7 @@ public struct NoSubscriptionsView: View {
             .restorePurchasesAlert(isPresented: $showRestoreAlert)
 
             .padding()
+            .frame(width: 300)
             .background(Color.blue)
             .foregroundColor(.white)
             .cornerRadius(10)

--- a/RevenueCatUI/Support/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/Support/RestorePurchasesAlert.swift
@@ -1,0 +1,82 @@
+//
+//  RestorePurchasesAlert.swift
+//
+//
+//  Created by Andrés Boedo on 5/3/24.
+//
+
+import Foundation
+import SwiftUI
+import RevenueCat
+
+@available(iOS 15.0, *)
+public struct RestorePurchasesAlert: ViewModifier {
+    @Binding var isPresented: Bool
+    @State private var alertType: AlertType = .restorePurchases
+
+    enum AlertType: Identifiable {
+        case purchasesRecovered, purchasesNotFound, restorePurchases
+        var id: Self { self }
+    }
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) var openURL
+
+
+    public func body(content: Content) -> some View {
+        content
+            .alert(isPresented: $isPresented) {
+                switch self.alertType {
+                case .restorePurchases:
+                    Alert(
+                        title: Text("Restore purchases"),
+                        message: Text("Let’s take a look! We’re going to check your Apple account for missing purchases."),
+                        primaryButton: .default(Text("Check past purchases"), action: {
+                            Task {
+                                guard let customerInfo = try? await Purchases.shared.restorePurchases() else {
+                                    // todo: handle errors
+                                    self.alertType = .purchasesNotFound
+                                    return
+                                }
+                                let hasEntitlements = customerInfo.entitlements.active.count > 0
+                                if hasEntitlements {
+                                    self.alertType = .purchasesRecovered
+                                } else {
+                                    self.alertType = .purchasesNotFound
+                                }
+                            }
+                        }),
+                        secondaryButton: .cancel(Text("Cancel"))
+                    )
+
+                case .purchasesRecovered:
+                    Alert(title: Text("Purchases recovered!"),
+                          message: Text("We applied the previously purchased items to your account. " +
+                                        "Sorry for the inconvenience.."),
+                          dismissButton: .default(Text("Dismiss")) {
+                        dismiss()
+                    })
+
+                case .purchasesNotFound:
+
+                    Alert(title: Text(""),
+                          message: Text("We couldn’t find any additional purchases under this account. \n\n" +
+                                        "Contact support for assistance if you think this is an error."),
+                          primaryButton: .default(Text("Contact Support"), action: {
+                        // todo: make configurable
+                        openURL(URL(string: "mailto:support@revenuecat.com")!)
+                    }),
+                          secondaryButton: .cancel(Text("Cancel")) {
+                        dismiss()
+                    })
+                }
+            }
+    }
+}
+
+@available(iOS 15.0, *)
+public extension View {
+    func restorePurchasesAlert(isPresented: Binding<Bool>) -> some View {
+        self.modifier(RestorePurchasesAlert(isPresented: isPresented))
+    }
+}

--- a/RevenueCatUI/Support/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/Support/RestorePurchasesAlert.swift
@@ -35,14 +35,14 @@ public struct RestorePurchasesAlert: ViewModifier {
                             Task {
                                 guard let customerInfo = try? await Purchases.shared.restorePurchases() else {
                                     // todo: handle errors
-                                    self.alertType = .purchasesNotFound
+                                    self.setAlertType(.purchasesNotFound)
                                     return
                                 }
                                 let hasEntitlements = customerInfo.entitlements.active.count > 0
                                 if hasEntitlements {
-                                    self.alertType = .purchasesRecovered
+                                    self.setAlertType(.purchasesRecovered)
                                 } else {
-                                    self.alertType = .purchasesNotFound
+                                    self.setAlertType(.purchasesNotFound)
                                 }
                             }
                         }),
@@ -64,7 +64,7 @@ public struct RestorePurchasesAlert: ViewModifier {
                                         "Contact support for assistance if you think this is an error."),
                           primaryButton: .default(Text("Contact Support"), action: {
                         // todo: make configurable
-                        openURL(URL(string: "mailto:support@revenuecat.com")!)
+                        openURL(self.createMailURL()!)
                     }),
                           secondaryButton: .cancel(Text("Cancel")) {
                         dismiss()
@@ -72,6 +72,24 @@ public struct RestorePurchasesAlert: ViewModifier {
                 }
             }
     }
+
+    private func setAlertType(_ newType: AlertType) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.alertType = newType
+            self.isPresented = true
+        }
+    }
+
+    func createMailURL() -> URL? {
+        let subject = "Support Request"
+        let body = "Please describe your issue or question."
+        let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let encodedBody = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+
+        let urlString = "mailto:support@revenuecat.com?subject=\(encodedSubject)&body=\(encodedBody)"
+        return URL(string: urlString)
+    }
+
 }
 
 @available(iOS 15.0, *)

--- a/RevenueCatUI/Support/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/Support/RestorePurchasesAlert.swift
@@ -52,7 +52,7 @@ public struct RestorePurchasesAlert: ViewModifier {
                 case .purchasesRecovered:
                     Alert(title: Text("Purchases recovered!"),
                           message: Text("We applied the previously purchased items to your account. " +
-                                        "Sorry for the inconvenience.."),
+                                        "Sorry for the inconvenience."),
                           dismissButton: .default(Text("Dismiss")) {
                         dismiss()
                     })

--- a/RevenueCatUI/Support/SupportView.swift
+++ b/RevenueCatUI/Support/SupportView.swift
@@ -1,0 +1,55 @@
+//
+//  SupportView.swift
+//
+//
+//  Created by Andrés Boedo on 5/3/24.
+//
+
+import SwiftUI
+import RevenueCat
+
+@available(iOS 15.0, *)
+public struct SupportView: View {
+
+    public init() { }
+
+    @State private var hasSubscriptions: Bool = false
+
+    public var body: some View {
+        NavigationView {
+            NavigationLink(destination: destinationView()) {
+                Text("Billing and subscription help")
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+            }
+        }
+            .task {
+                await loadHasSubscriptions()
+            }
+    }
+
+    private func loadHasSubscriptions() async {
+        Task {
+            self.hasSubscriptions = try await Purchases.shared.customerInfo().activeSubscriptions.count > 0
+        }
+    }
+
+    @ViewBuilder
+    private func destinationView() -> some View {
+        if self.hasSubscriptions {
+            ManageSubscriptionsView()
+        } else {
+            NoSubscriptionsView()
+        }
+    }
+
+}
+
+
+
+@available(iOS 15.0.0, *)
+#Preview {
+    SupportView()
+}

--- a/RevenueCatUI/Support/WrongPlatformView.swift
+++ b/RevenueCatUI/Support/WrongPlatformView.swift
@@ -1,0 +1,53 @@
+//
+//  WrongPlatformView.swift
+//
+//
+//  Created by Andrés Boedo on 5/3/24.
+//
+
+import Foundation
+import RevenueCat
+import SwiftUI
+
+@available(iOS 15.0, *)
+public struct WrongPlatformView: View {
+
+    @State private var platformName: String = "unknown"
+
+    public var body: some View {
+        VStack {
+            Text("Your subscription is being billed through \(platformName).")
+                .font(.title)
+                .padding()
+
+            Text("Go the app settings on \(platformName) to manage your subscription and billing.")
+                .padding()
+
+            Spacer()
+            Button("Open subscription settings") {
+                Task {
+                    try await Purchases.shared.showManageSubscriptions()
+                }
+            }
+            .padding()
+            .background(Color.blue)
+            .foregroundColor(.white)
+            .cornerRadius(10)
+
+        }
+        .task {
+            if let customerInfo = try? await Purchases.shared.customerInfo(),
+               let firstEntitlement = customerInfo.entitlements.active.first {
+//                // todo: clean up, make sure these are human-readable
+                self.platformName = "\(firstEntitlement.value.store)"
+            }
+
+        }
+    }
+
+}
+
+@available(iOS 15.0, *)
+#Preview {
+    WrongPlatformView()
+}

--- a/RevenueCatUI/Support/WrongPlatformView.swift
+++ b/RevenueCatUI/Support/WrongPlatformView.swift
@@ -30,6 +30,7 @@ public struct WrongPlatformView: View {
                 }
             }
             .padding()
+            .frame(width: 300)
             .background(Color.blue)
             .foregroundColor(.white)
             .cornerRadius(10)


### PR DESCRIPTION
https://www.loom.com/share/cd4d9305fb6d43338ee5905f095655a4

Adds the ability to open up a support workflow with a single line of code, `SupportView`. 

This is set up as a new folder within `RevenueCatUI`, and it reuses a lot of stuff from RevenueCat itself. 

It's currently very hacky, but all the functionality that is there works correctly. 

Includes: 
- Open up the support workflow
- If you have an active subscription
    - if subscription is from apple, open up manage subscriptions screen
    - if not, inform them that they need to manage it elsewhere, provide a button to open up management screen of the store
- Ability to restore with a nice-looking flow
- Ability to contact support (although we need to make the actual link configurable through a backend endpoint)
- Ability to begin a refund request through apple (although we'd also want to provide extra UI there with a winback offer)
- Ability to see your current subscription, expiration, renew status, date and price