### PR TITLE
Cleanup: Remove test storekit configuration files when importing through SPM

### DIFF
--- a/Tests/Package.swift
+++ b/Tests/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version:5.5
+//
+//  Package.swift
+//
+//
+//  Created by Andrés Boedo on 5/7/24.
+//
+// This empty file prevents Xcode from picking up the files in the Tests library
+// when importing through SPM. This is helpful so that users of the SDK
+// don't inadvertently get StoreKit Configuration files added to the project, which
+// can lead to confusion.
+
+import PackageDescription
+
+let package = Package()


### PR DESCRIPTION
Alternative approach to #3876, where in this one we _only_ add the Package.swift file. 
That was the most important part in any case. 

I would still love to clean up the project structure, but it's a much bigger change. 