### PR TITLE
Improved Error Handling

### DIFF
--- a/Sources/Misc/Codable/EnsureNonEmptyCollectionDecodable.swift
+++ b/Sources/Misc/Codable/EnsureNonEmptyCollectionDecodable.swift
@@ -24,7 +24,22 @@ import Foundation
 @propertyWrapper
 struct EnsureNonEmptyCollectionDecodable<Value: Collection> where Value: Codable {
 
-    struct Error: Swift.Error {}
+    struct Error: LocalizedError {
+        var type: String?
+
+        init(type: String? = nil) {
+            self.type = type
+        }
+
+        public var localizedDescription: String? {
+            "Collection cannot be empty"
+        }
+
+        public var failureReason: String? {
+            "A collection of type \(type ?? "unknown") was unexpectedly empty."
+        }
+
+    }
 
     var wrappedValue: Value
 
@@ -40,7 +55,7 @@ extension EnsureNonEmptyCollectionDecodable: Decodable {
         let array = try container.decode(Value.self)
 
         if array.isEmpty {
-            throw Error()
+            throw Error(type: "\(Value.self)")
         } else {
             self.wrappedValue = array
         }
@@ -64,7 +79,7 @@ extension KeyedDecodingContainer {
         forKey key: Key
     ) throws -> EnsureNonEmptyCollectionDecodable<T> {
         return try self.decodeIfPresent(type, forKey: key)
-            .orThrow(EnsureNonEmptyCollectionDecodable<T>.Error())
+            .orThrow(EnsureNonEmptyCollectionDecodable<T>.Error(type: "\(type)"))
     }
 
 }

--- a/Sources/Misc/Codable/EnsureNonEmptyCollectionDecodable.swift
+++ b/Sources/Misc/Codable/EnsureNonEmptyCollectionDecodable.swift
@@ -25,17 +25,19 @@ import Foundation
 struct EnsureNonEmptyCollectionDecodable<Value: Collection> where Value: Codable {
 
     struct Error: LocalizedError {
-        
+
         var path: String?
 
         init(codingPath: String? = nil) {
             self.path = codingPath
         }
 
+        /// Error message explaining that the collection cannot be empty
         public var localizedDescription: String? {
             "Collection cannot be empty"
         }
 
+        /// Error message that includes the path that contains the empty collection
         public var failureReason: String? {
             "A collection at \(path ?? "unknown") was unexpectedly empty."
         }

--- a/Sources/Misc/Codable/EnsureNonEmptyCollectionDecodable.swift
+++ b/Sources/Misc/Codable/EnsureNonEmptyCollectionDecodable.swift
@@ -25,10 +25,11 @@ import Foundation
 struct EnsureNonEmptyCollectionDecodable<Value: Collection> where Value: Codable {
 
     struct Error: LocalizedError {
-        var type: String?
+        
+        var path: String?
 
-        init(type: String? = nil) {
-            self.type = type
+        init(codingPath: String? = nil) {
+            self.path = codingPath
         }
 
         public var localizedDescription: String? {
@@ -36,7 +37,7 @@ struct EnsureNonEmptyCollectionDecodable<Value: Collection> where Value: Codable
         }
 
         public var failureReason: String? {
-            "A collection of type \(type ?? "unknown") was unexpectedly empty."
+            "A collection at \(path ?? "unknown") was unexpectedly empty."
         }
 
     }
@@ -55,7 +56,7 @@ extension EnsureNonEmptyCollectionDecodable: Decodable {
         let array = try container.decode(Value.self)
 
         if array.isEmpty {
-            throw Error(type: "\(Value.self)")
+            throw Error(codingPath: "\(decoder.codingPath)")
         } else {
             self.wrappedValue = array
         }
@@ -79,7 +80,7 @@ extension KeyedDecodingContainer {
         forKey key: Key
     ) throws -> EnsureNonEmptyCollectionDecodable<T> {
         return try self.decodeIfPresent(type, forKey: key)
-            .orThrow(EnsureNonEmptyCollectionDecodable<T>.Error(type: "\(type)"))
+            .orThrow(EnsureNonEmptyCollectionDecodable<T>.Error(codingPath: "\(self.codingPath)"))
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -31,10 +31,18 @@ final class OfferingsPaywallsViewModel {
     enum State {
         case notloaded
         case success
-        case error(NSError)
+        case error(Error)
     }
 
-    private(set) var state: State
+    var error: Error?
+
+    private(set) var state: State {
+        didSet {
+            if case let .error(stateError) = state {
+                self.error = stateError
+            }
+        }
+    }
     private(set) var hasMultipleTemplates = false
     private(set) var hasMultipleOfferingsWithPaywalls = false
     var presentedPaywall: PresentedPaywall?
@@ -75,7 +83,7 @@ final class OfferingsPaywallsViewModel {
             self.hasMultipleOfferingsWithPaywalls = listData.offeringsAndPaywalls.count > 1
             self.listData = listData
             self.state = .success
-        } catch let error as NSError {
+        } catch {
             Self.logger.log(level: .error, "Could not fetch offerings/paywalls: \(error)")
             self.state = .error(error)
         }
@@ -147,6 +155,7 @@ private extension OfferingsPaywallsViewModel {
             }
         case .error(let error):
             Self.logger.log(level: .error, "Could not find a paywall for id \(id), error: \(error)")
+            self.error = error as! LocalizedError
             self.presentedPaywall = nil
         }
     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -155,7 +155,7 @@ private extension OfferingsPaywallsViewModel {
             }
         case .error(let error):
             Self.logger.log(level: .error, "Could not find a paywall for id \(id), error: \(error)")
-            self.error = error as! LocalizedError
+            self.error = error
             self.presentedPaywall = nil
         }
     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Networking/HTTPClient.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Networking/HTTPClient.swift
@@ -105,6 +105,24 @@ extension HTTPClient {
 
         case notFound
 
+
+        public var errorDescription: String? {
+            switch self {
+            case .unrecognizedResponse(_):
+                "Unrecognized Server Response"
+            case .invalidResponse(_):
+                "Invalid Server Response"
+            case .errorResponse(_, _, _, _):
+                "Server Error Response"
+            case .failedParsingResponse(_, json: let json):
+                "Failed to Parse Repsponse"
+            case .failedBuildingURL:
+                "Failed to Build URL"
+            case .notFound:
+                "Unknown Error"
+            }
+        }
+
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Networking/HTTPClient.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Networking/HTTPClient.swift
@@ -218,6 +218,9 @@ extension HTTPClient.Error: LocalizedError {
         case .notFound:
             return "Page not found"
 
+        case let .failedParsingResponse(swiftError, _):
+            return swiftError.localizedDescription
+
         default:
             return self.localizedDescription
         }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Utility Views/AsyncButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Utility Views/AsyncButton.swift
@@ -16,7 +16,7 @@ struct AsyncButton<Label>: View where Label: View {
     private let label: Label
 
     @State
-    private var error: NSError?
+    private var error: Error?
 
     init(
         action: @escaping Action,
@@ -28,10 +28,10 @@ struct AsyncButton<Label>: View where Label: View {
 
     var body: some View {
         Button {
-            Task<Void, Never> {
+            Task {
                 do {
                     try await self.action()
-                } catch let error as NSError {
+                } catch {
                     self.error = error
                 }
             }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Utility Views/ErrorDisplay.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Utility Views/ErrorDisplay.swift
@@ -11,7 +11,7 @@ import SwiftUI
 private struct ErrorDisplay: ViewModifier {
 
     @Binding
-    var error: NSError?
+    var error: Error?
     var dismissOnClose: Bool
 
     @Environment(\.dismiss)
@@ -49,7 +49,7 @@ private struct ErrorDisplay: ViewModifier {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
-    func displayError(_ error: Binding<NSError?>, dismissOnClose: Bool = false) -> some View {
+    func displayError(_ error: Binding<Error?>, dismissOnClose: Bool = false) -> some View {
         self.modifier(ErrorDisplay(error: error, dismissOnClose: dismissOnClose))
     }
 
@@ -57,24 +57,25 @@ extension View {
 
 private struct LocalizedAlertError: LocalizedError {
 
-    private let underlyingError: NSError
+    private let underlyingError: Error
 
-    init(error: NSError) {
+    init(error: Error) {
         self.underlyingError = error
     }
 
     var errorDescription: String? {
-        return (self.underlyingError as? LocalizedError)?.errorDescription
-        ?? "\(self.underlyingError.domain) \(self.underlyingError.code)"
+        return (self.underlyingError as? LocalizedError)?.errorDescription ??
+        (self.underlyingError as NSError).localizedDescription
     }
 
     var failureReason: String? {
-        return (self.underlyingError as? LocalizedError)?.failureReason
-        ?? self.underlyingError.localizedDescription
+        return (self.underlyingError as? LocalizedError)?.failureReason ??
+        (self.underlyingError as NSError).localizedFailureReason
     }
 
     var recoverySuggestion: String? {
-        self.underlyingError.localizedRecoverySuggestion
+        return (self.underlyingError as? LocalizedError)?.recoverySuggestion ??
+        (self.underlyingError as NSError).localizedRecoverySuggestion
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginWall.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginWall.swift
@@ -12,8 +12,8 @@ struct LoginWall<ContentView: View>: View {
     @Environment(ApplicationData.self) private var application
     
     @State
-    private var error: NSError?
-    
+    private var error: Error?
+
     var content: (DeveloperResponse) -> ContentView
     
     var body: some View {
@@ -41,7 +41,7 @@ struct LoginWall<ContentView: View>: View {
         do {
             try await application.loadApplicationData()
         } catch {
-            self.error = error as NSError
+            self.error = error
         }
     }
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/ManagePaywallButton.swift
@@ -12,6 +12,9 @@ import WatchKit
 
 struct ManagePaywallButton: View {
 
+    @State
+    var error: Error?
+
     enum Kind: String {
         case edit
         case new
@@ -50,6 +53,7 @@ struct ManagePaywallButton: View {
                 kind.image
             }
         }
+        .displayError($error)
     }
 
     init(kind: Kind, appID: String, offeringID: String, buttonName: String? = nil) {
@@ -69,6 +73,8 @@ struct ManagePaywallButton: View {
 
         guard let url = URL(string: urlString) else {
             Self.logger.log(level: .error, "Could not create URL for \(urlString)")
+            self.error = URLError(.badURL, userInfo: [NSLocalizedDescriptionKey: "Could not create URL",
+                                               NSLocalizedFailureReasonErrorKey: "Attempted with \(urlString)"])
             return nil
         }
 
@@ -79,6 +85,8 @@ struct ManagePaywallButton: View {
         #if !os(watchOS)
         guard UIApplication.shared.canOpenURL(url) else {
             Self.logger.log(level: .error, "Could not open URL for \(url)")
+            self.error = URLError(.badURL, userInfo: [NSLocalizedDescriptionKey: "Could not open URL",
+                                               NSLocalizedFailureReasonErrorKey: "Could not open \(url)"])
             return
         }
         UIApplication.shared.open(url)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -40,6 +40,7 @@ struct OfferingsList: View {
                     }
                 }
             }
+            .displayError($viewModel.error)
     }
 
     init(app: DeveloperResponse.App, introEligility: Binding<IntroEligibilityStatus>) {
@@ -67,7 +68,7 @@ struct OfferingsList: View {
                 Text("No data available.")
             }
         case .error(let error):
-            Text(error.description)
+            ContentUnavailableView("Error loading paywalls", systemImage: "exclamationmark.triangle.fill", description: Text(error.localizedDescription))
         }
     }
     


### PR DESCRIPTION
Adds missing user-facing error alerts, makes the error messages more readable and uses `Error` rather than `NSError` as the type to use when passing errors for presentation.
 
resolves PWL-458