### PR TITLE
Preprocessor to make select constructs public

### DIFF
--- a/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker+TestData.swift
+++ b/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker+TestData.swift
@@ -14,12 +14,12 @@
 import Foundation
 import RevenueCat
 
-#if DEBUG
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 extension TrialOrIntroEligibilityChecker {
 
     /// Creates a mock `TrialOrIntroEligibilityChecker` with a constant result.
+    //@PublicForExternalTesting
     static func producing(eligibility: @autoclosure @escaping () -> IntroEligibilityStatus) -> Self {
         return .init { packages in
             return Dictionary(
@@ -34,7 +34,7 @@ extension TrialOrIntroEligibilityChecker {
             )
         }
     }
-
+#if DEBUG
     /// Creates a copy of this `TrialOrIntroEligibilityChecker` with a delay.
     func with(delay seconds: TimeInterval) -> Self {
         return .init { [checker = self.checker] in
@@ -43,7 +43,7 @@ extension TrialOrIntroEligibilityChecker {
             return await checker($0)
         }
     }
+#endif
 
 }
 
-#endif

--- a/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker+TestData.swift
+++ b/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker+TestData.swift
@@ -19,7 +19,7 @@ import RevenueCat
 extension TrialOrIntroEligibilityChecker {
 
     /// Creates a mock `TrialOrIntroEligibilityChecker` with a constant result.
-    //@PublicForExternalTesting
+    // @PublicForExternalTesting
     static func producing(eligibility: @autoclosure @escaping () -> IntroEligibilityStatus) -> Self {
         return .init { packages in
             return Dictionary(

--- a/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker+TestData.swift
+++ b/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker+TestData.swift
@@ -14,7 +14,6 @@
 import Foundation
 import RevenueCat
 
-
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 extension TrialOrIntroEligibilityChecker {
 
@@ -46,4 +45,3 @@ extension TrialOrIntroEligibilityChecker {
 #endif
 
 }
-

--- a/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker.swift
+++ b/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker.swift
@@ -15,6 +15,7 @@ import Foundation
 import RevenueCat
 
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
+//@PublicForExternalTesting
 final class TrialOrIntroEligibilityChecker: ObservableObject {
 
     typealias Checker = @Sendable ([Package]) async -> [Package: IntroEligibilityStatus]

--- a/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker.swift
+++ b/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker.swift
@@ -15,7 +15,7 @@ import Foundation
 import RevenueCat
 
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
-//@PublicForExternalTesting
+// @PublicForExternalTesting
 final class TrialOrIntroEligibilityChecker: ObservableObject {
 
     typealias Checker = @Sendable ([Package]) async -> [Package: IntroEligibilityStatus]

--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -11,7 +11,7 @@ import RevenueCat
 
 /// Parameters needed to configure a ``PaywallView``.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-//@PublicForExternalTesting
+// @PublicForExternalTesting
 struct PaywallViewConfiguration {
 
     var content: Content
@@ -46,7 +46,7 @@ struct PaywallViewConfiguration {
 extension PaywallViewConfiguration {
 
     /// Offering selection for the paywall.
-    //@PublicForExternalTesting
+    // @PublicForExternalTesting
     enum Content {
 
         case defaultOffering
@@ -62,7 +62,7 @@ extension PaywallViewConfiguration {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PaywallViewConfiguration {
     
-    //@PublicForExternalTesting
+    // @PublicForExternalTesting
     init(
         offering: Offering? = nil,
         customerInfo: CustomerInfo? = nil,

--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -11,6 +11,7 @@ import RevenueCat
 
 /// Parameters needed to configure a ``PaywallView``.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+//@PublicForExternalTesting
 struct PaywallViewConfiguration {
 
     var content: Content
@@ -45,6 +46,7 @@ struct PaywallViewConfiguration {
 extension PaywallViewConfiguration {
 
     /// Offering selection for the paywall.
+    //@PublicForExternalTesting
     enum Content {
 
         case defaultOffering
@@ -59,7 +61,8 @@ extension PaywallViewConfiguration {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PaywallViewConfiguration {
-
+    
+    //@PublicForExternalTesting
     init(
         offering: Offering? = nil,
         customerInfo: CustomerInfo? = nil,

--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -61,7 +61,7 @@ extension PaywallViewConfiguration {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PaywallViewConfiguration {
-    
+
     // @PublicForExternalTesting
     init(
         offering: Offering? = nil,

--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -86,7 +86,7 @@ extension View {
     }
 
     @ViewBuilder
-    //@PublicForExternalTesting
+    // @PublicForExternalTesting
     func scrollableIfNecessary(_ axis: Axis = .vertical, enabled: Bool = true) -> some View {
         if enabled {
             if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {

--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -86,6 +86,7 @@ extension View {
     }
 
     @ViewBuilder
+    //@PublicForExternalTesting
     func scrollableIfNecessary(_ axis: Axis = .vertical, enabled: Bool = true) -> some View {
         if enabled {
             if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -91,7 +91,7 @@ public struct PaywallView: View {
         )
     }
 
-    //@PublicForExternalTesting
+    // @PublicForExternalTesting
     init(configuration: PaywallViewConfiguration) {
         self._introEligibility = .init(wrappedValue: configuration.introEligibility ?? .default())
         self._purchaseHandler = .init(wrappedValue: configuration.purchaseHandler ?? .default())

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -91,6 +91,7 @@ public struct PaywallView: View {
         )
     }
 
+    //@PublicForExternalTesting
     init(configuration: PaywallViewConfiguration) {
         self._introEligibility = .init(wrappedValue: configuration.introEligibility ?? .default())
         self._purchaseHandler = .init(wrappedValue: configuration.purchaseHandler ?? .default())

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -16,6 +16,7 @@ import StoreKit
 import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+//@PublicForExternalTesting
 final class PurchaseHandler: ObservableObject {
 
     private let purchases: PaywallPurchasesType

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -16,7 +16,7 @@ import StoreKit
 import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-//@PublicForExternalTesting
+// @PublicForExternalTesting
 final class PurchaseHandler: ObservableObject {
 
     private let purchases: PaywallPurchasesType

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -181,7 +181,7 @@ extension View {
         )
     }
 
-    //@PublicForExternalTesting
+    // @PublicForExternalTesting
     func paywallFooter(
         offering: Offering?,
         customerInfo: CustomerInfo?,

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -181,6 +181,7 @@ extension View {
         )
     }
 
+    //@PublicForExternalTesting
     func paywallFooter(
         offering: Offering?,
         customerInfo: CustomerInfo?,

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		4FDF11212A72714C004F3680 /* SamplePaywalls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplePaywalls.swift; sourceTree = "<group>"; };
 		4FFD2A602AA154B4001F4B0C /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
 		880B2AF12BEC2D62006B9393 /* Preprocessor.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = Preprocessor.sh; sourceTree = SOURCE_ROOT; };
+		880B2AF32BEC35AA006B9393 /* Postprocessor.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Postprocessor.sh; sourceTree = SOURCE_ROOT; };
 		88B2F9872BE1943C00B43E0B /* ManagePaywallButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagePaywallButton.swift; sourceTree = "<group>"; };
 		88B2F98A2BE19B1200B43E0B /* OfferingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingButton.swift; sourceTree = "<group>"; };
 		88B2F98C2BE3F1E900B43E0B /* TemplateInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateInfo.swift; sourceTree = "<group>"; };
@@ -209,6 +210,7 @@
 				4F34FF642A60ADBD00AADF11 /* Configuration.swift */,
 				4FDF11212A72714C004F3680 /* SamplePaywalls.swift */,
 				880B2AF12BEC2D62006B9393 /* Preprocessor.sh */,
+				880B2AF32BEC35AA006B9393 /* Postprocessor.sh */,
 				4FC882E02A5870C6005BE85E /* Info.plist */,
 				4FC046BF2A572E3700A28BCF /* Assets.xcassets */,
 				4FC046BD2A572E3700A28BCF /* PaywallsTester.entitlements */,

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		4FCA01FB2A3A1CBD00B262C0 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FCA01FA2A3A1CBD00B262C0 /* StoreKit.framework */; };
 		4FDF11202A7270F3004F3680 /* SamplePaywallsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF111F2A7270F3004F3680 /* SamplePaywallsList.swift */; };
 		4FDF11222A72714C004F3680 /* SamplePaywalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF11212A72714C004F3680 /* SamplePaywalls.swift */; };
+		880B2AF22BEC2D62006B9393 /* Preprocessor.sh in Resources */ = {isa = PBXBuildFile; fileRef = 880B2AF12BEC2D62006B9393 /* Preprocessor.sh */; };
 		88B2F9882BE1943C00B43E0B /* ManagePaywallButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B2F9872BE1943C00B43E0B /* ManagePaywallButton.swift */; };
 		88B2F98B2BE19B1200B43E0B /* OfferingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B2F98A2BE19B1200B43E0B /* OfferingButton.swift */; };
 		88B2F98D2BE3F1E900B43E0B /* TemplateInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B2F98C2BE3F1E900B43E0B /* TemplateInfo.swift */; };
@@ -94,6 +95,7 @@
 		4FDF111F2A7270F3004F3680 /* SamplePaywallsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplePaywallsList.swift; sourceTree = "<group>"; };
 		4FDF11212A72714C004F3680 /* SamplePaywalls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplePaywalls.swift; sourceTree = "<group>"; };
 		4FFD2A602AA154B4001F4B0C /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
+		880B2AF12BEC2D62006B9393 /* Preprocessor.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = Preprocessor.sh; sourceTree = SOURCE_ROOT; };
 		88B2F9872BE1943C00B43E0B /* ManagePaywallButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagePaywallButton.swift; sourceTree = "<group>"; };
 		88B2F98A2BE19B1200B43E0B /* OfferingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingButton.swift; sourceTree = "<group>"; };
 		88B2F98C2BE3F1E900B43E0B /* TemplateInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateInfo.swift; sourceTree = "<group>"; };
@@ -206,6 +208,7 @@
 			children = (
 				4F34FF642A60ADBD00AADF11 /* Configuration.swift */,
 				4FDF11212A72714C004F3680 /* SamplePaywalls.swift */,
+				880B2AF12BEC2D62006B9393 /* Preprocessor.sh */,
 				4FC882E02A5870C6005BE85E /* Info.plist */,
 				4FC046BF2A572E3700A28BCF /* Assets.xcassets */,
 				4FC046BD2A572E3700A28BCF /* PaywallsTester.entitlements */,
@@ -397,6 +400,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4F217A102A6DB6FB000B092D /* Assets.xcassets in Resources */,
+				880B2AF22BEC2D62006B9393 /* Preprocessor.sh in Resources */,
 				4F4557E22A6FFE6A00160521 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - Live Config.xcscheme
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - Live Config.xcscheme
@@ -23,6 +23,24 @@
             </ActionContent>
          </ExecutionAction>
       </PreActions>
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Type a script or drag a script file from your workspace to insert its path.&#10;&#10;bash &quot;${PROJECT_DIR}/Postprocessor.sh&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "4F6BED992A26A64200CD9322"
+                     BuildableName = "PaywallsTester.app"
+                     BlueprintName = "PaywallsTester"
+                     ReferencedContainer = "container:PaywallsTester.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - Live Config.xcscheme
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - Live Config.xcscheme
@@ -66,7 +66,7 @@
       shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -106,7 +106,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - Live Config.xcscheme
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - Live Config.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "#!/bin/bash&#10;&#10;bash &quot;${PROJECT_DIR}/Preprocessor.sh&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "4F6BED992A26A64200CD9322"
+                     BuildableName = "PaywallsTester.app"
+                     BlueprintName = "PaywallsTester"
+                     ReferencedContainer = "container:PaywallsTester.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -30,7 +48,7 @@
       shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - SK config.xcscheme
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - SK config.xcscheme
@@ -23,6 +23,24 @@
             </ActionContent>
          </ExecutionAction>
       </PreActions>
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Type a script or drag a script file from your workspace to insert its path.&#10;&#10;bash &quot;${PROJECT_DIR}/Postprocessor.sh&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "4F6BED992A26A64200CD9322"
+                     BuildableName = "PaywallsTester.app"
+                     BlueprintName = "PaywallsTester"
+                     ReferencedContainer = "container:PaywallsTester.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - SK config.xcscheme
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - SK config.xcscheme
@@ -66,7 +66,7 @@
       shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - SK config.xcscheme
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - SK config.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "#!/bin/bash&#10;&#10;bash &quot;${PROJECT_DIR}/Preprocessor.sh&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "4F6BED992A26A64200CD9322"
+                     BuildableName = "PaywallsTester.app"
+                     BlueprintName = "PaywallsTester"
+                     ReferencedContainer = "container:PaywallsTester.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -30,7 +48,7 @@
       shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomPaywallContent.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomPaywallContent.swift
@@ -5,11 +5,7 @@
 //  Created by Nacho Soto on 8/25/23.
 //
 
-#if DEBUG
-@testable import RevenueCatUI
-#else
 import RevenueCatUI
-#endif
 
 import SwiftUI
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -6,11 +6,7 @@
 //
 
 import RevenueCat
-#if DEBUG
-@testable import RevenueCatUI
-#else
 import RevenueCatUI
-#endif
 import SwiftUI
 
 struct OfferingsList: View {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/PaywallPresenter.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/PaywallPresenter.swift
@@ -7,11 +7,7 @@
 
 import SwiftUI
 import RevenueCat
-#if DEBUG
-@testable import RevenueCatUI
-#else
 import RevenueCatUI
-#endif
 
 struct PaywallPresenter: View {
 

--- a/Tests/TestingApps/PaywallsTester/Postprocessor.sh
+++ b/Tests/TestingApps/PaywallsTester/Postprocessor.sh
@@ -14,23 +14,23 @@
 
 echo "Starting undo process."
 
-# directory containing RevenueCat.xcworkspace
-find_xcworkspace_dir() {
+find_dir() {
   local dir="$1"
+  local target_dir="$2"
   while [[ "$dir" != "/" ]]; do
-    if [[ -e "$dir/RevenueCat.xcworkspace" ]]; then
-      echo "$dir"
+    if [[ -e "$dir/$target_dir" ]]; then
+      echo "$dir/$target_dir"
       return 0
     fi
     dir=$(dirname "$dir")  # go up one level
   done
-  return 1  # RevenueCat.xcworkspace not found :'(
+  return 1  # Target directory not found
 }
 
-base_directory=$(find_xcworkspace_dir "${PROJECT_DIR}")
+base_directory=$(find_dir "${PROJECT_DIR}" "RevenueCatUI")
 
 if [[ -z "$base_directory" ]]; then
-  echo "Error: RevenueCat.xcworkspace not found in the current directory or any parent directory."
+  echo "Error: RevenueCatUI not found in the current directory or any parent directory."
   exit 1
 fi
 

--- a/Tests/TestingApps/PaywallsTester/Postprocessor.sh
+++ b/Tests/TestingApps/PaywallsTester/Postprocessor.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+#  Preprocessor.sh
+#  PaywallsTester
+#
+#  Created by James Borthwick on 2024-05-08.
+#
+
+# Intended to be run via the scheme's post-actions build phase
+#
+# This script undoes the changes made by "Preprocessor.sh" so that they don't
+# end up accidentally checked in.
+
+
+echo "Starting undo process."
+
+# directory containing RevenueCat.xcworkspace
+find_xcworkspace_dir() {
+  local dir="$1"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -e "$dir/RevenueCat.xcworkspace" ]]; then
+      echo "$dir"
+      return 0
+    fi
+    dir=$(dirname "$dir")  # go up one level
+  done
+  return 1  # RevenueCat.xcworkspace not found :'(
+}
+
+base_directory=$(find_xcworkspace_dir "${PROJECT_DIR}")
+
+if [[ -z "$base_directory" ]]; then
+  echo "Error: RevenueCat.xcworkspace not found in the current directory or any parent directory."
+  exit 1
+fi
+
+echo "Starting at: $base_directory"
+
+# debug log
+log_file="undo_log.txt"
+echo "Starting log at $(date)" > "$log_file"
+
+# Find all .orig files and restore them
+find "$base_directory" -type f -name "*.swift.orig" | while read -r backup_file; do
+  original_file="${backup_file%.orig}"
+  cp "$backup_file" "$original_file"
+  rm -f "$backup_file"
+
+  echo "Restored: $original_file" | tee -a "$log_file"
+done
+
+echo "Undo process completed." | tee -a "$log_file"

--- a/Tests/TestingApps/PaywallsTester/Preprocessor.sh
+++ b/Tests/TestingApps/PaywallsTester/Preprocessor.sh
@@ -8,30 +8,30 @@
 
 # Intended to be run via the scheme's pre-actions build phase
 #
-# This script searches up from ${PROJECT_DIR} to locate the RevenueCat.xcworkspace directory.
+# This script searches up from ${PROJECT_DIR} to locate the RevenueCatUI directory.
 # Once found, it searches through all `.swift` files starting from that base directory.
 # It finds occurrences of `//@PublicForExternalTesting` and modifies the subsequent class, struct,
 # func, init, and enum declaration to make it public.
 
-# directory containing RevenueCat.xcworkspace
-find_xcworkspace_dir() {
+find_dir() {
   local dir="$1"
+  local target_dir="$2"
   while [[ "$dir" != "/" ]]; do
-    if [[ -e "$dir/RevenueCat.xcworkspace" ]]; then
-      echo "$dir"
+    if [[ -e "$dir/$target_dir" ]]; then
+      echo "$dir/$target_dir"
       return 0
     fi
     dir=$(dirname "$dir")  # go up one level
   done
-  return 1  # RevenueCat.xcworkspace not found :'(
+  return 1  # Target directory not found
 }
 
 echo "Starting script to make items annotated with \`\\\\@PublicForExternalTesting\` public."
 
-base_directory=$(find_xcworkspace_dir "${PROJECT_DIR}")
+base_directory=$(find_dir "${PROJECT_DIR}" "RevenueCatUI")
 
 if [[ -z "$base_directory" ]]; then
-  echo "Error: RevenueCat.xcworkspace not found in the current directory or any parent directory."
+  echo "Error: RevenueCatUI not found in the current directory or any parent directory."
   exit 1
 fi
 

--- a/Tests/TestingApps/PaywallsTester/Preprocessor.sh
+++ b/Tests/TestingApps/PaywallsTester/Preprocessor.sh
@@ -26,7 +26,7 @@ find_dir() {
   return 1  # Target directory not found
 }
 
-echo "Starting script to make items annotated with \`\\\\@PublicForExternalTesting\` public."
+echo "Starting script to make items annotated with \`\/\/ @PublicForExternalTesting\` public."
 
 base_directory=$(find_dir "${PROJECT_DIR}" "RevenueCatUI")
 
@@ -44,16 +44,16 @@ echo "Starting log at $(date)" > "$log_file"
 # Find all .swift files recursively from the base directory
 find "$base_directory" -type f -name "*.swift" | while read -r file; do
 
-    if grep -q '//@PublicForExternalTesting' "$file"; then
+    if grep -q '// @PublicForExternalTesting' "$file"; then
         # Backup original file
         backup_file="${file}.orig"
         cp "$file" "$original_file"
 
         # Find //@PublicForExternalTesting and replace it with public before declarations
         sed -i.orig -E \
-        '/\/\/@PublicForExternalTesting[[:space:]]*$/{
+        '/\/\/ @PublicForExternalTesting[[:space:]]*$/{
         N
-        s/\/\/@PublicForExternalTesting[[:space:]]*\n[[:space:]]*(static[[:space:]]+)?(struct|class|final[[:space:]]+class|enum|init|func)/public \1\2/
+        s/\/\/ @PublicForExternalTesting[[:space:]]*\n[[:space:]]*(static[[:space:]]+)?(struct|class|final[[:space:]]+class|enum|init|func)/public \1\2/
         }' "$file"
 
         # Log changes made to the file

--- a/Tests/TestingApps/PaywallsTester/Preprocessor.sh
+++ b/Tests/TestingApps/PaywallsTester/Preprocessor.sh
@@ -46,25 +46,23 @@ find "$base_directory" -type f -name "*.swift" | while read -r file; do
 
     if grep -q '//@PublicForExternalTesting' "$file"; then
         # Backup original file
-        original_file="${file}.orig"
+        backup_file="${file}.orig"
         cp "$file" "$original_file"
 
         # Find //@PublicForExternalTesting and replace it with public before declarations
-        sed -i.bak -E \
+        sed -i.orig -E \
         '/\/\/@PublicForExternalTesting[[:space:]]*$/{
         N
         s/\/\/@PublicForExternalTesting[[:space:]]*\n[[:space:]]*(static[[:space:]]+)?(struct|class|final[[:space:]]+class|enum|init|func)/public \1\2/
         }' "$file"
 
         # Log changes made to the file
-        diff_output=$(diff "$original_file" "$file")
+        diff_output=$(diff "$backup_file" "$file")
         if [[ -n "$diff_output" ]]; then
             echo "Changes made in file: $file" | tee -a "$log_file"
             echo "$diff_output" | tee -a "$log_file"
         fi
 
-        # Remove the backup file
-        rm -f "${file}.bak"
     fi
 done
 

--- a/Tests/TestingApps/PaywallsTester/Preprocessor.sh
+++ b/Tests/TestingApps/PaywallsTester/Preprocessor.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+#  Preprocessor.sh
+#  PaywallsTester
+#
+#  Created by James Borthwick on 2024-05-08.
+#
+
+# This script searches up from ${PROJECT_DIR} to locate the RevenueCat.xcworkspace directory.
+# Once found, it searches through all `.swift` files starting from that base directory.
+# It finds occurances of `//@PublicForExternalTesting` and modifies the subsequent class, struct,
+# func, init and enum declaration to make it public.
+
+# directory containing RevenueCat.xcworkspace
+find_xcworkspace_dir() {
+  local dir="$1"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -e "$dir/RevenueCat.xcworkspace" ]]; then
+      echo "$dir"
+      return 0
+    fi
+    dir=$(dirname "$dir")  # go up one level
+  done
+  return 1  # RevenueCat.xcworkspace not found :'(
+}
+
+echo "Starting script to make items annotated with \`\\\\@PublicForExternalTesting\` public."
+
+echo "PWD is ${PROJECT_DIR}"
+
+base_directory=$(find_xcworkspace_dir ${PROJECT_DIR})
+
+if [[ -z "$base_directory" ]]; then
+  echo "Error: RevenueCat.xcworkspace not found in the current directory or any parent directory."
+  exit 1
+fi
+
+echo "Starting at: $base_directory"
+
+# debug log
+log_file="preprocess_log.txt"
+echo "Starting log at $(date)" > "$log_file"
+
+# Find all .swift files recursively from the base directory
+find "$base_directory" -type f -name "*.swift" | while read -r file; do
+
+    if grep -q '//@PublicForExternalTesting' "$file"; then
+        # Backup original file
+        original_file="${file}.orig"
+        cp "$file" "$original_file"
+
+        # Find //@PublicForExternalTesting and replace it with public before declarations
+        sed -i.bak -E \
+        '/\/\/@PublicForExternalTesting[[:space:]]*$/{
+        N
+        s/\/\/@PublicForExternalTesting[[:space:]]*\n[[:space:]]*(static[[:space:]]+)?(struct|class|final[[:space:]]+class|enum|init|func)/public \1\2/
+        }' "$file"
+
+        # Log changes made to the file
+        diff_output=$(diff "$original_file" "$file")
+        if [[ -n "$diff_output" ]]; then
+            echo "Changes made in file: $file" | tee -a "$log_file"
+            echo "$diff_output" | tee -a "$log_file"
+        fi
+
+        # Remove the backup file
+        rm -f "$original_file" "${file}.bak"
+    fi
+done
+
+echo "Processing completed." | tee -a "$log_file"
+

--- a/Tests/TestingApps/PaywallsTester/Preprocessor.sh
+++ b/Tests/TestingApps/PaywallsTester/Preprocessor.sh
@@ -6,10 +6,12 @@
 #  Created by James Borthwick on 2024-05-08.
 #
 
+# Intended to be run via the scheme's pre-actions build phase
+#
 # This script searches up from ${PROJECT_DIR} to locate the RevenueCat.xcworkspace directory.
 # Once found, it searches through all `.swift` files starting from that base directory.
-# It finds occurances of `//@PublicForExternalTesting` and modifies the subsequent class, struct,
-# func, init and enum declaration to make it public.
+# It finds occurrences of `//@PublicForExternalTesting` and modifies the subsequent class, struct,
+# func, init, and enum declaration to make it public.
 
 # directory containing RevenueCat.xcworkspace
 find_xcworkspace_dir() {
@@ -26,9 +28,7 @@ find_xcworkspace_dir() {
 
 echo "Starting script to make items annotated with \`\\\\@PublicForExternalTesting\` public."
 
-echo "PWD is ${PROJECT_DIR}"
-
-base_directory=$(find_xcworkspace_dir ${PROJECT_DIR})
+base_directory=$(find_xcworkspace_dir "${PROJECT_DIR}")
 
 if [[ -z "$base_directory" ]]; then
   echo "Error: RevenueCat.xcworkspace not found in the current directory or any parent directory."
@@ -64,9 +64,8 @@ find "$base_directory" -type f -name "*.swift" | while read -r file; do
         fi
 
         # Remove the backup file
-        rm -f "$original_file" "${file}.bak"
+        rm -f "${file}.bak"
     fi
 done
 
 echo "Processing completed." | tee -a "$log_file"
-


### PR DESCRIPTION
This PR allows the Paywalls Tester app to access some items internal to purchases-ios by temporarily marking them public during complication.

Items that need to be public have been annotated with `\\@PublicForExternalTesting`.

The Paywalls Tester project runs a script, Preprocessor.sh, as a pre-action to add `public` to all classes/structs/enums/functions/inits that have been annotated.

After compilation it runs a second script, Postprocessor.sh, as a post-action to undo these changes so that they don't accidentally get checked in.

The first script is run as a scheme pre-action rather than as a run script build phase, because when run as a build phase the changes to the files aren't picked up until the next compilation attempt.

<img width="669" alt="image" src="https://github.com/RevenueCat/purchases-ios/assets/109382862/0b0bacdb-79de-441d-8d61-2a5dd03b1b53">

It also changes the archive step to be built with a release configuration, and removes the use of `@testable import` for debug builds.

resolves PWL-459