### PR TITLE
Diagnostics: Add logic to retry on server errors

### DIFF
--- a/Sources/Diagnostics/Networking/DiagnosticsSynchronizer.swift
+++ b/Sources/Diagnostics/Networking/DiagnosticsSynchronizer.swift
@@ -25,15 +25,18 @@ actor DiagnosticsSynchronizer: DiagnosticsSynchronizerType {
 
     private let internalAPI: InternalAPI
     private let handler: DiagnosticsFileHandlerType
+    private let userDefaults: SynchronizedUserDefaults
 
     private var syncInProgress = false
 
     init(
         internalAPI: InternalAPI,
-        handler: DiagnosticsFileHandlerType
+        handler: DiagnosticsFileHandlerType,
+        userDefaults: SynchronizedUserDefaults
     ) {
         self.internalAPI = internalAPI
         self.handler = handler
+        self.userDefaults = userDefaults
     }
 
     func syncDiagnosticsIfNeeded() async throws {
@@ -59,15 +62,57 @@ actor DiagnosticsSynchronizer: DiagnosticsSynchronizerType {
             try await self.internalAPI.postDiagnosticsEvents(events: events)
 
             await self.handler.cleanSentDiagnostics(diagnosticsSentCount: count)
+
+            self.clearSyncRetries()
         } catch {
-            Logger.error(Strings.paywalls.event_sync_failed(error))
+            Logger.error(Strings.diagnostics.could_not_synchronize_diagnostics(error: error))
 
             if let backendError = error as? BackendError,
                backendError.successfullySynced {
                 await self.handler.cleanSentDiagnostics(diagnosticsSentCount: count)
+                self.clearSyncRetries()
+            } else {
+                let currentSyncRetries = self.getCurrentSyncRetries()
+
+                if currentSyncRetries >= Self.maxSyncRetries {
+                    Logger.error(Strings.diagnostics.failed_diagnostics_sync_more_than_max_retries)
+                    await self.handler.emptyDiagnosticsFile()
+                    self.clearSyncRetries()
+                } else {
+                    self.increaseSyncRetries(currentRetries: currentSyncRetries)
+                }
             }
 
             throw error
+        }
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension DiagnosticsSynchronizer {
+
+    static let maxSyncRetries = 3
+
+    enum CacheKeys: String {
+        case numberOfRetries = "com.revenuecat.diagnostics.number_sync_retries"
+    }
+
+    func increaseSyncRetries(currentRetries: Int) {
+        self.userDefaults.write {
+            $0.set(currentRetries + 1, forKey: CacheKeys.numberOfRetries.rawValue)
+        }
+    }
+
+    func clearSyncRetries() {
+        self.userDefaults.write {
+            $0.removeObject(forKey: CacheKeys.numberOfRetries.rawValue)
+        }
+    }
+
+    func getCurrentSyncRetries() -> Int {
+        return self.userDefaults.read {
+            $0.integer(forKey: CacheKeys.numberOfRetries.rawValue)
         }
     }
 

--- a/Sources/Logging/Strings/DiagnosticsStrings.swift
+++ b/Sources/Logging/Strings/DiagnosticsStrings.swift
@@ -33,6 +33,8 @@ enum DiagnosticsStrings {
     case failed_to_empty_diagnostics_file(error: Error)
     case failed_check_diagnostics_size(error: Error)
 
+    case failed_diagnostics_sync_more_than_max_retries
+
 }
 
 extension DiagnosticsStrings: LogMessage {
@@ -72,6 +74,9 @@ extension DiagnosticsStrings: LogMessage {
 
         case let .failed_check_diagnostics_size(error):
             return "Failed to check whether diagnostics file is too big: \(error.localizedDescription)"
+
+        case .failed_diagnostics_sync_more_than_max_retries:
+            return "Failed to sync diagnostics more than max retries. Clearing entire diagnostics file."
 
         }
     }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -455,8 +455,10 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                 var diagnosticsSynchronizer: DiagnosticsSynchronizer?
                 if diagnosticsEnabled {
                     if let diagnosticsFileHandler = diagnosticsFileHandler {
+                        let synchronizedUserDefaults = SynchronizedUserDefaults(userDefaults: userDefaults)
                         diagnosticsSynchronizer = DiagnosticsSynchronizer(internalAPI: backend.internalAPI,
-                                                                          handler: diagnosticsFileHandler)
+                                                                          handler: diagnosticsFileHandler,
+                                                                          userDefaults: synchronizedUserDefaults)
                     } else {
                         Logger.error(Strings.diagnostics.could_not_create_diagnostics_tracker)
                     }


### PR DESCRIPTION
### Description
This will make sure that we delete the diagnostics file if there is an issue syncing it over multiple retries (note these retries only happen during SDK configuration).