### PR TITLE
Only install `swiftlint` on Xcode 15 jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,18 @@ commands:
       - restore_cache:
           keys:
             - v2-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
+      # CircleCI images fail on Ruby 3.3
+      # https://github.com/fastlane/fastlane/issues/21794#issuecomment-2021331335
+      - run:
+          name: Set Ruby 3.2.2
+          command: |
+            eval "$(rbenv init -)"
+            rbenv install -s 3.2.2  # Replace with your required Ruby version
+            rbenv global 3.2.2
+            rbenv rehash
+      - run:
+          name: Verify Ruby version
+          command: ruby -v
       - run:
           name: Bundle install
           working_directory: << parameters.directory >>
@@ -119,18 +131,6 @@ commands:
         type: boolean
         default: true
     steps:
-      # CircleCI images fail on Ruby 3.3
-      # https://github.com/fastlane/fastlane/issues/21794#issuecomment-2021331335
-      - run:
-          name: Set Ruby 3.2.2
-          command: |
-            eval "$(rbenv init -)"
-            rbenv install -s 3.2.2  # Replace with your required Ruby version
-            rbenv global 3.2.2
-            rbenv rehash
-      - run:
-          name: Verify Ruby version
-          command: ruby -v
       - install-bundle-dependencies:
           directory: << parameters.directory >>
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ aliases:
       xcode_version:
         type: string
         default: '15.3'
+      install_swiftlint:
+        type: boolean
+        default: true
     environment:
       CIRCLECI_TESTS_GENERATE_SNAPSHOTS: << pipeline.parameters.generate_snapshots >>
       CIRCLECI_TESTS_GENERATE_REVENUECAT_UI_SNAPSHOTS: << pipeline.parameters.generate_revenuecatui_snapshots >>
@@ -112,6 +115,9 @@ commands:
       install_mint:
         type: boolean
         default: false
+      install_swiftlint:
+        type: boolean
+        default: true
     steps:
       # CircleCI images fail on Ruby 3.3
       # https://github.com/fastlane/fastlane/issues/21794#issuecomment-2021331335
@@ -135,13 +141,16 @@ commands:
           steps:
             - install-brew-dependency:
                 dependency_name: 'xcbeautify'
-      - install-brew-dependency:
-          dependency_name: 'swiftlint'
       - when:
           condition: << parameters.install_mint >>
           steps:
             - install-brew-dependency:
                 dependency_name: 'mint'
+      - when:
+          condition: << parameters.install_swiftlint >>
+          steps:
+            - install-brew-dependency:
+                dependency_name: "swiftlint"
       - run: brew tap robotsandpencils/made
       - save_cache:
           key: homebrew-cache-{{ checksum "Brewfile.lock.json" }}-{{ arch }}
@@ -411,7 +420,8 @@ jobs:
     <<: *base-job
     steps:
       - checkout
-      - install-dependencies
+      - install-dependencies:
+          install_swiftlint: << parameters.install_swiftlint >>
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Tests
@@ -436,7 +446,8 @@ jobs:
     <<: *base-job
     steps:
       - checkout
-      - install-dependencies
+      - install-dependencies:
+          install_swiftlint: << parameters.install_swiftlint >>
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Release Build
@@ -470,7 +481,8 @@ jobs:
     <<: *base-job
     steps:
       - checkout
-      - install-dependencies
+      - install-dependencies:
+          install_swiftlint: << parameters.install_swiftlint >>
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Release Build
@@ -544,7 +556,8 @@ jobs:
     <<: *base-job
     steps:
       - checkout
-      - install-dependencies
+      - install-dependencies:
+          install_swiftlint: << parameters.install_swiftlint >>
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
@@ -568,7 +581,8 @@ jobs:
     <<: *base-job
     steps:
       - checkout
-      - install-dependencies
+      - install-dependencies:
+          install_swiftlint: << parameters.install_swiftlint >>
       - update-spm-installation-commit
       - run:
           name: Run tests
@@ -598,7 +612,8 @@ jobs:
     resource_class: macos.x86.medium.gen2
     steps:
       - checkout
-      - install-dependencies
+      - install-dependencies:
+          install_swiftlint: << parameters.install_swiftlint >>
       - update-spm-installation-commit
       - run:
           name: Run tests
@@ -666,6 +681,7 @@ jobs:
       - install-dependencies:
           install_xcbeautify: false
           install_mint: true
+          install_swiftlint: << parameters.install_swiftlint >>
       - install-xcbeautify-for-xcode14
       - update-spm-installation-commit
       - install-runtime:
@@ -695,7 +711,8 @@ jobs:
     resource_class: macos.x86.medium.gen2
     steps:
       - checkout
-      - install-dependencies
+      - install-dependencies:
+          install_swiftlint: << parameters.install_swiftlint >>
       - update-spm-installation-commit
       - install-runtime:
           runtime-name: iOS 13.7
@@ -724,7 +741,8 @@ jobs:
     resource_class: macos.x86.medium.gen2
     steps:
       - checkout
-      - install-dependencies
+      - install-dependencies:
+          install_swiftlint: << parameters.install_swiftlint >>
       - update-spm-installation-commit
       - install-runtime:
           runtime-name: iOS 12.4
@@ -1149,14 +1167,19 @@ workflows:
           xcode_version: '15.2'
       - run-test-ios-16:
           xcode_version: '14.3.0'
+          install_swiftlint: false
       - run-test-ios-15:
           xcode_version: '14.3.0'
+          install_swiftlint: false
       - run-test-ios-14:
           xcode_version: '14.2.0'
+          install_swiftlint: false
       - run-test-ios-13:
           xcode_version: '14.2.0'
+          install_swiftlint: false
       - run-test-ios-12:
           xcode_version: '14.2.0'
+          install_swiftlint: false
       - run-test-macos
 
   generate_revenuecatui_snapshots:
@@ -1164,8 +1187,10 @@ workflows:
     jobs:
       - spm-revenuecat-ui-ios-15:
           xcode_version: '14.3.0'
+          install_swiftlint: false
       - spm-revenuecat-ui-ios-16:
           xcode_version: '14.3.0'
+          install_swiftlint: false
       - spm-revenuecat-ui-ios-17:
           xcode_version: '15.2'
 
@@ -1180,16 +1205,20 @@ workflows:
       - lint
       - spm-release-build-xcode-14:
           xcode_version: '14.3.0'
+          install_swiftlint: false
       - spm-release-build-xcode-15:
           xcode_version: '15.2'
       - spm-xcode-14-1:
           xcode_version: '14.1.0'
+          install_swiftlint: false
       - spm-custom-entitlement-computation-build
       - spm-receipt-parser
       - spm-revenuecat-ui-ios-15:
           xcode_version: '14.3.0'
+          install_swiftlint: false
       - spm-revenuecat-ui-ios-16:
           xcode_version: '14.3.0'
+          install_swiftlint: false
       - spm-revenuecat-ui-ios-17:
           xcode_version: '15.2'
       - spm-revenuecat-ui-watchos
@@ -1198,19 +1227,24 @@ workflows:
           xcode_version: '15.2'
       - run-test-ios-16:
           xcode_version: '14.3.0'
+          install_swiftlint: false
       - run-test-ios-15:
           xcode_version: '14.3.0'
+          install_swiftlint: false
       - run-test-watchos
       - run-test-tvos
       # Pre-iOS 15 requires macOS 12 which requires Xcode 14.2
       # See https://circleci.com/docs/using-macos/#supported-xcode-versions
       - run-test-ios-14:
           xcode_version: '14.2.0'
+          install_swiftlint: false
       - run-test-ios-13:
           xcode_version: '14.2.0'
+          install_swiftlint: false
           <<: *release-branches-and-main
       - run-test-ios-12:
           xcode_version: '14.2.0'
+          install_swiftlint: false
           <<: *release-branches-and-main
       - build-tv-watch-and-macos
       - build-visionos

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,6 +22,8 @@ disabled_rules:
   - blanket_disable_command
   # Broken: https://github.com/realm/SwiftLint/issues/5153
   - unneeded_synthesized_initializer
+  - non_optional_string_data_conversion
+  - static_over_final_class
 
 custom_rules:
   xctestcase_superclass:

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -487,7 +487,7 @@ private extension HTTPClient {
 
         let requestStartTime = self.dateProvider.now()
 
-        let task = self.session.dataTask(with: urlRequest) { (data, urlResponse, error) -> Void in
+        let task = self.session.dataTask(with: urlRequest) { (data, urlResponse, error) in
             self.handle(urlResponse: urlResponse,
                         request: request,
                         urlRequest: urlRequest,

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -487,7 +487,8 @@ private extension HTTPClient {
 
         let requestStartTime = self.dateProvider.now()
 
-        let task = self.session.dataTask(with: urlRequest) { (data, urlResponse, error) in
+        // swiftlint:disable:next redundant_void_return
+        let task = self.session.dataTask(with: urlRequest) { (data, urlResponse, error) -> Void in
             self.handle(urlResponse: urlResponse,
                         request: request,
                         urlRequest: urlRequest,

--- a/Sources/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
@@ -76,7 +76,7 @@ extension PromotionalOffer: Sendable {}
             return self == other
         }
 
-        // swiftlint:disable:next missing_docs
+        // swiftlint:disable:next missing_docs nsobject_prefer_isequal
         public static func == (
             lhs: PromotionalOffer.SignedData,
             rhs: PromotionalOffer.SignedData

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -91,6 +91,7 @@ internal struct SK2StoreProduct: StoreProductType {
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 private extension SK2StoreProduct {
 
+    // swiftlint:disable:next identifier_name
     var _currencyCodeAndLocale: (code: String?, locale: Locale?) {
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             let format = self.currencyFormat

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -100,8 +100,8 @@ private func checkTypealiases(
                                                   customerInfo: customerInfo,
                                                   userCancelled: userCancelled)
 
-    // swiftlint:disable:next line_length
-    let purchaseCompletedBlock: PurchaseCompletedBlock = { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
+    // swiftlint:disable:next line_length redundant_void_return
+    let purchaseCompletedBlock: PurchaseCompletedBlock = { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) -> Void in }
 
     let startPurchaseBlock: StartPurchaseBlock = { (_: PurchaseCompletedBlock) in }
 

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -101,7 +101,7 @@ private func checkTypealiases(
                                                   userCancelled: userCancelled)
 
     // swiftlint:disable:next line_length
-    let purchaseCompletedBlock: PurchaseCompletedBlock = { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) -> Void in }
+    let purchaseCompletedBlock: PurchaseCompletedBlock = { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
 
     let startPurchaseBlock: StartPurchaseBlock = { (_: PurchaseCompletedBlock) in }
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -112,8 +112,8 @@ private func checkTypealiases(
                                                   customerInfo: customerInfo,
                                                   userCancelled: userCancelled)
 
-    // swiftlint:disable:next line_length
-    let purchaseCompletedBlock: PurchaseCompletedBlock = { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
+    // swiftlint:disable:next line_length redundant_void_return
+    let purchaseCompletedBlock: PurchaseCompletedBlock = { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) -> Void in }
 
     let startPurchaseBlock: StartPurchaseBlock = { (_: PurchaseCompletedBlock) in }
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -113,7 +113,7 @@ private func checkTypealiases(
                                                   userCancelled: userCancelled)
 
     // swiftlint:disable:next line_length
-    let purchaseCompletedBlock: PurchaseCompletedBlock = { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) -> Void in }
+    let purchaseCompletedBlock: PurchaseCompletedBlock = { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
 
     let startPurchaseBlock: StartPurchaseBlock = { (_: PurchaseCompletedBlock) in }
 


### PR DESCRIPTION
### Motivation

Better implementation of https://github.com/RevenueCat/purchases-ios/pull/3909 and what was just commited to `5.0-dev`

### Description

- Only install `swiftlint` on Xcode 15.3 jobs
- Also moved Ruby 3.2.2 install into `install-bundle-dependencies` which was also done in `5.0-dev`
