### PR TITLE
SPMInstallation tests deployment version increase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1281,7 +1281,8 @@ workflows:
           <<: *release-branches
       - installation-tests-cocoapods:
           <<: *release-branches
-      - installation-tests-swift-package-manager
+      - installation-tests-swift-package-manager:
+          <<: *release-branches
       - installation-tests-custom-entitlement-computation-swift-package-manager:
           <<: *release-branches
       - installation-tests-receipt-parser:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1281,8 +1281,7 @@ workflows:
           <<: *release-branches
       - installation-tests-cocoapods:
           <<: *release-branches
-      - installation-tests-swift-package-manager:
-          <<: *release-branches
+      - installation-tests-swift-package-manager
       - installation-tests-custom-entitlement-computation-swift-package-manager:
           <<: *release-branches
       - installation-tests-receipt-parser:

--- a/Tests/InstallationTests/SPMInstallation/SPMInstallation.xcodeproj/project.pbxproj
+++ b/Tests/InstallationTests/SPMInstallation/SPMInstallation.xcodeproj/project.pbxproj
@@ -499,7 +499,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = SPMInstallationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -526,7 +526,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = SPMInstallationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Tests/InstallationTests/SPMInstallation/SPMInstallation.xcodeproj/project.pbxproj
+++ b/Tests/InstallationTests/SPMInstallation/SPMInstallation.xcodeproj/project.pbxproj
@@ -432,7 +432,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = ../CommonFiles/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -450,7 +450,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
-				TVOS_DEPLOYMENT_TARGET = 11.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Debug;
@@ -468,7 +468,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = ../CommonFiles/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -485,7 +485,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "SPMInstallation-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
-				TVOS_DEPLOYMENT_TARGET = 11.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Release;


### PR DESCRIPTION
Min supported deployment version is 12 in xcode 15

https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/19375/workflows/5e33fc29-dd59-44bf-9868-336faa32b595/jobs/212939