### PR TITLE
fix mac os sandbox check slowness

### DIFF
--- a/Sources/Misc/SandboxEnvironmentDetector.swift
+++ b/Sources/Misc/SandboxEnvironmentDetector.swift
@@ -50,7 +50,14 @@ final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
         }
 
         #if os(macOS) || targetEnvironment(macCatalyst)
-            return !self.isProductionReceipt || !self.isMacAppStore
+        // this relies on an undocumented field in the receipt that provides the Environment.
+        // if it's not present, we go to a secondary check.
+        if let isProductionReceipt = self.isProductionReceipt {
+            return !isProductionReceipt
+        } else {
+            return !self.isMacAppStore
+        }
+
         #else
             return path.contains("sandboxReceipt")
         #endif
@@ -73,12 +80,12 @@ extension BundleSandboxEnvironmentDetector: Sendable {}
 
 private extension BundleSandboxEnvironmentDetector {
 
-    var isProductionReceipt: Bool {
+    var isProductionReceipt: Bool? {
         do {
             return try self.receiptFetcher.fetchAndParseLocalReceipt().environment == .production
         } catch {
             Logger.error(Strings.receipt.parse_receipt_locally_error(error: error))
-            return false
+            return nil
         }
     }
 

--- a/Sources/Misc/SandboxEnvironmentDetector.swift
+++ b/Sources/Misc/SandboxEnvironmentDetector.swift
@@ -82,7 +82,9 @@ private extension BundleSandboxEnvironmentDetector {
 
     var isProductionReceipt: Bool? {
         do {
-            return try self.receiptFetcher.fetchAndParseLocalReceipt().environment == .production
+            let receiptEnvironment = try self.receiptFetcher.fetchAndParseLocalReceipt().environment
+            guard receiptEnvironment != .unknown else { return nil } // don't make assumptions if we're not sure
+            return receiptEnvironment == .production
         } catch {
             Logger.error(Strings.receipt.parse_receipt_locally_error(error: error))
             return nil

--- a/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
+++ b/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
@@ -91,6 +91,66 @@ class SandboxEnvironmentDetectorTests: TestCase {
         ) == true
     }
 
+    func testIsSandboxWhenReceiptEnvironmentIsUnknownDefaultToMacAppStoreDetector() throws {
+        let macAppStore = false
+        var isSandbox = false
+        let macAppStoreDetector = MockMacAppStoreDetector(isMacAppStore: macAppStore)
+        let detector = SystemInfo.with(
+            macAppStore: macAppStore,
+            receiptEnvironment: .unknown,
+            macAppStoreDetector: macAppStoreDetector
+        )
+
+        expect(detector.isSandbox) == isSandbox
+        expect(macAppStoreDetector.isMacAppStoreCalled) == true
+
+        isSandbox = !isSandbox
+
+        expect(detector.isSandbox) == isSandbox
+    }
+
+    func testIsSandboxWhenReceiptIsProductionReturnsProductionAndDoesntHitMacAppStoreDetector() throws {
+        let macAppStoreDetector = MockMacAppStoreDetector(isMacAppStore: false)
+        let detector = SystemInfo.with(
+            macAppStore: false,
+            receiptEnvironment: .production,
+            macAppStoreDetector: macAppStoreDetector
+        )
+
+        expect(detector.isSandbox) == false
+        expect(macAppStoreDetector.isMacAppStoreCalled) == false
+    }
+
+    func testIsSandboxWhenReceiptIsSandboxReturnsSandboxAndDoesntHitMacAppStoreDetector() throws {
+        let macAppStoreDetector = MockMacAppStoreDetector(isMacAppStore: false)
+        let detector = SystemInfo.with(
+            macAppStore: false,
+            receiptEnvironment: .sandbox,
+            macAppStoreDetector: macAppStoreDetector
+        )
+
+        expect(detector.isSandbox) == true
+        expect(macAppStoreDetector.isMacAppStoreCalled) == false
+    }
+
+    func testIsSandboxIfReceiptParsingFailsAndNotInMacAppStore() throws {
+        let macAppStore = false
+        var isSandbox = false
+        let macAppStoreDetector = MockMacAppStoreDetector(isMacAppStore: macAppStore)
+        let detector = SystemInfo.with(
+            macAppStore: macAppStore,
+            failReceiptParsing: true,
+            macAppStoreDetector: macAppStoreDetector
+        )
+
+        expect(detector.isSandbox) == isSandbox
+        expect(macAppStoreDetector.isMacAppStoreCalled) == true
+
+        isSandbox = !isSandbox
+
+        expect(detector.isSandbox) == isSandbox
+    }
+
 }
 
 #endif
@@ -104,7 +164,8 @@ private extension SandboxEnvironmentDetector {
         inSimulator: Bool = false,
         macAppStore: Bool = false,
         receiptEnvironment: AppleReceipt.Environment = .production,
-        failReceiptParsing: Bool = false
+        failReceiptParsing: Bool = false,
+        macAppStoreDetector: MockMacAppStoreDetector? = nil
     ) -> SandboxEnvironmentDetector {
         let bundle = MockBundle()
         bundle.receiptURLResult = result
@@ -126,7 +187,7 @@ private extension SandboxEnvironmentDetector {
             isRunningInSimulator: inSimulator,
             receiptFetcher: MockLocalReceiptFetcher(mockReceipt: mockReceipt,
                                                     failReceiptParsing: failReceiptParsing),
-            macAppStoreDetector: MockMacAppStoreDetector(isMacAppStore: macAppStore)
+            macAppStoreDetector: macAppStoreDetector ?? MockMacAppStoreDetector(isMacAppStore: macAppStore)
         )
     }
 
@@ -151,12 +212,17 @@ private final class MockLocalReceiptFetcher: LocalReceiptFetcherType {
 
 }
 
-private struct MockMacAppStoreDetector: MacAppStoreDetector {
+private final class MockMacAppStoreDetector: MacAppStoreDetector, @unchecked Sendable {
 
-    let isMacAppStore: Bool
+    let isMacAppStoreValue: Bool
+    private(set) var isMacAppStoreCalled = false
 
     init(isMacAppStore: Bool) {
-        self.isMacAppStore = isMacAppStore
+        self.isMacAppStoreValue = isMacAppStore
     }
 
+    var isMacAppStore: Bool {
+        isMacAppStoreCalled = true
+        return isMacAppStoreValue
+    }
 }

--- a/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
+++ b/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
@@ -45,7 +45,7 @@ class SandboxEnvironmentDetectorTests: TestCase {
 // `macOS` sandbox detection does not rely on receipt path
 class SandboxEnvironmentDetectorTests: TestCase {
 
-    func testIsNotSandboxIfReceiptIsProductionAndMAS() throws {
+    func testIsNotSandboxIfReceiptIsProduction() throws {
         expect(
             SystemInfo.with(
                 macAppStore: true,
@@ -54,49 +54,20 @@ class SandboxEnvironmentDetectorTests: TestCase {
         ) == false
     }
 
-    func testIsSandboxIfReceiptIsProductionAndNotMAS() throws {
-        expect(
-            SystemInfo.with(
-                macAppStore: false,
-                receiptEnvironment: .production
-            ).isSandbox
-        ) == true
-    }
-
-    func testIsSandboxIfReceiptIsNotProductionAndNotMAS() throws {
+    func testIsSandboxIfReceiptIsNotProduction() throws {
         expect(
             SystemInfo.with(
                 macAppStore: false,
                 receiptEnvironment: .sandbox
-            ).isSandbox
-        ) == true
-    }
-
-    func testIsSandboxIfReceiptIsNotProductionAndMAS() throws {
-        expect(
-            SystemInfo.with(
-                macAppStore: true,
-                receiptEnvironment: .sandbox
-            ).isSandbox
-        ) == true
-    }
-
-    func testIsSandboxIfReceiptParsingFailsAndBundleSignatureIsNotMAS() throws {
-        expect(
-            SystemInfo.with(
-                macAppStore: false,
-                receiptEnvironment: .production,
-                failReceiptParsing: true
             ).isSandbox
         ) == true
     }
 
     func testIsSandboxWhenReceiptEnvironmentIsUnknownDefaultToMacAppStoreDetector() throws {
-        let macAppStore = false
         var isSandbox = false
-        let macAppStoreDetector = MockMacAppStoreDetector(isMacAppStore: macAppStore)
-        let detector = SystemInfo.with(
-            macAppStore: macAppStore,
+        var macAppStoreDetector = MockMacAppStoreDetector(isMacAppStore: !isSandbox)
+        var detector = SystemInfo.with(
+            macAppStore: !isSandbox,
             receiptEnvironment: .unknown,
             macAppStoreDetector: macAppStoreDetector
         )
@@ -105,6 +76,37 @@ class SandboxEnvironmentDetectorTests: TestCase {
         expect(macAppStoreDetector.isMacAppStoreCalled) == true
 
         isSandbox = !isSandbox
+
+        macAppStoreDetector = MockMacAppStoreDetector(isMacAppStore: !isSandbox)
+        detector = SystemInfo.with(
+            macAppStore: !isSandbox,
+            receiptEnvironment: .unknown,
+            macAppStoreDetector: macAppStoreDetector
+        )
+
+        expect(detector.isSandbox) == isSandbox
+    }
+
+    func testIsSandboxWhenReceiptParsingFailsDefaultsToMacAppStoreDetector() throws {
+        var isSandbox = false
+        var macAppStoreDetector = MockMacAppStoreDetector(isMacAppStore: !isSandbox)
+        var detector = SystemInfo.with(
+            macAppStore: !isSandbox,
+            failReceiptParsing: true,
+            macAppStoreDetector: macAppStoreDetector
+        )
+
+        expect(detector.isSandbox) == isSandbox
+        expect(macAppStoreDetector.isMacAppStoreCalled) == true
+
+        isSandbox = !isSandbox
+
+        macAppStoreDetector = MockMacAppStoreDetector(isMacAppStore: !isSandbox)
+        detector = SystemInfo.with(
+            macAppStore: !isSandbox,
+            failReceiptParsing: true,
+            macAppStoreDetector: macAppStoreDetector
+        )
 
         expect(detector.isSandbox) == isSandbox
     }
@@ -131,24 +133,6 @@ class SandboxEnvironmentDetectorTests: TestCase {
 
         expect(detector.isSandbox) == true
         expect(macAppStoreDetector.isMacAppStoreCalled) == false
-    }
-
-    func testIsSandboxIfReceiptParsingFailsAndNotInMacAppStore() throws {
-        let macAppStore = false
-        var isSandbox = false
-        let macAppStoreDetector = MockMacAppStoreDetector(isMacAppStore: macAppStore)
-        let detector = SystemInfo.with(
-            macAppStore: macAppStore,
-            failReceiptParsing: true,
-            macAppStoreDetector: macAppStoreDetector
-        )
-
-        expect(detector.isSandbox) == isSandbox
-        expect(macAppStoreDetector.isMacAppStoreCalled) == true
-
-        isSandbox = !isSandbox
-
-        expect(detector.isSandbox) == isSandbox
     }
 
 }


### PR DESCRIPTION
Alternative approach to #3875, also meant to address https://github.com/RevenueCat/purchases-ios/issues/3871

We're currently looking at a field called Environment in the local receipt to check whether the app is running in sandbox on macOS. 

However, since it's an undocumented field, we can't trust that it will always be there, so if the value is production then we check the bundle's signature, which can be slow to run. 

This PR changes that behavior so that we only perform that check if the value for that variable isn't available, which would cause a receipt parsing failure since it's marked as non-optional. 

Still need to write tests for this, but it should be significantly easier than for the other PR. 