### PR TITLE
Diagnostics: Make setting public

### DIFF
--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -233,7 +233,7 @@ import Foundation
         /// Defaults to ``false``
         ///
         @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-        @objc internal func with(diagnosticsEnabled: Bool) -> Builder {
+        @objc public func with(diagnosticsEnabled: Bool) -> Builder {
             self.diagnosticsEnabled = diagnosticsEnabled
             return self
         }

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
@@ -29,6 +29,10 @@
         RCConfiguration *config __unused = [[builder
                                              withEntitlementVerificationMode:RCEntitlementVerificationModeInformational]                                            build];
     }
+
+    if (@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)) {
+        RCConfiguration *config __unused = [[builder withDiagnosticsEnabled:true] build];
+    }
 }
 
 @end

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
@@ -28,6 +28,12 @@ func checkConfigurationAPI() {
             .with(entitlementVerificationMode: .informational)
             .build()
     }
+
+    if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+        let _: Configuration = builder
+            .with(diagnosticsEnabled: true)
+            .build()
+    }
 }
 
 @available(*, deprecated)

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
@@ -46,6 +46,7 @@ public final class ConfiguredPurchases {
         let purchases = Purchases.configure(
             with: .builder(withAPIKey: apiKey)
                 .with(usesStoreKit2IfAvailable: useStoreKit2)
+                .with(diagnosticsEnabled: true)
                 .with(observerMode: observerMode)
                 .with(entitlementVerificationMode: entitlementVerificationMode)
                 #if DEBUG


### PR DESCRIPTION
### Description
This actually enables consumers to use diagnostics by making the setting public

#### TODO
- [ ] Write docs
- [x] Get #3930 merged