### PR TITLE
Deprecate observer mode in 5.0 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs:
-  macos: circleci/macos@2.0.1
+  macos: circleci/macos@2.5.1
   slack: circleci/slack@4.10.1
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
@@ -75,13 +75,23 @@ commands:
       runtime-name:
         type: string
     steps:
-      - install-brew-dependency:
-          dependency_name: "xcodes"
+      # - install-brew-dependency:
+      #     dependency_name: 'xcodes'
+      # - run:
+      #     name: Install simulator
+      #     command: | # Print all available simulators and install required one
+      #         xcodes runtimes
+      #         sudo xcodes runtimes install "<< parameters.runtime-name >>"
+      # Xcodes got broken with latest iOS 18 betas. This is a temporary workaround. https://github.com/XcodesOrg/xcodes/issues/368
+      - run:
+          name: Install fixed xcodes version
+          command: |
+              mint install https://github.com/alvar-bolt/xcodes.git@alvar/ios-18-quickfix
       - run:
           name: Install simulator
           command: | # Print all available simulators and install required one
-            xcodes runtimes
-            sudo xcodes runtimes install "<< parameters.runtime-name >>"
+              $HOME/.mint/bin/xcodes runtimes
+              sudo $HOME/.mint/bin/xcodes runtimes install "<< parameters.runtime-name >>"
 
   install-bundle-dependencies:
     parameters:
@@ -615,8 +625,6 @@ jobs:
 
   run-test-ios-15:
     <<: *base-job
-    # Fix-me: running on M1 makes these tests crash
-    resource_class: macos.x86.medium.gen2
     steps:
       - checkout
       - install-dependencies:
@@ -714,12 +722,14 @@ jobs:
 
   run-test-ios-13:
     <<: *base-job
-    # M1 unsupported
-    resource_class: macos.x86.medium.gen2
     steps:
       - checkout
       - install-dependencies:
+          install_xcbeautify: false
+          install_mint: true
           install_swiftlint: << parameters.install_swiftlint >>
+      - macos/install-rosetta
+      - install-xcbeautify-for-xcode14
       - update-spm-installation-commit
       - install-runtime:
           runtime-name: iOS 13.7

--- a/Examples/MagicWeather/MagicWeather/Sources/Lifecycle/AppDelegate.swift
+++ b/Examples/MagicWeather/MagicWeather/Sources/Lifecycle/AppDelegate.swift
@@ -21,9 +21,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
          
             - `appUserID` is nil by default, so an anonymous ID will be generated automatically by the Purchases SDK.
                 Read more about Identifying Users here: https://docs.revenuecat.com/docs/user-ids
-         
-            - `observerMode` is false by default, so Purchases will automatically handle finishing transactions.
-                Read more about Observer Mode here: https://docs.revenuecat.com/docs/observer-mode
          */
 
         Purchases.configure(

--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Lifecycle/MagicWeatherApp.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Lifecycle/MagicWeatherApp.swift
@@ -20,9 +20,7 @@ struct MagicWeatherApp: App {
          
          - `appUserID` is nil by default, so an anonymous ID will be generated automatically by the Purchases SDK.
             Read more about Identifying Users here: https://docs.revenuecat.com/docs/user-ids
-         
-         - `observerMode` is false by default, so Purchases will automatically handle finishing transactions.
-            Read more about Observer Mode here: https://dz gocs.revenuecat.com/docs/observer-mode
+
          */
 
         Purchases.configure(

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -624,6 +624,7 @@
 		6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECF627761D375C8431EB866 /* StoreProduct.swift */; };
 		805B60C97993B311CEC93EAF /* ProductsFetcherSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628C1F100BB3C1782860D24 /* ProductsFetcherSK2.swift */; };
 		80E80EF226970E04008F245A /* ReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E80EF026970DC3008F245A /* ReceiptFetcher.swift */; };
+		887E7B592C13CD2C002977DE /* PurchasesAreCompletedBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887E7B582C13CD2C002977DE /* PurchasesAreCompletedBy.swift */; };
 		9A65DFDE258AD60A00DE00B0 /* LogIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */; };
 		9A65E03625918B0500DE00B0 /* ConfigureStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */; };
 		9A65E03B25918B0900DE00B0 /* CustomerInfoStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E03A25918B0900DE00B0 /* CustomerInfoStrings.swift */; };
@@ -1379,6 +1380,7 @@
 		57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreTransaction.swift; sourceTree = "<group>"; };
 		80E80EF026970DC3008F245A /* ReceiptFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
 		84C3F1AC1D7E1E64341D3936 /* Pods_RevenueCat_PurchasesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RevenueCat_PurchasesTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		887E7B582C13CD2C002977DE /* PurchasesAreCompletedBy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesAreCompletedBy.swift; sourceTree = "<group>"; };
 		9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogIntent.swift; sourceTree = "<group>"; };
 		9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigureStrings.swift; sourceTree = "<group>"; };
 		9A65E03A25918B0900DE00B0 /* CustomerInfoStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerInfoStrings.swift; sourceTree = "<group>"; };
@@ -2878,6 +2880,7 @@
 			isa = PBXGroup;
 			children = (
 				B3843BCA285149A0009F4854 /* Attribution.swift */,
+				887E7B582C13CD2C002977DE /* PurchasesAreCompletedBy.swift */,
 				57FD7B1428DA4037009CA4E4 /* PurchasesType.swift */,
 				B35042C326CDB79A00905B95 /* Purchases.swift */,
 				B35042C526CDD3B100905B95 /* PurchasesDelegate.swift */,
@@ -3578,6 +3581,7 @@
 				35AAEB452BBB14D000A12548 /* DiagnosticsFileHandler.swift in Sources */,
 				B34D2AA626976FC700D88C3A /* ErrorCode.swift in Sources */,
 				4F15B4A12A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift in Sources */,
+				887E7B592C13CD2C002977DE /* PurchasesAreCompletedBy.swift in Sources */,
 				B39E811D268E887500D31189 /* SubscriberAttribute.swift in Sources */,
 				A5F0104E2717B3150090732D /* BeginRefundRequestHelper.swift in Sources */,
 				B378156D285A9772000A7B93 /* OfferingsAPI.swift in Sources */,

--- a/RevenueCatUI/Purchasing/MockPurchases.swift
+++ b/RevenueCatUI/Purchasing/MockPurchases.swift
@@ -22,12 +22,19 @@ final class MockPurchases: PaywallPurchasesType {
     typealias PurchaseBlock = @Sendable (Package) async throws -> PurchaseResultData
     typealias RestoreBlock = @Sendable () async throws -> CustomerInfo
     typealias TrackEventBlock = @Sendable (PaywallEvent) async -> Void
+    private let _purchasesAreCompletedBy: PurchasesAreCompletedBy
+
+    var purchasesAreCompletedBy: PurchasesAreCompletedBy {
+        get { return _purchasesAreCompletedBy }
+        set { _ = newValue }
+    }
 
     private let purchaseBlock: PurchaseBlock
     private let restoreBlock: RestoreBlock
     private let trackEventBlock: TrackEventBlock
 
     init(
+        purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat,
         purchase: @escaping PurchaseBlock,
         restorePurchases: @escaping RestoreBlock,
         trackEvent: @escaping TrackEventBlock
@@ -35,6 +42,7 @@ final class MockPurchases: PaywallPurchasesType {
         self.purchaseBlock = purchase
         self.restoreBlock = restorePurchases
         self.trackEventBlock = trackEvent
+        self._purchasesAreCompletedBy = purchasesAreCompletedBy
     }
 
     func purchase(package: Package) async throws -> PurchaseResultData {

--- a/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
@@ -19,9 +19,11 @@ import RevenueCat
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PurchaseHandler {
 
-    static func mock(_ customerInfo: CustomerInfo = TestData.customerInfo) -> Self {
+    static func mock(_ customerInfo: CustomerInfo = TestData.customerInfo,
+                     purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat)
+    -> Self {
         return self.init(
-            purchases: MockPurchases { _ in
+            purchases: MockPurchases(purchasesAreCompletedBy: purchasesAreCompletedBy) { _ in
                 return (
                     // No current way to create a mock transaction with RevenueCat's public methods.
                     transaction: nil,
@@ -36,8 +38,8 @@ extension PurchaseHandler {
         )
     }
 
-    static func cancelling() -> Self {
-        return .mock()
+    static func cancelling(purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat) -> Self {
+        return .mock(purchasesAreCompletedBy: purchasesAreCompletedBy)
             .map { block in {
                     var result = try await block($0)
                     result.userCancelled = true

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
@@ -159,9 +159,7 @@ Or browse our iOS sample apps:
 - ``Purchases/setOnesignalID(_:)``
 
 ### Configuring the SDK with parameters (deprecated)
-- ``Purchases/configure(withAPIKey:appUserID:)``
-- ``Purchases/configure(withAPIKey:appUserID:observerMode:storeKitVersion:)``
-- ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:)``
-- ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)``
 - ``Purchases/configure(withAPIKey:appUserID:)-57pv0``
 - ``Purchases/configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)-2k6md``
+- ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:)``
+- ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)``

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
@@ -163,3 +163,5 @@ Or browse our iOS sample apps:
 - ``Purchases/configure(withAPIKey:appUserID:observerMode:storeKitVersion:)``
 - ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:)``
 - ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)``
+- ``Purchases/configure(withAPIKey:appUserID:)-57pv0``
+- ``Purchases/configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)-2k6md``

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/V5_API_Migration_guide.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/V5_API_Migration_guide.md
@@ -61,7 +61,7 @@ let result = try await product?.purchase()
 _ = try await Purchases.shared.recordPurchase(result)
 ```
 
-#### StoreKit 1 Observer Mode Support
+#### Observing Purchases Completed by Your App with StoreKit 1
 
 If purchases are completed by your app using StoreKit 1, you will need to explicitly configure the SDK to use StoreKit 1:
 

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/V5_API_Migration_guide.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/V5_API_Migration_guide.md
@@ -34,34 +34,40 @@ If you are using any 3rd party analytics SDKs to automatically track in-app purc
 
 If you're using the Firebase SDK, you'll need to follow [these instructions](https://firebase.google.com/docs/analytics/measure-in-app-purchases#swift) to log purchases made with StoreKit 2.
 
-### Observer Mode
+### Observer Mode is now Purchasea Are Completed By
 
-Version 5.0 of the SDK introduces support for observer mode when making purchases with StoreKit 2. You can enable it when configuring the SDK:
+Version 5.0 of the SDK  deprecates the term "Observer Mode" (and the APIs where this term was used), and replaces it
+with Purchases Are Completed By (either RevenueCat or your app).
 
-```swift
-Purchases.configure(with: .builder(withAPIKey: apiKey)
-  .with(observerMode: true, storeKitVersion: .storeKit2)
-  .build()
-```
+Version 5.0 of the SDK also introduces support for recording purchases made directly by your app calling StoreKit 2. 
+
+You can enable it when configuring the SDK:
+
+| Version 4 | Version 5 |
+|------------|------------|
+| <pre lang="swift"><code>Purchases.configure(with: .builder(withAPIKey: apiKey)<br>  .with(observerMode: true)<br>  .build()</code></pre> | <pre lang="swift"><code>Purchases.configure(with: .builder(withAPIKey: apiKey)<br>  .with(purchasesAreCompletedBy: .myApp, storeKitVersion: .storeKit2)<br>  .build()</code></pre> |
+
+
+
 
 #### ⚠️ StoreKit 2 Observer Mode on macOS
 
-By default, Observer Mode with StoreKit 2 on macOS does not detect a user's purchase until after the user foregrounds the app after the purchase has been made. If you'd like RevenueCat to immediately detect the user's purchase, call `Purchases.shared.handleObserverModeTransaction(purchaseResult)` for any new purchases, like so:
+By default, when purchases are completed by your app using StoreKit 2 on macOS, the app does not detect a user's purchase until after the user foregrounds the app after the purchase has been made. If you'd like RevenueCat to immediately detect the user's purchase, call `Purchases.shared.recordPurchase(purchaseResult)` for any new purchases, like so:
 
 ```swift
 let product = try await StoreKit.Product.products(for: ["my_product_id"]).first
 let result = try await product?.purchase()
 
-_ = try await Purchases.shared.handleObserverModeTransaction(result)
+_ = try await Purchases.shared.recordPurchase(result)
 ```
 
 #### StoreKit 1 Observer Mode Support
 
-If you're using observer mode with StoreKit 1, you will need to explicitly configure the SDK to use StoreKit 1:
+If purchases are completed by your app using StoreKit 1, you will need to explicitly configure the SDK to use StoreKit 1:
 
 ```swift
 Purchases.configure(with: .builder(withAPIKey: apiKey)
-  .with(observerMode: true, storeKitVersion: .storeKit1)
+  .with(purchasesAreCompletedBy: .myApp, storeKitVersion: .storeKit1)
   .build()
 ```
 

--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -99,7 +99,7 @@ extension ConfigureStrings: LogMessage {
         case .debug_enabled:
             return "Debug logging enabled"
         case .observer_mode_enabled:
-            return "Purchases is configured in observer mode"
+            return "Purchases is configured with purchasesAreCompletedBy set to .myApp"
         case let .response_verification_mode(mode):
             switch mode {
             case .disabled:
@@ -189,8 +189,9 @@ extension ConfigureStrings: LogMessage {
             "when configuring the SDK."
 
         case .handle_transaction_observer_mode_required:
-            return "Attempted to manually handle transactions with observer mode not enabled. " +
-            "You must use `.with(observerMode: true, storeKitVersion: .storeKit2)` when configuring the SDK."
+            return "Attempted to manually handle transactions with purchasesAreCompletedBy not set to .myApp. " +
+            "You must use `.with(purchasesAreCompletedBy: .myApp, storeKitVersion: .storeKit2)` " +
+            "when configuring the SDK."
 
         case .sk2_required:
             return "StoreKit 2 must be enabled. You must use `.with(storeKitVersion: .storeKit2)` " +

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -141,7 +141,7 @@ extension PurchaseStrings: LogMessage {
             "it's a non-subscription and it's missing in CustomerInfo list: \(nonSubscriptions)"
 
         case .purchasing_with_observer_mode_and_finish_transactions_false_warning:
-            return "Observer mode is active (finishTransactions is set to false) and " +
+            return "purchasesAreCompletedBy is not set to .myApp and " +
             "purchase has been initiated. RevenueCat will not finish the " +
             "transaction, are you sure you want to do this?"
 
@@ -341,7 +341,7 @@ extension PurchaseStrings: LogMessage {
             return "allowSharingAppStoreAccount is set to false and restorePurchases has been called. " +
             "Are you sure you want to do this?"
         case let .sk2_observer_mode_error_processing_transaction(error):
-            return "Observer mode could not process transaction: \(error)"
+            return "RevenueCat could not process transaction completed by your app: \(error)"
         }
     }
 

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -335,6 +335,12 @@ public extension Purchases {
         self.attribution.setCreative(creative)
     }
 
+    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
+    @objc var finishTransactions: Bool {
+        get { self.systemInfo.finishTransactions }
+        set { self.systemInfo.finishTransactions = newValue }
+    }
+
 }
 
 public extension StoreProduct {

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -14,7 +14,7 @@
 import Foundation
 import StoreKit
 
-// swiftlint:disable line_length missing_docs file_length
+// swiftlint:disable line_length missing_docs
 
 #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -63,25 +63,6 @@ public extension Purchases {
     @available(watchOS, deprecated: 1, renamed: "configure(with:)")
     @available(macOS, deprecated: 1, renamed: "configure(with:)")
     @available(macCatalyst, deprecated: 1, renamed: "configure(with:)")
-    @objc(configureWithAPIKey:appUserID:observerMode:userDefaults:)
-    @discardableResult static func configure(withAPIKey apiKey: String,
-                                             appUserID: String?,
-                                             observerMode: Bool,
-                                             userDefaults: UserDefaults?) -> Purchases {
-        configure(
-            withAPIKey: apiKey,
-            appUserID: appUserID,
-            observerMode: observerMode,
-            userDefaults: userDefaults,
-            useStoreKit2IfAvailable: StoreKitVersion.default == .storeKit2
-        )
-    }
-
-    @available(iOS, deprecated: 1, renamed: "configure(with:)")
-    @available(tvOS, deprecated: 1, renamed: "configure(with:)")
-    @available(watchOS, deprecated: 1, renamed: "configure(with:)")
-    @available(macOS, deprecated: 1, renamed: "configure(with:)")
-    @available(macCatalyst, deprecated: 1, renamed: "configure(with:)")
     @objc(configureWithAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)
     @discardableResult static func configure(withAPIKey apiKey: String,
                                              appUserID: String?,

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -335,12 +335,6 @@ public extension Purchases {
         self.attribution.setCreative(creative)
     }
 
-    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
-    @objc var finishTransactions: Bool {
-        get { self.systemInfo.finishTransactions }
-        set { self.systemInfo.finishTransactions = newValue }
-    }
-
 }
 
 public extension StoreProduct {

--- a/Sources/Misc/Obsoletions.swift
+++ b/Sources/Misc/Obsoletions.swift
@@ -587,6 +587,42 @@ public extension Purchases {
         fatalError()
     }
 
+    @available(iOS, obsoleted: 1,
+               message: """
+Explicitly setting the StoreKit version is now required when setting
+purchasesAreCompletedBy. Please use the Configuration.Builder class to configure the SDK with
+custom UserDefaults.
+""",
+               renamed: "configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)")
+    @available(tvOS, obsoleted: 1,
+               message: """
+Explicitly setting the StoreKit version is now required when setting
+purchasesAreCompletedBy. Please use the Configuration.Builder class to configure the SDK with
+custom UserDefaults.
+""",
+               renamed: "configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)")
+    @available(watchOS, obsoleted: 1,
+               message: """
+Explicitly setting the StoreKit version is now required when setting
+purchasesAreCompletedBy. Please use the Configuration.Builder class to configure the SDK with
+custom UserDefaults.
+""",
+               renamed: "configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)")
+    @available(macOS, obsoleted: 1,
+               message: """
+Explicitly setting the StoreKit version is now required when setting
+purchasesAreCompletedBy. Please use the Configuration.Builder class to configure the SDK with
+custom UserDefaults.
+""",
+               renamed: "configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)")
+    @objc(configureWithAPIKey:appUserID:observerMode:userDefaults:)
+    @discardableResult static func configure(withAPIKey apiKey: String,
+                                             appUserID: String?,
+                                             observerMode: Bool,
+                                             userDefaults: UserDefaults?) -> Purchases {
+        fatalError()
+
+    }
 }
 
 @available(iOS, obsoleted: 1, renamed: "StartPurchaseBlock")

--- a/Sources/Misc/Obsoletions.swift
+++ b/Sources/Misc/Obsoletions.swift
@@ -546,7 +546,7 @@ public extension Purchases {
      * - Returns: An instantiated ``Purchases`` object that has been set as a singleton.
      *
      * - Warning: This assumes your IAP implementation uses StoreKit 1.
-     * - Warning: If you're using observer mode with StoreKit 2, configure the SDK with `configure(withAPIKey:appUserID:observerMode:storeKitVersion:)` passing in `.storeKit2` as the `storeKitVersion` and ensure that you call ``Purchases/handleObserverModeTransaction(_:)`` after making a purchase.
+     * - Warning: If you're using observer mode with StoreKit 2, configure the SDK with `configure(withAPIKey:appUserID:observerMode:storeKitVersion:)` passing in `.storeKit2` as the `storeKitVersion` and ensure that you call ``Purchases/recordPurchase(_:)`` after making a purchase.
      */
     @available(iOS, obsoleted: 1,
                message: "Explicitly setting the StoreKit version is now required when setting purchasesAreCompletedBy.",

--- a/Sources/Misc/Obsoletions.swift
+++ b/Sources/Misc/Obsoletions.swift
@@ -549,21 +549,40 @@ public extension Purchases {
      * - Warning: If you're using observer mode with StoreKit 2, configure the SDK with `configure(withAPIKey:appUserID:observerMode:storeKitVersion:)` passing in `.storeKit2` as the `storeKitVersion` and ensure that you call ``Purchases/handleObserverModeTransaction(_:)`` after making a purchase.
      */
     @available(iOS, obsoleted: 1,
-               message: "Explicitly setting the StoreKit version is now required when using observer mode.",
-               renamed: "configure(withAPIKey:appUserID:observerMode:storeKitVersion:)")
+               message: "Explicitly setting the StoreKit version is now required when setting purchasesAreCompletedBy.",
+               renamed: "configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)")
     @available(tvOS, obsoleted: 1,
-               message: "Explicitly setting the StoreKit version is now required when using observer mode.",
-               renamed: "configure(withAPIKey:appUserID:storeKitVersion:)")
+               message: "Explicitly setting the StoreKit version is now required when setting purchasesAreCompletedBy.",
+               renamed: "configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)")
     @available(watchOS, obsoleted: 1,
-               message: "Explicitly setting the StoreKit version is now required when using observer mode.",
-               renamed: "configure(withAPIKey:appUserID:observerMode:storeKitVersion:)")
+               message: "Explicitly setting the StoreKit version is now required when setting purchasesAreCompletedBy.",
+               renamed: "configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)")
     @available(macOS, obsoleted: 1,
-               message: "Explicitly setting the StoreKit version is now required when using observer mode.",
-               renamed: "configure(withAPIKey:appUserID:observerMode:storeKitVersion:)")
+               message: "Explicitly setting the StoreKit version is now required when setting purchasesAreCompletedBy.",
+               renamed: "configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)")
     @objc(configureWithAPIKey:appUserID:observerMode:)
     @_disfavoredOverload
     @discardableResult static func configure(withAPIKey apiKey: String,
                                              appUserID: String?,
+                                             observerMode: Bool) -> Purchases {
+        fatalError()
+    }
+
+    @available(iOS, obsoleted: 1,
+               message: "Explicitly setting the StoreKit version is now required when setting purchasesAreCompletedBy.",
+               renamed: "configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)")
+    @available(tvOS, obsoleted: 1,
+               message: "Explicitly setting the StoreKit version is now required when setting purchasesAreCompletedBy.",
+               renamed: "configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)")
+    @available(watchOS, obsoleted: 1,
+               message: "Explicitly setting the StoreKit version is now required when setting purchasesAreCompletedBy.",
+               renamed: "configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)")
+    @available(macOS, obsoleted: 1,
+               message: "Explicitly setting the StoreKit version is now required when setting purchasesAreCompletedBy.",
+               renamed: "configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)")
+    // swiftlint:disable:next missing_docs
+    @discardableResult static func configure(withAPIKey apiKey: String,
+                                             appUserID: StaticString,
                                              observerMode: Bool) -> Purchases {
         fatalError()
     }

--- a/Sources/Misc/Obsoletions.swift
+++ b/Sources/Misc/Obsoletions.swift
@@ -624,8 +624,6 @@ custom UserDefaults.
     }
 }
 
-
-
 @available(iOS, obsoleted: 1, renamed: "StartPurchaseBlock")
 @available(tvOS, obsoleted: 1, renamed: "StartPurchaseBlock")
 @available(watchOS, obsoleted: 1, renamed: "StartPurchaseBlock")

--- a/Sources/Misc/Obsoletions.swift
+++ b/Sources/Misc/Obsoletions.swift
@@ -580,7 +580,6 @@ public extension Purchases {
     @available(macOS, obsoleted: 1,
                message: "Explicitly setting the StoreKit version is now required when setting purchasesAreCompletedBy.",
                renamed: "configure(withAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)")
-    // swiftlint:disable:next missing_docs
     @discardableResult static func configure(withAPIKey apiKey: String,
                                              appUserID: StaticString,
                                              observerMode: Bool) -> Purchases {
@@ -624,6 +623,8 @@ custom UserDefaults.
 
     }
 }
+
+
 
 @available(iOS, obsoleted: 1, renamed: "StartPurchaseBlock")
 @available(tvOS, obsoleted: 1, renamed: "StartPurchaseBlock")

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -144,8 +144,9 @@ import Foundation
 
         /**
          * Set `purchasesAreCompletedBy`.
-         * - Parameter purchasesAreCompletedBy: Set this to ``.myApp`` if you have your own IAP implementation
-         * and want to use only RevenueCat's backend. Default is ``.revenueCat``.
+         * - Parameter purchasesAreCompletedBy: Set this to ``PurchasesAreCompletedBy/myApp``
+         * if you have your own IAP implementation and want to use only RevenueCat's backend. 
+         * Default is ``PurchasesAreCompletedBy/revenueCat``.
          * - Parameter storeKitVersion: Set the StoreKit version you're using to make purchases.
          */
         @objc public func with(

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -144,8 +144,8 @@ import Foundation
 
         /**
          * Set `observerMode`.
-         * - Parameter purchasesAreCompletedBy: Set this to `.myApp` if you have your own IAP implementation
-         * and want to use only RevenueCat's backend. Default is `.revenueCat`.
+         * - Parameter purchasesAreCompletedBy: Set this to ``.myApp`` if you have your own IAP implementation
+         * and want to use only RevenueCat's backend. Default is ``.revenueCat``.
          * - Parameter storeKitVersion: Set the StoreKit version you're using to make purchases.
          */
         @objc public func with(

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -143,7 +143,7 @@ import Foundation
         }
 
         /**
-         * Set `observerMode`.
+         * Set `purchasesAreCompletedBy`.
          * - Parameter purchasesAreCompletedBy: Set this to ``.myApp`` if you have your own IAP implementation
          * and want to use only RevenueCat's backend. Default is ``.revenueCat``.
          * - Parameter storeKitVersion: Set the StoreKit version you're using to make purchases.

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -82,7 +82,15 @@ import Foundation
 
         private(set) var apiKey: String
         private(set) var appUserID: String?
-        private(set) var observerMode: Bool = false
+        var observerMode: Bool {
+            switch purchasesAreCompletedBy {
+            case .revenueCat:
+                return false
+            case .myApp:
+                return true
+            }
+        }
+        private(set) var purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat
         private(set) var userDefaults: UserDefaults?
         private(set) var dangerousSettings: DangerousSettings?
         private(set) var networkTimeout = Configuration.networkTimeoutDefault
@@ -136,15 +144,15 @@ import Foundation
 
         /**
          * Set `observerMode`.
-         * - Parameter observerMode: Set this to `true` if you have your own IAP implementation and want to use only
-         * RevenueCat's backend. Default is `false`.
+         * - Parameter purchasesAreCompletedBy: Set this to `.myApp` if you have your own IAP implementation
+         * and want to use only RevenueCat's backend. Default is `.revenueCat`.
          * - Parameter storeKitVersion: Set the StoreKit version you're using to make purchases.
          */
         @objc public func with(
-            observerMode: Bool,
+            purchasesAreCompletedBy: PurchasesAreCompletedBy,
             storeKitVersion: StoreKitVersion
         ) -> Configuration.Builder {
-            self.observerMode = observerMode
+            self.purchasesAreCompletedBy = purchasesAreCompletedBy
             self.storeKitVersion = storeKitVersion
             return self
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1350,8 +1350,8 @@ public extension Purchases {
      * purchases and subscriptions across devices. Pass `nil` or an empty string if you want ``Purchases``
      * to generate this for you.
      *
-     * - Parameter purchasesAreCompletedBy: Set this to `.myApp` if you have your own IAP implementation and want to use only
-     * RevenueCat's backend. Default is `.revenueCat`.
+     * - Parameter purchasesAreCompletedBy: Set this to ``.myApp`` if you have your own IAP implementation and want to use only
+     * RevenueCat's backend. Default is ``.revenueCat``.
      *
      * - Parameter storeKitVersion: The StoreKit version Purchases will use to process your purchases.
      *

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -253,7 +253,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let receiptFetcher: ReceiptFetcher
     private let requestFetcher: StoreKitRequestFetcher
     private let paymentQueueWrapper: EitherPaymentQueueWrapper
-    private let systemInfo: SystemInfo
+    fileprivate let systemInfo: SystemInfo
     private let storeMessagesHelper: StoreMessagesHelperType?
     private var customerInfoObservationDisposable: (() -> Void)?
 
@@ -1535,6 +1535,12 @@ public extension Purchases {
     @objc var allowSharingAppStoreAccount: Bool {
         get { purchasesOrchestrator.allowSharingAppStoreAccount }
         set { purchasesOrchestrator.allowSharingAppStoreAccount = newValue }
+    }
+
+    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
+    @objc var finishTransactions: Bool {
+        get { self.systemInfo.finishTransactions }
+        set { self.systemInfo.finishTransactions = newValue }
     }
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1159,7 +1159,7 @@ public extension Purchases {
 #endif
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func addPurchaseCompletedByMyAppPurchaseResult(
+    func didCompletePurchaseWithResult(
         _ purchaseResult: StoreKit.Product.PurchaseResult
     ) async throws -> StoreTransaction? {
         guard self.systemInfo.observerMode else {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1383,16 +1383,15 @@ public extension Purchases {
     // swiftlint:disable:next missing_docs
     @discardableResult static func configure(withAPIKey apiKey: String,
                                              appUserID: StaticString,
-                                             observerMode: Bool) -> Purchases {
+                                             purchasesAreCompletedBy: PurchasesAreCompletedBy,
+                                             storeKitVersion: StoreKitVersion) -> Purchases {
         Logger.warn(Strings.identity.logging_in_with_static_string)
-
-        let purchasesBy: PurchasesAreCompletedBy = observerMode ? .myApp : .revenueCat
 
         return Self.configure(
             with: Configuration
                 .builder(withAPIKey: apiKey)
                 .with(appUserID: "\(appUserID)")
-                .with(purchasesAreCompletedBy: purchasesBy, storeKitVersion: .default)
+                .with(purchasesAreCompletedBy: purchasesAreCompletedBy, storeKitVersion: storeKitVersion)
                 .build()
         )
     }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1381,7 +1381,6 @@ public extension Purchases {
         )
     }
 
-
     @available(*, deprecated, message: """
     The appUserID passed to logIn is a constant string known at compile time.
     This is likely a programmer error. This ID is used to identify the current user.

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1537,7 +1537,10 @@ public extension Purchases {
         set { purchasesOrchestrator.allowSharingAppStoreAccount = newValue }
     }
 
-    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
+    /**
+     * Deprecated. Where responsibility for completing purchase transactions lies.
+     */
+    @available(*, deprecated, message: "Use ``purchasesAreCompletedBy`` instead.")
     @objc var finishTransactions: Bool {
         get { self.systemInfo.finishTransactions }
         set { self.systemInfo.finishTransactions = newValue }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1159,7 +1159,7 @@ public extension Purchases {
 #endif
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func handleObserverModeTransaction(
+    func addPurchaseCompletedByMyAppPurchaseResult(
         _ purchaseResult: StoreKit.Product.PurchaseResult
     ) async throws -> StoreTransaction? {
         guard self.systemInfo.observerMode else {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1159,7 +1159,7 @@ public extension Purchases {
 #endif
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func register(
+    func recordPurchase(
         _ purchaseResult: StoreKit.Product.PurchaseResult
     ) async throws -> StoreTransaction? {
         guard self.systemInfo.observerMode else {
@@ -1360,7 +1360,7 @@ public extension Purchases {
      *
      * - Warning: If purchasesAreCompletedBy is ``PurchasesAreCompletedBy/myApp``
      * and storeKitVersion is ``StoreKitVersion/storeKit2``, ensure that you're
-     * calling ``Purchases/register(_:)`` after making a purchase.
+     * calling ``Purchases/recordPurchase(_:)`` after making a purchase.
      */
     @_disfavoredOverload
     @objc(configureWithAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1223,7 +1223,7 @@ public extension Purchases {
      * ```swift
      *  Purchases.configure(
      *      with: Configuration.Builder(withAPIKey: Constants.apiKey)
-     *               .with(observerMode: false, storeKitVersion: .storeKit1)
+     *               .with(userDefaults: customUserDefaults),
      *               .with(appUserID: "<app_user_id>")
      *               .build()
      *      )
@@ -1338,10 +1338,10 @@ public extension Purchases {
     }
 
     /**
-     * Configures an instance of the Purchases SDK with a specified API key, app user ID, observer mode
+     * Configures an instance of the Purchases SDK with a specified API key, app user ID, purchasesAreCompletedBy
      * setting, and StoreKit version.
      *
-     * Use this constructor if you want to use observer mode. The instance of the Purchases SDK 
+     * Use this constructor if you want to set purchasesAreCompletedBy. The instance of the Purchases SDK
      * will be set as a singleton. You should access the singleton instance using ``Purchases/shared``.
      *
      * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
@@ -1357,8 +1357,8 @@ public extension Purchases {
      *
      * - Returns: An instantiated ``Purchases`` object that has been set as a singleton.
      *
-     * - Warning: If you are using observer mode with StoreKit 2, ensure that you're
-     * calling ``Purchases/handleObserverModeTransaction(_:)`` after making a purchase.
+     * - Warning: If purchasesAreCompletedBy is ``.myApp`` and storeKitVersion is ``.storeKit2``, ensure that you're
+     * calling ``Purchases/addPurchaseCompletedByMyAppPurchaseResult(_:)`` after making a purchase.
      */
     @_disfavoredOverload
     @objc(configureWithAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1159,7 +1159,7 @@ public extension Purchases {
 #endif
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func didCompletePurchaseWithResult(
+    func register(
         _ purchaseResult: StoreKit.Product.PurchaseResult
     ) async throws -> StoreTransaction? {
         guard self.systemInfo.observerMode else {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -228,15 +228,9 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     @objc public let attribution: Attribution
 
-    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
-    @objc public var finishTransactions: Bool {
-        get { self.systemInfo.finishTransactions }
-        set { self.systemInfo.finishTransactions = newValue }
-    }
-
     @objc public var purchasesAreCompletedBy: PurchasesAreCompletedBy {
         get { self.systemInfo.finishTransactions ? .revenueCat : .myApp }
-        set { self.systemInfo.finishTransactions = (newValue == .revenueCat ? true : false) }
+        set { self.systemInfo.finishTransactions = newValue.finishTransactions }
     }
 
     private let attributionFetcher: AttributionFetcher

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1350,15 +1350,17 @@ public extension Purchases {
      * purchases and subscriptions across devices. Pass `nil` or an empty string if you want ``Purchases``
      * to generate this for you.
      *
-     * - Parameter purchasesAreCompletedBy: Set this to ``.myApp`` if you have your own IAP implementation and want to use only
-     * RevenueCat's backend. Default is ``.revenueCat``.
+     * - Parameter purchasesAreCompletedBy: Set this to ``PurchasesAreCompletedBy/myApp``
+     *  if you have your own IAP implementation and want to use only RevenueCat's backend.
+     *  Default is ``PurchasesAreCompletedBy/revenueCat``.
      *
      * - Parameter storeKitVersion: The StoreKit version Purchases will use to process your purchases.
      *
      * - Returns: An instantiated ``Purchases`` object that has been set as a singleton.
      *
-     * - Warning: If purchasesAreCompletedBy is ``.myApp`` and storeKitVersion is ``.storeKit2``, ensure that you're
-     * calling ``Purchases/addPurchaseCompletedByMyAppPurchaseResult(_:)`` after making a purchase.
+     * - Warning: If purchasesAreCompletedBy is ``PurchasesAreCompletedBy/myApp``
+     * and storeKitVersion is ``StoreKitVersion/storeKit2``, ensure that you're
+     * calling ``Purchases/register(_:)`` after making a purchase.
      */
     @_disfavoredOverload
     @objc(configureWithAPIKey:appUserID:purchasesAreCompletedBy:storeKitVersion:)

--- a/Sources/Purchasing/Purchases/PurchasesAreCompletedBy.swift
+++ b/Sources/Purchasing/Purchases/PurchasesAreCompletedBy.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesAreCompletedBy.swift
+//
+//  Created by James Borthwick on 2024-05-30.
+
+import Foundation
+
+/// Where responsibility for completing purchase transactions lies.
+@objc(RCPurchasesAreCompletedBy)
+public enum PurchasesAreCompletedBy: Int {
+
+    /// Purchase transactions are to be finished by RevenueCat.
+    case revenueCat
+
+    /// Purchase transactions are to be finished by the app.
+    case myApp
+
+}
+
+extension PurchasesAreCompletedBy: Sendable {}

--- a/Sources/Purchasing/Purchases/PurchasesAreCompletedBy.swift
+++ b/Sources/Purchasing/Purchases/PurchasesAreCompletedBy.swift
@@ -20,7 +20,7 @@ public enum PurchasesAreCompletedBy: Int {
     /// Purchase transactions are to be finished by RevenueCat.
     case revenueCat
 
-    /// Purchase transactions are to be finished by the app.
+    /// Purchase transactions are to be finished by your app.
     case myApp
 
 }

--- a/Sources/Purchasing/Purchases/PurchasesAreCompletedBy.swift
+++ b/Sources/Purchasing/Purchases/PurchasesAreCompletedBy.swift
@@ -25,4 +25,10 @@ public enum PurchasesAreCompletedBy: Int {
 
 }
 
+extension PurchasesAreCompletedBy {
+    var finishTransactions: Bool {
+        self == .revenueCat
+    }
+}
+
 extension PurchasesAreCompletedBy: Sendable {}

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1068,7 +1068,8 @@ public protocol PurchasesSwiftType: AnyObject {
      *
      * - Returns: A ``StoreTransaction`` if there was a transacton found and handled for the provided product ID.
      *
-     * - Important: This should only be used if you have enabled observer mode during SDK configuration using 
+     * - Important: This should only be used if you are processing transactions directly within your app, configuring
+     * the SDK by passing ``PurchasesAreCompletedBy/myApp`` to `purchasesAreCompletedBy`: in
      * ``Configuration/Builder/with(purchasesAreCompletedBy:storeKitVersion:)``
      */
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -41,9 +41,9 @@ public protocol PurchasesType: AnyObject {
     @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
     var finishTransactions: Bool { get set }
 
-    /** Controls if purchaess should be made and transactions finished automatically by RevenueCat.
+    /** Controls if purchases should be made and transactions finished automatically by RevenueCat.
      * `.revenueCat` by default.
-     * - Warning: Setting this value to `.myApp` will prevent the SDK from making purchaes and finishing transactions.
+     * - Warning: Setting this value to `.myApp` will prevent the SDK from making purchases and finishing transactions.
      * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
      */
     var purchasesAreCompletedBy: PurchasesAreCompletedBy { get set }

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1071,7 +1071,7 @@ public protocol PurchasesSwiftType: AnyObject {
      * ``Configuration/Builder/with(observerMode:storeKitVersion:)``
      */
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func didCompletePurchaseWithResult(
+    func register(
         _ purchaseResult: StoreKit.Product.PurchaseResult
     ) async throws -> StoreTransaction?
 

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -32,15 +32,6 @@ public protocol PurchasesType: AnyObject {
      */
     var isAnonymous: Bool { get }
 
-    /** Whether transactions should be finished automatically. `true` by default.
-     * - Warning: Setting this value to `false` will prevent the SDK from finishing transactions.
-     * In this case, you *must* finish transactions in your app, otherwise they will remain in the queue and
-     * will turn up every time the app is opened.
-     * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
-     */
-    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
-    var finishTransactions: Bool { get set }
-
     /** Controls if purchases should be made and transactions finished automatically by RevenueCat.
      * ``.revenueCat`` by default.
      * - Warning: Setting this value to ``.myApp`` will prevent the SDK from making purchases and finishing transactions.
@@ -919,6 +910,15 @@ public protocol PurchasesType: AnyObject {
     // swiftlint:enable missing_docs
 
     #endif
+
+    /** Whether transactions should be finished automatically. `true` by default.
+     * - Warning: Setting this value to `false` will prevent the SDK from finishing transactions.
+     * In this case, you *must* finish transactions in your app, otherwise they will remain in the queue and
+     * will turn up every time the app is opened.
+     * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
+     */
+    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
+    var finishTransactions: Bool { get set }
 
 }
 

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -38,7 +38,15 @@ public protocol PurchasesType: AnyObject {
      * will turn up every time the app is opened.
      * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
      */
+    @available(*, deprecated, message: "Use purchasesAreCompletedBy instead.")
     var finishTransactions: Bool { get set }
+
+    /** Controls if purchaess should be made and transactions finished automatically by RevenueCat.
+     * `.revenueCat` by default.
+     * - Warning: Setting this value to `.myApp` will prevent the SDK from making purchaes and finishing transactions.
+     * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
+     */
+    var purchasesAreCompletedBy: PurchasesAreCompletedBy { get set }
 
     /**
      * Delegate for ``Purchases`` instance. The delegate is responsible for handling promotional product purchases and

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1068,7 +1068,7 @@ public protocol PurchasesSwiftType: AnyObject {
      * - Returns: A ``StoreTransaction`` if there was a transacton found and handled for the provided product ID.
      *
      * - Important: This should only be used if you have enabled observer mode during SDK configuration using 
-     * ``Configuration/Builder/with(observerMode:storeKitVersion:)``
+     * ``Configuration/Builder/with(purchasesAreCompletedBy:storeKitVersion:)``
      */
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     func register(

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1072,7 +1072,7 @@ public protocol PurchasesSwiftType: AnyObject {
      * ``Configuration/Builder/with(purchasesAreCompletedBy:storeKitVersion:)``
      */
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func register(
+    func recordPurchase(
         _ purchaseResult: StoreKit.Product.PurchaseResult
     ) async throws -> StoreTransaction?
 

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -42,8 +42,8 @@ public protocol PurchasesType: AnyObject {
     var finishTransactions: Bool { get set }
 
     /** Controls if purchases should be made and transactions finished automatically by RevenueCat.
-     * `.revenueCat` by default.
-     * - Warning: Setting this value to `.myApp` will prevent the SDK from making purchases and finishing transactions.
+     * ``.revenueCat`` by default.
+     * - Warning: Setting this value to ``.myApp`` will prevent the SDK from making purchases and finishing transactions.
      * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
      */
     var purchasesAreCompletedBy: PurchasesAreCompletedBy { get set }

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -33,8 +33,8 @@ public protocol PurchasesType: AnyObject {
     var isAnonymous: Bool { get }
 
     /** Controls if purchases should be made and transactions finished automatically by RevenueCat.
-     * `.revenueCat` by default.
-     * - Warning: Setting this value to `.myApp` will prevent the SDK from making purchases and finishing transactions.
+     * ``PurchasesAreCompletedBy/revenueCat`` by default.
+     * - Warning: Setting this value to ``PurchasesAreCompletedBy/myApp`` will prevent the SDK from making purchases and finishing transactions.
      * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
      */
     var purchasesAreCompletedBy: PurchasesAreCompletedBy { get set }

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1071,7 +1071,7 @@ public protocol PurchasesSwiftType: AnyObject {
      * ``Configuration/Builder/with(observerMode:storeKitVersion:)``
      */
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func addPurchaseCompletedByMyAppPurchaseResult(
+    func didCompletePurchaseWithResult(
         _ purchaseResult: StoreKit.Product.PurchaseResult
     ) async throws -> StoreTransaction?
 

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -34,7 +34,8 @@ public protocol PurchasesType: AnyObject {
 
     /** Controls if purchases should be made and transactions finished automatically by RevenueCat.
      * ``PurchasesAreCompletedBy/revenueCat`` by default.
-     * - Warning: Setting this value to ``PurchasesAreCompletedBy/myApp`` will prevent the SDK from making purchases and finishing transactions.
+     * - Warning: Setting this value to ``PurchasesAreCompletedBy/myApp``
+     * will prevent the SDK from making purchases and finishing transactions.
      * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
      */
     var purchasesAreCompletedBy: PurchasesAreCompletedBy { get set }

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1071,7 +1071,7 @@ public protocol PurchasesSwiftType: AnyObject {
      * ``Configuration/Builder/with(observerMode:storeKitVersion:)``
      */
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func handleObserverModeTransaction(
+    func addPurchaseCompletedByMyAppPurchaseResult(
         _ purchaseResult: StoreKit.Product.PurchaseResult
     ) async throws -> StoreTransaction?
 

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -33,8 +33,8 @@ public protocol PurchasesType: AnyObject {
     var isAnonymous: Bool { get }
 
     /** Controls if purchases should be made and transactions finished automatically by RevenueCat.
-     * ``.revenueCat`` by default.
-     * - Warning: Setting this value to ``.myApp`` will prevent the SDK from making purchases and finishing transactions.
+     * `.revenueCat` by default.
+     * - Warning: Setting this value to `.myApp` will prevent the SDK from making purchases and finishing transactions.
      * More information on finishing transactions manually [is available here](https://rev.cat/finish-transactions).
      */
     var purchasesAreCompletedBy: PurchasesAreCompletedBy { get set }

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1040,7 +1040,7 @@ public protocol PurchasesSwiftType: AnyObject {
      * guard let product = product else { return }
      * let result = try await product.purchase()
      * // Let RevenueCat handle the transaction result
-     * _ = try await Purchases.shared.handleObserverModeTransaction(result)
+     * _ = try await Purchases.shared.recordPurchase(result)
      * // Handle the result and finish the transaction
      * switch result {
      * case .success(let verification):

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
@@ -13,7 +13,7 @@ func checkConfigurationAPI() {
         .builder(withAPIKey: "")
         .with(apiKey: "")
         .with(appUserID: nil)
-        .with(observerMode: false, storeKitVersion: .storeKit1)
+        .with(purchasesAreCompletedBy: .myApp, storeKitVersion: .storeKit1)
         .with(userDefaults: UserDefaults.standard)
         .with(dangerousSettings: DangerousSettings())
         .with(dangerousSettings: DangerousSettings(autoSyncPurchases: true))

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -19,12 +19,12 @@ func checkPurchasesAPI() {
     let purch = checkConfigure()!
 
     // initializers
-    let finishTransactions: Bool = purch.finishTransactions
+    let purchasesAreCompletedBy: PurchasesAreCompletedBy = purch.purchasesAreCompletedBy
     let delegate: PurchasesDelegate? = purch.delegate
     let appUserID: String = purch.appUserID
     let isAnonymous: Bool = purch.isAnonymous
 
-    print(finishTransactions, delegate!, appUserID, isAnonymous)
+    print(purchasesAreCompletedBy, delegate!, appUserID, isAnonymous)
 
     checkStaticMethods()
     checkIdentity(purchases: purch)

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
@@ -14,7 +14,7 @@
 + (void)checkAPI {
     RCConfigurationBuilder *builder = [RCConfiguration builderWithAPIKey:@""];
     RCConfiguration *config __unused = [[[[[[[[[[[[[builder withApiKey:@""]
-                                                   withObserverMode:false storeKitVersion:RCStoreKitVersion2]
+                                                   withPurchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat storeKitVersion:RCStoreKitVersion2]
                                                   withUserDefaults:NSUserDefaults.standardUserDefaults]
                                                  withAppUserID:@""]
                                                 withAppUserID:nil]

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -252,6 +252,7 @@ BOOL isAnonymous;
         case RCPurchasesAreCompletedByMyApp:
         case RCPurchasesAreCompletedByRevenueCat:
             NSLog(@"%ld", (long)pacb);
+    }
 }
 
 + (void)checkConstants {

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -36,10 +36,6 @@ BOOL isAnonymous;
     [RCPurchases configureWithConfigurationBuilder:[RCConfiguration builderWithAPIKey:@""]];
     [RCPurchases configureWithAPIKey:@"" appUserID:@""];
     [RCPurchases configureWithAPIKey:@"" appUserID:nil];
-    [RCPurchases configureWithAPIKey:@"" appUserID:@"" observerMode:false userDefaults:nil];
-    [RCPurchases configureWithAPIKey:@"" appUserID:nil observerMode:false userDefaults:nil];
-    [RCPurchases configureWithAPIKey:@"" appUserID:@"" observerMode:false userDefaults:[[NSUserDefaults alloc] init]];
-    [RCPurchases configureWithAPIKey:@"" appUserID:nil observerMode:false userDefaults:[[NSUserDefaults alloc] init]];
     [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat storeKitVersion:RCStoreKitVersion2];
     [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:RCPurchasesAreCompletedByMyApp storeKitVersion:RCStoreKitVersion1];
     [RCPurchases configureWithAPIKey:@""

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -36,16 +36,12 @@ BOOL isAnonymous;
     [RCPurchases configureWithConfigurationBuilder:[RCConfiguration builderWithAPIKey:@""]];
     [RCPurchases configureWithAPIKey:@"" appUserID:@""];
     [RCPurchases configureWithAPIKey:@"" appUserID:nil];
-    [RCPurchases configureWithAPIKey:@"" appUserID:@"" observerMode:false storeKitVersion:RCStoreKitVersion1];
-    [RCPurchases configureWithAPIKey:@"" appUserID:nil observerMode:false storeKitVersion:RCStoreKitVersion2];
     [RCPurchases configureWithAPIKey:@"" appUserID:@"" observerMode:false userDefaults:nil];
     [RCPurchases configureWithAPIKey:@"" appUserID:nil observerMode:false userDefaults:nil];
     [RCPurchases configureWithAPIKey:@"" appUserID:@"" observerMode:false userDefaults:[[NSUserDefaults alloc] init]];
     [RCPurchases configureWithAPIKey:@"" appUserID:nil observerMode:false userDefaults:[[NSUserDefaults alloc] init]];
-    [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat];
-    [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat];
-    [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByMyApp];
-    [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:RCPurchasesAreCompletedByMyApp];
+    [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat storeKitVersion:RCStoreKitVersion2];
+    [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:RCPurchasesAreCompletedByMyApp storeKitVersion:RCStoreKitVersion1];
     [RCPurchases configureWithAPIKey:@""
                            appUserID:nil
                         observerMode:false

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -25,6 +25,7 @@ RCPurchases *sharedPurchases;
 BOOL isConfigured;
 BOOL allowSharingAppStoreAccount;
 BOOL finishTransactions;
+RCPurchasesAreCompletedBy purchasesAreCompletedBy;
 id<RCPurchasesDelegate> delegate;
 NSString *appUserID;
 BOOL isAnonymous;
@@ -41,6 +42,10 @@ BOOL isAnonymous;
     [RCPurchases configureWithAPIKey:@"" appUserID:nil observerMode:false userDefaults:nil];
     [RCPurchases configureWithAPIKey:@"" appUserID:@"" observerMode:false userDefaults:[[NSUserDefaults alloc] init]];
     [RCPurchases configureWithAPIKey:@"" appUserID:nil observerMode:false userDefaults:[[NSUserDefaults alloc] init]];
+    [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat];
+    [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat];
+    [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByMyApp];
+    [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:
     [RCPurchases configureWithAPIKey:@""
                            appUserID:nil
                         observerMode:false
@@ -96,6 +101,7 @@ BOOL isAnonymous;
     allowSharingAppStoreAccount = [p allowSharingAppStoreAccount];
 
     finishTransactions = [p finishTransactions];
+    purchasesAreCompletedBy = [p purchasesAreCompletedBy];
     delegate = [p delegate];
     appUserID = [p appUserID];
     isAnonymous = [p isAnonymous];
@@ -230,7 +236,7 @@ BOOL isAnonymous;
         case RCLogLevelInfo:
         case RCLogLevelWarn:
         case RCLogLevelError:
-            NSLog(@"%ld", (long)o);
+            NSLog(@"%ld", (long)l);
     }
 
     RCStoreMessageType smt = RCStoreMessageTypeBillingIssue;
@@ -238,8 +244,14 @@ BOOL isAnonymous;
         case RCStoreMessageTypeBillingIssue:
         case RCStoreMessageTypePriceIncreaseConsent:
         case RCStoreMessageTypeGeneric:
-            NSLog(@"%ld", (long)o);
+            NSLog(@"%ld", (long)smt);
     }
+
+    RCPurchasesAreCompletedBy pacb = RCPurchasesAreCompletedByRevenueCat;
+    switch(pacb) {
+        case RCPurchasesAreCompletedByMyApp:
+        case RCPurchasesAreCompletedByRevenueCat:
+            NSLog(@"%ld", (long)pacb);
 }
 
 + (void)checkConstants {

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -45,7 +45,7 @@ BOOL isAnonymous;
     [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat];
     [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat];
     [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByMyApp];
-    [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:
+    [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:RCPurchasesAreCompletedByMyApp];
     [RCPurchases configureWithAPIKey:@""
                            appUserID:nil
                         observerMode:false

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
@@ -13,7 +13,7 @@ func checkConfigurationAPI() {
         .builder(withAPIKey: "")
         .with(apiKey: "")
         .with(appUserID: nil)
-        .with(observerMode: true, storeKitVersion: .storeKit2)
+        .with(purchasesAreCompletedBy: .myApp, storeKitVersion: .storeKit2)
         .with(userDefaults: UserDefaults.standard)
         .with(dangerousSettings: DangerousSettings())
         .with(dangerousSettings: DangerousSettings(autoSyncPurchases: true))

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -261,7 +261,7 @@ private func checkAsyncMethods(purchases: Purchases) async {
 
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
             let result = try await StoreKit.Product.products(for: [""]).first!.purchase()
-            let _: StoreTransaction? = try await purchases.register(result)
+            let _: StoreTransaction? = try await purchases.recordPurchase(result)
         }
 
         for try await _: CustomerInfo in purchases.customerInfoStream {}

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -376,6 +376,8 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
                         useStoreKit2IfAvailable: true,
                         dangerousSettings: DangerousSettings(autoSyncPurchases: false))
 
+    let _: Bool = purchases.finishTransactions
+
     _ = Configuration
         .builder(withAPIKey: "")
         .with(observerMode: true)

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -345,10 +345,6 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
 
     purchases.logIn("") { (_: CustomerInfo?, _: Bool, _: Error?) in }
 
-    Purchases.configure(withAPIKey: "", appUserID: "", observerMode: true, userDefaults: nil)
-    Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true, userDefaults: nil)
-    Purchases.configure(withAPIKey: "", appUserID: "", observerMode: true, userDefaults: UserDefaults())
-    Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true, userDefaults: UserDefaults())
     Purchases.configure(withAPIKey: "", appUserID: "")
     Purchases.configure(withAPIKey: "",
                         appUserID: nil,

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -261,7 +261,7 @@ private func checkAsyncMethods(purchases: Purchases) async {
 
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
             let result = try await StoreKit.Product.products(for: [""]).first!.purchase()
-            let _: StoreTransaction? = try await purchases.addPurchaseCompletedByMyAppPurchaseResult(result)
+            let _: StoreTransaction? = try await purchases.didCompletePurchaseWithResult(result)
         }
 
         for try await _: CustomerInfo in purchases.customerInfoStream {}

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -261,7 +261,7 @@ private func checkAsyncMethods(purchases: Purchases) async {
 
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
             let result = try await StoreKit.Product.products(for: [""]).first!.purchase()
-            let _: StoreTransaction? = try await purchases.didCompletePurchaseWithResult(result)
+            let _: StoreTransaction? = try await purchases.register(result)
         }
 
         for try await _: CustomerInfo in purchases.customerInfoStream {}

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -261,7 +261,7 @@ private func checkAsyncMethods(purchases: Purchases) async {
 
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
             let result = try await StoreKit.Product.products(for: [""]).first!.purchase()
-            let _: StoreTransaction? = try await purchases.handleObserverModeTransaction(result)
+            let _: StoreTransaction? = try await purchases.addPurchaseCompletedByMyAppPurchaseResult(result)
         }
 
         for try await _: CustomerInfo in purchases.customerInfoStream {}

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -300,7 +300,7 @@ private func checkConfigure() -> Purchases! {
     Purchases.configure(with: Configuration.Builder(withAPIKey: ""))
     Purchases.configure(with: Configuration.Builder(withAPIKey: "").build())
     Purchases.configure(with: Configuration.Builder(withAPIKey: "")
-        .with(observerMode: true, storeKitVersion: .default)
+        .with(purchasesAreCompletedBy: .myApp, storeKitVersion: .default)
         .build())
     Purchases.configure(with: Configuration.Builder(withAPIKey: "")
         .with(showStoreMessagesAutomatically: false)
@@ -350,8 +350,6 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
     Purchases.configure(withAPIKey: "", appUserID: "", observerMode: true, userDefaults: UserDefaults())
     Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true, userDefaults: UserDefaults())
     Purchases.configure(withAPIKey: "", appUserID: "")
-    Purchases.configure(withAPIKey: "", appUserID: "", observerMode: false)
-    Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true)
     Purchases.configure(withAPIKey: "",
                         appUserID: nil,
                         observerMode: true,
@@ -378,7 +376,4 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
 
     let _: Bool = purchases.finishTransactions
 
-    _ = Configuration
-        .builder(withAPIKey: "")
-        .with(observerMode: true)
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -19,12 +19,12 @@ func checkPurchasesAPI() {
     let purch = checkConfigure()!
 
     // initializers
-    let finishTransactions: Bool = purch.finishTransactions
+    let purchasesAreCompletedBy: PurchasesAreCompletedBy = purch.purchasesAreCompletedBy
     let delegate: PurchasesDelegate? = purch.delegate
     let appUserID: String = purch.appUserID
     let isAnonymous: Bool = purch.isAnonymous
 
-    print(finishTransactions, delegate!, appUserID, isAnonymous)
+    print(purchasesAreCompletedBy, delegate!, appUserID, isAnonymous)
 
     checkStaticMethods()
     checkIdentity(purchases: purch)
@@ -308,7 +308,7 @@ private func checkConfigure() -> Purchases! {
 
     Purchases.configure(withAPIKey: "")
     Purchases.configure(withAPIKey: "", appUserID: nil)
-    Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true, storeKitVersion: .default)
+    Purchases.configure(withAPIKey: "", appUserID: nil, purchasesAreCompletedBy: .myApp, storeKitVersion: .default)
 
     return nil
 }
@@ -339,6 +339,7 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
     Purchases.addAttributionData([String: Any](), from: AttributionNetwork.adjust, forNetworkUserId: nil)
     let _: Bool = Purchases.automaticAppleSearchAdsAttributionCollection
     Purchases.automaticAppleSearchAdsAttributionCollection = false
+    purchases.finishTransactions = true
 
     purchases.checkTrialOrIntroDiscountEligibility([String]()) { (_: [String: IntroEligibility]) in }
 
@@ -350,6 +351,7 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
     Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true, userDefaults: UserDefaults())
     Purchases.configure(withAPIKey: "", appUserID: "")
     Purchases.configure(withAPIKey: "", appUserID: "", observerMode: false)
+    Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true)
     Purchases.configure(withAPIKey: "",
                         appUserID: nil,
                         observerMode: true,
@@ -373,4 +375,8 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
                         userDefaults: UserDefaults(),
                         useStoreKit2IfAvailable: true,
                         dangerousSettings: DangerousSettings(autoSyncPurchases: false))
+
+    _ = Configuration
+        .builder(withAPIKey: "")
+        .with(observerMode: true)
 }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -21,12 +21,12 @@ class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
     override class var storeKitVersion: StoreKitVersion { return .storeKit2 }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func testObservingTransactionThrowsIfObserverModeNotEnabled() async throws {
+    func testRecordingPurchaseThrowsIfPurchasesAreNotCompletedByMyApp() async throws {
         let manager = ObserverModeManager()
         let result = try await manager.purchaseProductFromStoreKit2()
 
         do {
-            _ = try await Purchases.shared.handleObserverModeTransaction(result)
+            _ = try await Purchases.shared.recordPurchase(result)
             fail("Expected error")
         } catch {
             expect(error).to(matchError(ErrorCode.configurationError))

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -197,7 +197,7 @@ class StoreKit2NotEnabledObserverModeIntegrationTests: BaseStoreKitObserverModeI
         let result = try await manager.purchaseProductFromStoreKit2()
 
         do {
-            _ = try await Purchases.shared.handleObserverModeTransaction(result)
+            _ = try await Purchases.shared.recordPurchase(result)
             fail("Expected error")
         } catch {
             expect(error).to(matchError(ErrorCode.configurationError))

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -255,6 +255,7 @@ class PurchaseCompletedHandlerTests: TestCase {
         expect(error).toEventually(matchError(Self.failureError))
     }
 
+    private static let externalPurchaseHandler: PurchaseHandler = .mock(purchasesAreCompletedBy: .myApp)
     private static let purchaseHandler: PurchaseHandler = .mock()
     private static let failingHandler: PurchaseHandler = .failing(failureError)
     private static let offering = TestData.offeringWithNoIntroOffer

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -452,7 +452,7 @@ extension MockPurchases: PurchasesSwiftType {
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func didCompletePurchaseWithResult(
+    func register(
         _ purchaseResult: Product.PurchaseResult
     ) async throws -> RevenueCat.StoreTransaction? {
         self.unimplemented()

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -452,7 +452,7 @@ extension MockPurchases: PurchasesSwiftType {
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func addPurchaseCompletedByMyAppPurchaseResult(
+    func didCompletePurchaseWithResult(
         _ purchaseResult: Product.PurchaseResult
     ) async throws -> RevenueCat.StoreTransaction? {
         self.unimplemented()

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -129,6 +129,12 @@ extension MockPurchases: PurchasesType {
         set { self.unimplemented() }
     }
 
+    var purchasesAreCompletedBy: PurchasesAreCompletedBy {
+        get { self.unimplemented() }
+        // swiftlint:disable:next unused_setter_value
+        set { self.unimplemented() }
+    }
+
     var delegate: PurchasesDelegate? {
         get { self.unimplemented() }
         // swiftlint:disable:next unused_setter_value

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -452,7 +452,7 @@ extension MockPurchases: PurchasesSwiftType {
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func register(
+    func recordPurchase(
         _ purchaseResult: Product.PurchaseResult
     ) async throws -> RevenueCat.StoreTransaction? {
         self.unimplemented()

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -452,7 +452,7 @@ extension MockPurchases: PurchasesSwiftType {
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func handleObserverModeTransaction(
+    func addPurchaseCompletedByMyAppPurchaseResult(
         _ purchaseResult: Product.PurchaseResult
     ) async throws -> RevenueCat.StoreTransaction? {
         self.unimplemented()

--- a/Tests/UnitTests/Purchasing/ConfigurationTests.swift
+++ b/Tests/UnitTests/Purchasing/ConfigurationTests.swift
@@ -49,9 +49,9 @@ class ConfigurationTests: TestCase {
         expect(configuration.storeKitVersion) == .storeKit2
     }
 
-    func testObserverModeWithStoreKit1() {
+    func testPurchasesAreCompletedByMyAppWithStoreKit1() {
         let configuration = Configuration.Builder(withAPIKey: "test")
-            .with(observerMode: true, storeKitVersion: .storeKit1)
+            .with(purchasesAreCompletedBy: .myApp, storeKitVersion: .storeKit1)
             .build()
 
         expect(configuration.observerMode) == true
@@ -60,7 +60,7 @@ class ConfigurationTests: TestCase {
 
     func testObserverModeWithStoreKit2() {
         let configuration = Configuration.Builder(withAPIKey: "test")
-            .with(observerMode: true, storeKitVersion: .storeKit2)
+            .with(purchasesAreCompletedBy: .myApp, storeKitVersion: .storeKit2)
             .build()
 
         expect(configuration.observerMode) == true

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -493,8 +493,8 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     // MARK: - OfflineCustomerInfoCreator
 
-    func testObserverModeDoesNotCreateOfflineCustomerInfoCreator() {
-        expect(Self.create(observerMode: true).offlineCustomerInfoEnabled) == false
+    func testPurchaesAreCompletedByMyAppDoesNotCreateOfflineCustomerInfoCreator() {
+        expect(Self.create(purchasesAreCompletedBy: .myApp).offlineCustomerInfoEnabled) == false
     }
 
     func testOlderVersionsDoNoCreateOfflineCustomerInfo() throws {
@@ -502,19 +502,19 @@ class PurchasesConfiguringTests: BasePurchasesTests {
             throw XCTSkip("Test for older versions")
         }
 
-        expect(Self.create(observerMode: false).offlineCustomerInfoEnabled) == false
+        expect(Self.create(purchasesAreCompletedBy: .revenueCat).offlineCustomerInfoEnabled) == false
     }
 
     func testOfflineCustomerInfoEnabled() throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        expect(Self.create(observerMode: false).offlineCustomerInfoEnabled) == true
+        expect(Self.create(purchasesAreCompletedBy: .revenueCat).offlineCustomerInfoEnabled) == true
     }
 
-    private static func create(observerMode: Bool) -> Purchases {
+    private static func create(purchasesAreCompletedBy: PurchasesAreCompletedBy) -> Purchases {
         return Purchases.configure(
             with: .init(withAPIKey: "")
-                .with(observerMode: observerMode, storeKitVersion: .storeKit1)
+                .with(purchasesAreCompletedBy: purchasesAreCompletedBy, storeKitVersion: .storeKit1)
         )
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -98,9 +98,15 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     @available(*, deprecated) // Ignore deprecation warnings
     func testSharedInstanceIsSetWhenConfiguringWithAppUserIDAndUserDefaults() {
-        let purchases = Purchases.configure(withAPIKey: "", appUserID: "", observerMode: false, userDefaults: nil)
+        let nonStaticString = String(123)
+        let configurationBuilder = Configuration.Builder(withAPIKey: "")
+            .with(appUserID: nonStaticString)
+            .with(userDefaults: UserDefaults.standard)
+        let purchases = Purchases.configure(with: configurationBuilder.build())
+
         expect(Purchases.shared) === purchases
         expect(Purchases.shared.finishTransactions) == true
+        expect(Purchases.shared.purchasesAreCompletedBy) == .revenueCat
     }
 
     @available(*, deprecated) // Ignore deprecation warnings
@@ -112,6 +118,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
                                             useStoreKit2IfAvailable: true)
         expect(Purchases.shared) === purchases
         expect(Purchases.shared.finishTransactions) == true
+        expect(Purchases.shared.purchasesAreCompletedBy) == .revenueCat
     }
 
     func testUserIdIsSetWhenConfiguringWithUserID() {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -74,16 +74,26 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     @available(*, deprecated)
     func testSharedInstanceIsSetWhenConfiguringWithObserverMode() {
-        let purchases = Purchases.configure(withAPIKey: "", appUserID: "", observerMode: true)
+        let nonStaticString = String(123)
+        let purchases = Purchases.configure(withAPIKey: "",
+                                            appUserID: nonStaticString,
+                                            purchasesAreCompletedBy: .myApp,
+                                            storeKitVersion: .storeKit2)
         expect(Purchases.shared) === purchases
         expect(Purchases.shared.finishTransactions) == false
+        expect(Purchases.shared.purchasesAreCompletedBy) == .myApp
     }
 
     @available(*, deprecated)
     func testSharedInstanceIsSetWhenConfiguringWithObserverModeDisabled() {
-        let purchases = Purchases.configure(withAPIKey: "", appUserID: "", observerMode: false)
+        let nonStaticString = String(123)
+        let purchases = Purchases.configure(withAPIKey: "",
+                                            appUserID: nonStaticString,
+                                            purchasesAreCompletedBy: .revenueCat,
+                                            storeKitVersion: .storeKit2)
         expect(Purchases.shared) === purchases
         expect(Purchases.shared.finishTransactions) == true
+        expect(Purchases.shared.purchasesAreCompletedBy) == .revenueCat
     }
 
     @available(*, deprecated) // Ignore deprecation warnings

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -214,7 +214,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
     }
 
     func testDoesntFinishTransactionsIfFinishingDisabled() throws {
-        self.purchases.finishTransactions = false
+        self.purchases.purchasesAreCompletedBy = .myApp
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 


### PR DESCRIPTION
Adds a `PurchasesAreCompletedBy` enum which is used to set if the RC SDK performs the purchase, formerly referred to as "observer mode". This replaces observer mode and finishTransactions. The change has only been made to public-facing APIs, internal ones will be renamed as part of a subsequent PR.

Other changes:

- Renamed `handleObserverModeTransaction(_ PurchaseResult:` to `recordPurchase(_ PurchaseResult:` to try to better communicate what the purpose of the call is. Feedback on if this is needed and what the new name should be is welcome!

- There is a "deprecated" method that doesn't appear to really be a deprecated method, but the deprecation is used as a way of generating a warning where customers are likely mis-using the API. I updated its signature to match the new API. Screenshot of the change for clarity:
<img width="906" alt="image" src="https://github.com/RevenueCat/purchases-ios/assets/109382862/a7780f50-7f85-443f-8312-b0ef4a0b1928">

