### PR TITLE
Fix prepare next version job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -894,6 +894,7 @@ jobs:
   prepare-next-version:
     <<: *base-job
     steps:
+      - setup-git-credentials
       - checkout
       - install-dependencies
       - trust-github-key


### PR DESCRIPTION
### Description
Looks like the `prepare-next-version` is failing because the git credentials are not set. This should fix it. I haven't checked the other jobs... But we can fix them later if needed.