### PR TITLE
[EXTERNAL]  Hide decorative Paywall images from accessibility (#3886) via @shiftingsand

### DIFF
--- a/RevenueCatUI/Views/RemoteImage.swift
+++ b/RevenueCatUI/Views/RemoteImage.swift
@@ -40,10 +40,12 @@ struct RemoteImage: View {
                     image
                         .fitToAspect(aspectRatio, contentMode: .fill)
                         .frame(maxWidth: self.maxWidth)
+                        .accessibilityHidden(true)
 
                 } else {
                     image
                         .resizable()
+                        .accessibilityHidden(true)
                 }
 
             case let .failure(error):


### PR DESCRIPTION
### Motivation

The paywall template I'm using (five) displays a decorative image but the image isn't marked as decorative to accessibility. In my particular test case that meant that VoiceOver could access it, but there was no audible description of what the image actually was. 

Normally I would change Image() to Image(decorative: ), but since that wasn't possible I used .accessibilityHidden(true).

### Description

Added .accessibilityHidden(true) to the two images in RemoteImage. I initially was hesitant to change RemoteImage itself, but went ahead and did so since it seems to be only used by the Paywall templates.

Contributed by @shiftingsand in #3886