### PR TITLE
Revert docs-deploy to xcode 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -853,7 +853,7 @@ jobs:
           name: Build docs
           command: bundle exec fastlane generate_docs
           environment:
-            DOCS_IOS_VERSION: "16.1"
+            DOCS_IOS_VERSION: "17.4"
 
   make-release:
     <<: *base-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1321,6 +1321,7 @@ workflows:
             - make-release
           <<: *release-tags
       - docs-deploy:
+          xcode_version: '14.3.0'
           <<: *release-tags
       - deploy-purchase-tester:
           <<: *release-tags

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -700,7 +700,7 @@ platform :ios do
        "--target", "RevenueCat",
        # Build for iOS instead of the default macOS. This ensures that iOS-only symbols are included in the docs.
        "-Xswiftc", "-sdk", "-Xswiftc", sh("xcrun", "--sdk", "iphonesimulator", "--show-sdk-path").strip!,
-       "-Xswiftc", "-target", "-Xswiftc", "x86_64-apple-ios#{ios_version}-simulator",
+       "-Xswiftc", "-target", "-Xswiftc", "arm64-apple-ios#{ios_version}-simulator",
        "-Xswiftc", "-emit-symbol-graph",
        "-Xswiftc", "-emit-symbol-graph-dir",
        "-Xswiftc", ".build")


### PR DESCRIPTION
Reverted to xcode 14 because it failed in #3932 

I used this PR to also force deploy the docs of that version

I tried with upgrading the ios version and also the arch, but still got issues in xcode 15 see https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/19513/workflows/7d8d2c53-a081-4761-9d77-dfaac7b49d30/jobs/215993