### PR TITLE
[WIP] Paywalls manually handle purchases init based

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,7 +338,6 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
-  ruby
   x86_64-darwin-22
   x86_64-linux
 

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -620,6 +620,7 @@
 		6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECF627761D375C8431EB866 /* StoreProduct.swift */; };
 		805B60C97993B311CEC93EAF /* ProductsFetcherSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628C1F100BB3C1782860D24 /* ProductsFetcherSK2.swift */; };
 		80E80EF226970E04008F245A /* ReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E80EF026970DC3008F245A /* ReceiptFetcher.swift */; };
+		884D3CE62C08E86400412198 /* PurchasesAreCompletedBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884D3CE52C08E86400412198 /* PurchasesAreCompletedBy.swift */; };
 		9A65DFDE258AD60A00DE00B0 /* LogIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */; };
 		9A65E03625918B0500DE00B0 /* ConfigureStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */; };
 		9A65E03B25918B0900DE00B0 /* CustomerInfoStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E03A25918B0900DE00B0 /* CustomerInfoStrings.swift */; };
@@ -1364,6 +1365,7 @@
 		57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreTransaction.swift; sourceTree = "<group>"; };
 		80E80EF026970DC3008F245A /* ReceiptFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
 		84C3F1AC1D7E1E64341D3936 /* Pods_RevenueCat_PurchasesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RevenueCat_PurchasesTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		884D3CE52C08E86400412198 /* PurchasesAreCompletedBy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesAreCompletedBy.swift; sourceTree = "<group>"; };
 		9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogIntent.swift; sourceTree = "<group>"; };
 		9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigureStrings.swift; sourceTree = "<group>"; };
 		9A65E03A25918B0900DE00B0 /* CustomerInfoStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerInfoStrings.swift; sourceTree = "<group>"; };
@@ -2853,6 +2855,7 @@
 				B3843BCA285149A0009F4854 /* Attribution.swift */,
 				57FD7B1428DA4037009CA4E4 /* PurchasesType.swift */,
 				B35042C326CDB79A00905B95 /* Purchases.swift */,
+				884D3CE52C08E86400412198 /* PurchasesAreCompletedBy.swift */,
 				B35042C526CDD3B100905B95 /* PurchasesDelegate.swift */,
 				2D9F4A5426C30CA800B07B43 /* PurchasesOrchestrator.swift */,
 				4F8038322A1EA7C300D21039 /* TransactionPoster.swift */,
@@ -3535,6 +3538,7 @@
 				35AAEB452BBB14D000A12548 /* DiagnosticsFileHandler.swift in Sources */,
 				B34D2AA626976FC700D88C3A /* ErrorCode.swift in Sources */,
 				4F15B4A12A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift in Sources */,
+				884D3CE62C08E86400412198 /* PurchasesAreCompletedBy.swift in Sources */,
 				B39E811D268E887500D31189 /* SubscriberAttribute.swift in Sources */,
 				A5F0104E2717B3150090732D /* BeginRefundRequestHelper.swift in Sources */,
 				B378156D285A9772000A7B93 /* OfferingsAPI.swift in Sources */,

--- a/RevenueCatUI/Data/Errors/PaywallError.swift
+++ b/RevenueCatUI/Data/Errors/PaywallError.swift
@@ -25,6 +25,9 @@ enum PaywallError: Error {
     /// The selected offering was not found.
     case offeringNotFound(identifier: String)
 
+    /// The PaywallView must be initizlied with performPurchase and performRestore when ``purchasesAreCompletedBy`` is ``.myApp``
+    case performPurchaseAndRestoreHandlersNotDefined
+
 }
 
 extension PaywallError: CustomNSError {
@@ -45,6 +48,9 @@ extension PaywallError: CustomNSError {
 
         case let .offeringNotFound(identifier):
             return "The RevenueCat dashboard does not have an offering with identifier '\(identifier)'."
+        case .performPurchaseAndRestoreHandlersNotDefined:
+            return "A PaywallView must be initialized with a PerformPurchase and PerformRestore hander " +
+            "when purchasesAreCompletedBy is equal to .myApp"
         }
     }
 

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -105,8 +105,9 @@ extension Strings: CustomStringConvertible {
             return "Setting restored customer info"
 
         case .executing_external_purchase_logic:
-            return "Will execute custom StoreKit purchase logic provided by the SDK adopter. " +
-            "No StoreKit purchasing logic will be performed by RevenueCat."
+            return "Will execute custom StoreKit purchase logic provided by yourapp. " +
+            "No StoreKit purchasing logic will be performed by RevenueCat. " +
+            "You must use `.handlePurchase` on your `PaywallView`"
 
         case .executing_purchase_logic:
             return "Will execute purchase logic provided by RevenueCat."
@@ -115,8 +116,9 @@ extension Strings: CustomStringConvertible {
             return "Will execute restore purchases logic provided by RevenueCat."
 
         case .executing_external_restore_logic:
-            return "Will execute custom StoreKit restore purchases logic provided by the SDK adopter. " +
-            "No StoreKit restore purchases logic will be performed by RevenueCat."
+            return "Will execute custom StoreKit restore purchases logic provided by your app. " +
+            "No StoreKit restore purchases logic will be performed by RevenueCat. " +
+            "You must use `.handleRestorePurchases` on your `PaywallView`"
         }
     }
 

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -107,7 +107,7 @@ extension Strings: CustomStringConvertible {
         case .executing_external_purchase_logic:
             return "Will execute custom StoreKit purchase logic provided by your app. " +
             "No StoreKit purchasing logic will be performed by RevenueCat. " +
-            "You must use `.handlePurchase` on your `PaywallView`."
+            "You must use `.handlePurchaseAndRestore` on your `PaywallView`."
 
         case .executing_purchase_logic:
             return "Will execute purchase logic provided by RevenueCat."
@@ -118,7 +118,7 @@ extension Strings: CustomStringConvertible {
         case .executing_external_restore_logic:
             return "Will execute custom StoreKit restore purchases logic provided by your app. " +
             "No StoreKit restore purchases logic will be performed by RevenueCat. " +
-            "You must use `.handleRestorePurchases` on your `PaywallView`."
+            "You must use `.handlePurchaseAndRestore` on your `PaywallView`."
         }
     }
 

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -105,7 +105,7 @@ extension Strings: CustomStringConvertible {
             return "Setting restored customer info"
 
         case .executing_external_purchase_logic:
-            return "Will execute custom StoreKit purchase logic provided by yourapp. " +
+            return "Will execute custom StoreKit purchase logic provided by your app. " +
             "No StoreKit purchasing logic will be performed by RevenueCat. " +
             "You must use `.handlePurchase` on your `PaywallView`."
 

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -40,7 +40,11 @@ enum Strings {
     case restore_purchases_with_empty_result
     case setting_restored_customer_info
 
+    case executing_purchase_logic
     case executing_external_purchase_logic
+    case executing_restore_logic
+    case executing_external_restore_logic
+
 
 }
 
@@ -104,6 +108,16 @@ extension Strings: CustomStringConvertible {
         case .executing_external_purchase_logic:
             return "Will execute custom StoreKit purchase logic provided by the SDK adopter. " +
             "No StoreKit purchasing logic will be performed by RevenueCat."
+
+        case .executing_purchase_logic:
+            return "Will execute purchase logic provided by RevenueCat."
+
+        case .executing_restore_logic:
+            return "Will execute restore purchases logic provided by RevenueCat."
+
+        case .executing_external_restore_logic:
+            return "Will execute custom StoreKit restore purchases logic provided by the SDK adopter. " +
+            "No StoreKit restore purchases logic will be performed by RevenueCat."
         }
     }
 

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -107,7 +107,7 @@ extension Strings: CustomStringConvertible {
         case .executing_external_purchase_logic:
             return "Will execute custom StoreKit purchase logic provided by yourapp. " +
             "No StoreKit purchasing logic will be performed by RevenueCat. " +
-            "You must use `.handlePurchase` on your `PaywallView`"
+            "You must use `.handlePurchase` on your `PaywallView`."
 
         case .executing_purchase_logic:
             return "Will execute purchase logic provided by RevenueCat."
@@ -118,7 +118,7 @@ extension Strings: CustomStringConvertible {
         case .executing_external_restore_logic:
             return "Will execute custom StoreKit restore purchases logic provided by your app. " +
             "No StoreKit restore purchases logic will be performed by RevenueCat. " +
-            "You must use `.handleRestorePurchases` on your `PaywallView`"
+            "You must use `.handleRestorePurchases` on your `PaywallView`."
         }
     }
 

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -45,7 +45,6 @@ enum Strings {
     case executing_restore_logic
     case executing_external_restore_logic
 
-
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)

--- a/RevenueCatUI/Helpers/Logger.swift
+++ b/RevenueCatUI/Helpers/Logger.swift
@@ -63,6 +63,21 @@ enum Logger {
         )
     }
 
+    static func error(
+        _ text: CustomStringConvertible,
+        file: String = #file,
+        function: String = #function,
+        line: UInt = #line
+    ) {
+        Self.log(
+            text,
+            .error,
+            file: file,
+            function: function,
+            line: line
+        )
+    }
+
     private static func log(
         _ text: CustomStringConvertible,
         _ level: LogLevel,

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -311,7 +311,7 @@ struct LoadedOfferingPaywallView: View {
             .preference(key: PurchasedResultPreferenceKey.self,
                         value: .init(data: self.purchaseHandler.purchaseResult))
             .preference(key: HandlePurchasePreferenceKey.self,
-                        value: .init(data: self.purchaseHandler.handlePurchase))
+                        value: self.purchaseHandler.handlePurchase)
             .preference(key: HandleRestorePreferenceKey.self,
                         value: self.purchaseHandler.handleRestore)
             .preference(key: RestoredCustomerInfoPreferenceKey.self,

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -313,7 +313,7 @@ struct LoadedOfferingPaywallView: View {
             .preference(key: HandlePurchasePreferenceKey.self,
                         value: .init(data: self.purchaseHandler.handlePurchase))
             .preference(key: HandleRestorePreferenceKey.self,
-                        value: .init(callback: self.purchaseHandler.handleRestore))
+                        value: self.purchaseHandler.handleRestore)
             .preference(key: RestoredCustomerInfoPreferenceKey.self,
                         value: self.purchaseHandler.restoredCustomerInfo)
             .preference(key: RestoreInProgressPreferenceKey.self,

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -311,9 +311,9 @@ struct LoadedOfferingPaywallView: View {
             .preference(key: PurchasedResultPreferenceKey.self,
                         value: .init(data: self.purchaseHandler.purchaseResult))
             .preference(key: HandlePurchasePreferenceKey.self,
-                        value: self.purchaseHandler.handlePurchase)
+                        value: self.purchaseHandler.performPurchase)
             .preference(key: HandleRestorePreferenceKey.self,
-                        value: self.purchaseHandler.handleRestore)
+                        value: self.purchaseHandler.performRestore)
             .preference(key: RestoredCustomerInfoPreferenceKey.self,
                         value: self.purchaseHandler.restoredCustomerInfo)
             .preference(key: RestoreInProgressPreferenceKey.self,

--- a/RevenueCatUI/Purchasing/MockPurchases.swift
+++ b/RevenueCatUI/Purchasing/MockPurchases.swift
@@ -30,7 +30,7 @@ final class MockPurchases: PaywallPurchasesType {
     private let trackEventBlock: TrackEventBlock
     private let _finishTransactions: Bool
 
-    var finishTransactions: Bool {
+    var purchasesAreCompletedBy: Bool {
         get { return _finishTransactions }
         set { _ = newValue }
     }

--- a/RevenueCatUI/Purchasing/MockPurchases.swift
+++ b/RevenueCatUI/Purchasing/MockPurchases.swift
@@ -28,15 +28,15 @@ final class MockPurchases: PaywallPurchasesType {
     private let purchaseBlock: PurchaseBlock
     private let restoreBlock: RestoreBlock
     private let trackEventBlock: TrackEventBlock
-    private let _finishTransactions: Bool
+    private let _purchasesAreCompletedBy: PurchasesAreCompletedBy
 
-    var purchasesAreCompletedBy: Bool {
-        get { return _finishTransactions }
+    var purchasesAreCompletedBy: PurchasesAreCompletedBy {
+        get { return _purchasesAreCompletedBy }
         set { _ = newValue }
     }
 
     init(
-        finishTransactions: Bool = true,
+        purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat,
         purchase: @escaping PurchaseBlock,
         restorePurchases: @escaping RestoreBlock,
         trackEvent: @escaping TrackEventBlock,
@@ -46,7 +46,7 @@ final class MockPurchases: PaywallPurchasesType {
         self.restoreBlock = restorePurchases
         self.trackEventBlock = trackEvent
         self.customerInfoBlock = customerInfo
-        self._finishTransactions = finishTransactions
+        self._purchasesAreCompletedBy = purchasesAreCompletedBy
     }
 
     func customerInfo() async throws -> RevenueCat.CustomerInfo {

--- a/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
+++ b/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
@@ -17,7 +17,7 @@ import RevenueCat
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 protocol PaywallPurchasesType: Sendable {
 
-    var purchasesAreCompletedBy: Bool { get set }
+    var purchasesAreCompletedBy: PurchasesAreCompletedBy { get set }
 
     @Sendable
     func purchase(package: Package) async throws -> PurchaseResultData

--- a/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
+++ b/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
@@ -17,7 +17,7 @@ import RevenueCat
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 protocol PaywallPurchasesType: Sendable {
 
-    var finishTransactions: Bool { get set }
+    var purchasesAreCompletedBy: Bool { get set }
 
     @Sendable
     func purchase(package: Package) async throws -> PurchaseResultData

--- a/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
@@ -19,9 +19,11 @@ import RevenueCat
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PurchaseHandler {
 
-    static func mock(_ customerInfo: CustomerInfo = TestData.customerInfo, finishTransactions: Bool = true) -> Self {
+    static func mock(_ customerInfo: CustomerInfo = TestData.customerInfo,
+                     purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat)
+    -> Self {
         return self.init(
-            purchases: MockPurchases(finishTransactions: finishTransactions) { _ in
+            purchases: MockPurchases(purchasesAreCompletedBy: purchasesAreCompletedBy) { _ in
                 return (
                     // No current way to create a mock transaction with RevenueCat's public methods.
                     transaction: nil,
@@ -38,8 +40,8 @@ extension PurchaseHandler {
         )
     }
 
-    static func cancelling(finishTransactions: Bool = true) -> Self {
-        return .mock(finishTransactions: finishTransactions)
+    static func cancelling(purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat) -> Self {
+        return .mock(purchasesAreCompletedBy: purchasesAreCompletedBy)
             .map { block in {
                     var result = try await block($0)
                     result.userCancelled = true

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -115,7 +115,7 @@ extension PurchaseHandler {
 
     @MainActor
     func purchase(package: Package) async throws -> PurchaseResultData {
-        if self.purchases.purchasesAreCompletedBy {
+        if self.purchases.purchasesAreCompletedBy == .revenueCat {
             return try await performPurchase(package: package)
         } else {
             return try await performExternalPurchaseLogic(package: package)
@@ -189,7 +189,7 @@ extension PurchaseHandler {
     // MARK: - Restore
 
     func restorePurchases() async throws -> (info: CustomerInfo, success: Bool) {
-        if self.purchases.purchasesAreCompletedBy {
+        if self.purchases.purchasesAreCompletedBy == .revenueCat {
             return try await performRestorePurchases()
         } else {
             return try await performExternalRestoreLogic()
@@ -352,8 +352,8 @@ private extension PurchaseHandler {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private final class NotConfiguredPurchases: PaywallPurchasesType {
 
-    var purchasesAreCompletedBy: Bool {
-        get { return false }
+    var purchasesAreCompletedBy: PurchasesAreCompletedBy {
+        get { return .myApp }
         set { _ = newValue }
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -34,7 +34,6 @@ class HandleRestoreCallbackContainer: Equatable {
 
 }
 
-
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 // @PublicForExternalTesting
 final class PurchaseHandler: ObservableObject {
@@ -168,8 +167,6 @@ extension PurchaseHandler {
 
         return PurchaseResultData(nil, try await self.purchases.customerInfo(), false)
     }
-
-
 
     @MainActor
     func completeExternalHandlePurchase(_ userCancelled: Bool, _ error: Error?) {

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -61,6 +61,7 @@ public class RestoreResultReporter: Equatable {
         reportRestoreResultCallback(success, error)
     }
 
+    /// Returns true if objects are the same object (same memory address); false otherwise.
     public static func == (lhs: RestoreResultReporter, rhs: RestoreResultReporter) -> Bool {
         return lhs === rhs
     }

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -135,8 +135,8 @@ final class PurchaseHandler: ObservableObject {
 
     /// Returns a new instance of `PurchaseHandler` using `Purchases.shared` if `Purchases`
     /// has been configured, and using a PurchaseHandler that cannot be used for purchases otherwise.
-    static func `default`() -> Self {
     // @PublicForExternalTesting
+    static func `default`() -> Self {
         return Purchases.isConfigured ? .init() : Self.notConfigured()
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -136,6 +136,7 @@ final class PurchaseHandler: ObservableObject {
     /// Returns a new instance of `PurchaseHandler` using `Purchases.shared` if `Purchases`
     /// has been configured, and using a PurchaseHandler that cannot be used for purchases otherwise.
     static func `default`() -> Self {
+    // @PublicForExternalTesting
         return Purchases.isConfigured ? .init() : Self.notConfigured()
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -152,10 +152,11 @@ extension PurchaseHandler {
 
     @MainActor
     func purchase(package: Package) async throws -> PurchaseResultData {
-        if self.purchases.purchasesAreCompletedBy == .revenueCat {
-            return try await performPurchase(package: package)
-        } else {
-            return try await performExternalPurchaseLogic(package: package)
+        switch self.purchases.purchasesAreCompletedBy {
+        case .revenueCat:
+            try await performPurchase(package: package)
+        case .myApp:
+            try await performExternalPurchaseLogic(package: package)
         }
     }
 
@@ -227,10 +228,11 @@ extension PurchaseHandler {
     // MARK: - Restore
 
     func restorePurchases() async throws -> (info: CustomerInfo, success: Bool) {
-        if self.purchases.purchasesAreCompletedBy == .revenueCat {
-            return try await performRestorePurchases()
-        } else {
-            return try await performExternalRestoreLogic()
+        switch self.purchases.purchasesAreCompletedBy {
+        case .revenueCat:
+            try await performRestorePurchases()
+        case .myApp:
+            try await performExternalRestoreLogic()
         }
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -124,6 +124,7 @@ extension PurchaseHandler {
 
     @MainActor
     func performPurchase(package: Package) async throws -> PurchaseResultData {
+        Logger.debug(Strings.executing_purchase_logic)
         self.packageBeingPurchased = package
         self.purchaseResult = nil
         self.purchaseError = nil
@@ -210,6 +211,7 @@ extension PurchaseHandler {
     /// This allows the UI to display an alert before dismissing the paywall.
     @MainActor
     func performRestorePurchases() async throws -> (info: CustomerInfo, success: Bool) {
+        Logger.debug(Strings.executing_restore_logic)
         self.restoreInProgress = true
         self.restoredCustomerInfo = nil
         self.restoreError = nil
@@ -233,6 +235,8 @@ extension PurchaseHandler {
 
     @MainActor
     func performDeveloperRestoreLogic() async throws -> (info: CustomerInfo, success: Bool) {
+        Logger.debug(Strings.executing_external_restore_logic)
+
         self.restoreInProgress = true
         self.restoredCustomerInfo = nil
         self.restoreError = nil

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -132,6 +132,8 @@ final class PurchaseHandler: ObservableObject {
         self.purchases = purchases
     }
 
+    /// Returns a new instance of `PurchaseHandler` using `Purchases.shared` if `Purchases`
+    /// has been configured, and using a PurchaseHandler that cannot be used for purchases otherwise.
     public static func `default`() -> Self {
         return Purchases.isConfigured ? .init() : Self.notConfigured()
     }

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -74,10 +74,10 @@ final class PurchaseHandler: ObservableObject {
     fileprivate(set) var purchaseResult: PurchaseResultData?
 
     @Published
-    fileprivate(set) var handlePurchase: PerformPurchaseInfo?
+    fileprivate(set) var performPurchase: PerformPurchaseInfo?
 
     @Published
-    fileprivate(set) var handleRestore: PerformRestoreInfo?
+    fileprivate(set) var performRestore: PerformRestoreInfo?
 
     /// Whether a restore is currently in progress
     @Published
@@ -175,7 +175,7 @@ extension PurchaseHandler {
         self.packageBeingPurchased = package
         self.purchaseResult = nil
         self.purchaseError = nil
-        self.handlePurchase = PerformPurchaseInfo(storeProduct: package.storeProduct,
+        self.performPurchase = PerformPurchaseInfo(storeProduct: package.storeProduct,
                                                   reportPurchaseResult: self.completeExternalHandlePurchase)
 
         self.startAction()
@@ -186,7 +186,7 @@ extension PurchaseHandler {
     @MainActor
     func completeExternalHandlePurchase(_ userCancelled: Bool, _ error: Error?) {
         self.actionInProgress = false
-        self.handlePurchase = nil
+        self.performPurchase = nil
 
         if let error {
             self.purchaseError = error
@@ -251,7 +251,7 @@ extension PurchaseHandler {
         DispatchQueue.main.async {
             // this triggers the view's `.handleRestore` function, and its callback must be called
             // after the continuation is set below
-            self.handleRestore = PerformRestoreInfo(callback: self.completeExternalRestorePurchases)
+            self.performRestore = PerformRestoreInfo(callback: self.completeExternalRestorePurchases)
         }
 
         self.startAction()

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -185,7 +185,7 @@ extension PurchaseHandler {
         self.purchaseResult = nil
         self.purchaseError = nil
         self.performPurchase = PurchaseResultReporter(storeProduct: package.storeProduct,
-                                                   reportPurchaseResult: self.reportExternalPurchaseResult)
+                                                      reportPurchaseResult: self.reportExternalPurchaseResult)
 
         self.startAction()
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -27,17 +27,23 @@ class PerformPurchaseInfo: Equatable {
         self.reportPurchaseResultCallback = reportPurchaseResult
     }
 
-    public func reportResult(userCancelled: Bool, error: Error?) -> Void {
+    /// Use this method to report the result of the purchase.
+    /// - Parameters:
+    ///   - userCancelled: A boolean indicating whether the user cancelled the purchase.
+    ///   - error: An optional error object if an error occurred during the purchase.
+    public func reportResult(userCancelled: Bool, error: Error?) {
         reportPurchaseResultCallback(userCancelled, error)
     }
 
+    /// Checks whether two `PurchaseResultReporter` instances are equal.
+    /// They are considered equal if the object represents the same `StoreProduct`
     public static func == (lhs: PurchaseResultReporter, rhs: PurchaseResultReporter) -> Bool {
         return lhs.storeProduct == rhs.storeProduct
     }
 
 }
 
-
+/// A class that can be used to report the result of a restoring purchases.
 public class RestoreResultReporter: Equatable {
 
     let reportRestoreResultCallback: (_ success: Bool, _ error: Error?) -> Void
@@ -46,7 +52,11 @@ public class RestoreResultReporter: Equatable {
         self.reportRestoreResultCallback = callback
     }
 
-    public func reportResult(success: Bool, error: Error?) -> Void {
+    /// Use this method to report the result of a restore operation.
+    /// - Parameters:
+    ///   - success: A boolean indicating whether the restore operation was successful.
+    ///   - error: An optional error object if an error occurred during the restore operation.
+    public func reportResult(success: Bool, error: Error?) {
         reportRestoreResultCallback(success, error)
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -135,7 +135,7 @@ final class PurchaseHandler: ObservableObject {
 
     /// Returns a new instance of `PurchaseHandler` using `Purchases.shared` if `Purchases`
     /// has been configured, and using a PurchaseHandler that cannot be used for purchases otherwise.
-    public static func `default`() -> Self {
+    static func `default`() -> Self {
         return Purchases.isConfigured ? .init() : Self.notConfigured()
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -73,9 +73,11 @@ final class PurchaseHandler: ObservableObject {
     @Published
     fileprivate(set) var purchaseResult: PurchaseResultData?
 
+    /// Information used to perform a purchase in the app (rather than in RevenueCat)
     @Published
     fileprivate(set) var performPurchase: PerformPurchaseInfo?
 
+    /// Information used to perform restoring a purchase in the app (rather than in RevenueCat)
     @Published
     fileprivate(set) var performRestore: PerformRestoreInfo?
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -269,6 +269,11 @@ extension PurchaseHandler {
     func performExternalRestoreLogic() async throws -> (info: CustomerInfo, success: Bool) {
         Logger.debug(Strings.executing_external_restore_logic)
 
+        defer {
+            self.restoreInProgress = false
+            self.actionInProgress = false
+        }
+
         self.restoreInProgress = true
         self.restoredCustomerInfo = nil
         self.restoreError = nil
@@ -280,11 +285,6 @@ extension PurchaseHandler {
         }
 
         self.startAction()
-
-        defer {
-            self.restoreInProgress = false
-            self.actionInProgress = false
-        }
 
         let success = try await withCheckedThrowingContinuation { continuation in
             externalRestorePurchaseContinuation = continuation

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -17,7 +17,8 @@ import SwiftUI
 
 // swiftlint:disable file_length
 
-class PerformPurchaseInfo: Equatable {
+/// A class that can be used to report the result of a purchase.
+public class PurchaseResultReporter: Equatable {
 
     let storeProduct: StoreProduct
     let reportPurchaseResultCallback: (_ userCancelled: Bool, _ error: Error?) -> Void

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -17,7 +17,6 @@ import SwiftUI
 
 // swiftlint:disable file_length
 
-
 typealias HandlePurchaseData = (storeProduct: StoreProduct,
                                     callback: (_ userCancelled: Bool, _ error: Error?) -> Void)
 
@@ -29,7 +28,7 @@ class HandleRestoreCallbackContainer: Equatable {
             self.handleRestoreCallback = callback
         }
 
-    static func ==(lhs: HandleRestoreCallbackContainer, rhs: HandleRestoreCallbackContainer) -> Bool {
+    static func == (lhs: HandleRestoreCallbackContainer, rhs: HandleRestoreCallbackContainer) -> Bool {
         return lhs === rhs
     }
 
@@ -441,7 +440,6 @@ struct HandleRestorePreferenceKey: PreferenceKey {
     }
 
 }
-
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct PurchasedResultPreferenceKey: PreferenceKey {

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -20,7 +20,7 @@ import SwiftUI
 typealias HandlePurchaseData = (storeProduct: StoreProduct,
                                     callback: (_ userCancelled: Bool, _ error: Error?) -> Void)
 
-class HandleRestoreCallbackContainer: Equatable {
+class PerformRestoreInfo: Equatable {
 
     let handleRestoreCallback: (_ userCancelled: Bool, _ error: Error?) -> Void
 
@@ -28,7 +28,7 @@ class HandleRestoreCallbackContainer: Equatable {
         self.handleRestoreCallback = callback
     }
 
-    static func == (lhs: HandleRestoreCallbackContainer, rhs: HandleRestoreCallbackContainer) -> Bool {
+    static func == (lhs: PerformRestoreInfo, rhs: PerformRestoreInfo) -> Bool {
         return lhs === rhs
     }
 
@@ -63,7 +63,7 @@ final class PurchaseHandler: ObservableObject {
     fileprivate(set) var handlePurchase: HandlePurchaseData?
 
     @Published
-    fileprivate(set) var handleRestore: HandleRestoreCallbackContainer?
+    fileprivate(set) var handleRestore: PerformRestoreInfo?
 
     /// Whether a restore is currently in progress
     @Published
@@ -236,7 +236,7 @@ extension PurchaseHandler {
         DispatchQueue.main.async {
             // this triggers the view's `.handleRestore` function, and its callback must be called
             // after the continuation is set below
-            self.handleRestore = HandleRestoreCallbackContainer(callback: self.completeExternalRestorePurchases)
+            self.handleRestore = PerformRestoreInfo(callback: self.completeExternalRestorePurchases)
         }
 
         self.startAction()
@@ -437,9 +437,9 @@ struct HandlePurchasePreferenceKey: PreferenceKey {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct HandleRestorePreferenceKey: PreferenceKey {
 
-    static var defaultValue: HandleRestoreCallbackContainer?
+    static var defaultValue: PerformRestoreInfo?
 
-    static func reduce(value: inout HandleRestoreCallbackContainer?, nextValue: () -> HandleRestoreCallbackContainer?) {
+    static func reduce(value: inout PerformRestoreInfo?, nextValue: () -> PerformRestoreInfo?) {
         value = nextValue()
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -115,7 +115,7 @@ extension PurchaseHandler {
 
     @MainActor
     func purchase(package: Package) async throws -> PurchaseResultData {
-        if self.purchases.finishTransactions {
+        if self.purchases.purchasesAreCompletedBy {
             return try await performPurchase(package: package)
         } else {
             return try await performExternalPurchaseLogic(package: package)
@@ -189,7 +189,7 @@ extension PurchaseHandler {
     // MARK: - Restore
 
     func restorePurchases() async throws -> (info: CustomerInfo, success: Bool) {
-        if self.purchases.finishTransactions {
+        if self.purchases.purchasesAreCompletedBy {
             return try await performRestorePurchases()
         } else {
             return try await performExternalRestoreLogic()
@@ -352,7 +352,7 @@ private extension PurchaseHandler {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private final class NotConfiguredPurchases: PaywallPurchasesType {
 
-    var finishTransactions: Bool {
+    var purchasesAreCompletedBy: Bool {
         get { return false }
         set { _ = newValue }
     }

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -27,7 +27,7 @@ class PerformPurchaseInfo: Equatable {
         self.reportPurchaseResultCallback = reportPurchaseResult
     }
 
-    public func reportPurchaseResult(userCancelled: Bool, error: Error?) -> Void {
+    public func reportResult(userCancelled: Bool, error: Error?) -> Void {
         reportPurchaseResultCallback(userCancelled, error)
     }
 
@@ -46,7 +46,7 @@ public class RestoreResultReporter: Equatable {
         self.reportRestoreResultCallback = callback
     }
 
-    public func report(success: Bool, error: Error?) -> Void {
+    public func reportResult(success: Bool, error: Error?) -> Void {
         reportRestoreResultCallback(success, error)
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -155,9 +155,9 @@ extension PurchaseHandler {
     func purchase(package: Package) async throws -> PurchaseResultData {
         switch self.purchases.purchasesAreCompletedBy {
         case .revenueCat:
-            try await performPurchase(package: package)
+            return try await performPurchase(package: package)
         case .myApp:
-            try await performExternalPurchaseLogic(package: package)
+            return try await performExternalPurchaseLogic(package: package)
         }
     }
 
@@ -231,9 +231,9 @@ extension PurchaseHandler {
     func restorePurchases() async throws -> (info: CustomerInfo, success: Bool) {
         switch self.purchases.purchasesAreCompletedBy {
         case .revenueCat:
-            try await performRestorePurchases()
+            return try await performRestorePurchases()
         case .myApp:
-            try await performExternalRestoreLogic()
+            return try await performExternalRestoreLogic()
         }
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -272,7 +272,7 @@ extension PurchaseHandler {
         self.restoreError = nil
 
         DispatchQueue.main.async {
-            // this triggers the view's `.handleRestore` function, and its callback must be called
+            // this triggers the view's `.handlePurchaseAndRestore` function, and its callback must be called
             // after the continuation is set below
             self.performRestore = RestoreResultReporter(callback: self.reportExternalRestoreResult)
         }

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -382,7 +382,9 @@ private struct PaywallContainerView: View {
     let onSizeChange: (CGSize) -> Void
 
     var body: some View {
-        PaywallView(configuration: self.configuration)
+        PaywallView(configuration: self.configuration,
+        performPurchase: nil,
+        performRestore: nil)
             .onPurchaseStarted(self.purchaseStarted)
             .onPurchaseCompleted(self.purchaseCompleted)
             .onPurchaseCancelled(self.purchaseCancelled)

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -413,7 +413,8 @@ private struct PresentingPaywallModifier: ViewModifier {
         self.fontProvider = fontProvider
         self.customerInfoFetcher = customerInfoFetcher
         self.introEligibility = introEligibility
-        self._purchaseHandler = .init(wrappedValue: purchaseHandler ?? .default())
+        // TODO: support initializer based purchase actions from `presentPaywallIfNeeded`
+        self._purchaseHandler = .init(wrappedValue: purchaseHandler ?? .default(performPurchase: nil, performRestore: nil))
     }
 
     @StateObject
@@ -461,7 +462,9 @@ private struct PresentingPaywallModifier: ViewModifier {
                 displayCloseButton: true,
                 introEligibility: self.introEligibility,
                 purchaseHandler: self.purchaseHandler
-            )
+            ),
+            performPurchase: nil,
+            performRestore: nil // TODO support this?
         )
         .onPurchaseStarted {
             self.purchaseStarted?($0)

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -238,7 +238,9 @@ private struct PresentingPaywallFooterModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .safeAreaInset(edge: .bottom) {
-                PaywallView(configuration: self.configuration)
+                PaywallView(configuration: self.configuration,
+                performPurchase: nil,
+                performRestore: nil) // TODO support footer view
                     .onPurchaseStarted {
                         self.purchaseStarted?($0)
                     }

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -292,7 +292,7 @@ extension View {
     /// RevenueCat for experiments and growth tools only.
     ///
     /// After executing your StoreKit purchae code, you **must** communicate the result of your purchase
-    /// code by calling `reportPurchaseResult` and `reportRestoreResult` when your code
+    /// code by calling `reportResult`on the passed result reporter object when your code
     /// has finished executing. Failure to do so will result in undefined behavior.
     ///
     /// Example:

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -296,7 +296,7 @@ extension View {
     /// confiugured with `finishTransactions` set to `false`. This is typically used
     /// when migrating from a direct StoreKit implementation to RevenueCat in stages.
     ///
-    /// After executing your StoreKit purchaecode, you must call `purchaseCompletedHandler`
+    /// After executing your StoreKit purchae code, you must call `purchaseCompletedHandler`
     /// for accurate statistics.
     ///
     /// Example:
@@ -318,6 +318,26 @@ extension View {
         return self.modifier(HandlePurchaseModifier(handler: handler))
     }
 
+    /// Use this method if you wish to execute your own StoreKit restore purchases logic,
+    /// skipping RevenueCat's. This method is **only** called if `Purchases` is
+    /// confiugured with `finishTransactions` set to `false`. This is typically used
+    /// when migrating from a direct StoreKit implementation to RevenueCat in stages.
+    ///
+    /// After executing your StoreKit purchae code, you must call `purchaseRestoreHandler`.
+    ///
+    /// Example:
+    /// ```swift
+    ///  PaywallView()
+    ///     .handleRestore { purchaseRestoreHandler in
+    ///        var success: Bool = false
+    ///        var error: Error? = nil
+    ///
+    ///        // Manually call StoreKit purchasing logic
+    ///        // and update success and error
+    ///
+    ///        purchaseRestoreHandler(success, error)
+    ///     }
+    /// ```
     public func handleRestore(
         _ handler: @escaping HandleRestoreHandler
     ) -> some View {

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -39,8 +39,7 @@ public typealias PurchaseOfPackageStartedHandler = @MainActor @Sendable (_ packa
 /// A closure used for notifying of purchase cancellation.
 public typealias PurchaseCancelledHandler = @MainActor @Sendable () -> Void
 
-
-/// A closure used for notifying of purchase initiation is requred.
+/// A closure used for notifying that custom purchase logic has completed.
 public typealias HandlePurchaseHandler = @MainActor @Sendable (
     _ storeProduct: StoreProduct,
     _ purchaseCompletedHandler: @escaping (
@@ -49,6 +48,7 @@ public typealias HandlePurchaseHandler = @MainActor @Sendable (
     ) -> Void
 ) -> Void
 
+/// A closure used for notifying that custom restore logic has completed.
 public typealias HandleRestoreHandler = @MainActor @Sendable (
     _ purchaseRestoreHandler: @escaping (
         _ success: Bool,

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -410,10 +410,6 @@ private struct HandleRestoreModifier: ViewModifier {
 
     let handler: HandleRestoreHandler
 
-    init(handler: @escaping HandleRestoreHandler) {
-        self.handler = handler
-    }
-
     func body(content: Content) -> some View {
         content
             .onPreferenceChange(HandleRestorePreferenceKey.self) { result in

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -423,6 +423,9 @@ private struct HandleRestoreModifier: ViewModifier {
             .onPreferenceChange(HandleRestorePreferenceKey.self) { restoreResultReporter in
                 if let restoreResultReporter {
                     self.handler(restoreResultReporter)
+                } else {
+                    Logger.error("Change to `HandleRestorePreferenceKey` with a value of `nil` means " +
+                                 "the performPurchase modifier cannot be called.")
                 }
             }
     }

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -294,8 +294,8 @@ extension View {
     /// Use this method if you wish to execute your own StoreKit purchase and restore logic,
     /// skipping RevenueCat's. This method is **only** called if `Purchases` is
     /// confiugured with `purchasesAreCompletedBy` set to `.myApp`. This is typically used
-    /// when migrating from a direct StoreKit implementation to RevenueCat in stages, or when using
-    /// RevenueCat for experiments and growth tools.
+    /// when migrating from a direct StoreKit implementation to RevenueCat in stages, or if integrating
+    /// RevenueCat for experiments and growth tools only.
     ///
     /// After executing your StoreKit purchae code, you **must** communicate the result of your purchase
     /// code by calling `reportPurchaseResult` and `reportRestoreResult` when your code

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -293,7 +293,7 @@ extension View {
 
     /// Use this method if you wish to execute your own StoreKit purchase logic,
     /// skipping RevenueCat's. This method is **only** called if `Purchases` is
-    /// confiugured with `finishTransactions` set to `false`. This is typically used
+    /// confiugured with `purchasesAreCompletedBy` set to `.myApp`. This is typically used
     /// when migrating from a direct StoreKit implementation to RevenueCat in stages.
     ///
     /// After executing your StoreKit purchae code, you must call `purchaseCompletedHandler`
@@ -320,7 +320,7 @@ extension View {
 
     /// Use this method if you wish to execute your own StoreKit restore purchases logic,
     /// skipping RevenueCat's. This method is **only** called if `Purchases` is
-    /// confiugured with `finishTransactions` set to `false`. This is typically used
+    /// confiugured with `purchasesAreCompletedBy` set to `.myApp`. This is typically used
     /// when migrating from a direct StoreKit implementation to RevenueCat in stages.
     ///
     /// After executing your StoreKit purchae code, you must call `purchaseRestoreHandler`.

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -51,7 +51,7 @@ public typealias HandlePurchaseHandler = @MainActor @Sendable (
 
 public typealias HandleRestoreHandler = @MainActor @Sendable (
     _ purchaseRestoreHandler: @escaping (
-        _ userCancelled: Bool,
+        _ success: Bool,
         _ error: Error?
     ) -> Void
 ) -> Void

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -299,21 +299,17 @@ extension View {
     /// ```swift
     /// PaywallView()
     ///     .handlePurchaseAndRestore(
-    ///         performPurchase: { storeProduct, reportPurchaseResult in
-    ///             var userDidCancel = false
-    ///             var error: Error?
+    ///         performPurchase: { storeProduct, purchaseResultReporter in
+    ///             // make purchase for `storeProduct`
     ///
-    ///             // your app's purchase logic
+    ///             // report result to RevenueCat
+    ///             purchaseResultReporter.reportResult(userCancelled: false, error: nil)
+    ///     }, performRestore: { restoreResultReporter in
+    ///             // restore purchases
     ///
-    ///             reportPurchaseResult(userDidCancel, error)
-    ///         }, performRestore: { reportRestoreResult in
-    ///             var success = false
-    ///             var error: Error?
-    ///
-    ///             // your app's restore logic
-    ///
-    ///             reportRestoreResult(success, error)
-    ///         })
+    ///             // report result to RevenueCat
+    ///             restoreResultReporter.reportResult(success: true, error: nil)
+    ///     })
     /// ```
     ///
     public func handlePurchaseAndRestore(

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -50,7 +50,7 @@ public typealias HandlePurchaseHandler = @MainActor @Sendable (
 
 /// A closure used for notifying that custom restore logic has completed.
 public typealias HandleRestoreHandler = @MainActor @Sendable (
-    _ purchaseRestoreHandler: @escaping (
+    _ restorePurchasesCompletedHandler: @escaping (
         _ success: Bool,
         _ error: Error?
     ) -> Void
@@ -335,10 +335,10 @@ extension View {
     ///        // Manually call StoreKit purchasing logic
     ///        // and update success and error
     ///
-    ///        purchaseRestoreHandler(success, error)
+    ///        restorePurchasesCompletedHandler(success, error)
     ///     }
     /// ```
-    public func handleRestore(
+    public func handleRestorePurchases(
         _ handler: @escaping HandleRestoreHandler
     ) -> some View {
         return self.modifier(HandleRestoreModifier(handler: handler))
@@ -410,10 +410,6 @@ private struct HandlePurchaseModifier: ViewModifier {
 
     let handler: HandlePurchaseHandler
 
-    init(handler: @escaping HandlePurchaseHandler) {
-        self.handler = handler
-    }
-
     func body(content: Content) -> some View {
         content
             .onPreferenceChange(HandlePurchasePreferenceKey.self) { data in
@@ -432,8 +428,8 @@ private struct HandleRestoreModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onPreferenceChange(HandleRestorePreferenceKey.self) { result in
-                if let callback = result?.handleRestoreCallback {
+            .onPreferenceChange(HandleRestorePreferenceKey.self) { callbackContainer in
+                if let callback = callbackContainer?.handleRestoreCallback {
                     self.handler(callback)
                 }
             }

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -404,9 +404,9 @@ private struct HandlePurchaseModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onPreferenceChange(HandlePurchasePreferenceKey.self) { performPurchaseInfo in
-                if let performPurchaseInfo {
-                    self.handler(performPurchaseInfo.storeProduct, performPurchaseInfo)
+            .onPreferenceChange(HandlePurchasePreferenceKey.self) { purchaseResultReporter in
+                if let purchaseResultReporter {
+                    self.handler(purchaseResultReporter.storeProduct, purchaseResultReporter)
                 }
             }
     }
@@ -420,9 +420,9 @@ private struct HandleRestoreModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onPreferenceChange(HandleRestorePreferenceKey.self) { performRestoreInfo in
-                if let performRestoreInfo {
-                    self.handler(performRestoreInfo)
+            .onPreferenceChange(HandleRestorePreferenceKey.self) { restoreResultReporter in
+                if let restoreResultReporter {
+                    self.handler(restoreResultReporter)
                 }
             }
     }

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -41,15 +41,13 @@ public typealias PurchaseCancelledHandler = @MainActor @Sendable () -> Void
 
 /// A closure used for notifying that custom purchase logic has completed.
 public typealias PerformPurchase = @MainActor @Sendable (
-    _ reportPurchaseResult: PerformPurchaseInfo
+    _ storeProduct: StoreProduct,
+    _ purchaseResultReporter: PurchaseResultReporter
 ) -> Void
 
 /// A closure used for notifying that custom restore logic has completed.
 public typealias PerformRestore = @MainActor @Sendable (
-    _ reportRestoreResult: @escaping (
-        _ success: Bool,
-        _ error: Error?
-    ) -> Void
+    _ restoreResultReporter: RestoreResultReporter
 ) -> Void
 
 /// A closure used for notifying of failures during purchases or restores.
@@ -412,7 +410,7 @@ private struct HandlePurchaseModifier: ViewModifier {
         content
             .onPreferenceChange(HandlePurchasePreferenceKey.self) { performPurchaseInfo in
                 if let performPurchaseInfo {
-                    self.handler(performPurchaseInfo)
+                    self.handler(performPurchaseInfo.storeProduct, performPurchaseInfo)
                 }
             }
     }
@@ -426,9 +424,9 @@ private struct HandleRestoreModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onPreferenceChange(HandleRestorePreferenceKey.self) { callbackContainer in
-                if let callback = callbackContainer?.handleRestoreCallback {
-                    self.handler(callback)
+            .onPreferenceChange(HandleRestorePreferenceKey.self) { performRestoreInfo in
+                if let performRestoreInfo {
+                    self.handler(performRestoreInfo)
                 }
             }
     }

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -41,11 +41,7 @@ public typealias PurchaseCancelledHandler = @MainActor @Sendable () -> Void
 
 /// A closure used for notifying that custom purchase logic has completed.
 public typealias PerformPurchase = @MainActor @Sendable (
-    _ storeProduct: StoreProduct,
-    _ reportPurchaseResult: @escaping (
-        _ userCancelled: Bool,
-        _ error: Error?
-    ) -> Void
+    _ reportPurchaseResult: PerformPurchaseInfo
 ) -> Void
 
 /// A closure used for notifying that custom restore logic has completed.
@@ -414,9 +410,9 @@ private struct HandlePurchaseModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onPreferenceChange(HandlePurchasePreferenceKey.self) { data in
-                if let storeProduct = data?.storeProduct, let callback = data?.reportPurchaseResult {
-                    self.handler(storeProduct, callback)
+            .onPreferenceChange(HandlePurchasePreferenceKey.self) { performPurchaseInfo in
+                if let performPurchaseInfo {
+                    self.handler(performPurchaseInfo)
                 }
             }
     }

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -415,7 +415,7 @@ private struct HandlePurchaseModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .onPreferenceChange(HandlePurchasePreferenceKey.self) { data in
-                if let storeProduct = data?.storeProduct, let callback = data?.callback {
+                if let storeProduct = data?.storeProduct, let callback = data?.reportPurchaseResult {
                     self.handler(storeProduct, callback)
                 }
             }

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -144,8 +144,8 @@ private extension LoadingPaywallView {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 private final class LoadingPaywallPurchases: PaywallPurchasesType {
 
-    var purchasesAreCompletedBy: Bool {
-        get { return false }
+    var purchasesAreCompletedBy: PurchasesAreCompletedBy {
+        get { return .myApp }
         set { _ = newValue }
     }
 

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -144,7 +144,7 @@ private extension LoadingPaywallView {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 private final class LoadingPaywallPurchases: PaywallPurchasesType {
 
-    var finishTransactions: Bool {
+    var purchasesAreCompletedBy: Bool {
         get { return false }
         set { _ = newValue }
     }

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -160,8 +160,8 @@ import Foundation
         }
         /**
          * Set `purchasesAreCompletedBy`.
-         * - Parameter purchasesAreCompletedBy: Set this to `.myApp` if you have your own IAP implementation and want to use only
-         * RevenueCat's backend. Default is `.revenueCat`.
+         * - Parameter purchasesAreCompletedBy: Set this to `.myApp` if you have your own IAP implementation and
+         * want to use only RevenueCat's backend. Default is `.revenueCat`.
          *
          * - Warning: This assumes your IAP implementation uses StoreKit 1.
          * `.myApp` is not compatible with StoreKit 2.

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -86,7 +86,15 @@ import Foundation
 
         private(set) var apiKey: String
         private(set) var appUserID: String?
-        private(set) var observerMode: Bool = false
+        var observerMode: Bool {
+            switch purchasesAreCompletedBy {
+            case .revenueCat:
+                false
+            case .myApp:
+                true
+            }
+        }
+        private(set) var purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat
         private(set) var userDefaults: UserDefaults?
         private(set) var dangerousSettings: DangerousSettings?
         private(set) var networkTimeout = Configuration.networkTimeoutDefault
@@ -143,12 +151,26 @@ import Foundation
          * RevenueCat's backend. Default is `false`.
          *
          * - Warning: This assumes your IAP implementation uses StoreKit 1.
-         * Observer mode is not compatible with StoreKit 2.
+         * `.myApp` is not compatible with StoreKit 2.
          */
+        @available(*, deprecated, message: "Use with(purchasesAreCompletedBy:) instead.")
         @objc public func with(observerMode: Bool) -> Configuration.Builder {
-            self.observerMode = observerMode
+            self.purchasesAreCompletedBy = observerMode ? .myApp : .revenueCat
             return self
         }
+        /**
+         * Set `purchasesAreCompletedBy`.
+         * - Parameter purchasesAreCompletedBy: Set this to `.myApp` if you have your own IAP implementation and want to use only
+         * RevenueCat's backend. Default is `.revenueCat`.
+         *
+         * - Warning: This assumes your IAP implementation uses StoreKit 1.
+         * `.myApp` is not compatible with StoreKit 2.
+         */
+        @objc public func with(purchasesAreCompletedBy: PurchasesAreCompletedBy) -> Configuration.Builder {
+            self.purchasesAreCompletedBy = purchasesAreCompletedBy
+            return self
+        }
+
         /**
          * Set `userDefaults`.
          * - Parameter userDefaults: Custom `UserDefaults` to use

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -89,9 +89,9 @@ import Foundation
         var observerMode: Bool {
             switch purchasesAreCompletedBy {
             case .revenueCat:
-                false
+                return false
             case .myApp:
-                true
+                return true
             }
         }
         private(set) var purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1231,7 +1231,7 @@ public extension Purchases {
      * ```swift
      *  Purchases.configure(
      *      with: Configuration.Builder(withAPIKey: Constants.apiKey)
-     *               .with(observerMode: false)
+     *               .with(purchasesAreCompletedBy: .revenueCat)
      *               .with(appUserID: "<app_user_id>")
      *               .build()
      *      )
@@ -1272,7 +1272,7 @@ public extension Purchases {
      * ```swift
      *  Purchases.configure(
      *      with: .init(withAPIKey: Constants.apiKey)
-     *               .with(observerMode: false)
+     *               .with(purchasesAreCompletedBy: .revenueCat)
      *               .with(appUserID: "<app_user_id>")
      *      )
      * ```
@@ -1325,7 +1325,7 @@ public extension Purchases {
     @_disfavoredOverload
     @objc(configureWithAPIKey:appUserID:)
     @discardableResult static func configure(withAPIKey apiKey: String, appUserID: String?) -> Purchases {
-        Self.configure(withAPIKey: apiKey, appUserID: appUserID, observerMode: false)
+        Self.configure(withAPIKey: apiKey, appUserID: appUserID, purchasesAreCompletedBy: .revenueCat)
     }
 
     @available(*, deprecated, message: """
@@ -1362,18 +1362,58 @@ public extension Purchases {
      * Observer mode is not compatible with StoreKit 2.
      */
     @_disfavoredOverload
+    @available(*, deprecated, message: "Use configure(withAPIKey:appUserID:purchasesAreCompletedBy:) instead.")
     @objc(configureWithAPIKey:appUserID:observerMode:)
     @discardableResult static func configure(withAPIKey apiKey: String,
                                              appUserID: String?,
                                              observerMode: Bool) -> Purchases {
+        let purchasesBy: PurchasesAreCompletedBy = observerMode ? .myApp : .revenueCat
+
+        return Self.configure(
+            with: Configuration
+                .builder(withAPIKey: apiKey)
+                .with(appUserID: appUserID)
+                .with(purchasesAreCompletedBy: purchasesBy)
+                .build()
+        )
+    }
+
+    /**
+     * Configures an instance of the Purchases SDK with a custom `UserDefaults`.
+     *
+     * Use this constructor if you want to
+     * sync status across a shared container, such as between a host app and an extension. The instance of the
+     * Purchases SDK will be set as a singleton.
+     * You should access the singleton instance using ``Purchases/shared``
+     *
+     * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
+     *
+     * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
+     * purchases and subscriptions across devices. Pass `nil` or an empty string if you want ``Purchases``
+     * to generate this for you.
+     *
+     * - Parameter purchasesAreCompletedBy: Set this to `.myApp` if you have your own IAP implementation and want to use only
+     * RevenueCat's backend. Default is `.revenueCat`.
+     *
+     * - Returns: An instantiated ``Purchases`` object that has been set as a singleton.
+     *
+     * - Warning: This assumes your IAP implementation uses StoreKit 1.
+     * Observer mode is not compatible with StoreKit 2.
+     */
+    @_disfavoredOverload
+    @objc(configureWithAPIKey:appUserID:purchasesAreCompletedBy:)
+    @discardableResult static func configure(withAPIKey apiKey: String,
+                                             appUserID: String?,
+                                             purchasesAreCompletedBy: PurchasesAreCompletedBy) -> Purchases {
         Self.configure(
             with: Configuration
                 .builder(withAPIKey: apiKey)
                 .with(appUserID: appUserID)
-                .with(observerMode: observerMode)
+                .with(purchasesAreCompletedBy: purchasesAreCompletedBy)
                 .build()
         )
     }
+
 
     @available(*, deprecated, message: """
     The appUserID passed to logIn is a constant string known at compile time.
@@ -1385,11 +1425,13 @@ public extension Purchases {
                                              appUserID: StaticString,
                                              observerMode: Bool) -> Purchases {
         Logger.warn(Strings.identity.logging_in_with_static_string)
+        let purchasesBy: PurchasesAreCompletedBy = observerMode ? .myApp : .revenueCat
+
         return Self.configure(
             with: Configuration
                 .builder(withAPIKey: apiKey)
                 .with(appUserID: "\(appUserID)")
-                .with(observerMode: observerMode)
+                .with(purchasesAreCompletedBy: purchasesBy)
                 .build()
         )
     }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1392,8 +1392,8 @@ public extension Purchases {
      * purchases and subscriptions across devices. Pass `nil` or an empty string if you want ``Purchases``
      * to generate this for you.
      *
-     * - Parameter purchasesAreCompletedBy: Set this to `.myApp` if you have your own IAP implementation and want to use only
-     * RevenueCat's backend. Default is `.revenueCat`.
+     * - Parameter purchasesAreCompletedBy: Set this to `.myApp` if you have your own IAP implementation
+     * and want to use only RevenueCat's backend. Default is `.revenueCat`.
      *
      * - Returns: An instantiated ``Purchases`` object that has been set as a singleton.
      *
@@ -1413,7 +1413,6 @@ public extension Purchases {
                 .build()
         )
     }
-
 
     @available(*, deprecated, message: """
     The appUserID passed to logIn is a constant string known at compile time.

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -229,7 +229,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     @objc public let attribution: Attribution
 
 
-    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead")
+    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
     @objc public var finishTransactions: Bool {
         get { self.systemInfo.finishTransactions }
         set { self.systemInfo.finishTransactions = newValue }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -228,7 +228,14 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     @objc public let attribution: Attribution
 
+
+    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead")
     @objc public var finishTransactions: Bool {
+        get { self.systemInfo.finishTransactions }
+        set { self.systemInfo.finishTransactions = newValue }
+    }
+
+    @objc public var purchasesAreCompletedBy: Bool {
         get { self.systemInfo.finishTransactions }
         set { self.systemInfo.finishTransactions = newValue }
     }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -228,7 +228,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     @objc public let attribution: Attribution
 
-
     @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
     @objc public var finishTransactions: Bool {
         get { self.systemInfo.finishTransactions }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -235,9 +235,9 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         set { self.systemInfo.finishTransactions = newValue }
     }
 
-    @objc public var purchasesAreCompletedBy: Bool {
-        get { self.systemInfo.finishTransactions }
-        set { self.systemInfo.finishTransactions = newValue }
+    @objc public var purchasesAreCompletedBy: PurchasesAreCompletedBy {
+        get { self.systemInfo.finishTransactions ? .revenueCat : .myApp }
+        set { self.systemInfo.finishTransactions = (newValue == .revenueCat ? true : false) }
     }
 
     private let attributionFetcher: AttributionFetcher

--- a/Sources/Purchasing/Purchases/PurchasesAreCompletedBy.swift
+++ b/Sources/Purchasing/Purchases/PurchasesAreCompletedBy.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesAreCompletedBy.swift
+//
+//  Created by James Borthwick on 2024-05-30.
+
+import Foundation
+
+/// Where responsibility for completing purchase transactions lies.
+@objc(RCPurchasesAreCompletedBy)
+public enum PurchasesAreCompletedBy: Int {
+
+    /// Purchase transactions are to be finished by RevenueCat.
+    case revenueCat
+
+    /// Purchase transactions are to be finished by the app.
+    case myApp
+
+}
+
+extension PurchasesAreCompletedBy: Sendable {}

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -40,7 +40,7 @@ public protocol PurchasesType: AnyObject {
     @available(*, deprecated, message: "Use purchasesAreCompletedBy instead")
     var finishTransactions: Bool { get set }
 
-    var purchasesAreCompletedBy: Bool { get set }
+    var purchasesAreCompletedBy: PurchasesAreCompletedBy { get set }
 
     /**
      * Delegate for ``Purchases`` instance. The delegate is responsible for handling promotional product purchases and

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -41,9 +41,9 @@ public protocol PurchasesType: AnyObject {
     var finishTransactions: Bool { get set }
 
     /** Whether transactions should be finished automatically. `.revenueCat` by default.
-     * - Warning: Setting this value to `.myApp` will prevent the SDK from finishing transactions.
-     * In this case, you *must* finish transactions in your app, otherwise they will remain in the queue and
-     * will turn up every time the app is opened.
+     * - Warning: Setting this value to `.myApp` will prevent the SDK from making purchaes and finishing transactions.
+     * In this case, you *must* perform all of this logic in your app. If using a `PaywallView`, use the modifier
+     * `.handlePurchaseAndRestore`.
      * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
      */
     var purchasesAreCompletedBy: PurchasesAreCompletedBy { get set }

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -37,7 +37,10 @@ public protocol PurchasesType: AnyObject {
      * will turn up every time the app is opened.
      * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
      */
+    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead")
     var finishTransactions: Bool { get set }
+
+    var purchasesAreCompletedBy: Bool { get set }
 
     /**
      * Delegate for ``Purchases`` instance. The delegate is responsible for handling promotional product purchases and

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -37,9 +37,15 @@ public protocol PurchasesType: AnyObject {
      * will turn up every time the app is opened.
      * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
      */
-    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead")
+    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
     var finishTransactions: Bool { get set }
 
+    /** Whether transactions should be finished automatically. `.revenueCat` by default.
+     * - Warning: Setting this value to `.myApp` will prevent the SDK from finishing transactions.
+     * In this case, you *must* finish transactions in your app, otherwise they will remain in the queue and
+     * will turn up every time the app is opened.
+     * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
+     */
     var purchasesAreCompletedBy: PurchasesAreCompletedBy { get set }
 
     /**

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -40,7 +40,8 @@ public protocol PurchasesType: AnyObject {
     @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
     var finishTransactions: Bool { get set }
 
-    /** Whether purchaess should be made and transactions finished automatically by RevenueCat. `.revenueCat` by default.
+    /** Controls if purchaess should be made and transactions finished automatically by RevenueCat.
+     * `.revenueCat` by default.
      * - Warning: Setting this value to `.myApp` will prevent the SDK from making purchaes and finishing transactions.
      * In this case, you *must* perform all of this logic in your app. If using a `PaywallView`, use the modifier
      * `.handlePurchaseAndRestore`.

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -40,7 +40,7 @@ public protocol PurchasesType: AnyObject {
     @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
     var finishTransactions: Bool { get set }
 
-    /** Whether transactions should be finished automatically. `.revenueCat` by default.
+    /** Whether purchaess should be made and transactions finished automatically by RevenueCat. `.revenueCat` by default.
      * - Warning: Setting this value to `.myApp` will prevent the SDK from making purchaes and finishing transactions.
      * In this case, you *must* perform all of this logic in your app. If using a `PaywallView`, use the modifier
      * `.handlePurchaseAndRestore`.

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
@@ -13,7 +13,7 @@ func checkConfigurationAPI() {
         .builder(withAPIKey: "")
         .with(apiKey: "")
         .with(appUserID: nil)
-        .with(observerMode: false)
+        .with(purchasesAreCompletedBy: .myApp)
         .with(userDefaults: UserDefaults.standard)
         .with(dangerousSettings: DangerousSettings())
         .with(dangerousSettings: DangerousSettings(autoSyncPurchases: true))

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -19,12 +19,12 @@ func checkPurchasesAPI() {
     let purch = checkConfigure()!
 
     // initializers
-    let finishTransactions: Bool = purch.finishTransactions
+    let purchasesAreCompletedBy: PurchasesAreCompletedBy = purch.purchasesAreCompletedBy
     let delegate: PurchasesDelegate? = purch.delegate
     let appUserID: String = purch.appUserID
     let isAnonymous: Bool = purch.isAnonymous
 
-    print(finishTransactions, delegate!, appUserID, isAnonymous)
+    print(purchasesAreCompletedBy, delegate!, appUserID, isAnonymous)
 
     checkStaticMethods()
     checkIdentity(purchases: purch)

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
@@ -14,7 +14,7 @@
 + (void)checkAPI {
     RCConfigurationBuilder *builder = [RCConfiguration builderWithAPIKey:@""];
     RCConfiguration *config __unused = [[[[[[[[[[[builder withApiKey:@""]
-                                                 withObserverMode:false]
+                                                 withPurchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat]
                                                 withUserDefaults:NSUserDefaults.standardUserDefaults]
                                                withAppUserID:@""]
                                               withAppUserID:nil]
@@ -24,6 +24,8 @@
                                           withPlatformInfo:[[RCPlatformInfo alloc] initWithFlavor:@"" version:@""]]
                                          withUsesStoreKit2IfAvailable:false]
                                         build];
+
+    RCConfiguration *configDeprecated __unused = [[[builder withApiKey:@""] withObserverMode:true] build];
 
     if (@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)) {
         RCConfiguration *config __unused = [[builder

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -25,6 +25,7 @@ RCPurchases *sharedPurchases;
 BOOL isConfigured;
 BOOL allowSharingAppStoreAccount;
 BOOL finishTransactions;
+RCPurchasesAreCompletedBy purchasesAreCompletedBy;
 id<RCPurchasesDelegate> delegate;
 NSString *appUserID;
 BOOL isAnonymous;
@@ -41,6 +42,10 @@ BOOL isAnonymous;
     [RCPurchases configureWithAPIKey:@"" appUserID:nil observerMode:false userDefaults:nil];
     [RCPurchases configureWithAPIKey:@"" appUserID:@"" observerMode:false userDefaults:[[NSUserDefaults alloc] init]];
     [RCPurchases configureWithAPIKey:@"" appUserID:nil observerMode:false userDefaults:[[NSUserDefaults alloc] init]];
+    [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat];
+    [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat];
+    [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByMyApp];
+    [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:RCPurchasesAreCompletedByMyApp];
     [RCPurchases configureWithAPIKey:@""
                            appUserID:nil
                         observerMode:false
@@ -96,6 +101,8 @@ BOOL isAnonymous;
     allowSharingAppStoreAccount = [p allowSharingAppStoreAccount];
 
     finishTransactions = [p finishTransactions];
+    purchasesAreCompletedBy = [p purchasesAreCompletedBy];
+
     delegate = [p delegate];
     appUserID = [p appUserID];
     isAnonymous = [p isAnonymous];
@@ -232,7 +239,7 @@ BOOL isAnonymous;
         case RCLogLevelInfo:
         case RCLogLevelWarn:
         case RCLogLevelError:
-            NSLog(@"%ld", (long)o);
+            NSLog(@"%ld", (long)l);
     }
 
     RCStoreMessageType smt = RCStoreMessageTypeBillingIssue;
@@ -240,7 +247,14 @@ BOOL isAnonymous;
         case RCStoreMessageTypeBillingIssue:
         case RCStoreMessageTypePriceIncreaseConsent:
         case RCStoreMessageTypeGeneric:
-            NSLog(@"%ld", (long)o);
+            NSLog(@"%ld", (long)smt);
+    }
+
+    RCPurchasesAreCompletedBy pacb = RCPurchasesAreCompletedByRevenueCat;
+    switch(pacb) {
+        case RCPurchasesAreCompletedByMyApp:
+        case RCPurchasesAreCompletedByRevenueCat:
+            NSLog(@"%ld", (long)pacb);
     }
 }
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
@@ -13,7 +13,7 @@ func checkConfigurationAPI() {
         .builder(withAPIKey: "")
         .with(apiKey: "")
         .with(appUserID: nil)
-        .with(observerMode: true)
+        .with(purchasesAreCompletedBy: .myApp)
         .with(userDefaults: UserDefaults.standard)
         .with(dangerousSettings: DangerousSettings())
         .with(dangerousSettings: DangerousSettings(autoSyncPurchases: true))

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -306,7 +306,7 @@ private func checkConfigure() -> Purchases! {
 
     Purchases.configure(withAPIKey: "")
     Purchases.configure(withAPIKey: "", appUserID: nil)
-    Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true)
+    Purchases.configure(withAPIKey: "", appUserID: nil, purchasesAreCompletedBy: .myApp)
 
     return nil
 }
@@ -339,6 +339,7 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
     Purchases.addAttributionData([String: Any](), from: AttributionNetwork.adjust, forNetworkUserId: nil)
     let _: Bool = Purchases.automaticAppleSearchAdsAttributionCollection
     Purchases.automaticAppleSearchAdsAttributionCollection = false
+    purchases.finishTransactions = true
 
     purchases.checkTrialOrIntroDiscountEligibility([String]()) { (_: [String: IntroEligibility]) in }
 
@@ -350,6 +351,7 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
     Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true, userDefaults: UserDefaults())
     Purchases.configure(withAPIKey: "", appUserID: "")
     Purchases.configure(withAPIKey: "", appUserID: "", observerMode: false)
+    Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true)
     Purchases.configure(withAPIKey: "",
                         appUserID: nil,
                         observerMode: true,
@@ -373,4 +375,9 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
                         userDefaults: UserDefaults(),
                         useStoreKit2IfAvailable: true,
                         dangerousSettings: DangerousSettings(autoSyncPurchases: false))
+
+    _ = Configuration
+        .builder(withAPIKey: "")
+        .with(observerMode: true)
+
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -19,12 +19,12 @@ func checkPurchasesAPI() {
     let purch = checkConfigure()!
 
     // initializers
-    let finishTransactions: Bool = purch.finishTransactions
+    let purchasesAreCompletedBy: Bool = purch.purchasesAreCompletedBy
     let delegate: PurchasesDelegate? = purch.delegate
     let appUserID: String = purch.appUserID
     let isAnonymous: Bool = purch.isAnonymous
 
-    print(finishTransactions, delegate!, appUserID, isAnonymous)
+    print(purchasesAreCompletedBy, delegate!, appUserID, isAnonymous)
 
     checkStaticMethods()
     checkIdentity(purchases: purch)

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -19,7 +19,7 @@ func checkPurchasesAPI() {
     let purch = checkConfigure()!
 
     // initializers
-    let purchasesAreCompletedBy: Bool = purch.purchasesAreCompletedBy
+    let purchasesAreCompletedBy: PurchasesAreCompletedBy = purch.purchasesAreCompletedBy
     let delegate: PurchasesDelegate? = purch.delegate
     let appUserID: String = purch.appUserID
     let isAnonymous: Bool = purch.isAnonymous

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -200,7 +200,7 @@ class PurchaseCompletedHandlerTests: TestCase {
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.externalPurchaseHandler
         )
-        .handlePurchase { storeProduct, purchaseCompletedHandler in
+        .handlePurchase { _, purchaseCompletedHandler in
             purchaseCompletedHandler(false, nil)
             customPurchaseCodeExecuted = true
         }

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -190,7 +190,7 @@ class PurchaseCompletedHandlerTests: TestCase {
         expect(error).toEventually(matchError(Self.failureError))
     }
 
-    func testHandleExternalPurchase() throws {
+    func testHandleExternalPurchaseAndRestore() throws {
         var completed = false
         var customPurchaseCodeExecuted = false
 
@@ -200,10 +200,12 @@ class PurchaseCompletedHandlerTests: TestCase {
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.externalPurchaseHandler
         )
-        .handlePurchase { _, purchaseCompletedHandler in
-            purchaseCompletedHandler(false, nil)
+        .handlePurchaseAndRestore(performPurchase: { storeProduct, purchaseResultReporter in
+            purchaseResultReporter.reportResult(userCancelled: false, error: nil)
             customPurchaseCodeExecuted = true
-        }
+        }, performRestore: { restoreResultReporter in
+
+        })
         .addToHierarchy()
 
         Task {
@@ -225,10 +227,12 @@ class PurchaseCompletedHandlerTests: TestCase {
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.externalPurchaseHandler
         )
-        .handleRestorePurchases { purchaseRestoreHandler in
-            purchaseRestoreHandler(true, nil)
+        .handlePurchaseAndRestore(performPurchase: { storeProduct, purchaseResultReporter in
+
+        }, performRestore: { restoreResultReporter in
+            restoreResultReporter.reportResult(success: true, error: nil)
             customRestoreCodeExecuted = true
-        }
+        })
         .addToHierarchy()
 
         Task {

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -200,10 +200,10 @@ class PurchaseCompletedHandlerTests: TestCase {
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.externalPurchaseHandler
         )
-        .handlePurchaseAndRestore(performPurchase: { storeProduct, purchaseResultReporter in
+        .handlePurchaseAndRestore(performPurchase: { _, purchaseResultReporter in
             purchaseResultReporter.reportResult(userCancelled: false, error: nil)
             customPurchaseCodeExecuted = true
-        }, performRestore: { restoreResultReporter in
+        }, performRestore: { _ in
 
         })
         .addToHierarchy()
@@ -227,7 +227,7 @@ class PurchaseCompletedHandlerTests: TestCase {
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.externalPurchaseHandler
         )
-        .handlePurchaseAndRestore(performPurchase: { storeProduct, purchaseResultReporter in
+        .handlePurchaseAndRestore(performPurchase: { _, _ in
 
         }, performRestore: { restoreResultReporter in
             restoreResultReporter.reportResult(success: true, error: nil)

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -305,7 +305,7 @@ class PurchaseCompletedHandlerTests: TestCase {
         expect(error).toEventually(matchError(Self.failureError))
     }
 
-    private static let externalPurchaseHandler: PurchaseHandler = .mock(finishTransactions: false)
+    private static let externalPurchaseHandler: PurchaseHandler = .mock(purchasesAreCompletedBy: .myApp)
     private static let purchaseHandler: PurchaseHandler = .mock()
     private static let failingHandler: PurchaseHandler = .failing(failureError)
     private static let offering = TestData.offeringWithNoIntroOffer

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -201,6 +201,7 @@ class PurchaseCompletedHandlerTests: TestCase {
             purchaseHandler: Self.externalPurchaseHandler
         )
         .handlePurchase { storeProduct, purchaseCompletedHandler in
+            purchaseCompletedHandler(false, nil)
             customPurchaseCodeExecuted = true
         }
         .addToHierarchy()
@@ -212,6 +213,31 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         expect(completed).toEventually(beTrue())
         expect(customPurchaseCodeExecuted) == true
+    }
+
+    func testHandleExternalRestore() throws {
+        var completed = false
+        var customRestoreCodeExecuted = false
+
+        try PaywallView(
+            offering: Self.offering.withLocalImages,
+            customerInfo: TestData.customerInfo,
+            introEligibility: .producing(eligibility: .eligible),
+            purchaseHandler: Self.externalPurchaseHandler
+        )
+        .handleRestore { purchaseRestoreHandler in
+            purchaseRestoreHandler(true, nil)
+            customRestoreCodeExecuted = true
+        }
+        .addToHierarchy()
+
+        Task {
+            _ = try await Self.externalPurchaseHandler.restorePurchases()
+            completed = true
+        }
+
+        expect(completed).toEventually(beTrue())
+        expect(customRestoreCodeExecuted) == true
     }
 
     func testOnRestoreStarted() throws {

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -225,7 +225,7 @@ class PurchaseCompletedHandlerTests: TestCase {
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.externalPurchaseHandler
         )
-        .handleRestore { purchaseRestoreHandler in
+        .handleRestorePurchases { purchaseRestoreHandler in
             purchaseRestoreHandler(true, nil)
             customRestoreCodeExecuted = true
         }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
@@ -38,6 +38,7 @@ final class Configuration: ObservableObject {
             with: .init(withAPIKey: ConfigItem.apiKey)
                 .with(entitlementVerificationMode: .informational)
                 .with(usesStoreKit2IfAvailable: true)
+                .with(purchasesAreCompletedBy: .myApp)
         )
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomPaywall.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomPaywall.swift
@@ -36,7 +36,7 @@ struct CustomPaywall: View {
                            condensed: self.condensed,
                            fonts: DefaultPaywallFontProvider(),
                            introEligibility: self.introEligibility ?? .default(),
-                           purchaseHandler: self.purchaseHandler ?? .default()
+                           purchaseHandler: self.purchaseHandler ?? .default(performPurchase: nil, performRestore: nil)
             )
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/PaywallPresenter.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/PaywallPresenter.swift
@@ -25,7 +25,12 @@ struct PaywallPresenter: View {
                 displayCloseButton: displayCloseButton,
                 introEligibility: .producing(eligibility: introEligility)
             )
-            PaywallView(configuration: config)
+            PaywallView(configuration: config) { storeProduct, purchaseResultReporter in
+                print("purchase callback")
+            } performRestore: { restoreResultReporter in
+                print("restore callback")
+            }
+
 
 #if !os(watchOS)
         case .footer:

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -40,8 +40,10 @@ struct SamplePaywallsList: View {
                         customerInfo: Self.loader.customerInfo,
                         displayCloseButton: Self.displayCloseButton,
                         introEligibility: Self.introEligibility,
-                        purchaseHandler: .default()
-                    )
+                        purchaseHandler: .default(performPurchase: nil, performRestore: nil)
+                    ),
+                    performPurchase: nil,
+                    performRestore: nil
                 )
 
             #if !os(watchOS)
@@ -50,7 +52,7 @@ struct SamplePaywallsList: View {
                               customerInfo: Self.loader.customerInfo,
                               condensed: mode == .condensedFooter,
                               introEligibility: Self.introEligibility,
-                              purchaseHandler: .default())
+                              purchaseHandler: .default(performPurchase: nil, performRestore: nil))
             #endif
             }
 
@@ -62,8 +64,10 @@ struct SamplePaywallsList: View {
                     fonts: Self.customFontProvider,
                     displayCloseButton: Self.displayCloseButton,
                     introEligibility: Self.introEligibility,
-                    purchaseHandler: .default()
-                )
+                    purchaseHandler: .default(performPurchase: nil, performRestore: nil)
+                ),
+                performPurchase: nil,
+                performRestore: nil
             )
 
         #if !os(watchOS)
@@ -78,8 +82,10 @@ struct SamplePaywallsList: View {
                     offering: Self.loader.offeringWithDefaultPaywall(),
                     customerInfo: Self.loader.customerInfo,
                     introEligibility: Self.introEligibility,
-                    purchaseHandler: .default()
-                )
+                    purchaseHandler: .default(performPurchase: nil, performRestore: nil)
+                ),
+                performPurchase: nil,
+                performRestore: nil
             )
 
         case .unrecognizedPaywall:
@@ -88,8 +94,10 @@ struct SamplePaywallsList: View {
                     offering: Self.loader.offeringWithUnrecognizedPaywall(),
                     customerInfo: Self.loader.customerInfo,
                     introEligibility: Self.introEligibility,
-                    purchaseHandler: .default()
-                )
+                    purchaseHandler: .default(performPurchase: nil, performRestore: nil)
+                ),
+                performPurchase: nil,
+                performRestore: nil
             )
         }
     }

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -126,7 +126,7 @@ extension MockPurchases: PurchasesType {
         self.unimplemented()
     }
 
-    var finishTransactions: Bool {
+    var purchasesAreCompletedBy: PurchasesAreCompletedBy {
         get { self.unimplemented() }
         // swiftlint:disable:next unused_setter_value
         set { self.unimplemented() }

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -126,6 +126,12 @@ extension MockPurchases: PurchasesType {
         self.unimplemented()
     }
 
+    var finishTransactions: Bool {
+        get { self.unimplemented() }
+        // swiftlint:disable:next unused_setter_value
+        set { self.unimplemented() }
+    }
+
     var purchasesAreCompletedBy: PurchasesAreCompletedBy {
         get { self.unimplemented() }
         // swiftlint:disable:next unused_setter_value

--- a/Tests/UnitTests/Purchasing/ConfigurationTests.swift
+++ b/Tests/UnitTests/Purchasing/ConfigurationTests.swift
@@ -52,9 +52,9 @@ class ConfigurationTests: TestCase {
         self.logger.verifyMessageWasNotLogged(Strings.configure.observer_mode_with_storekit2)
     }
 
-    func testObserverModeWithStoreKit1() {
+    func testPurchasesAreCompletedByMyAppWithStoreKit1() {
         let configuration = Configuration.Builder(withAPIKey: "test")
-            .with(observerMode: true)
+            .with(purchasesAreCompletedBy: .myApp)
             .build()
 
         expect(configuration.observerMode) == true
@@ -64,9 +64,9 @@ class ConfigurationTests: TestCase {
     }
 
     @available(*, deprecated)
-    func testObserverModeWithStoreKit2() {
+    func testPurchasesAreCompletedByMyAppWithStoreKit2() {
         let configuration = Configuration.Builder(withAPIKey: "test")
-            .with(observerMode: true)
+            .with(purchasesAreCompletedBy: .myApp)
             .with(usesStoreKit2IfAvailable: true)
             .build()
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -504,8 +504,8 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     // MARK: - OfflineCustomerInfoCreator
 
-    func testObserverModeDoesNotCreateOfflineCustomerInfoCreator() {
-        expect(Self.create(observerMode: true).offlineCustomerInfoEnabled) == false
+    func testPurchaesAreCompletedByMyAppDoesNotCreateOfflineCustomerInfoCreator() {
+        expect(Self.create(purchasesAreCompletedBy: .myApp).offlineCustomerInfoEnabled) == false
     }
 
     func testOlderVersionsDoNoCreateOfflineCustomerInfo() throws {
@@ -513,19 +513,19 @@ class PurchasesConfiguringTests: BasePurchasesTests {
             throw XCTSkip("Test for older versions")
         }
 
-        expect(Self.create(observerMode: false).offlineCustomerInfoEnabled) == false
+        expect(Self.create(purchasesAreCompletedBy: .revenueCat).offlineCustomerInfoEnabled) == false
     }
 
     func testOfflineCustomerInfoEnabled() throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        expect(Self.create(observerMode: false).offlineCustomerInfoEnabled) == true
+        expect(Self.create(purchasesAreCompletedBy: .revenueCat).offlineCustomerInfoEnabled) == true
     }
 
-    private static func create(observerMode: Bool) -> Purchases {
+    private static func create(purchasesAreCompletedBy: PurchasesAreCompletedBy) -> Purchases {
         return Purchases.configure(
             with: .init(withAPIKey: "")
-                .with(observerMode: observerMode)
+                .with(purchasesAreCompletedBy: purchasesAreCompletedBy)
         )
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -214,7 +214,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
     }
 
     func testDoesntFinishTransactionsIfFinishingDisabled() throws {
-        self.purchases.finishTransactions = false
+        self.purchases.purchasesAreCompletedBy = .myApp
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 


### PR DESCRIPTION
This is a WIP making the paywall's ability to handle purchases and restore logic directly via trailing closures in its initializer rather than as a view modifier because it is easier for API consumers to use correctly. Note its base is https://github.com/RevenueCat/purchases-ios/pull/3917 where it is done via view modifiers.