### PR TITLE
Remove SK2 warning

### DIFF
--- a/Sources/Misc/StoreKitVersion.swift
+++ b/Sources/Misc/StoreKitVersion.swift
@@ -24,8 +24,6 @@ public enum StoreKitVersion: Int {
     /// Always use StoreKit 2 (StoreKit 1 will be used if StoreKit 2 is not available in the current device.)
     ///
     /// - Warning: Make sure you have an In-App Purchase Key configured in your app.
-    /// - Warning: If you are using observer mode with StoreKit 2, ensure that you're
-    /// calling ``Purchases/handleObserverModeTransaction(_:)`` after making a purchase.
     /// Please see https://rev.cat/in-app-purchase-key-configuration for more info.
     @objc(RCStoreKitVersion2)
     case storeKit2 = 2


### PR DESCRIPTION
Removes an unneeded warning from StoreKitVersion.storeKit2 since we no longer require `handleObserverModePurchase()` to be called for SK2 observer mode.