### PR TITLE
fix mac os sandbox check slowness

### DIFF
--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -100,11 +100,11 @@ class CustomerInfoManager {
                                           isAppBackgrounded: Bool,
                                           completion: CustomerInfoCompletion?) {
         self.operationDispatcher.dispatchOnWorkerThread {
-            
+
             let isCacheStale = self.withData {
                 $0.deviceCache.isCustomerInfoCacheStale(appUserID: appUserID, isAppBackgrounded: isAppBackgrounded)
             }
-            
+
             guard !isCacheStale, let customerInfo = self.cachedCustomerInfo(appUserID: appUserID) else {
                 Logger.debug(isAppBackgrounded
                              ? Strings.customerInfo.customerinfo_stale_updating_in_background
@@ -114,7 +114,7 @@ class CustomerInfoManager {
                                                completion: completion)
                 return
             }
-            
+
             if let completion = completion {
                 self.operationDispatcher.dispatchOnMainActor {
                     completion(.success(customerInfo))

--- a/Sources/Misc/MapAppStoreDetector.swift
+++ b/Sources/Misc/MapAppStoreDetector.swift
@@ -32,6 +32,8 @@ final class DefaultMacAppStoreDetector: MacAppStoreDetector {
     /// it checked the common name but was changed to an extension check to make it more
     /// future-proof.
     ///
+    /// - warning: this method may take a long time to run on macOS. It should not be called on the main thread. 
+    ///
     /// For more information, see the following references:
     /// - https://github.com/objective-see/ProcInfo/blob/master/procInfo/Signing.m#L184-L247
     /// - https://gist.github.com/lukaskubanek/cbfcab29c0c93e0e9e0a16ab09586996#gistcomment-3993808

--- a/Sources/Misc/SandboxEnvironmentDetector.swift
+++ b/Sources/Misc/SandboxEnvironmentDetector.swift
@@ -40,7 +40,8 @@ final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
         self.macAppStoreDetector = macAppStoreDetector
     }
 
-    /// - warning: this method should not be called on the main thread, since on macOS it may take a long time to complete.
+    /// - warning: this method should not be called on the main thread, 
+    /// since on macOS it may take a long time to complete.
     var isSandbox: Bool {
         guard !self.isRunningInSimulator else {
             return true

--- a/Sources/Misc/SandboxEnvironmentDetector.swift
+++ b/Sources/Misc/SandboxEnvironmentDetector.swift
@@ -40,6 +40,7 @@ final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
         self.macAppStoreDetector = macAppStoreDetector
     }
 
+    /// - warning: this method should not be called on the main thread, since on macOS it may take a long time to complete.
     var isSandbox: Bool {
         guard !self.isRunningInSimulator else {
             return true

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -144,6 +144,11 @@ class SystemInfo {
         self.responseVerificationMode = responseVerificationMode
         self.dangerousSettings = dangerousSettings ?? DangerousSettings()
         self.clock = clock
+        // eager-load the isSandbox value from a worker thread so that's immediately available
+        // this is useful on macOS where it may take long for the value to compute
+        self.operationDispatcher.dispatchOnWorkerThread {
+            _ = self._isSandbox
+        }
     }
 
     /// Asynchronous API if caller can't ensure that it's invoked in the `@MainActor`

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1743,21 +1743,23 @@ private extension Purchases {
         // Note: it's important that we observe "will enter foreground" instead of
         // "did become active" so that we don't trigger cache updates in the middle
         // of purchases due to pop-ups stealing focus from the app.
-        self.updateAllCachesIfNeeded(isAppBackgrounded: false)
-        self.dispatchSyncSubscriberAttributes()
+        self.operationDispatcher.dispatchOnWorkerThread {
+            self.updateAllCachesIfNeeded(isAppBackgrounded: false)
+            self.dispatchSyncSubscriberAttributes()
 
-        #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-        (self as DeprecatedSearchAdsAttribution).postAppleSearchAddsAttributionCollectionIfNeeded()
+            #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+            (self as DeprecatedSearchAdsAttribution).postAppleSearchAddsAttributionCollectionIfNeeded()
 
-        #if os(iOS) || os(macOS) || VISION_OS
-        if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
-            self.attribution.postAdServicesTokenOncePerInstallIfNeeded()
+            #if os(iOS) || os(macOS) || VISION_OS
+            if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
+                self.attribution.postAdServicesTokenOncePerInstallIfNeeded()
+            }
+            #endif
+
+            self.postPaywallEventsIfNeeded()
+
+            #endif
         }
-        #endif
-
-        self.postPaywallEventsIfNeeded()
-
-        #endif
     }
 
     @objc func applicationDidEnterBackground() {

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -208,6 +208,20 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
     }
 
+    @MainActor
+    func testFetchAndCacheCustomerInfoIfStaleExecutesOnWorkerThread() throws {
+        mockDeviceCache.stubbedIsCustomerInfoCacheStale = false
+
+        var invokedCompletion = false
+        customerInfoManager.fetchAndCacheCustomerInfoIfStale(appUserID: Self.appUserID,
+                                                             isAppBackgrounded: false) { _ in
+            invokedCompletion = true
+        }
+
+        expect(invokedCompletion).toEventually(beTrue())
+        expect(self.mockOperationDispatcher.invokedDispatchOnWorkerThread) == true
+    }
+
     func testSetLastSentCustomerInfo() {
         expect(self.customerInfoManager.lastSentCustomerInfo).to(beNil())
         self.customerInfoManager.setLastSentCustomerInfo(self.mockCustomerInfo)

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
@@ -69,6 +69,18 @@ class PurchasesDelegateTests: BasePurchasesTests {
         expect(self.backend.getCustomerInfoCallCount).toEventually(equal(2))
     }
 
+    func testAutomaticFetchesOnDidBecomeActiveArePerformedInWorkerThread() {
+        expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
+
+        self.deviceCache.stubbedIsCustomerInfoCacheStale = false
+        let workerThreadCountBeforeNotifications = self.mockOperationDispatcher.invokedDispatchOnWorkerThreadCount
+
+        self.notificationCenter.fireNotifications()
+
+        expect(self.mockOperationDispatcher.invokedDispatchOnWorkerThread) == true
+        expect(self.mockOperationDispatcher.invokedDispatchOnWorkerThreadCount) == workerThreadCountBeforeNotifications + 1
+    }
+
     func testDoesntAutomaticallyFetchCustomerInfoOnDidBecomeActiveIfCacheValid() {
         expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
         self.deviceCache.stubbedIsCustomerInfoCacheStale = false

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
@@ -73,12 +73,10 @@ class PurchasesDelegateTests: BasePurchasesTests {
         expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
 
         self.deviceCache.stubbedIsCustomerInfoCacheStale = false
-        let workerThreadCountBeforeNotifications = self.mockOperationDispatcher.invokedDispatchOnWorkerThreadCount
 
         self.notificationCenter.fireNotifications()
 
         expect(self.mockOperationDispatcher.invokedDispatchOnWorkerThread) == true
-        expect(self.mockOperationDispatcher.invokedDispatchOnWorkerThreadCount) == workerThreadCountBeforeNotifications + 1
     }
 
     func testDoesntAutomaticallyFetchCustomerInfoOnDidBecomeActiveIfCacheValid() {


### PR DESCRIPTION
Addresses #3871 

Solves the issue by ensuring that the calls to `isSandbox` are performed on a worker thread, and that we're pre-loading the values. 

I'm not a huge fan of this solution since it isn't technically perfectly safe, meaning that it's possible (albeit very unlikely) for us to still check sandbox values in the main thread. 

Additionally I don't love how hard it is to actually write tests for it. 

The ideal solutions would be: 
- change the check so that it loads instantly, which would fix the issue without further changes. But... I don't know of a faster way to check on macOS, sadly. 
- update `isSandbox` to make it asynchronous... which would be a BIG refactor, affecting a large chunk of the codebase. It doesn't feel worth the trouble. 