### PR TITLE
Rename handleObserverModeTransaction

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/V5_API_Migration_guide.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/V5_API_Migration_guide.md
@@ -46,13 +46,13 @@ Purchases.configure(with: .builder(withAPIKey: apiKey)
 
 #### ⚠️ StoreKit 2 Observer Mode on macOS
 
-By default, Observer Mode with StoreKit 2 on macOS does not detect a user's purchase until after the user foregrounds the app after the purchase has been made. If you'd like RevenueCat to immediately detect the user's purchase, call `Purchases.shared.handleObserverModeTransaction(purchaseResult)` for any new purchases, like so:
+By default, Observer Mode with StoreKit 2 on macOS does not detect a user's purchase until after the user foregrounds the app after the purchase has been made. If you'd like RevenueCat to immediately detect the user's purchase, call `Purchases.shared.handlePurchaseResult(purchaseResult)` for any new purchases, like so:
 
 ```swift
 let product = try await StoreKit.Product.products(for: ["my_product_id"]).first
 let result = try await product?.purchase()
 
-_ = try await Purchases.shared.handleObserverModeTransaction(result)
+_ = try await Purchases.shared.handlePurchaseResult(result)
 ```
 
 #### StoreKit 1 Observer Mode Support

--- a/Sources/Misc/Obsoletions.swift
+++ b/Sources/Misc/Obsoletions.swift
@@ -546,7 +546,6 @@ public extension Purchases {
      * - Returns: An instantiated ``Purchases`` object that has been set as a singleton.
      *
      * - Warning: This assumes your IAP implementation uses StoreKit 1.
-     * - Warning: If you're using observer mode with StoreKit 2, configure the SDK with `configure(withAPIKey:appUserID:observerMode:storeKitVersion:)` passing in `.storeKit2` as the `storeKitVersion` and ensure that you call ``Purchases/handleObserverModeTransaction(_:)`` after making a purchase.
      */
     @available(iOS, obsoleted: 1,
                message: "Explicitly setting the StoreKit version is now required when using observer mode.",

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1159,7 +1159,7 @@ public extension Purchases {
 #endif
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func handleObserverModeTransaction(
+    func handlePurchaseResult(
         _ purchaseResult: StoreKit.Product.PurchaseResult
     ) async throws -> StoreTransaction? {
         guard self.systemInfo.observerMode else {
@@ -1353,9 +1353,6 @@ public extension Purchases {
      * - Parameter storeKitVersion: The StoreKit version Purchases will use to process your purchases.
      *
      * - Returns: An instantiated ``Purchases`` object that has been set as a singleton.
-     *
-     * - Warning: If you are using observer mode with StoreKit 2, ensure that you're
-     * calling ``Purchases/handleObserverModeTransaction(_:)`` after making a purchase.
      */
     @objc(configureWithAPIKey:appUserID:observerMode:storeKitVersion:)
     @discardableResult static func configure(withAPIKey apiKey: String,

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1019,8 +1019,8 @@ public protocol PurchasesSwiftType: AnyObject {
 
     /**
      * Use this method only if you already have your own IAP implementation using StoreKit 2, want to use
-     * RevenueCat's backend, and want RevenueCat to handle the transaction outside of how the SDK 
-     * typically detects transactions. If you are using StoreKit 1 for your implementation, you do not need this method.
+     * RevenueCat's backend, and need RevenueCat to process the transaction at a time other than when the
+     * app is foregrounded. If you are using StoreKit 1 for your implementation, you do not need this method.
      *
      * You only need to use this method with *new* purchases. Subscription updates are observed automatically.
      *

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1018,8 +1018,9 @@ public protocol PurchasesSwiftType: AnyObject {
     #endif
 
     /**
-     * Use this method only if you already have your own IAP implementation using StoreKit 2 and want to use
-     * RevenueCat's backend. If you are using StoreKit 1 for your implementation, you do not need this method.
+     * Use this method only if you already have your own IAP implementation using StoreKit 2, want to use
+     * RevenueCat's backend, and want RevenueCat to handle the transaction outside of how the SDK 
+     * typically detects transactions. If you are using StoreKit 1 for your implementation, you do not need this method.
      *
      * You only need to use this method with *new* purchases. Subscription updates are observed automatically.
      *
@@ -1031,7 +1032,7 @@ public protocol PurchasesSwiftType: AnyObject {
      * guard let product = product else { return }
      * let result = try await product.purchase()
      * // Let RevenueCat handle the transaction result
-     * _ = try await Purchases.shared.handleObserverModeTransaction(result)
+     * _ = try await Purchases.shared.handlePurchaseResult(result)
      * // Handle the result and finish the transaction
      * switch result {
      * case .success(let verification):
@@ -1063,7 +1064,7 @@ public protocol PurchasesSwiftType: AnyObject {
      * ``Configuration/Builder/with(observerMode:storeKitVersion:)``
      */
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func handleObserverModeTransaction(
+    func handlePurchaseResult(
         _ purchaseResult: StoreKit.Product.PurchaseResult
     ) async throws -> StoreTransaction?
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -261,7 +261,7 @@ private func checkAsyncMethods(purchases: Purchases) async {
 
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
             let result = try await StoreKit.Product.products(for: [""]).first!.purchase()
-            let _: StoreTransaction? = try await purchases.handleObserverModeTransaction(result)
+            let _: StoreTransaction? = try await purchases.handlePurchaseResult(result)
         }
 
         for try await _: CustomerInfo in purchases.customerInfoStream {}

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -26,7 +26,7 @@ class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
         let result = try await manager.purchaseProductFromStoreKit2()
 
         do {
-            _ = try await Purchases.shared.handleObserverModeTransaction(result)
+            _ = try await Purchases.shared.handlePurchaseResult(result)
             fail("Expected error")
         } catch {
             expect(error).to(matchError(ErrorCode.configurationError))

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -197,7 +197,7 @@ class StoreKit2NotEnabledObserverModeIntegrationTests: BaseStoreKitObserverModeI
         let result = try await manager.purchaseProductFromStoreKit2()
 
         do {
-            _ = try await Purchases.shared.handleObserverModeTransaction(result)
+            _ = try await Purchases.shared.handlePurchaseResult(result)
             fail("Expected error")
         } catch {
             expect(error).to(matchError(ErrorCode.configurationError))

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -446,7 +446,7 @@ extension MockPurchases: PurchasesSwiftType {
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func handleObserverModeTransaction(
+    func handlePurchaseResult(
         _ purchaseResult: Product.PurchaseResult
     ) async throws -> RevenueCat.StoreTransaction? {
         self.unimplemented()


### PR DESCRIPTION
### Motivation
This PR renames `handleObserverModeTransaction()` to `handlePurchaseResult()` to be consistent with the upcoming observer mode name changes.

### Changes
- Renames `handleObserverModeTransaction()` to `handlePurchaseResult()`
- Removes a few DocC comments that described `handleObserverModeTransaction()` as being required for a SK2 observer mode implementation. 
