### PR TITLE
Fix onChangeOf to be internal instead of public

### DIFF
--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -36,7 +36,7 @@ extension View {
     /// Wraps the 2 `onChange(of:)` implementations in iOS 17+ and below depending on what's available
     @inlinable
     @ViewBuilder
-    public func onChangeOf<V>(
+    func onChangeOf<V>(
         _ value: V,
         perform action: @escaping (_ newValue: V) -> Void
     ) -> some View where V: Equatable {


### PR DESCRIPTION
### Motivation

Prevent `onChangeOf` from being leaked as a public method

### Description

Remove `public` from `onChangeOf` which will make it `internal`

⚠️ Not marking as deprecated but will put something in the release notes about this
