### PR TITLE
Only POST AppTransaction in syncPurchases if No Transactions Present

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ commands:
           command: bundle exec fastlane retry_failed_tests retry_attempt:4 fail_build:true
           no_output_timeout: 5m
           environment:
-            SCAN_DEVICE: iPhone SE (17.4.0)
+            SCAN_DEVICE: iPhone 14 (17.4.0)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: BackendIntegrationTests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ commands:
           command: bundle exec fastlane retry_failed_tests retry_attempt:4 fail_build:true
           no_output_timeout: 5m
           environment:
-            SCAN_DEVICE: iPhone 14 (17.4.0)
+            SCAN_DEVICE: iPhone SE (17.4.0)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: BackendIntegrationTests

--- a/Sources/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Sources/Networking/Operations/PostOfferForSigningOperation.swift
@@ -122,7 +122,7 @@ private extension PostOfferForSigningOperation {
         }
 
         let appUserID: String
-        let fetchToken: String
+        let fetchToken: String?
         let generateOffers: [Offer]
 
         init(appUserID: String, data: PostOfferForSigningData) {

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1114,24 +1114,28 @@ private extension PurchasesOrchestrator {
         self.attribution.unsyncedAdServicesToken { adServicesToken in
             _ = Task<Void, Never> {
                 let transaction = await self.transactionFetcher.firstVerifiedTransaction
-                guard let transaction = transaction, let jwsRepresentation = transaction.jwsRepresentation  else {
-                    self.customerInfoManager.customerInfo(appUserID: currentAppUserID,
-                                                          fetchPolicy: .cachedOrFetched) { result in
-                        self.operationDispatcher.dispatchOnMainThread {
-                            completion?(result.mapError(\.asPurchasesError))
-                        }
+                let appTransactionJWS = await self.transactionFetcher.appTransactionJWS
+
+                guard let transaction = transaction, let jwsRepresentation = transaction.jwsRepresentation else {
+                    // No receipt is found, just post the AppTransaction.
+                    self.backend.post(receipt: .empty,
+                                      productData: nil,
+                                      transactionData: .init(appUserID: self.appUserID,
+                                                             source: .init(isRestore: true, 
+                                                                           initiationSource: .restore)),
+                                      observerMode: self.observerMode,
+                                      appTransaction: appTransactionJWS) { result in
+
+                        self.handleReceiptPost(result: result,
+                                               transactionData: nil,
+                                               subscriberAttributes: unsyncedAttributes,
+                                               adServicesToken: adServicesToken,
+                                               completion: completion)
                     }
                     return
                 }
 
                 let receipt = await self.encodedReceipt(transaction: transaction, jwsRepresentation: jwsRepresentation)
-
-                let appTransactionJWS: String?
-                if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
-                    appTransactionJWS = await self.transactionFetcher.appTransactionJWS
-                } else {
-                    appTransactionJWS = nil
-                }
 
                 self.createProductRequestData(with: transaction.productIdentifier) { productRequestData in
                     let transactionData: PurchasedTransactionData = .init(
@@ -1159,7 +1163,7 @@ private extension PurchasesOrchestrator {
     }
 
     func handleReceiptPost(result: Result<CustomerInfo, BackendError>,
-                           transactionData: PurchasedTransactionData,
+                           transactionData: PurchasedTransactionData?,
                            subscriberAttributes: SubscriberAttribute.Dictionary,
                            adServicesToken: String?,
                            completion: (@Sendable (Result<CustomerInfo, PurchasesError>) -> Void)?) {
@@ -1178,7 +1182,7 @@ private extension PurchasesOrchestrator {
     }
 
     func handlePostReceiptResult(_ result: Result<CustomerInfo, BackendError>,
-                                 transactionData: PurchasedTransactionData,
+                                 transactionData: PurchasedTransactionData?,
                                  subscriberAttributes: SubscriberAttribute.Dictionary,
                                  adServicesToken: String?) {
         switch result {
@@ -1187,7 +1191,7 @@ private extension PurchasesOrchestrator {
 
         case .failure:
             // Cache paywall again in case purchase is retried.
-            if let paywall = transactionData.presentedPaywall {
+            if let paywall = transactionData?.presentedPaywall {
                 self.cachePresentedPaywall(paywall)
             }
         }

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1121,7 +1121,7 @@ private extension PurchasesOrchestrator {
                     self.backend.post(receipt: .empty,
                                       productData: nil,
                                       transactionData: .init(appUserID: self.appUserID,
-                                                             source: .init(isRestore: true, 
+                                                             source: .init(isRestore: true,
                                                                            initiationSource: .restore)),
                                       observerMode: self.observerMode,
                                       appTransaction: appTransactionJWS) { result in

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1120,10 +1120,9 @@ private extension PurchasesOrchestrator {
                 guard let transaction = transaction, let jwsRepresentation = transaction.jwsRepresentation else {
                     // No transactions are present. If we have the originalPurchaseDate and originalApplicationVersion
                     // in the cached CustomerInfo, return it. Otherwise, post the AppTransaction.
+                    let cachedCustomerInfo = self.customerInfoManager.cachedCustomerInfo(appUserID: currentAppUserID)
 
-                    if let cachedCustomerInfo = self.customerInfoManager.cachedCustomerInfo(
-                        appUserID: currentAppUserID
-                    ),
+                    if let cachedCustomerInfo,
                        cachedCustomerInfo.originalPurchaseDate != nil,
                        cachedCustomerInfo.originalApplicationVersion != nil {
                         completion?(.success(cachedCustomerInfo))

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1120,7 +1120,7 @@ private extension PurchasesOrchestrator {
                     // No receipt is found, just post the AppTransaction.
                     self.backend.post(receipt: .empty,
                                       productData: nil,
-                                      transactionData: .init(appUserID: self.appUserID,
+                                      transactionData: .init(appUserID: currentAppUserID,
                                                              source: .init(isRestore: true,
                                                                            initiationSource: .restore)),
                                       observerMode: self.observerMode,

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
@@ -103,11 +103,13 @@ final class StoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
         )
     }
 
-    /// A computed property that retrieves the JWS (JSON Web Signature) representation of the app transaction asynchronously.
+    /// A computed property that retrieves the JWS (JSON Web Signature) representation 
+    /// of the app transaction asynchronously.
     ///
     /// If the OS does not support AppTransaction (available in iOS16+), it returns `nil`.
     ///
-    /// - Returns: A `String` containing the JWS representation of the app transaction, or `nil` if the feature is unavailable on the current platform version.
+    /// - Returns: A `String` containing the JWS representation of the app transaction, 
+    /// or `nil` if the feature is unavailable on the current platform version.
     var appTransactionJWS: String? {
         get async {
             if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
@@ -123,11 +123,13 @@ final class StoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
     /// Retrieves the JWS (JSON Web Signature) representation of the AppTransaction asynchronously and
     /// passes it to the provided completion handler.
     ///
-    /// If the OS does not support AppTransaction (available in iOS16+), it returns `nil` through the completion handler.
+    /// If the OS does not support AppTransaction (available in iOS16+), it returns `nil` through the 
+    /// completion handler.
     ///
     /// - Parameter completion: A closure that is called with the JWS representation of the app transaction, or `nil`
     /// if the feature is unavailable on the current platform version.
-    /// - Parameter result: A `String?` containing the JWS representation of the app transaction, or `nil` if unavailable.
+    /// - Parameter result: A `String?` containing the JWS representation of the app transaction, 
+    /// or `nil` if unavailable.
     func appTransactionJWS(_ completion: @escaping (String?) -> Void) {
         Async.call(with: completion) {
             if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {

--- a/Sources/Purchasing/StoreKitAbstractions/EncodedAppleReceipt.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/EncodedAppleReceipt.swift
@@ -20,12 +20,13 @@ enum EncodedAppleReceipt: Equatable {
   case jws(String)
   case receipt(Data)
   case sk2receipt(StoreKit2Receipt)
+  case empty
 
 }
 
 extension EncodedAppleReceipt {
 
-    func serialized() -> String {
+    func serialized() -> String? {
         switch self {
         case .jws(let jws):
             return jws
@@ -38,6 +39,8 @@ extension EncodedAppleReceipt {
                 Logger.warn(Strings.storeKit.sk2_error_encoding_receipt(error))
                 return ""
             }
+        case .empty:
+            return nil
         }
     }
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
@@ -626,26 +626,25 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
         expect(customerInfo) == mockCustomerInfo
     }
 
-    func testSyncPurchasesSK1PostsReceiptIfNoTransactionsAndEmptyOriginalPurchaseDate() async throws {
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = try .init(data: [
-            "request_date": "2019-08-16T10:30:42Z",
-            "subscriber": [
-                "first_seen": "2019-07-17T00:05:54Z",
-                "original_app_user_id": "app_user_id",
-                "subscriptions": [:] as [String: Any],
-                "other_purchases": [:] as [String: Any],
-                "original_application_version": "1.0",
-                // Explicitly setting nil original_purchase_date
-                "original_purchase_date": nil
-            ] as [String: Any?]
-        ])
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-        self.receiptParser.stubbedReceiptHasTransactionsResult = false
+    func testSyncPurchasesPostsReceiptIfNoTransactionsAndNoCachedCustomerInfo() async throws {
+        self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = nil
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = nil
+        self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
         let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
-                                                                     isRestore: false,
-                                                                     initiationSource: .purchase)
+                                                                     isRestore: true,
+                                                                     initiationSource: .restore)
+
+        expect(self.customerInfoManager.invokedCachedCustomerInfo).to(beTrue())
+        expect(self.customerInfoManager.invokedCachedCustomerInfoCount) == 1
+
         expect(self.backend.invokedPostReceiptData).to(beTrue())
+        expect(self.backend.invokedPostReceiptDataParameters?.data) == .receipt(self.receiptFetcher.mockReceiptData)
+        expect(self.backend.invokedPostReceiptDataCount) == 1
+        expect(
+            self.backend.invokedPostReceiptDataParameters?.transactionData.appUserID
+        ) == Self.mockUserID
+
         expect(self.customerInfoManager.invokedCustomerInfo).to(beFalse())
         expect(customerInfo) == mockCustomerInfo
     }

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -629,16 +629,90 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         expect(customerInfo) == mockCustomerInfo
     }
 
-    func testSyncPurchasesPostsAppTransactionAndReturnsCustomerInfoIfNoTransaction() async throws {
+    func testSyncPurchasesDoesntPostReceiptAndReturnsCustomerInfoIfNoTransactionsAndOriginalPurchaseDatePresent()
+    async throws {
+        self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = nil
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
+
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+                                                                     isRestore: true,
+                                                                     initiationSource: .restore)
+
+        expect(self.backend.invokedPostReceiptData).to(beFalse())
+
+        expect(self.customerInfoManager.invokedCachedCustomerInfo).to(beTrue())
+        expect(self.customerInfoManager.invokedCachedCustomerInfoCount) == 1
+        expect(customerInfo) == mockCustomerInfo
+    }
+
+    func testSyncPurchasesPostsReceiptIfNoTransactionsAndEmptyOriginalPurchaseDate() async throws {
         let appTransactionJWS = "some_jws"
 
         self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = nil
         self.mockTransactionFetcher.stubbedAppTransactionJWS = appTransactionJWS
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = CustomerInfo.missingOriginalPurchaseDate
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
         let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
                                                                      isRestore: true,
                                                                      initiationSource: .restore)
+
+        expect(self.customerInfoManager.invokedCachedCustomerInfo).to(beTrue())
+        expect(self.customerInfoManager.invokedCachedCustomerInfoCount) == 1
+
+        expect(self.backend.invokedPostReceiptData).to(beTrue())
+        expect(self.backend.invokedPostReceiptDataCount) == 1
+        expect(self.backend.invokedPostReceiptDataParameters?.appTransaction) == appTransactionJWS
+        expect(self.backend.invokedPostReceiptDataParameters?.data) == .empty // No fetch_token
+        expect(
+            self.backend.invokedPostReceiptDataParameters?.transactionData.appUserID
+        ) == Self.mockUserID
+
+        expect(self.customerInfoManager.invokedCustomerInfo).to(beFalse())
+        expect(customerInfo) == mockCustomerInfo
+    }
+
+    func testSyncPurchasesPostsReceiptIfNoTransactionsAndEmptyOriginalApplicationVersion() async throws {
+        let appTransactionJWS = "some_jws"
+
+        self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = nil
+        self.mockTransactionFetcher.stubbedAppTransactionJWS = appTransactionJWS
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = CustomerInfo.missingOriginalApplicationVersion
+        self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
+
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+                                                                     isRestore: true,
+                                                                     initiationSource: .restore)
+
+        expect(self.customerInfoManager.invokedCachedCustomerInfo).to(beTrue())
+        expect(self.customerInfoManager.invokedCachedCustomerInfoCount) == 1
+
+        expect(self.backend.invokedPostReceiptData).to(beTrue())
+        expect(self.backend.invokedPostReceiptDataCount) == 1
+        expect(self.backend.invokedPostReceiptDataParameters?.appTransaction) == appTransactionJWS
+        expect(self.backend.invokedPostReceiptDataParameters?.data) == .empty // No fetch_token
+        expect(
+            self.backend.invokedPostReceiptDataParameters?.transactionData.appUserID
+        ) == Self.mockUserID
+
+        expect(self.customerInfoManager.invokedCustomerInfo).to(beFalse())
+        expect(customerInfo) == mockCustomerInfo
+    }
+
+    func testSyncPurchasesPostsReceiptIfNoTransactionsAndNoCachedCustomerInfo() async throws {
+        let appTransactionJWS = "some_jws"
+
+        self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = nil
+        self.mockTransactionFetcher.stubbedAppTransactionJWS = appTransactionJWS
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = nil
+        self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
+
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+                                                                     isRestore: true,
+                                                                     initiationSource: .restore)
+
+        expect(self.customerInfoManager.invokedCachedCustomerInfo).to(beTrue())
+        expect(self.customerInfoManager.invokedCachedCustomerInfoCount) == 1
 
         expect(self.backend.invokedPostReceiptData).to(beTrue())
         expect(self.backend.invokedPostReceiptDataCount) == 1

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -672,7 +672,7 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         expect(customerInfo) == mockCustomerInfo
     }
 
-    func testSyncPurchasesPostsReceiptIfNoTransactionsAndEmptyOriginalApplicationVersion() async throws {
+    func testSyncPurchasesPostsReceiptIfNoTransactionsAndEmptyOriginalApplicationVersionSK2() async throws {
         let appTransactionJWS = "some_jws"
 
         self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = nil

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -55,8 +55,6 @@ protocol PurchasesOrchestratorTests {
 
     func testSyncPurchasesPostsReceipt() async throws
 
-    func testSyncPurchasesDoesntPostReceiptAndReturnsCustomerInfoIfNoTransaction() async throws
-
     func testSyncPurchasesCallsSuccessDelegateMethod() async throws
 
     func testSyncPurchasesPassesErrorOnFailure() async throws

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -64,4 +64,6 @@ protocol PurchasesOrchestratorTests {
 
     func testSyncPurchasesPostsReceiptIfNoTransactionsAndEmptyOriginalPurchaseDate() async throws
 
+    func testSyncPurchasesPostsReceiptIfNoTransactionsAndNoCachedCustomerInfo() async throws
+
 }

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -59,4 +59,9 @@ protocol PurchasesOrchestratorTests {
 
     func testSyncPurchasesPassesErrorOnFailure() async throws
 
+    func testSyncPurchasesDoesntPostReceiptAndReturnsCustomerInfoIfNoTransactionsAndOriginalPurchaseDatePresent()
+    async throws
+
+    func testSyncPurchasesPostsReceiptIfNoTransactionsAndEmptyOriginalPurchaseDate() async throws
+
 }

--- a/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
+++ b/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
@@ -43,6 +43,30 @@ extension CustomerInfo {
         ] as [String: Any]
     ])
 
+    // swiftlint:disable:next force_try
+    static let missingOriginalPurchaseDate: CustomerInfo = try! .init(data: [
+        "request_date": "2019-08-16T10:30:42Z",
+        "subscriber": [
+            "first_seen": "2019-07-17T00:05:54Z",
+            "original_app_user_id": "app_user_id",
+            "subscriptions": [:] as [String: Any],
+            "other_purchases": [:] as [String: Any],
+            "original_application_version": "1.0"
+        ] as [String: Any]
+    ])
+
+    // swiftlint:disable:next force_try
+    static let missingOriginalApplicationVersion: CustomerInfo = try! .init(data: [
+        "request_date": "2019-08-16T10:30:42Z",
+        "subscriber": [
+            "first_seen": "2019-07-17T00:05:54Z",
+            "original_app_user_id": "app_user_id",
+            "subscriptions": [:] as [String: Any],
+            "other_purchases": [:] as [String: Any],
+            "original_purchase_date": "2019-07-17T00:05:54Z"
+        ] as [String: Any]
+    ])
+
 }
 
 extension CustomerInfo {

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
@@ -74,14 +74,12 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
     var appTransactionJWS: String? {
         get async {
             return self.stubbedAppTransactionJWS
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
     func appTransactionJWS(_ completion: @escaping (String?) -> Void) {
         completion(self.stubbedAppTransactionJWS)
     }

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -89,6 +89,8 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
     }
 
     func testPostsReceiptDataWithAppTransactionCorrectly() throws {
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
+
         let path: HTTPRequest.Path = .postReceiptData
 
         httpClient.mock(
@@ -104,6 +106,40 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
         waitUntil { completed in
             self.backend.post(receipt: Self.receipt,
                               productData: productData,
+                              transactionData: .init(
+                                 appUserID: Self.userID,
+                                 presentedOfferingContext: nil,
+                                 unsyncedAttributes: nil,
+                                 storefront: nil,
+                                 source: .init(isRestore: isRestore, initiationSource: .purchase)
+                              ),
+                              observerMode: observerMode,
+                              appTransaction: appTransaction,
+                              completion: { _ in
+                completed()
+            })
+        }
+
+        expect(self.httpClient.calls).to(haveCount(1))
+    }
+
+    func testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly() throws {
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
+
+        let path: HTTPRequest.Path = .postReceiptData
+
+        httpClient.mock(
+            requestPath: path,
+            response: .init(statusCode: .success, response: Self.validCustomerResponse)
+        )
+
+        let isRestore = false
+        let observerMode = true
+        let appTransaction = "some_jws_token"
+
+        waitUntil { completed in
+            self.backend.post(receipt: .empty,
+                              productData: nil,
                               transactionData: .init(
                                  appUserID: Self.userID,
                                  presentedOfferingContext: nil,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -1,19 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret",
-    "content-type" : "application/json",
-    "X-Client-Build-Version" : "12345",
-    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
-    "X-Client-Version" : "17.0.0",
-    "X-Is-Sandbox" : "false",
-    "X-Observer-Mode-Enabled" : "false",
-    "X-Platform" : "iOS",
-    "X-Platform-Flavor" : "native",
-    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
-    "X-Version" : "4.0.0"
+    "Authorization": "Bearer asharedsecret",
+    "content-type": "application/json",
+    "X-Apple-Device-Identifier": "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version": "12345",
+    "X-Client-Bundle-ID": "com.apple.dt.xctest.tool",
+    "X-Client-Version": "17.0.0",
+    "X-Is-Sandbox": "true",
+    "X-Observer-Mode-Enabled": "false",
+    "X-Platform": "iOS",
+    "X-Platform-Flavor": "native",
+    "X-Platform-Version": "Version 17.0.0 (Build 21A342)",
+    "X-Storefront": "USA",
+    "X-StoreKit-Version": "2",
+    "X-StoreKit2-Enabled": "true",
+    "X-Version": "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -1,0 +1,35 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : {
+      "app_transaction" : "some_jws_token",
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "initiation_source" : "purchase",
+      "is_restore" : false,
+      "observer_mode" : true
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -1,20 +1,20 @@
 {
   "headers" : {
-    "Authorization": "Bearer asharedsecret",
-    "content-type": "application/json",
-    "X-Apple-Device-Identifier": "5D7C0074-07E4-4564-AAA4-4008D0640881",
-    "X-Client-Build-Version": "12345",
-    "X-Client-Bundle-ID": "com.apple.dt.xctest.tool",
-    "X-Client-Version": "17.0.0",
-    "X-Is-Sandbox": "true",
-    "X-Observer-Mode-Enabled": "false",
-    "X-Platform": "iOS",
-    "X-Platform-Flavor": "native",
-    "X-Platform-Version": "Version 17.0.0 (Build 21A342)",
-    "X-Storefront": "USA",
-    "X-StoreKit-Version": "2",
-    "X-StoreKit2-Enabled": "true",
-    "X-Version": "4.0.0"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -1,19 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret",
-    "content-type" : "application/json",
-    "X-Client-Build-Version" : "12345",
-    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
-    "X-Client-Version" : "17.0.0",
-    "X-Is-Sandbox" : "false",
-    "X-Observer-Mode-Enabled" : "false",
-    "X-Platform" : "iOS",
-    "X-Platform-Flavor" : "native",
-    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
-    "X-Version" : "4.0.0"
+    "Authorization": "Bearer asharedsecret",
+    "content-type": "application/json",
+    "X-Apple-Device-Identifier": "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version": "12345",
+    "X-Client-Bundle-ID": "com.apple.dt.xctest.tool",
+    "X-Client-Version": "17.0.0",
+    "X-Is-Sandbox": "true",
+    "X-Observer-Mode-Enabled": "false",
+    "X-Platform": "iOS",
+    "X-Platform-Flavor": "native",
+    "X-Platform-Version": "Version 17.0.0 (Build 21A342)",
+    "X-Storefront": "USA",
+    "X-StoreKit-Version": "2",
+    "X-StoreKit2-Enabled": "true",
+    "X-Version": "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -1,0 +1,35 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : {
+      "app_transaction" : "some_jws_token",
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "initiation_source" : "purchase",
+      "is_restore" : false,
+      "observer_mode" : true
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -1,20 +1,20 @@
 {
   "headers" : {
-    "Authorization": "Bearer asharedsecret",
-    "content-type": "application/json",
-    "X-Apple-Device-Identifier": "5D7C0074-07E4-4564-AAA4-4008D0640881",
-    "X-Client-Build-Version": "12345",
-    "X-Client-Bundle-ID": "com.apple.dt.xctest.tool",
-    "X-Client-Version": "17.0.0",
-    "X-Is-Sandbox": "true",
-    "X-Observer-Mode-Enabled": "false",
-    "X-Platform": "iOS",
-    "X-Platform-Flavor": "native",
-    "X-Platform-Version": "Version 17.0.0 (Build 21A342)",
-    "X-Storefront": "USA",
-    "X-StoreKit-Version": "2",
-    "X-StoreKit2-Enabled": "true",
-    "X-Version": "4.0.0"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -1,19 +1,20 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret",
-    "content-type" : "application/json",
-    "X-Client-Build-Version" : "12345",
-    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
-    "X-Client-Version" : "17.0.0",
-    "X-Is-Sandbox" : "false",
-    "X-Observer-Mode-Enabled" : "false",
-    "X-Platform" : "iOS",
-    "X-Platform-Flavor" : "native",
-    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
-    "X-Version" : "4.0.0"
+    "Authorization": "Bearer asharedsecret",
+    "content-type": "application/json",
+    "X-Apple-Device-Identifier": "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version": "12345",
+    "X-Client-Bundle-ID": "com.apple.dt.xctest.tool",
+    "X-Client-Version": "17.0.0",
+    "X-Is-Sandbox": "true",
+    "X-Observer-Mode-Enabled": "false",
+    "X-Platform": "iOS",
+    "X-Platform-Flavor": "native",
+    "X-Platform-Version": "Version 17.0.0 (Build 21A342)",
+    "X-Storefront": "USA",
+    "X-StoreKit-Version": "2",
+    "X-StoreKit2-Enabled": "true",
+    "X-Version": "4.0.0"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -1,0 +1,35 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : {
+      "app_transaction" : "some_jws_token",
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "initiation_source" : "purchase",
+      "is_restore" : false,
+      "observer_mode" : true
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -1,20 +1,19 @@
 {
   "headers" : {
-    "Authorization": "Bearer asharedsecret",
-    "content-type": "application/json",
-    "X-Apple-Device-Identifier": "5D7C0074-07E4-4564-AAA4-4008D0640881",
-    "X-Client-Build-Version": "12345",
-    "X-Client-Bundle-ID": "com.apple.dt.xctest.tool",
-    "X-Client-Version": "17.0.0",
-    "X-Is-Sandbox": "true",
-    "X-Observer-Mode-Enabled": "false",
-    "X-Platform": "iOS",
-    "X-Platform-Flavor": "native",
-    "X-Platform-Version": "Version 17.0.0 (Build 21A342)",
-    "X-Storefront": "USA",
-    "X-StoreKit-Version": "2",
-    "X-StoreKit2-Enabled": "true",
-    "X-Version": "4.0.0"
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {


### PR DESCRIPTION
This PR adjusts the behavior in `syncPurchases()` so that if no purchases are present, we still POST the `AppTransaction` to POST /receipt instead of just fetching the CustomerInfo.

## Description
- If no transactions are present when `syncPurchases()` is called and SK2 is used, then we POST the `AppTransaction` to the POST /receipt endpoint instead of just fetching the CustomerInfo.
- This PR introduces the ability to make a call to POST /receipt without a `fetch_token`.