### PR TITLE
finishTransactions/ObserverMode -> PurchasesAreCompletedBy

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -620,6 +620,7 @@
 		6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECF627761D375C8431EB866 /* StoreProduct.swift */; };
 		805B60C97993B311CEC93EAF /* ProductsFetcherSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628C1F100BB3C1782860D24 /* ProductsFetcherSK2.swift */; };
 		80E80EF226970E04008F245A /* ReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E80EF026970DC3008F245A /* ReceiptFetcher.swift */; };
+		887E7B592C13CD2C002977DE /* PurchasesAreCompletedBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887E7B582C13CD2C002977DE /* PurchasesAreCompletedBy.swift */; };
 		9A65DFDE258AD60A00DE00B0 /* LogIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */; };
 		9A65E03625918B0500DE00B0 /* ConfigureStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */; };
 		9A65E03B25918B0900DE00B0 /* CustomerInfoStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E03A25918B0900DE00B0 /* CustomerInfoStrings.swift */; };
@@ -1364,6 +1365,7 @@
 		57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreTransaction.swift; sourceTree = "<group>"; };
 		80E80EF026970DC3008F245A /* ReceiptFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
 		84C3F1AC1D7E1E64341D3936 /* Pods_RevenueCat_PurchasesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RevenueCat_PurchasesTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		887E7B582C13CD2C002977DE /* PurchasesAreCompletedBy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesAreCompletedBy.swift; sourceTree = "<group>"; };
 		9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogIntent.swift; sourceTree = "<group>"; };
 		9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigureStrings.swift; sourceTree = "<group>"; };
 		9A65E03A25918B0900DE00B0 /* CustomerInfoStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerInfoStrings.swift; sourceTree = "<group>"; };
@@ -2851,6 +2853,7 @@
 			isa = PBXGroup;
 			children = (
 				B3843BCA285149A0009F4854 /* Attribution.swift */,
+				887E7B582C13CD2C002977DE /* PurchasesAreCompletedBy.swift */,
 				57FD7B1428DA4037009CA4E4 /* PurchasesType.swift */,
 				B35042C326CDB79A00905B95 /* Purchases.swift */,
 				B35042C526CDD3B100905B95 /* PurchasesDelegate.swift */,
@@ -3535,6 +3538,7 @@
 				35AAEB452BBB14D000A12548 /* DiagnosticsFileHandler.swift in Sources */,
 				B34D2AA626976FC700D88C3A /* ErrorCode.swift in Sources */,
 				4F15B4A12A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift in Sources */,
+				887E7B592C13CD2C002977DE /* PurchasesAreCompletedBy.swift in Sources */,
 				B39E811D268E887500D31189 /* SubscriberAttribute.swift in Sources */,
 				A5F0104E2717B3150090732D /* BeginRefundRequestHelper.swift in Sources */,
 				B378156D285A9772000A7B93 /* OfferingsAPI.swift in Sources */,

--- a/RevenueCatUI/Purchasing/MockPurchases.swift
+++ b/RevenueCatUI/Purchasing/MockPurchases.swift
@@ -22,12 +22,19 @@ final class MockPurchases: PaywallPurchasesType {
     typealias PurchaseBlock = @Sendable (Package) async throws -> PurchaseResultData
     typealias RestoreBlock = @Sendable () async throws -> CustomerInfo
     typealias TrackEventBlock = @Sendable (PaywallEvent) async -> Void
+    private let _purchasesAreCompletedBy: PurchasesAreCompletedBy
+
+    var purchasesAreCompletedBy: PurchasesAreCompletedBy {
+        get { return _purchasesAreCompletedBy }
+        set { _ = newValue }
+    }
 
     private let purchaseBlock: PurchaseBlock
     private let restoreBlock: RestoreBlock
     private let trackEventBlock: TrackEventBlock
 
     init(
+        purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat,
         purchase: @escaping PurchaseBlock,
         restorePurchases: @escaping RestoreBlock,
         trackEvent: @escaping TrackEventBlock
@@ -35,6 +42,7 @@ final class MockPurchases: PaywallPurchasesType {
         self.purchaseBlock = purchase
         self.restoreBlock = restorePurchases
         self.trackEventBlock = trackEvent
+        self._purchasesAreCompletedBy = purchasesAreCompletedBy
     }
 
     func purchase(package: Package) async throws -> PurchaseResultData {

--- a/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
@@ -19,9 +19,11 @@ import RevenueCat
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PurchaseHandler {
 
-    static func mock(_ customerInfo: CustomerInfo = TestData.customerInfo) -> Self {
+    static func mock(_ customerInfo: CustomerInfo = TestData.customerInfo,
+                     purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat)
+    -> Self {
         return self.init(
-            purchases: MockPurchases { _ in
+            purchases: MockPurchases(purchasesAreCompletedBy: purchasesAreCompletedBy) { _ in
                 return (
                     // No current way to create a mock transaction with RevenueCat's public methods.
                     transaction: nil,
@@ -36,8 +38,8 @@ extension PurchaseHandler {
         )
     }
 
-    static func cancelling() -> Self {
-        return .mock()
+    static func cancelling(purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat) -> Self {
+        return .mock(purchasesAreCompletedBy: purchasesAreCompletedBy)
             .map { block in {
                     var result = try await block($0)
                     result.userCancelled = true

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -335,6 +335,12 @@ public extension Purchases {
         self.attribution.setCreative(creative)
     }
 
+    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
+    @objc var finishTransactions: Bool {
+        get { self.systemInfo.finishTransactions }
+        set { self.systemInfo.finishTransactions = newValue }
+    }
+
 }
 
 public extension StoreProduct {

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -335,12 +335,6 @@ public extension Purchases {
         self.attribution.setCreative(creative)
     }
 
-    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
-    @objc var finishTransactions: Bool {
-        get { self.systemInfo.finishTransactions }
-        set { self.systemInfo.finishTransactions = newValue }
-    }
-
 }
 
 public extension StoreProduct {

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -86,7 +86,15 @@ import Foundation
 
         private(set) var apiKey: String
         private(set) var appUserID: String?
-        private(set) var observerMode: Bool = false
+        var observerMode: Bool {
+            switch purchasesAreCompletedBy {
+            case .revenueCat:
+                return false
+            case .myApp:
+                return true
+            }
+        }
+        private(set) var purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat
         private(set) var userDefaults: UserDefaults?
         private(set) var dangerousSettings: DangerousSettings?
         private(set) var networkTimeout = Configuration.networkTimeoutDefault
@@ -145,8 +153,21 @@ import Foundation
          * - Warning: This assumes your IAP implementation uses StoreKit 1.
          * Observer mode is not compatible with StoreKit 2.
          */
+        @available(*, deprecated, message: "Use with(purchasesAreCompletedBy:) instead.")
         @objc public func with(observerMode: Bool) -> Configuration.Builder {
-            self.observerMode = observerMode
+            self.purchasesAreCompletedBy = observerMode ? .myApp : .revenueCat
+            return self
+        }
+        /**
+         * Set `purchasesAreCompletedBy`.
+         * - Parameter purchasesAreCompletedBy: Set this to `.myApp` if you have your own IAP implementation and
+         * want to use only RevenueCat's backend. Default is `.revenueCat`.
+         *
+         * - Warning: This assumes your IAP implementation uses StoreKit 1.
+         * `.myApp` is not compatible with StoreKit 2.
+         */
+        @objc public func with(purchasesAreCompletedBy: PurchasesAreCompletedBy) -> Configuration.Builder {
+            self.purchasesAreCompletedBy = purchasesAreCompletedBy
             return self
         }
         /**

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1416,8 +1416,6 @@ public extension Purchases {
         )
     }
 
-
-
     @available(*, deprecated, message: """
     The appUserID passed to logIn is a constant string known at compile time.
     This is likely a programmer error. This ID is used to identify the current user.

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1572,7 +1572,10 @@ public extension Purchases {
         set { purchasesOrchestrator.allowSharingAppStoreAccount = newValue }
     }
 
-    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
+    /**
+     * Deprecated. Where responsibility for completing purchase transactions lies.
+     */
+    @available(*, deprecated, message: "Use ``purchasesAreCompletedBy`` instead.")
     @objc var finishTransactions: Bool {
         get { self.systemInfo.finishTransactions }
         set { self.systemInfo.finishTransactions = newValue }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1233,7 +1233,7 @@ public extension Purchases {
      * ```swift
      *  Purchases.configure(
      *      with: Configuration.Builder(withAPIKey: Constants.apiKey)
-     *               .with(observerMode: false)
+     *               .with(purchasesAreCompletedBy: .revenueCat)
      *               .with(appUserID: "<app_user_id>")
      *               .build()
      *      )

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -228,15 +228,9 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     @objc public let attribution: Attribution
 
-    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
-    @objc public var finishTransactions: Bool {
-        get { self.systemInfo.finishTransactions }
-        set { self.systemInfo.finishTransactions = newValue }
-    }
-
     @objc public var purchasesAreCompletedBy: PurchasesAreCompletedBy {
         get { self.systemInfo.finishTransactions ? .revenueCat : .myApp }
-        set { self.systemInfo.finishTransactions = (newValue == .revenueCat ? true : false) }
+        set { self.systemInfo.finishTransactions = newValue.finishTransactions }
     }
 
     private let attributionFetcher: AttributionFetcher

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1388,8 +1388,8 @@ public extension Purchases {
      * purchases and subscriptions across devices. Pass `nil` or an empty string if you want ``Purchases``
      * to generate this for you.
      *
-     * - Parameter purchasesAreCompletedBy: Set this to `.myApp` if you have your own IAP implementation
-     * and want to use only RevenueCat's backend. Default is `.revenueCat`.
+     * - Parameter purchasesAreCompletedBy: Set this to ``.myApp`` if you have your own IAP implementation
+     * and want to use only RevenueCat's backend. Default is ``.revenueCat``.
      *
      * - Returns: An instantiated ``Purchases`` object that has been set as a singleton.
      *

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -253,7 +253,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let receiptFetcher: ReceiptFetcher
     private let requestFetcher: StoreKitRequestFetcher
     private let paymentQueueWrapper: EitherPaymentQueueWrapper
-    private let systemInfo: SystemInfo
+    fileprivate let systemInfo: SystemInfo
     private let storeMessagesHelper: StoreMessagesHelperType?
     private var customerInfoObservationDisposable: (() -> Void)?
 
@@ -1570,6 +1570,12 @@ public extension Purchases {
     @objc var allowSharingAppStoreAccount: Bool {
         get { purchasesOrchestrator.allowSharingAppStoreAccount }
         set { purchasesOrchestrator.allowSharingAppStoreAccount = newValue }
+    }
+
+    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
+    @objc var finishTransactions: Bool {
+        get { self.systemInfo.finishTransactions }
+        set { self.systemInfo.finishTransactions = newValue }
     }
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION

--- a/Sources/Purchasing/Purchases/PurchasesAreCompletedBy.swift
+++ b/Sources/Purchasing/Purchases/PurchasesAreCompletedBy.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesAreCompletedBy.swift
+//
+//  Created by James Borthwick on 2024-05-30.
+
+import Foundation
+
+/// Where responsibility for completing purchase transactions lies.
+@objc(RCPurchasesAreCompletedBy)
+public enum PurchasesAreCompletedBy: Int {
+
+    /// Purchase transactions are to be finished by RevenueCat.
+    case revenueCat
+
+    /// Purchase transactions are to be finished by the app.
+    case myApp
+
+}
+
+extension PurchasesAreCompletedBy: Sendable {}

--- a/Sources/Purchasing/Purchases/PurchasesAreCompletedBy.swift
+++ b/Sources/Purchasing/Purchases/PurchasesAreCompletedBy.swift
@@ -25,4 +25,10 @@ public enum PurchasesAreCompletedBy: Int {
 
 }
 
+extension PurchasesAreCompletedBy {
+    var finishTransactions: Bool {
+        self == .revenueCat
+    }
+}
+
 extension PurchasesAreCompletedBy: Sendable {}

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -37,7 +37,15 @@ public protocol PurchasesType: AnyObject {
      * will turn up every time the app is opened.
      * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
      */
+    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
     var finishTransactions: Bool { get set }
+
+    /** Controls if purchaess should be made and transactions finished automatically by RevenueCat.
+     * `.revenueCat` by default.
+     * - Warning: Setting this value to `.myApp` will prevent the SDK from making purchaes and finishing transactions.
+     * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
+     */
+    var purchasesAreCompletedBy: PurchasesAreCompletedBy { get set }
 
     /**
      * Delegate for ``Purchases`` instance. The delegate is responsible for handling promotional product purchases and

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -40,9 +40,9 @@ public protocol PurchasesType: AnyObject {
     @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
     var finishTransactions: Bool { get set }
 
-    /** Controls if purchaess should be made and transactions finished automatically by RevenueCat.
+    /** Controls if purchases should be made and transactions finished automatically by RevenueCat.
      * `.revenueCat` by default.
-     * - Warning: Setting this value to `.myApp` will prevent the SDK from making purchaes and finishing transactions.
+     * - Warning: Setting this value to `.myApp` will prevent the SDK from making purchases and finishing transactions.
      * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
      */
     var purchasesAreCompletedBy: PurchasesAreCompletedBy { get set }

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
@@ -13,7 +13,7 @@ func checkConfigurationAPI() {
         .builder(withAPIKey: "")
         .with(apiKey: "")
         .with(appUserID: nil)
-        .with(observerMode: false)
+        .with(purchasesAreCompletedBy: .myApp)
         .with(userDefaults: UserDefaults.standard)
         .with(dangerousSettings: DangerousSettings())
         .with(dangerousSettings: DangerousSettings(autoSyncPurchases: true))

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -19,12 +19,12 @@ func checkPurchasesAPI() {
     let purch = checkConfigure()!
 
     // initializers
-    let finishTransactions: Bool = purch.finishTransactions
+    let purchasesAreCompletedBy: PurchasesAreCompletedBy = purch.purchasesAreCompletedBy
     let delegate: PurchasesDelegate? = purch.delegate
     let appUserID: String = purch.appUserID
     let isAnonymous: Bool = purch.isAnonymous
 
-    print(finishTransactions, delegate!, appUserID, isAnonymous)
+    print(purchasesAreCompletedBy, delegate!, appUserID, isAnonymous)
 
     checkStaticMethods()
     checkIdentity(purchases: purch)

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
@@ -14,7 +14,7 @@
 + (void)checkAPI {
     RCConfigurationBuilder *builder = [RCConfiguration builderWithAPIKey:@""];
     RCConfiguration *config __unused = [[[[[[[[[[[builder withApiKey:@""]
-                                                 withObserverMode:false]
+                                                 withPurchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat]
                                                 withUserDefaults:NSUserDefaults.standardUserDefaults]
                                                withAppUserID:@""]
                                               withAppUserID:nil]
@@ -24,6 +24,8 @@
                                           withPlatformInfo:[[RCPlatformInfo alloc] initWithFlavor:@"" version:@""]]
                                          withUsesStoreKit2IfAvailable:false]
                                         build];
+
+    RCConfiguration *configDeprecated __unused = [[[builder withApiKey:@""] withObserverMode:true] build];
 
     if (@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)) {
         RCConfiguration *config __unused = [[builder

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -254,6 +254,7 @@ BOOL isAnonymous;
         case RCPurchasesAreCompletedByMyApp:
         case RCPurchasesAreCompletedByRevenueCat:
             NSLog(@"%ld", (long)pacb);
+    }
 }
 
 + (void)checkConstants {

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -45,7 +45,7 @@ BOOL isAnonymous;
     [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat];
     [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat];
     [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByMyApp];
-    [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:
+    [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:RCPurchasesAreCompletedByMyApp];
     [RCPurchases configureWithAPIKey:@""
                            appUserID:nil
                         observerMode:false

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -25,6 +25,7 @@ RCPurchases *sharedPurchases;
 BOOL isConfigured;
 BOOL allowSharingAppStoreAccount;
 BOOL finishTransactions;
+RCPurchasesAreCompletedBy purchasesAreCompletedBy;
 id<RCPurchasesDelegate> delegate;
 NSString *appUserID;
 BOOL isAnonymous;
@@ -41,6 +42,10 @@ BOOL isAnonymous;
     [RCPurchases configureWithAPIKey:@"" appUserID:nil observerMode:false userDefaults:nil];
     [RCPurchases configureWithAPIKey:@"" appUserID:@"" observerMode:false userDefaults:[[NSUserDefaults alloc] init]];
     [RCPurchases configureWithAPIKey:@"" appUserID:nil observerMode:false userDefaults:[[NSUserDefaults alloc] init]];
+    [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat];
+    [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat];
+    [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByMyApp];
+    [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:
     [RCPurchases configureWithAPIKey:@""
                            appUserID:nil
                         observerMode:false
@@ -96,6 +101,7 @@ BOOL isAnonymous;
     allowSharingAppStoreAccount = [p allowSharingAppStoreAccount];
 
     finishTransactions = [p finishTransactions];
+    purchasesAreCompletedBy = [p purchasesAreCompletedBy];
     delegate = [p delegate];
     appUserID = [p appUserID];
     isAnonymous = [p isAnonymous];
@@ -232,7 +238,7 @@ BOOL isAnonymous;
         case RCLogLevelInfo:
         case RCLogLevelWarn:
         case RCLogLevelError:
-            NSLog(@"%ld", (long)o);
+            NSLog(@"%ld", (long)l);
     }
 
     RCStoreMessageType smt = RCStoreMessageTypeBillingIssue;
@@ -240,8 +246,14 @@ BOOL isAnonymous;
         case RCStoreMessageTypeBillingIssue:
         case RCStoreMessageTypePriceIncreaseConsent:
         case RCStoreMessageTypeGeneric:
-            NSLog(@"%ld", (long)o);
+            NSLog(@"%ld", (long)smt);
     }
+
+    RCPurchasesAreCompletedBy pacb = RCPurchasesAreCompletedByRevenueCat;
+    switch(pacb) {
+        case RCPurchasesAreCompletedByMyApp:
+        case RCPurchasesAreCompletedByRevenueCat:
+            NSLog(@"%ld", (long)pacb);
 }
 
 + (void)checkConstants {

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
@@ -13,7 +13,7 @@ func checkConfigurationAPI() {
         .builder(withAPIKey: "")
         .with(apiKey: "")
         .with(appUserID: nil)
-        .with(observerMode: true)
+        .with(purchasesAreCompletedBy: .myApp)
         .with(userDefaults: UserDefaults.standard)
         .with(dangerousSettings: DangerousSettings())
         .with(dangerousSettings: DangerousSettings(autoSyncPurchases: true))

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -376,6 +376,8 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
                         useStoreKit2IfAvailable: true,
                         dangerousSettings: DangerousSettings(autoSyncPurchases: false))
 
+    let _: Bool = purchases.finishTransactions
+
     _ = Configuration
         .builder(withAPIKey: "")
         .with(observerMode: true)

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -19,12 +19,12 @@ func checkPurchasesAPI() {
     let purch = checkConfigure()!
 
     // initializers
-    let finishTransactions: Bool = purch.finishTransactions
+    let purchasesAreCompletedBy: PurchasesAreCompletedBy = purch.purchasesAreCompletedBy
     let delegate: PurchasesDelegate? = purch.delegate
     let appUserID: String = purch.appUserID
     let isAnonymous: Bool = purch.isAnonymous
 
-    print(finishTransactions, delegate!, appUserID, isAnonymous)
+    print(purchasesAreCompletedBy, delegate!, appUserID, isAnonymous)
 
     checkStaticMethods()
     checkIdentity(purchases: purch)
@@ -306,7 +306,7 @@ private func checkConfigure() -> Purchases! {
 
     Purchases.configure(withAPIKey: "")
     Purchases.configure(withAPIKey: "", appUserID: nil)
-    Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true)
+    Purchases.configure(withAPIKey: "", appUserID: nil, purchasesAreCompletedBy: .myApp)
 
     return nil
 }
@@ -339,6 +339,7 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
     Purchases.addAttributionData([String: Any](), from: AttributionNetwork.adjust, forNetworkUserId: nil)
     let _: Bool = Purchases.automaticAppleSearchAdsAttributionCollection
     Purchases.automaticAppleSearchAdsAttributionCollection = false
+    purchases.finishTransactions = true
 
     purchases.checkTrialOrIntroDiscountEligibility([String]()) { (_: [String: IntroEligibility]) in }
 
@@ -350,6 +351,7 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
     Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true, userDefaults: UserDefaults())
     Purchases.configure(withAPIKey: "", appUserID: "")
     Purchases.configure(withAPIKey: "", appUserID: "", observerMode: false)
+    Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true)
     Purchases.configure(withAPIKey: "",
                         appUserID: nil,
                         observerMode: true,
@@ -373,4 +375,8 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
                         userDefaults: UserDefaults(),
                         useStoreKit2IfAvailable: true,
                         dangerousSettings: DangerousSettings(autoSyncPurchases: false))
+
+    _ = Configuration
+        .builder(withAPIKey: "")
+        .with(observerMode: true)
 }

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -255,6 +255,7 @@ class PurchaseCompletedHandlerTests: TestCase {
         expect(error).toEventually(matchError(Self.failureError))
     }
 
+    private static let externalPurchaseHandler: PurchaseHandler = .mock(purchasesAreCompletedBy: .myApp)
     private static let purchaseHandler: PurchaseHandler = .mock()
     private static let failingHandler: PurchaseHandler = .failing(failureError)
     private static let offering = TestData.offeringWithNoIntroOffer

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -132,6 +132,12 @@ extension MockPurchases: PurchasesType {
         set { self.unimplemented() }
     }
 
+    var purchasesAreCompletedBy: PurchasesAreCompletedBy {
+        get { self.unimplemented() }
+        // swiftlint:disable:next unused_setter_value
+        set { self.unimplemented() }
+    }
+
     var delegate: PurchasesDelegate? {
         get { self.unimplemented() }
         // swiftlint:disable:next unused_setter_value

--- a/Tests/UnitTests/Purchasing/ConfigurationTests.swift
+++ b/Tests/UnitTests/Purchasing/ConfigurationTests.swift
@@ -52,9 +52,9 @@ class ConfigurationTests: TestCase {
         self.logger.verifyMessageWasNotLogged(Strings.configure.observer_mode_with_storekit2)
     }
 
-    func testObserverModeWithStoreKit1() {
+    func testPurchasesAreCompletedByMyAppWithStoreKit1() {
         let configuration = Configuration.Builder(withAPIKey: "test")
-            .with(observerMode: true)
+            .with(purchasesAreCompletedBy: .myApp)
             .build()
 
         expect(configuration.observerMode) == true
@@ -64,9 +64,9 @@ class ConfigurationTests: TestCase {
     }
 
     @available(*, deprecated)
-    func testObserverModeWithStoreKit2() {
+    func testPurchasesAreCompletedByMyAppWithStoreKit2() {
         let configuration = Configuration.Builder(withAPIKey: "test")
-            .with(observerMode: true)
+            .with(purchasesAreCompletedBy: .myApp)
             .with(usesStoreKit2IfAvailable: true)
             .build()
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -504,8 +504,8 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     // MARK: - OfflineCustomerInfoCreator
 
-    func testObserverModeDoesNotCreateOfflineCustomerInfoCreator() {
-        expect(Self.create(observerMode: true).offlineCustomerInfoEnabled) == false
+    func testPurchaesAreCompletedByMyAppDoesNotCreateOfflineCustomerInfoCreator() {
+        expect(Self.create(purchasesAreCompletedBy: .myApp).offlineCustomerInfoEnabled) == false
     }
 
     func testOlderVersionsDoNoCreateOfflineCustomerInfo() throws {
@@ -513,19 +513,19 @@ class PurchasesConfiguringTests: BasePurchasesTests {
             throw XCTSkip("Test for older versions")
         }
 
-        expect(Self.create(observerMode: false).offlineCustomerInfoEnabled) == false
+        expect(Self.create(purchasesAreCompletedBy: .revenueCat).offlineCustomerInfoEnabled) == false
     }
 
     func testOfflineCustomerInfoEnabled() throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        expect(Self.create(observerMode: false).offlineCustomerInfoEnabled) == true
+        expect(Self.create(purchasesAreCompletedBy: .revenueCat).offlineCustomerInfoEnabled) == true
     }
 
-    private static func create(observerMode: Bool) -> Purchases {
+    private static func create(purchasesAreCompletedBy: PurchasesAreCompletedBy) -> Purchases {
         return Purchases.configure(
             with: .init(withAPIKey: "")
-                .with(observerMode: observerMode)
+                .with(purchasesAreCompletedBy: purchasesAreCompletedBy)
         )
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -504,7 +504,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     // MARK: - OfflineCustomerInfoCreator
 
-    func testPurchaesAreCompletedByMyAppDoesNotCreateOfflineCustomerInfoCreator() {
+    func testPurchasesAreCompletedByMyAppDoesNotCreateOfflineCustomerInfoCreator() {
         expect(Self.create(purchasesAreCompletedBy: .myApp).offlineCustomerInfoEnabled) == false
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -214,7 +214,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
     }
 
     func testDoesntFinishTransactionsIfFinishingDisabled() throws {
-        self.purchases.finishTransactions = false
+        self.purchases.purchasesAreCompletedBy = .myApp
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 


### PR DESCRIPTION
This PR adds:

* `purchasesAreCompletedBy`

which replaces and deprecates public instances of:
* `observerMode`
* `finishTransactions`

Internal references to the above will be removed in a subsequent PR.
