### PR TITLE
Drop xcode 14 support in v5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,16 +387,7 @@ commands:
           destination: scan-test-output
 
 jobs:
-  spm-release-build-xcode-14:
-    <<: *base-job
-    steps:
-      - checkout
-      - run:
-          name: SPM Release Build
-          command: swift build -c release --target RevenueCat
-          no_output_timeout: 30m
-
-  spm-release-build-xcode-15:
+  spm-release-build:
     <<: *base-job
     steps:
       - checkout
@@ -426,19 +417,6 @@ jobs:
       - run:
           name: SPM Receipt Parser
           command: swift build -c release --target ReceiptParser
-          no_output_timeout: 30m
-
-  spm-xcode-14-1:
-    <<: *base-job
-    steps:
-      - checkout
-      - run:
-          name: SPM RevenueCat Release Build
-          command: swift build -c release --target RevenueCat
-          no_output_timeout: 30m
-      - run:
-          name: SPM RevenueCatUI Release Build
-          command: swift build -c release --target RevenueCatUI
           no_output_timeout: 30m
 
   spm-revenuecat-ui-ios-15:
@@ -1191,13 +1169,7 @@ workflows:
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
       - lint
-      - spm-release-build-xcode-14:
-          xcode_version: '14.3.0'
-          install_swiftlint: false
-      - spm-release-build-xcode-15:
-          xcode_version: "15.2"
-      - spm-xcode-14-1:
-          xcode_version: '14.1.0'
+      - spm-release-build
       - spm-custom-entitlement-computation-build
       - spm-receipt-parser
       - spm-revenuecat-ui-ios-15:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,6 +395,10 @@ jobs:
           name: SPM Release Build
           command: swift build -c release --target RevenueCat
           no_output_timeout: 30m
+      - run:
+          name: SPM RevenueCatUI Release Build
+          command: swift build -c release --target RevenueCatUI
+          no_output_timeout: 30m
 
   spm-custom-entitlement-computation-build:
     <<: *base-job

--- a/README.md
+++ b/README.md
@@ -55,15 +55,15 @@ Or view our iOS sample apps:
 - [MagicWeather SwiftUI](Examples/MagicWeatherSwiftUI)
 
 ## Requirements
-- Xcode 14.0+
+- Xcode 15.0+
 
 | Platform | Minimum target |
-| --- | --- |
-| iOS | 13.0+ |
-| tvOS | 13.0+ |
-| macOS | 10.15+ |
-| watchOS | 6.2+ |
-| visionOS | 1.0+ |
+|----------|----------------|
+| iOS      | 13.0+          |
+| tvOS     | 13.0+          |
+| macOS    | 10.15+         |
+| watchOS  | 6.2+           |
+| visionOS | 1.0+           |
 
 ## SDK Reference
 Our full SDK reference [can be found here](https://revenuecat.github.io/purchases-ios-docs).


### PR DESCRIPTION
- Remove jobs that check we can build on xcode 14
- Update requirements section in README.md