### PR TITLE
Paywalls Tester: Enable Example Paywalls in Release Mode

### DIFF
--- a/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker.swift
+++ b/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker.swift
@@ -18,6 +18,7 @@ import RevenueCat
 // @PublicForExternalTesting
 final class TrialOrIntroEligibilityChecker: ObservableObject {
 
+    // @PublicForExternalTesting
     typealias Checker = @Sendable ([Package]) async -> [Package: IntroEligibilityStatus]
 
     /// `false` if this `TrialOrIntroEligibilityChecker` is not backend by a configured `Purchases`instance.
@@ -33,11 +34,13 @@ final class TrialOrIntroEligibilityChecker: ObservableObject {
     }
 
     /// Creates an instance with a custom checker, useful for testing or previews.
+    // @PublicForExternalTesting
     init(isConfigured: Bool = true, checker: @escaping Checker) {
         self.isConfigured = isConfigured
         self.checker = checker
     }
 
+    // @PublicForExternalTesting
     static func `default`() -> Self {
         return Purchases.isConfigured ? .init() : .notConfigured()
     }
@@ -67,6 +70,7 @@ extension TrialOrIntroEligibilityChecker {
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
 extension StoreProduct {
 
+    // @PublicForExternalTesting
     var hasIntroDiscount: Bool {
         // Fix-me: this needs to handle other types of intro discounts
         return self.introductoryDiscount != nil

--- a/RevenueCatUI/Data/PaywallTemplate.swift
+++ b/RevenueCatUI/Data/PaywallTemplate.swift
@@ -14,7 +14,8 @@
 import Foundation
 
 /// The type of template used to display a paywall.
-internal enum PaywallTemplate: String {
+// @PublicForExternalTesting
+enum PaywallTemplate: String {
 
     case template1 = "1"
     case template2 = "2"

--- a/RevenueCatUI/Data/TestData.swift
+++ b/RevenueCatUI/Data/TestData.swift
@@ -11,10 +11,10 @@ import SwiftUI
 
 // swiftlint:disable type_body_length file_length
 
-#if DEBUG
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-internal enum TestData {
+// @PublicForExternalTesting
+enum TestData {
 
     static let weeklyProduct = TestStoreProduct(
         localizedTitle: "Weekly",
@@ -469,6 +469,7 @@ internal enum TestData {
     static let colors: PaywallData.Configuration.Colors = .combine(light: Self.lightColors, dark: Self.darkColors)
     #endif
 
+    // @PublicForExternalTesting
     static let customerInfo: CustomerInfo = {
         return .decode(
         """
@@ -567,6 +568,7 @@ extension PaywallColor: ExpressibleByStringLiteral {
 
 extension PackageType {
 
+    // @PublicForExternalTesting
     var identifier: String {
         return Package.string(from: self)!
     }
@@ -585,5 +587,3 @@ extension CustomerInfo {
     }
 
 }
-
-#endif

--- a/RevenueCatUI/Data/TestData.swift
+++ b/RevenueCatUI/Data/TestData.swift
@@ -16,6 +16,37 @@ import SwiftUI
 // @PublicForExternalTesting
 enum TestData {
 
+    // @PublicForExternalTesting
+    static let customerInfo: CustomerInfo = {
+        return .decode(
+        """
+        {
+            "schema_version": "4",
+            "request_date": "2022-03-08T17:42:58Z",
+            "request_date_ms": 1646761378845,
+            "subscriber": {
+                "first_seen": "2022-03-08T17:42:58Z",
+                "last_seen": "2022-03-08T17:42:58Z",
+                "management_url": "https://apps.apple.com/account/subscriptions",
+                "non_subscriptions": {
+                },
+                "original_app_user_id": "$RCAnonymousID:5b6fdbac3a0c4f879e43d269ecdf9ba1",
+                "original_application_version": "1.0",
+                "original_purchase_date": "2022-04-12T00:03:24Z",
+                "other_purchases": {
+                },
+                "subscriptions": {
+                },
+                "entitlements": {
+                }
+            }
+        }
+        """
+        )
+    }()
+
+    #if DEBUG
+
     static let weeklyProduct = TestStoreProduct(
         localizedTitle: "Weekly",
         price: 1.99,
@@ -469,35 +500,6 @@ enum TestData {
     static let colors: PaywallData.Configuration.Colors = .combine(light: Self.lightColors, dark: Self.darkColors)
     #endif
 
-    // @PublicForExternalTesting
-    static let customerInfo: CustomerInfo = {
-        return .decode(
-        """
-        {
-            "schema_version": "4",
-            "request_date": "2022-03-08T17:42:58Z",
-            "request_date_ms": 1646761378845,
-            "subscriber": {
-                "first_seen": "2022-03-08T17:42:58Z",
-                "last_seen": "2022-03-08T17:42:58Z",
-                "management_url": "https://apps.apple.com/account/subscriptions",
-                "non_subscriptions": {
-                },
-                "original_app_user_id": "$RCAnonymousID:5b6fdbac3a0c4f879e43d269ecdf9ba1",
-                "original_application_version": "1.0",
-                "original_purchase_date": "2022-04-12T00:03:24Z",
-                "other_purchases": {
-                },
-                "subscriptions": {
-                },
-                "entitlements": {
-                }
-            }
-        }
-        """
-        )
-    }()
-
     static let localization1: PaywallData.LocalizedConfiguration = .init(
         title: "Ignite your child's *curiosity*",
         subtitle: "Get access to all our educational content trusted by **thousands** of parents.",
@@ -551,9 +553,13 @@ enum TestData {
         )
     }
 
+    #endif
+
 }
 
 // MARK: -
+
+#if DEBUG
 
 extension PaywallColor: ExpressibleByStringLiteral {
 
@@ -565,6 +571,8 @@ extension PaywallColor: ExpressibleByStringLiteral {
     }
 
 }
+
+#endif
 
 extension PackageType {
 

--- a/RevenueCatUI/Data/TestData.swift
+++ b/RevenueCatUI/Data/TestData.swift
@@ -11,7 +11,6 @@ import SwiftUI
 
 // swiftlint:disable type_body_length file_length
 
-
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 // @PublicForExternalTesting
 enum TestData {

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -70,6 +70,7 @@ final class PurchaseHandler: ObservableObject {
         self.purchases = purchases
     }
 
+    // @PublicForExternalTesting
     static func `default`() -> Self {
         return Purchases.isConfigured ? .init() : Self.notConfigured()
     }

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -60,7 +60,7 @@ extension TemplateViewType {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private extension PaywallTemplate {
+extension PaywallTemplate {
 
     var packageSetting: TemplateViewConfiguration.PackageSetting {
         switch self {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/SamplePaywalls.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/SamplePaywalls.swift
@@ -454,14 +454,14 @@ private extension SamplePaywallLoader {
 // But we want to be able to use it in release builds too.
 #if !DEBUG
 
-//extension PaywallColor: ExpressibleByStringLiteral {
-//
-//    public init(stringLiteral value: StringLiteralType) {
-//        // swiftlint:disable:next force_try
-//        try! self.init(stringRepresentation: value)
-//    }
-//
-//}
+extension PaywallColor: ExpressibleByStringLiteral {
+
+    public init(stringLiteral value: StringLiteralType) {
+        // swiftlint:disable:next force_try
+        try! self.init(stringRepresentation: value)
+    }
+
+}
 
 #endif
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/SamplePaywalls.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/SamplePaywalls.swift
@@ -5,11 +5,11 @@
 //  Created by Nacho Soto on 7/27/23.
 //
 
-#if DEBUG
+
 
 import Foundation
 import RevenueCat
-@testable import RevenueCatUI
+import RevenueCatUI
 
 final class SamplePaywallLoader {
 
@@ -465,4 +465,3 @@ extension PaywallColor: ExpressibleByStringLiteral {
 
 #endif
 
-#endif

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/SamplePaywalls.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/SamplePaywalls.swift
@@ -454,14 +454,14 @@ private extension SamplePaywallLoader {
 // But we want to be able to use it in release builds too.
 #if !DEBUG
 
-extension PaywallColor: ExpressibleByStringLiteral {
-
-    public init(stringLiteral value: StringLiteralType) {
-        // swiftlint:disable:next force_try
-        try! self.init(stringRepresentation: value)
-    }
-
-}
+//extension PaywallColor: ExpressibleByStringLiteral {
+//
+//    public init(stringLiteral value: StringLiteralType) {
+//        // swiftlint:disable:next force_try
+//        try! self.init(stringRepresentation: value)
+//    }
+//
+//}
 
 #endif
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
@@ -40,14 +40,12 @@ struct AppContentView: View {
                 .navigationViewStyle(StackNavigationViewStyle())
             }
 
-            #if DEBUG
             SamplePaywallsList()
                 .tabItem {
                     Image("logo")
                         .renderingMode(.template)
                     Text("Examples")
                 }
-            #endif
 
             AppList()
                 .tabItem {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomPaywall.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomPaywall.swift
@@ -5,10 +5,10 @@
 //  Created by Nacho Soto on 8/9/23.
 //
 
-#if DEBUG && !os(watchOS)
+#if !os(watchOS)
 
 import RevenueCat
-@testable import RevenueCatUI
+import RevenueCatUI
 import SwiftUI
 
 struct CustomPaywall: View {
@@ -36,53 +36,54 @@ struct CustomPaywall: View {
 
 }
 
+#endif
 
 #if DEBUG
 
-struct CustomPaywall_Previews: PreviewProvider {
-    
-    static var previews: some View {
-        ForEach(Self.condensedOptions, id: \.self) { mode in
-            CustomPaywall(
-                offering: TestData.offeringWithMultiPackagePaywall,
-                customerInfo: TestData.customerInfo,
-                condensed: mode,
-                introEligibility: .producing(eligibility: .eligible),
-                purchaseHandler: .mock()
-            )
-            .previewDisplayName("Template2\(mode ? " condensed" : "")")
-        }
-
-        ForEach(Self.condensedOptions, id: \.self) { mode in
-            CustomPaywall(
-                offering: TestData.offeringWithMultiPackageHorizontalPaywall,
-                customerInfo: TestData.customerInfo,
-                condensed: mode,
-                introEligibility: .producing(eligibility: .eligible),
-                purchaseHandler: .mock()
-            )
-            .previewDisplayName("Template4\(mode ? " condensed" : "")")
-        }
-
-        ForEach(Self.condensedOptions, id: \.self) { mode in
-            CustomPaywall(
-                offering: TestData.offeringWithTemplate5Paywall,
-                customerInfo: TestData.customerInfo,
-                condensed: mode,
-                introEligibility: .producing(eligibility: .eligible),
-                purchaseHandler: .mock()
-            )
-            .previewDisplayName("Template5\(mode ? " condensed" : "")")
-        }
-    }
-
-    private static let condensedOptions: [Bool] = [
-        true,
-        false
-    ]
-
-}
-
-#endif
+//struct CustomPaywall_Previews: PreviewProvider {
+//    
+//    static var previews: some View {
+//        ForEach(Self.condensedOptions, id: \.self) { mode in
+//            CustomPaywall(
+//                offering: TestData.offeringWithMultiPackagePaywall,
+//                customerInfo: TestData.customerInfo,
+//                condensed: mode,
+//                introEligibility: .producing(eligibility: .eligible),
+//                purchaseHandler: .mock()
+//            )
+//            .previewDisplayName("Template2\(mode ? " condensed" : "")")
+//        }
+//
+//        ForEach(Self.condensedOptions, id: \.self) { mode in
+//            CustomPaywall(
+//                offering: TestData.offeringWithMultiPackageHorizontalPaywall,
+//                customerInfo: TestData.customerInfo,
+//                condensed: mode,
+//                introEligibility: .producing(eligibility: .eligible),
+//                purchaseHandler: .mock()
+//            )
+//            .previewDisplayName("Template4\(mode ? " condensed" : "")")
+//        }
+//
+//        ForEach(Self.condensedOptions, id: \.self) { mode in
+//            CustomPaywall(
+//                offering: TestData.offeringWithTemplate5Paywall,
+//                customerInfo: TestData.customerInfo,
+//                condensed: mode,
+//                introEligibility: .producing(eligibility: .eligible),
+//                purchaseHandler: .mock()
+//            )
+//            .previewDisplayName("Template5\(mode ? " condensed" : "")")
+//        }
+//    }
+//
+//    private static let condensedOptions: [Bool] = [
+//        true,
+//        false
+//    ]
+//
+//}
 
 #endif
+
+

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomPaywall.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomPaywall.swift
@@ -8,7 +8,13 @@
 #if !os(watchOS)
 
 import RevenueCat
+
+#if DEBUG
+// this @testable access should used for the SwiftUI previews only
+@testable import RevenueCatUI
+#else
 import RevenueCatUI
+#endif
 import SwiftUI
 
 struct CustomPaywall: View {
@@ -40,49 +46,49 @@ struct CustomPaywall: View {
 
 #if DEBUG
 
-//struct CustomPaywall_Previews: PreviewProvider {
-//    
-//    static var previews: some View {
-//        ForEach(Self.condensedOptions, id: \.self) { mode in
-//            CustomPaywall(
-//                offering: TestData.offeringWithMultiPackagePaywall,
-//                customerInfo: TestData.customerInfo,
-//                condensed: mode,
-//                introEligibility: .producing(eligibility: .eligible),
-//                purchaseHandler: .mock()
-//            )
-//            .previewDisplayName("Template2\(mode ? " condensed" : "")")
-//        }
-//
-//        ForEach(Self.condensedOptions, id: \.self) { mode in
-//            CustomPaywall(
-//                offering: TestData.offeringWithMultiPackageHorizontalPaywall,
-//                customerInfo: TestData.customerInfo,
-//                condensed: mode,
-//                introEligibility: .producing(eligibility: .eligible),
-//                purchaseHandler: .mock()
-//            )
-//            .previewDisplayName("Template4\(mode ? " condensed" : "")")
-//        }
-//
-//        ForEach(Self.condensedOptions, id: \.self) { mode in
-//            CustomPaywall(
-//                offering: TestData.offeringWithTemplate5Paywall,
-//                customerInfo: TestData.customerInfo,
-//                condensed: mode,
-//                introEligibility: .producing(eligibility: .eligible),
-//                purchaseHandler: .mock()
-//            )
-//            .previewDisplayName("Template5\(mode ? " condensed" : "")")
-//        }
-//    }
-//
-//    private static let condensedOptions: [Bool] = [
-//        true,
-//        false
-//    ]
-//
-//}
+struct CustomPaywall_Previews: PreviewProvider {
+    
+    static var previews: some View {
+        ForEach(Self.condensedOptions, id: \.self) { mode in
+            CustomPaywall(
+                offering: TestData.offeringWithMultiPackagePaywall,
+                customerInfo: TestData.customerInfo,
+                condensed: mode,
+                introEligibility: .producing(eligibility: .eligible),
+                purchaseHandler: .mock()
+            )
+            .previewDisplayName("Template2\(mode ? " condensed" : "")")
+        }
+
+        ForEach(Self.condensedOptions, id: \.self) { mode in
+            CustomPaywall(
+                offering: TestData.offeringWithMultiPackageHorizontalPaywall,
+                customerInfo: TestData.customerInfo,
+                condensed: mode,
+                introEligibility: .producing(eligibility: .eligible),
+                purchaseHandler: .mock()
+            )
+            .previewDisplayName("Template4\(mode ? " condensed" : "")")
+        }
+
+        ForEach(Self.condensedOptions, id: \.self) { mode in
+            CustomPaywall(
+                offering: TestData.offeringWithTemplate5Paywall,
+                customerInfo: TestData.customerInfo,
+                condensed: mode,
+                introEligibility: .producing(eligibility: .eligible),
+                purchaseHandler: .mock()
+            )
+            .previewDisplayName("Template5\(mode ? " condensed" : "")")
+        }
+    }
+
+    private static let condensedOptions: [Bool] = [
+        true,
+        false
+    ]
+
+}
 
 #endif
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomPaywallContent.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomPaywallContent.swift
@@ -16,9 +16,7 @@ struct CustomPaywallContent: View {
 
     var body: some View {
         self.content
-        #if DEBUG
             .scrollableIfNecessary(.vertical)
-        #endif
             .background(CustomPaywallContent.backgroundColor)
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -5,10 +5,10 @@
 //  Created by Nacho Soto on 7/27/23.
 //
 
-#if DEBUG
+
 
 import RevenueCat
-@testable import RevenueCatUI
+import RevenueCatUI
 import SwiftUI
 
 struct SamplePaywallsList: View {
@@ -254,4 +254,3 @@ struct SamplePaywallsList_Previews: PreviewProvider {
     }
 }
 
-#endif

--- a/Tests/TestingApps/PaywallsTester/Preprocessor.sh
+++ b/Tests/TestingApps/PaywallsTester/Preprocessor.sh
@@ -53,7 +53,7 @@ find "$base_directory" -type f -name "*.swift" | while read -r file; do
         sed -i.orig -E \
         '/\/\/ @PublicForExternalTesting[[:space:]]*$/{
         N
-        s/\/\/ @PublicForExternalTesting[[:space:]]*\n[[:space:]]*(static[[:space:]]+)?(struct|class|final[[:space:]]+class|enum|init|func)/public \1\2/
+        s/\/\/ @PublicForExternalTesting[[:space:]]*\n[[:space:]]*(static[[:space:]]+)?(struct|class|final[[:space:]]+class|enum|init|convenience[[:space:]]+init|func|var|let|typealias)/public \1\2/
         }' "$file"
 
         # Log changes made to the file


### PR DESCRIPTION
The paywalls examples weren't showing up when compiled in release mode. Enabling it meant making a bunch of more internal things public via the preprocessing script. `TestData` is no longer `#ifdef DEBUG`ed out, but most of its data is still `#ifdef DEBUG`, and when it's compiled with an `internal` modifier and thus nothing uses it, I'd expect what remains to be stripped away during linking.