### PR TITLE
Cleanup: Remove test storekit configuration files when importing through SPM. 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,11 +9,7 @@ import class Foundation.ProcessInfo
 let environmentVariables = ProcessInfo.processInfo.environment
 let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "true"
 
-var dependencies: [Package.Dependency] = [
-    .package(url: "git@github.com:Quick/Nimble.git", from: "10.0.0"),
-    // SST requires iOS 13 starting from version 1.13.0
-    .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", .upToNextMinor(from: "1.12.0"))
-]
+var dependencies: [Package.Dependency] = []
 if shouldIncludeDocCPlugin {
     dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
 }

--- a/Package.swift
+++ b/Package.swift
@@ -64,9 +64,6 @@ let package = Package(
         // Receipt Parser
         .target(name: "ReceiptParser",
                 path: "LocalReceiptParsing"),
-        .testTarget(name: "ReceiptParserTests",
-                    dependencies: ["ReceiptParser", "Nimble"],
-                    exclude: ["ReceiptParserTests-Info.plist"]),
         // RevenueCatUI
         .target(name: "RevenueCatUI",
                 dependencies: ["RevenueCat"],
@@ -75,14 +72,6 @@ let package = Package(
                     // Note: these have to match the values in RevenueCatUI.podspec
                     .copy("Resources/background.jpg"),
                     .process("Resources/icons.xcassets")
-                ]),
-        .testTarget(name: "RevenueCatUITests",
-                    dependencies: [
-                        "RevenueCatUI",
-                        "Nimble",
-                        .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
-                    ],
-                    exclude: ["Templates/__Snapshots__", "Data/__Snapshots__", "TestPlans"],
-                    resources: [.copy("Resources/header.jpg"), .copy("Resources/background.jpg")])
+                ])
     ]
 )

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -859,6 +859,7 @@
 		2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriod.swift; sourceTree = "<group>"; };
 		2D1015E0275A676F0086173F /* SubscriptionPeriodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriodTests.swift; sourceTree = "<group>"; };
 		2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionStrings.swift; sourceTree = "<group>"; };
+		2D2063142BEABA030002710C /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		2D222BAA27FB7008003D5F37 /* LocalReceiptParserStoreKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalReceiptParserStoreKitTests.swift; sourceTree = "<group>"; };
 		2D22BF6626F3CBFB001AE2F9 /* XCTestCase+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extensions.swift"; sourceTree = "<group>"; };
 		2D294E5B26DECFD500B8FE4F /* StoreKit2TransactionListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionListener.swift; sourceTree = "<group>"; };
@@ -1868,6 +1869,7 @@
 		2DDE870027E5238500D8B390 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				2D2063142BEABA030002710C /* Package.swift */,
 				570896B627596E6E00296F1C /* APITesters */,
 				2DE20B8026409EB7004C597D /* BackendIntegrationTestApp */,
 				2DE20B6D264087FB004C597D /* BackendIntegrationTests */,

--- a/Tests/Package.swift
+++ b/Tests/Package.swift
@@ -1,0 +1,11 @@
+// swift-tools-version:5.5
+//
+//  Package.swift
+//
+//
+//  Created by Andrés Boedo on 5/7/24.
+//
+
+import PackageDescription
+
+let package = Package()

--- a/Tests/Package.swift
+++ b/Tests/Package.swift
@@ -5,6 +5,10 @@
 //
 //  Created by Andrés Boedo on 5/7/24.
 //
+// This empty file prevents Xcode from picking up the files in the Tests library
+// when importing through SPM. This is helpful so that users of the SDK
+// don't inadvertently get StoreKit Configuration files added to the project, which
+// can lead to confusion.
 
 import PackageDescription
 


### PR DESCRIPTION
This PR removes the storekit configuration files we use for testing when you import the SDK through SPM. 

This cleans up apps, since those files were somewhat "leaked" from our tests, but not meant for consumption by a customer. 

| Before | After |
| :-: | :-: |
| <img width="647" alt="Screenshot 2024-05-07 at 4 23 39 PM" src="https://github.com/RevenueCat/purchases-ios/assets/3922667/268243ef-8068-4b09-8644-262782c050fd"> | <img width="749" alt="Screenshot 2024-05-07 at 4 34 20 PM" src="https://github.com/RevenueCat/purchases-ios/assets/3922667/ac6fb72f-c22d-40b5-b98a-d7c4be56b3d9"> |

## Implementation
This PR does two things: 
- Removes all test targets from SPM. We don't really use SPM for testing directly, so they didn't really add value there. 
- Adds a new `Package.swift` file at the root of the `Tests` folder, which in turn tells SPM to treat that folder as a separate package, and thus the files in there don't get picked up automatically when importing RevenueCat. 
