### PR TITLE
Add `http_request_performed` diagnostics event

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -39,6 +39,11 @@ extension DiagnosticsEvent {
     enum DiagnosticsPropertyKey: String, Codable {
 
         case verificationResultKey
+        case endpointNameKey
+        case responseTimeMillisKey
+        case successfulKey
+        case responseCodeKey
+        case eTagHitKey
 
     }
 

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -21,6 +21,15 @@ protocol DiagnosticsTrackerType {
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func trackCustomerInfoVerificationResultIfNeeded(_ customerInfo: CustomerInfo) async
 
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    // swiftlint:disable:next function_parameter_count
+    func trackHttpRequestPerformed(endpointName: String,
+                                   responseTime: TimeInterval,
+                                   wasSuccessful: Bool,
+                                   responseCode: Int,
+                                   resultOrigin: HTTPResponseOrigin?,
+                                   verificationResult: VerificationResult) async
+
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -54,6 +63,29 @@ final class DiagnosticsTracker: DiagnosticsTrackerType {
             timestamp: self.dateProvider.now()
         )
         await track(event)
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    func trackHttpRequestPerformed(endpointName: String,
+                                   responseTime: TimeInterval,
+                                   wasSuccessful: Bool,
+                                   responseCode: Int,
+                                   resultOrigin: HTTPResponseOrigin?,
+                                   verificationResult: VerificationResult) async {
+        await track(
+            DiagnosticsEvent(
+                eventType: DiagnosticsEvent.EventType.httpRequestPerformed,
+                properties: [
+                    .endpointNameKey: AnyEncodable(endpointName),
+                    .responseTimeMillisKey: AnyEncodable(responseTime * 1000),
+                    .successfulKey: AnyEncodable(wasSuccessful),
+                    .responseCodeKey: AnyEncodable(responseCode),
+                    .eTagHitKey: AnyEncodable(resultOrigin == .cache),
+                    .verificationResultKey: AnyEncodable(verificationResult.name)
+                ],
+                timestamp: self.dateProvider.now()
+            )
+        )
     }
 
 }

--- a/Sources/Diagnostics/Networking/DiagnosticsEventsRequest.swift
+++ b/Sources/Diagnostics/Networking/DiagnosticsEventsRequest.swift
@@ -76,6 +76,16 @@ private extension DiagnosticsEvent.DiagnosticsPropertyKey {
         switch self {
         case .verificationResultKey:
             return "verification_result"
+        case .endpointNameKey:
+            return "endpoint_name"
+        case .responseTimeMillisKey:
+            return "response_time_millis"
+        case .successfulKey:
+            return "successful"
+        case .responseCodeKey:
+            return "response_code"
+        case .eTagHitKey:
+            return "etag_hit"
         }
     }
 

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -285,7 +285,7 @@ class CustomerInfoManager {
 
             if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
                 if let tracker = self.diagnosticsTracker, lastSentCustomerInfo != customerInfo {
-                    Task {
+                    Task(priority: .background) {
                         await tracker.trackCustomerInfoVerificationResultIfNeeded(customerInfo)
                     }
                 }

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -31,12 +31,14 @@ class Backend {
         operationDispatcher: OperationDispatcher,
         attributionFetcher: AttributionFetcher,
         offlineCustomerInfoCreator: OfflineCustomerInfoCreator?,
+        diagnosticsTracker: DiagnosticsTrackerType?,
         dateProvider: DateProvider = DateProvider()
     ) {
         let httpClient = HTTPClient(apiKey: apiKey,
                                     systemInfo: systemInfo,
                                     eTagManager: eTagManager,
                                     signing: Signing(apiKey: apiKey, clock: systemInfo.clock),
+                                    diagnosticsTracker: diagnosticsTracker,
                                     requestTimeout: httpClientTimeout)
         let config = BackendConfiguration(httpClient: httpClient,
                                           operationDispatcher: operationDispatcher,

--- a/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
@@ -106,6 +106,29 @@ class DiagnosticsTrackerTests: TestCase {
         ]
     }
 
+    // MARK: - http request performed
+
+    func testTracksHttpRequestPerformedWithExpectedParameters() async {
+        await self.tracker.trackHttpRequestPerformed(endpointName: "mock_endpoint",
+                                                     responseTime: 50,
+                                                     wasSuccessful: true,
+                                                     responseCode: 200,
+                                                     resultOrigin: .cache,
+                                                     verificationResult: .verified)
+        let entries = await self.handler.getEntries()
+        expect(entries) == [
+            .init(eventType: .httpRequestPerformed,
+                  properties: [
+                    .endpointNameKey: AnyEncodable("mock_endpoint"),
+                    .responseTimeMillisKey: AnyEncodable(50000),
+                    .successfulKey: AnyEncodable(true),
+                    .responseCodeKey: AnyEncodable(200),
+                    .eTagHitKey: AnyEncodable(true),
+                    .verificationResultKey: AnyEncodable("VERIFIED")],
+                  timestamp: Self.eventTimestamp1)
+        ]
+    }
+
     // MARK: - empty diagnostics file when too big
 
     func testTrackingEventClearsDiagnosticsFileIfTooBig() async throws {

--- a/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
+++ b/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
@@ -18,9 +18,14 @@ class MockBackendConfiguration: BackendConfiguration {
     init() {
         let systemInfo = MockSystemInfo(finishTransactions: false)
         let mockAPIKey = "mockAPIKey"
+        var diagnosticsTracker: DiagnosticsTrackerType?
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            diagnosticsTracker = MockDiagnosticsTracker()
+        }
         let httpClient = MockHTTPClient(apiKey: mockAPIKey,
                                         systemInfo: systemInfo,
                                         eTagManager: MockETagManager(),
+                                        diagnosticsTracker: diagnosticsTracker,
                                         requestTimeout: 7)
 
         super.init(

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -30,7 +30,10 @@ class MockDiagnosticsTracker: DiagnosticsTrackerType {
         trackedCustomerInfo.append(customerInfo)
     }
 
-    private(set) var trackedHttpRequestPerformedCount = 0
+    private(set) var trackedHttpRequestPerformedParams: [
+        // swiftlint:disable:next large_tuple
+        (String, TimeInterval, Bool, Int, HTTPResponseOrigin?, VerificationResult)
+    ] = []
     // swiftlint:disable:next function_parameter_count
     func trackHttpRequestPerformed(endpointName: String,
                                    responseTime: TimeInterval,
@@ -38,7 +41,9 @@ class MockDiagnosticsTracker: DiagnosticsTrackerType {
                                    responseCode: Int,
                                    resultOrigin: HTTPResponseOrigin?,
                                    verificationResult: VerificationResult) async {
-        self.trackedHttpRequestPerformedCount += 1
+        self.trackedHttpRequestPerformedParams.append(
+            (endpointName, responseTime, wasSuccessful, responseCode, resultOrigin, verificationResult)
+        )
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -30,4 +30,15 @@ class MockDiagnosticsTracker: DiagnosticsTrackerType {
         trackedCustomerInfo.append(customerInfo)
     }
 
+    private(set) var trackedHttpRequestPerformedCount = 0
+    // swiftlint:disable:next function_parameter_count
+    func trackHttpRequestPerformed(endpointName: String,
+                                   responseTime: TimeInterval,
+                                   wasSuccessful: Bool,
+                                   responseCode: Int,
+                                   resultOrigin: HTTPResponseOrigin?,
+                                   verificationResult: VerificationResult) async {
+        self.trackedHttpRequestPerformedCount += 1
+    }
+
 }

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -57,6 +57,7 @@ class MockHTTPClient: HTTPClient {
     init(apiKey: String,
          systemInfo: SystemInfo,
          eTagManager: ETagManager,
+         diagnosticsTracker: DiagnosticsTrackerType?,
          dnsChecker: DNSCheckerType.Type = DNSChecker.self,
          requestTimeout: TimeInterval = 7,
          sourceTestFile: StaticString = #file) {
@@ -66,6 +67,7 @@ class MockHTTPClient: HTTPClient {
                    systemInfo: systemInfo,
                    eTagManager: eTagManager,
                    signing: FakeSigning.default,
+                   diagnosticsTracker: diagnosticsTracker,
                    dnsChecker: dnsChecker,
                    requestTimeout: requestTimeout)
     }

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -22,6 +22,7 @@ class BaseBackendTests: TestCase {
 
     private(set) var systemInfo: SystemInfo!
     private(set) var httpClient: MockHTTPClient!
+    private(set) var diagnosticsTracker: DiagnosticsTrackerType?
     private(set) var operationDispatcher: MockOperationDispatcher!
     private(set) var mockProductEntitlementMappingFetcher: MockProductEntitlementMappingFetcher!
     private(set) var mockOfflineCustomerInfoCreator: MockOfflineCustomerInfoCreator!
@@ -101,9 +102,16 @@ extension BaseBackendTests {
     final func createClient(_ file: StaticString) -> MockHTTPClient {
         let eTagManager = MockETagManager()
 
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            self.diagnosticsTracker = MockDiagnosticsTracker()
+        } else {
+            self.diagnosticsTracker = nil
+        }
+
         return MockHTTPClient(apiKey: Self.apiKey,
                               systemInfo: self.systemInfo,
                               eTagManager: eTagManager,
+                              diagnosticsTracker: self.diagnosticsTracker,
                               sourceTestFile: file)
     }
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1636,7 +1636,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             "log_in",
             -1, // Any
             false,
-            -1,
+            401,
             nil,
             .notRequested
         )))

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1599,9 +1599,13 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         }
 
         // swiftlint:disable:next force_cast
-        let trackedParams = (self.diagnosticsTracker as! MockDiagnosticsTracker).trackedHttpRequestPerformedParams
-        expect(trackedParams.count) == 1
-        expect(trackedParams[0]).to(matchTrackParams((
+        let mockDiagnosticsTracker = self.diagnosticsTracker as! MockDiagnosticsTracker
+        expect(mockDiagnosticsTracker.trackedHttpRequestPerformedParams.count).toEventually(equal(1))
+        guard let trackedParams = mockDiagnosticsTracker.trackedHttpRequestPerformedParams.first else {
+            fail("Should have at least one call to tracked diagnostics")
+            return
+        }
+        expect(trackedParams).to(matchTrackParams((
             "log_in",
             -1, // Any
             true,
@@ -1622,9 +1626,13 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         }
 
         // swiftlint:disable:next force_cast
-        let trackedParams = (self.diagnosticsTracker as! MockDiagnosticsTracker).trackedHttpRequestPerformedParams
-        expect(trackedParams.count) == 1
-        expect(trackedParams[0]).to(matchTrackParams((
+        let mockDiagnosticsTracker = self.diagnosticsTracker as! MockDiagnosticsTracker
+        expect(mockDiagnosticsTracker.trackedHttpRequestPerformedParams.count).toEventually(equal(1))
+        guard let trackedParams = mockDiagnosticsTracker.trackedHttpRequestPerformedParams.first else {
+            fail("Should have at least one call to tracked diagnostics")
+            return
+        }
+        expect(trackedParams).to(matchTrackParams((
             "log_in",
             -1, // Any
             false,
@@ -1643,7 +1651,9 @@ private func matchTrackParams(
 ) -> Nimble.Predicate<(String, TimeInterval, Bool, Int, HTTPResponseOrigin?, VerificationResult)> {
     return .init {
         let other = try $0.evaluate()
+        let timeInterval = other?.1 ?? -1
         let matches = (other?.0 == data.0 &&
+                       timeInterval > 0 && timeInterval.isLess(than: 1) &&
                        other?.2 == data.2 &&
                        other?.3 == data.3 &&
                        other?.4 == data.4 &&

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -25,6 +25,7 @@ class BaseHTTPClientTests<ETag: ETagManager>: TestCase {
     var signing: MockSigning!
     var client: HTTPClient!
     var eTagManager: ETag!
+    var diagnosticsTracker: DiagnosticsTrackerType?
     var operationDispatcher: OperationDispatcher!
 
     fileprivate let apiKey = "MockAPIKey"
@@ -39,6 +40,11 @@ class BaseHTTPClientTests<ETag: ETagManager>: TestCase {
 
         self.systemInfo = MockSystemInfo(finishTransactions: true)
         self.signing = MockSigning()
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            self.diagnosticsTracker = MockDiagnosticsTracker()
+        } else {
+            self.diagnosticsTracker = nil
+        }
         self.operationDispatcher = OperationDispatcher()
         MockDNSChecker.resetData()
 
@@ -61,6 +67,7 @@ class BaseHTTPClientTests<ETag: ETagManager>: TestCase {
                           systemInfo: systemInfo,
                           eTagManager: self.eTagManager,
                           signing: self.signing,
+                          diagnosticsTracker: self.diagnosticsTracker,
                           dnsChecker: MockDNSChecker.self,
                           requestTimeout: defaultTimeout.seconds)
     }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -73,9 +73,17 @@ class BasePurchasesTests: TestCase {
         self.mockProductEntitlementMappingFetcher = MockProductEntitlementMappingFetcher()
         self.mockPurchasedProductsFetcher = MockPurchasedProductsFetcher()
         self.mockTransactionFetcher = MockStoreKit2TransactionFetcher()
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            self.diagnosticsTracker = MockDiagnosticsTracker()
+        } else {
+            self.diagnosticsTracker = nil
+        }
 
         let apiKey = "mockAPIKey"
-        let httpClient = MockHTTPClient(apiKey: apiKey, systemInfo: self.systemInfo, eTagManager: MockETagManager())
+        let httpClient = MockHTTPClient(apiKey: apiKey,
+                                        systemInfo: self.systemInfo,
+                                        eTagManager: MockETagManager(),
+                                        diagnosticsTracker: self.diagnosticsTracker)
         let config = BackendConfiguration(httpClient: httpClient,
                                           operationDispatcher: self.mockOperationDispatcher,
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
@@ -184,6 +192,7 @@ class BasePurchasesTests: TestCase {
     var mockManageSubsHelper: MockManageSubscriptionsHelper!
     var mockBeginRefundRequestHelper: MockBeginRefundRequestHelper!
     var mockStoreMessagesHelper: MockStoreMessagesHelper!
+    var diagnosticsTracker: DiagnosticsTrackerType?
 
     // swiftlint:disable:next weak_delegate
     var purchasesDelegate: MockPurchasesDelegate!

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -30,6 +30,7 @@ class BackendSubscriberAttributesTests: TestCase {
 
     private var dateProvider: MockDateProvider!
     private var mockETagManager: MockETagManager!
+    private var mockDiagnosticsTracker: DiagnosticsTrackerType?
 
     private static let apiKey = "the api key"
 
@@ -411,10 +412,14 @@ class BackendSubscriberAttributesTests: TestCase {
 
     final func createClient(_ file: StaticString) -> MockHTTPClient {
         self.mockETagManager = MockETagManager()
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            self.mockDiagnosticsTracker = MockDiagnosticsTracker()
+        }
 
         return MockHTTPClient(apiKey: Self.apiKey,
                               systemInfo: self.systemInfo,
                               eTagManager: self.mockETagManager,
+                              diagnosticsTracker: self.mockDiagnosticsTracker,
                               sourceTestFile: file)
     }
 


### PR DESCRIPTION
### Description
This adds a new diagnostics event `http_request_performed` with some useful information we would like to track about the http requests performed to our servers.