### PR TITLE
Remote Image Tweaks

### DIFF
--- a/RevenueCatUI/Views/RemoteImage.swift
+++ b/RevenueCatUI/Views/RemoteImage.swift
@@ -56,6 +56,7 @@ struct RemoteImage: View {
                 emptyView(error: nil)
             }
         }
+        .accessibilityHidden(true)
         .transition(Self.transition)
         .task(id: self.url) { // This cancels the previous task when the URL changes.
             await loadImages()
@@ -68,11 +69,9 @@ struct RemoteImage: View {
             image
                 .fitToAspect(aspectRatio, contentMode: .fill)
                 .frame(maxWidth: self.maxWidth)
-                .accessibilityHidden(true)
         } else {
             image
                 .resizable()
-                .accessibilityHidden(true)
         }
     }
 

--- a/RevenueCatUI/Views/RemoteImage.swift
+++ b/RevenueCatUI/Views/RemoteImage.swift
@@ -62,20 +62,17 @@ struct RemoteImage: View {
         }
     }
 
+    @ViewBuilder
     private func displayImage(_ image: Image) -> some View {
         if let aspectRatio {
-            return AnyView(
-                image
-                    .fitToAspect(aspectRatio, contentMode: .fill)
-                    .frame(maxWidth: self.maxWidth)
-                    .accessibilityHidden(true)
-            )
+            image
+                .fitToAspect(aspectRatio, contentMode: .fill)
+                .frame(maxWidth: self.maxWidth)
+                .accessibilityHidden(true)
         } else {
-            return AnyView(
-                image
-                    .resizable()
-                    .accessibilityHidden(true)
-            )
+            image
+                .resizable()
+                .accessibilityHidden(true)
         }
     }
 


### PR DESCRIPTION

Addressing some feedback from https://github.com/RevenueCat/purchases-ios/pull/3906

* Uses a @ViewBuilder to avoid erasing type to AnyView
* Moves `accessibilityHidden` to a shared location