### PR TITLE
Bring back offline integration tests on M1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1228,76 +1228,77 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      - lint
-      - spm-release-build-xcode-14:
-          xcode_version: '14.3.0'
-          install_swiftlint: false
-      - spm-release-build-xcode-15:
-          xcode_version: '15.2'
-      - spm-xcode-14-1:
-          xcode_version: '14.1.0'
-          install_swiftlint: false
-      - spm-custom-entitlement-computation-build
-      - spm-receipt-parser
-      - spm-revenuecat-ui-ios-15:
-          xcode_version: '14.3.0'
-          install_swiftlint: false
-      - spm-revenuecat-ui-ios-16:
-          xcode_version: '14.3.0'
-          install_swiftlint: false
-      - spm-revenuecat-ui-ios-17:
-          xcode_version: '15.2'
-      - spm-revenuecat-ui-watchos
-      - run-test-macos
-      - run-test-ios-17:
-          xcode_version: '15.2'
-      - run-test-ios-16:
-          xcode_version: '14.3.0'
-          install_swiftlint: false
-      - run-test-ios-15:
-          xcode_version: '14.3.0'
-          install_swiftlint: false
-      - run-test-watchos:
-          xcode_version: '14.3.0'
-      - run-test-tvos
-      # Pre-iOS 15 requires macOS 12 which requires Xcode 14.2
-      # See https://circleci.com/docs/using-macos/#supported-xcode-versions
-      - run-test-ios-14:
-          xcode_version: '14.2.0'
-          install_swiftlint: false
-      - run-test-ios-13:
-          xcode_version: '14.2.0'
-          install_swiftlint: false
-          <<: *release-branches-and-main
+      # - lint
+      # - spm-release-build-xcode-14:
+      #     xcode_version: '14.3.0'
+      #     install_swiftlint: false
+      # - spm-release-build-xcode-15:
+      #     xcode_version: '15.2'
+      # - spm-xcode-14-1:
+      #     xcode_version: '14.1.0'
+      #     install_swiftlint: false
+      # - spm-custom-entitlement-computation-build
+      # - spm-receipt-parser
+      # - spm-revenuecat-ui-ios-15:
+      #     xcode_version: '14.3.0'
+      #     install_swiftlint: false
+      # - spm-revenuecat-ui-ios-16:
+      #     xcode_version: '14.3.0'
+      #     install_swiftlint: false
+      # - spm-revenuecat-ui-ios-17:
+      #     xcode_version: '15.2'
+      # - spm-revenuecat-ui-watchos
+      # - run-test-macos
+      # - run-test-ios-17:
+      #     xcode_version: '15.2'
+      # - run-test-ios-16:
+      #     xcode_version: '14.3.0'
+      #     install_swiftlint: false
+      # - run-test-ios-15:
+      #     xcode_version: '14.3.0'
+      #     install_swiftlint: false
+      # - run-test-watchos:
+      #     xcode_version: '14.3.0'
+      # - run-test-tvos
+      # # Pre-iOS 15 requires macOS 12 which requires Xcode 14.2
+      # # See https://circleci.com/docs/using-macos/#supported-xcode-versions
+      # - run-test-ios-14:
+      #     xcode_version: '14.2.0'
+      #     install_swiftlint: false
+      # - run-test-ios-13:
+      #     xcode_version: '14.2.0'
+      #     install_swiftlint: false
+      #     <<: *release-branches-and-main
+      - installation-tests-carthage
       - run-test-ios-12:
           xcode_version: '14.2.0'
           install_swiftlint: false
-          <<: *release-branches-and-main
-      - build-tv-watch-and-macos
-      - build-visionos
-      - backend-integration-tests-SK1:
-          filters:
-              branches:
-                # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-                ignore: /pull\/[0-9]+/
-      - backend-integration-tests-SK2:
-          filters:
-              branches:
-                # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-                ignore: /pull\/[0-9]+/
-      - backend-integration-tests-other:
-          filters:
-              branches:
-                # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-                ignore: /pull\/[0-9]+/
-      - backend-integration-tests-offline:
-          # These tests are flaky due to FB13133387 so we don't want the noise in every PR
-          <<: *release-branches-and-main
-      - backend-integration-tests-custom-entitlements:
-          filters:
-              branches:
-                # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-                ignore: /pull\/[0-9]+/
+      #     <<: *release-branches-and-main
+      # - build-tv-watch-and-macos
+      # - build-visionos
+      # - backend-integration-tests-SK1:
+      #     filters:
+      #         branches:
+      #           # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+      #           ignore: /pull\/[0-9]+/
+      # - backend-integration-tests-SK2:
+      #     filters:
+      #         branches:
+      #           # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+      #           ignore: /pull\/[0-9]+/
+      # - backend-integration-tests-other:
+      #     filters:
+      #         branches:
+      #           # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+      #           ignore: /pull\/[0-9]+/
+      - backend-integration-tests-offline
+      #     # These tests are flaky due to FB13133387 so we don't want the noise in every PR
+      #     <<: *release-branches-and-main
+      # - backend-integration-tests-custom-entitlements:
+      #     filters:
+      #         branches:
+      #           # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+      #           ignore: /pull\/[0-9]+/
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1228,77 +1228,76 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      # - lint
-      # - spm-release-build-xcode-14:
-      #     xcode_version: '14.3.0'
-      #     install_swiftlint: false
-      # - spm-release-build-xcode-15:
-      #     xcode_version: '15.2'
-      # - spm-xcode-14-1:
-      #     xcode_version: '14.1.0'
-      #     install_swiftlint: false
-      # - spm-custom-entitlement-computation-build
-      # - spm-receipt-parser
-      # - spm-revenuecat-ui-ios-15:
-      #     xcode_version: '14.3.0'
-      #     install_swiftlint: false
-      # - spm-revenuecat-ui-ios-16:
-      #     xcode_version: '14.3.0'
-      #     install_swiftlint: false
-      # - spm-revenuecat-ui-ios-17:
-      #     xcode_version: '15.2'
-      # - spm-revenuecat-ui-watchos
-      # - run-test-macos
-      # - run-test-ios-17:
-      #     xcode_version: '15.2'
-      # - run-test-ios-16:
-      #     xcode_version: '14.3.0'
-      #     install_swiftlint: false
-      # - run-test-ios-15:
-      #     xcode_version: '14.3.0'
-      #     install_swiftlint: false
-      # - run-test-watchos:
-      #     xcode_version: '14.3.0'
-      # - run-test-tvos
-      # # Pre-iOS 15 requires macOS 12 which requires Xcode 14.2
-      # # See https://circleci.com/docs/using-macos/#supported-xcode-versions
-      # - run-test-ios-14:
-      #     xcode_version: '14.2.0'
-      #     install_swiftlint: false
-      # - run-test-ios-13:
-      #     xcode_version: '14.2.0'
-      #     install_swiftlint: false
-      #     <<: *release-branches-and-main
-      - installation-tests-carthage
+      - lint
+      - spm-release-build-xcode-14:
+          xcode_version: '14.3.0'
+          install_swiftlint: false
+      - spm-release-build-xcode-15:
+          xcode_version: '15.2'
+      - spm-xcode-14-1:
+          xcode_version: '14.1.0'
+          install_swiftlint: false
+      - spm-custom-entitlement-computation-build
+      - spm-receipt-parser
+      - spm-revenuecat-ui-ios-15:
+          xcode_version: '14.3.0'
+          install_swiftlint: false
+      - spm-revenuecat-ui-ios-16:
+          xcode_version: '14.3.0'
+          install_swiftlint: false
+      - spm-revenuecat-ui-ios-17:
+          xcode_version: '15.2'
+      - spm-revenuecat-ui-watchos
+      - run-test-macos
+      - run-test-ios-17:
+          xcode_version: '15.2'
+      - run-test-ios-16:
+          xcode_version: '14.3.0'
+          install_swiftlint: false
+      - run-test-ios-15:
+          xcode_version: '14.3.0'
+          install_swiftlint: false
+      - run-test-watchos:
+          xcode_version: '14.3.0'
+      - run-test-tvos
+      # Pre-iOS 15 requires macOS 12 which requires Xcode 14.2
+      # See https://circleci.com/docs/using-macos/#supported-xcode-versions
+      - run-test-ios-14:
+          xcode_version: '14.2.0'
+          install_swiftlint: false
+      - run-test-ios-13:
+          xcode_version: '14.2.0'
+          install_swiftlint: false
+          <<: *release-branches-and-main
       - run-test-ios-12:
           xcode_version: '14.2.0'
           install_swiftlint: false
-      #     <<: *release-branches-and-main
-      # - build-tv-watch-and-macos
-      # - build-visionos
-      # - backend-integration-tests-SK1:
-      #     filters:
-      #         branches:
-      #           # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-      #           ignore: /pull\/[0-9]+/
-      # - backend-integration-tests-SK2:
-      #     filters:
-      #         branches:
-      #           # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-      #           ignore: /pull\/[0-9]+/
-      # - backend-integration-tests-other:
-      #     filters:
-      #         branches:
-      #           # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-      #           ignore: /pull\/[0-9]+/
-      - backend-integration-tests-offline
-      #     # These tests are flaky due to FB13133387 so we don't want the noise in every PR
-      #     <<: *release-branches-and-main
-      # - backend-integration-tests-custom-entitlements:
-      #     filters:
-      #         branches:
-      #           # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-      #           ignore: /pull\/[0-9]+/
+          <<: *release-branches-and-main
+      - build-tv-watch-and-macos
+      - build-visionos
+      - backend-integration-tests-SK1:
+          filters:
+              branches:
+                # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+                ignore: /pull\/[0-9]+/
+      - backend-integration-tests-SK2:
+          filters:
+              branches:
+                # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+                ignore: /pull\/[0-9]+/
+      - backend-integration-tests-other:
+          filters:
+              branches:
+                # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+                ignore: /pull\/[0-9]+/
+      - backend-integration-tests-offline:
+          # These tests are flaky due to FB13133387 so we don't want the noise in every PR
+          <<: *release-branches-and-main
+      - backend-integration-tests-custom-entitlements:
+          filters:
+              branches:
+                # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+                ignore: /pull\/[0-9]+/
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,12 +150,12 @@ commands:
           condition: << parameters.install_xcbeautify >>
           steps:
             - install-brew-dependency:
-                dependency_name: 'xcbeautify'
+                dependency_name: "xcbeautify"
       - when:
           condition: << parameters.install_mint >>
           steps:
             - install-brew-dependency:
-                dependency_name: 'mint'
+                dependency_name: "mint"
       - when:
           condition: << parameters.install_swiftlint >>
           steps:
@@ -361,7 +361,31 @@ commands:
           command: bundle exec fastlane backend_integration_tests test_plan:"<< parameters.test_plan >>"
           no_output_timeout: 5m
           environment:
-            SCAN_DEVICE: iPhone 14 (17.2.0)
+            SCAN_DEVICE: iPhone 15 (17.4.0)
+      - run:
+          name: Run RETRY 1 (of 4) backend_integration Tests
+          command: bundle exec fastlane retry_failed_tests retry_attempt:1
+          no_output_timeout: 5m
+          environment:
+            SCAN_DEVICE: iPhone 15 Pro (17.4.0)
+      - run:
+          name: Run RETRY 2 (of 4) backend_integration Tests
+          command: bundle exec fastlane retry_failed_tests retry_attempt:2
+          no_output_timeout: 5m
+          environment:
+            SCAN_DEVICE: iPhone 15 Pro Max (17.4.0)
+      - run:
+          name: Run RETRY 3 (of 4) backend_integration Tests
+          command: bundle exec fastlane retry_failed_tests retry_attempt:3
+          no_output_timeout: 5m
+          environment:
+            SCAN_DEVICE: iPhone 15 Plus (17.4.0)
+      - run:
+          name: Run RETRY 4 (of 4) backend_integration Tests
+          command: bundle exec fastlane retry_failed_tests retry_attempt:4 fail_build:true
+          no_output_timeout: 5m
+          environment:
+            SCAN_DEVICE: iPhone 15 Pro (17.4.0)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: BackendIntegrationTests
@@ -813,8 +837,6 @@ jobs:
 
   backend-integration-tests-offline:
     <<: *base-job
-    # These tests are even flakier running on M1
-    resource_class: macos.x86.medium.gen2
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-Offline"

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gem 'cocoapods'
 gem 'cocoapods-trunk'
 gem 'danger'
 gem 'rest-client'
+gem 'nokogiri'
 eval_gemfile("fastlane/Pluginfile")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,12 @@ GEM
     netrc (0.11.0)
     nkf (0.2.0)
     no_proxy_fix (0.1.2)
+    nokogiri (1.16.5-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.5-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.5-x86_64-linux)
+      racc (~> 1.4)
     octokit (8.1.0)
       base64
       faraday (>= 1, < 3)
@@ -278,6 +284,7 @@ GEM
     os (1.1.4)
     plist (3.7.1)
     public_suffix (4.0.7)
+    racc (1.7.3)
     rake (13.2.1)
     rchardet (1.8.0)
     representable (3.2.0)
@@ -350,6 +357,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-create_xcframework
   fastlane-plugin-revenuecat_internal!
+  nokogiri
   rest-client
 
 BUNDLED WITH

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -14,10 +14,10 @@
 import Nimble
 @testable import RevenueCat
 import StoreKit
+import StoreKitTest
 import XCTest
 
 // swiftlint:disable type_name file_length
-
 class BaseOfflineStoreKitIntegrationTests: BaseStoreKitIntegrationTests {
 
     override func setUp() async throws {

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -223,15 +223,20 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         try await self.verifyEntitlementWentThrough(customerInfo)
     }
 
+    @available(iOS 17.0, tvOS 17.0, watchOS 10.0, macOS 14.0, *)
     func testPurchaseFailuresAreReportedCorrectly() async throws {
-        self.testSession.failTransactionsEnabled = true
-        self.testSession.failureError = .invalidSignature
+        try AvailabilityChecks.iOS17APIAvailableOrSkipTest()
+
+        try await self.testSession.setSimulatedError(
+            .purchase(Product.PurchaseError.purchaseNotAllowed),
+            forAPI: .purchase
+        )
 
         do {
             try await self.purchaseMonthlyOffering()
             fail("Expected error")
         } catch {
-            expect(error).to(matchError(ErrorCode.invalidPromotionalOfferError))
+            expect(error).to(matchError(ErrorCode.purchaseNotAllowedError))
         }
     }
 
@@ -351,18 +356,21 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testRenewalsOnASeparateUserDontTransferPurchases() async throws {
+        // forceRenewalOfSubscription doesn't work well, so we use this instead
+        setShortestTestSessionTimeRate(self.testSession)
+
         let prefix = UUID().uuidString
         let userID1 = "\(prefix)-user-1"
         let userID2 = "\(prefix)-user-2"
 
         let anonymousUser = try self.purchases.appUserID
-        let productIdentifier = try await self.monthlyPackage.storeProduct.productIdentifier
+        let productIdentifier = "shortest_duration"
 
         // 1. Purchase with user 1
         let user1CustomerInfo = try await self.purchases.logIn(userID1).customerInfo
         self.assertNoPurchases(user1CustomerInfo)
         expect(user1CustomerInfo.originalAppUserId) == anonymousUser
-        try await self.purchaseMonthlyOffering()
+        try await self.purchaseShortestDuration()
 
         // 2. Change to user 2
         let (identifiedCustomerInfo, _) = try await self.purchases.logIn(userID2)
@@ -370,8 +378,8 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         // 3. Renew subscription
         self.logger.clearMessages()
-
-        try self.testSession.forceRenewalOfSubscription(productIdentifier: productIdentifier)
+        // swiftlint:disable:next force_try
+        try! await Task.sleep(nanoseconds: 3 * 1_000_000_000)
 
         try await self.verifyReceiptIsEventuallyPosted()
 
@@ -382,18 +390,21 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testUserCanMakePurchaseAfterTransferBlocked() async throws {
+        // forceRenewalOfSubscription doesn't work well, so we use this instead
+        setShortestTestSessionTimeRate(self.testSession)
+
         let prefix = UUID().uuidString
         let userID1 = "\(prefix)-user-1"
         let userID2 = "\(prefix)-user-2"
 
         let anonymousUser = try self.purchases.appUserID
-        let productIdentifier = try await self.monthlyPackage.storeProduct.productIdentifier
+        let productIdentifier = "shortest_duration"
 
         // 1. Purchase with user 1
         var user1CustomerInfo = try await self.purchases.logIn(userID1).customerInfo
         self.assertNoPurchases(user1CustomerInfo)
         expect(user1CustomerInfo.originalAppUserId) == anonymousUser
-        try await self.purchaseMonthlyOffering()
+        try await self.purchaseShortestDuration()
 
         // 2. Change to user 2
         let (identifiedCustomerInfo, _) = try await self.purchases.logIn(userID2)
@@ -402,7 +413,8 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         // 3. Renew subscription
         self.logger.clearMessages()
 
-        try self.testSession.forceRenewalOfSubscription(productIdentifier: productIdentifier)
+        // swiftlint:disable:next force_try
+        try! await Task.sleep(nanoseconds: 3 * 1_000_000_000)
 
         try await self.verifyReceiptIsEventuallyPosted()
 
@@ -490,9 +502,11 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testIneligibleForIntroAfterPurchase() async throws {
-        let product = try await self.monthlyPackage.storeProduct
+        setShortestTestSessionTimeRate(self.testSession)
 
-        try await self.purchaseMonthlyOffering()
+        let product = try await self.shortestDurationProduct
+
+        try await self.purchaseShortestDuration()
 
         let eligibility = try await self.purchases.checkTrialOrIntroDiscountEligibility(product: product)
         expect(eligibility) == .ineligible
@@ -548,10 +562,12 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testIneligibleForIntroAfterPurchaseExpires() async throws {
-        let product = try await self.monthlyPackage.storeProduct
+        setShortestTestSessionTimeRate(self.testSession)
+
+        let product = try await self.shortestDurationProduct
 
         // 1. Purchase monthly offering
-        let customerInfo = try await self.purchaseMonthlyOffering().customerInfo
+        let customerInfo = try await self.purchaseShortestDuration().customerInfo
 
         // 2. Expire subscription
         let entitlement = try XCTUnwrap(customerInfo.entitlements[Self.entitlementIdentifier])
@@ -579,10 +595,12 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     // MARK: -
 
     func testExpireSubscription() async throws {
+        setShortestTestSessionTimeRate(self.testSession)
+
         let (_, created) = try await self.purchases.logIn(UUID().uuidString)
         expect(created) == true
 
-        let customerInfo = try await self.purchaseMonthlyOffering().customerInfo
+        let customerInfo = try await self.purchaseShortestDuration().customerInfo
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all[Self.entitlementIdentifier])
 
         try await self.expireSubscription(entitlement)
@@ -610,10 +628,13 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testSubscribeAfterExpirationWhileAppIsClosed() async throws {
+        // forceRenewalOfSubscription doesn't work well, so we use this instead
+        setShortestTestSessionTimeRate(self.testSession)
+
         func waitForNewPurchaseDate() async {
             // The backend uses the transaction purchase date as a way to disambiguate transactions.
             // Therefor we need to sleep to force these to have unique dates.
-            try? await Task.sleep(nanoseconds: DispatchTimeInterval.seconds(2).nanoseconds)
+            try? await Task.sleep(nanoseconds: DispatchTimeInterval.seconds(3).nanoseconds)
         }
 
         // 1. Subscribe
@@ -626,7 +647,6 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         // 3. Force several renewals while app is closed.
         for _ in 0..<3 {
             await waitForNewPurchaseDate()
-            try self.testSession.forceRenewalOfSubscription(productIdentifier: entitlement.productIdentifier)
         }
 
         await waitForNewPurchaseDate()
@@ -638,11 +658,13 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         await self.resetSingleton()
 
         // 6. Wait for pending transactions to be posted
-        try await self.waitUntilNoUnfinishedTransactions()
+        // Should be using self.waitUntilNoUnfinishedTransactions() but its been unreliable
+        // Sleeping has been working for now
+        try? await Task.sleep(nanoseconds: DispatchTimeInterval.seconds(5).nanoseconds)
 
         // 7. Purchase again
         self.logger.clearMessages()
-        try await self.purchaseMonthlyProduct()
+        try await self.purchaseShortestDuration()
 
         // 8. Verify transaction is posted as a purchase.
         try await self.verifyReceiptIsEventuallyPosted()

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -68,13 +68,15 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTes
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testRenewalsPostReceipt() async throws {
-        self.testSession.timeRate = .realTime
+        // forceRenewalOfSubscription doesn't work well, so we use this instead
+        setShortestTestSessionTimeRate(self.testSession)
 
-        let productID = Self.monthlyNoIntroProductID
+        let productID = Self.group3MonthlyNoTrialProductID
 
         try await self.manager.purchaseProductFromStoreKit2(productIdentifier: productID)
 
-        try self.testSession.forceRenewalOfSubscription(productIdentifier: productID)
+        // swiftlint:disable:next force_try
+        try! await Task.sleep(nanoseconds: 3 * 1_000_000_000)
 
         try await self.verifyReceiptIsEventuallyPosted()
     }

--- a/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionListenerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionListenerTests.swift
@@ -217,11 +217,16 @@ class StoreKit2TransactionListenerTransactionUpdatesTests: StoreKit2TransactionL
 
     @available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *)
     func testNotifiesDelegateForRenewals() async throws {
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
+
+        setShortestTestSessionTimeRate(self.testSession)
+
         try await self.simulateAnyPurchase(finishTransaction: true)
 
         await self.listener.listenForTransactions()
 
-        try? self.testSession.forceRenewalOfSubscription(productIdentifier: Self.productID)
+        // swiftlint:disable:next force_try
+        try! await Task.sleep(nanoseconds: 3 * 1_000_000_000)
 
         try await self.waitForTransactionUpdated()
 

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -25,11 +25,13 @@ extension XCTestCase {
     }
 
     func setShortestTestSessionTimeRate(_ testSession: SKTestSession) {
+        #if swift(>=5.8)
         if #available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *) {
             testSession.timeRate = .oneRenewalEveryTwoSeconds
         } else if #available(iOS 15.2, tvOS 15.2, macOS 12.1, watchOS 8.3, *) {
             testSession.timeRate = SKTestSession.TimeRate.monthlyRenewalEveryThirtySeconds
         }
+        #endif
     }
 
     func verifyNoUnfinishedTransactions(file: StaticString = #file, line: UInt = #line) async {

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -25,13 +25,15 @@ extension XCTestCase {
     }
 
     func setShortestTestSessionTimeRate(_ testSession: SKTestSession) {
-        #if swift(>=5.8)
         if #available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *) {
+            #if swift(>=5.8)
             testSession.timeRate = .oneRenewalEveryTwoSeconds
+            #else
+            testSession.timeRate = SKTestSession.TimeRate.monthlyRenewalEveryThirtySeconds
+            #endif
         } else if #available(iOS 15.2, tvOS 15.2, macOS 12.1, watchOS 8.3, *) {
             testSession.timeRate = SKTestSession.TimeRate.monthlyRenewalEveryThirtySeconds
         }
-        #endif
     }
 
     func verifyNoUnfinishedTransactions(file: StaticString = #file, line: UInt = #line) async {

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -24,6 +24,14 @@ extension XCTestCase {
         case invalidTransactions([StoreKit.VerificationResult<Transaction>])
     }
 
+    func setShortestTestSessionTimeRate(_ testSession: SKTestSession) {
+        if #available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *) {
+            testSession.timeRate = .oneRenewalEveryTwoSeconds
+        } else if #available(iOS 15.2, tvOS 15.2, macOS 12.1, watchOS 8.3, *) {
+            testSession.timeRate = SKTestSession.TimeRate.monthlyRenewalEveryThirtySeconds
+        }
+    }
+
     func verifyNoUnfinishedTransactions(file: StaticString = #file, line: UInt = #line) async {
         let unfinished = await StoreKit.Transaction.unfinished.extractValues()
         expect(file: file, line: line, unfinished).to(beEmpty())

--- a/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
+++ b/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
@@ -50,6 +50,54 @@
     }
   ],
   "settings" : {
+    "_failTransactionsEnabled" : false,
+    "_storeKitErrors" : [
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Load Products"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Purchase"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Verification"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Store Sync"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Subscription Status"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Transaction"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Manage Subscriptions Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Refund Request Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Offer Code Redeem Sheet"
+      }
+    ],
     "_timeRate" : 6
   },
   "subscriptionGroups" : [
@@ -377,6 +425,45 @@
           "type" : "RecurringSubscription"
         }
       ]
+    },
+    {
+      "id" : "3B8FF1D7",
+      "localizations" : [
+
+      ],
+      "name" : "shortest_durations_group",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "0.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "D8DAF7AC",
+          "introductoryOffer" : {
+            "displayPrice" : "0.99",
+            "internalID" : "AC7330E8",
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P3D"
+          },
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "shortest_duration",
+          "recurringSubscriptionPeriod" : "P1W",
+          "referenceName" : "shortest_duration",
+          "subscriptionGroupID" : "3B8FF1D7",
+          "type" : "RecurringSubscription"
+        }
+      ]
     }
   ],
   "subscriptionOffersKeyPair" : {
@@ -384,7 +471,7 @@
     "privateKey" : "MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgMpw0LScUC+8o+WsEAM20KOMzZOMSWKFjUixtwDidPMugCgYIKoZIzj0DAQehRANCAAQIMw4YEVZrDPrk/1dx5WV3hpkuy8enQs+yDAuJRtsrOnzRH6EFgTyiydprKlgUOHW6xBocrRNTMZXioCBQtchg"
   },
   "version" : {
-    "major" : 2,
+    "major" : 3,
     "minor" : 0
   }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -609,20 +609,77 @@ platform :ios do
 
   end
 
+  private_lane :test_artifact_path do
+    File.absolute_path('./test_output/xctest/ios')
+  end
+
   desc "Run BackendIntegrationTests"
   lane :backend_integration_tests do |options|
+    fail_build = options[:fail_build]
+
     fetch_snapshots
     replace_api_key_integration_tests
-    scan(
-      scheme: "BackendIntegrationTests",
-      derived_data_path: "scan_derived_data",
-      output_types: 'junit',
-      output_style: 'raw',
-      result_bundle: true,
-      testplan: options[:test_plan],
-      configuration: 'Debug',
-      output_directory: "fastlane/test_output/xctest/ios"
+
+    begin
+      scan(
+        scheme: "BackendIntegrationTests",
+        ensure_devices_found: true,
+        derived_data_path: "scan_derived_data",
+        output_types: 'junit',
+        output_style: 'raw',
+        result_bundle: true,
+        testplan: options[:test_plan],
+        configuration: 'Debug',
+        output_directory: test_artifact_path,
+
+        fail_build: !!fail_build
+      )
+    rescue => ex
+        UI.error("Tests failed: #{ex}")
+    end
+
+    retry_scan_save_failed_tests(
+      junit_report_path: File.join(test_artifact_path, 'report.junit'),
+      copy_path: File.join(test_artifact_path, 'report.junit.original')
     )
+  end
+
+  private_lane :failed_tests_path do
+    File.join(test_artifact_path, 'failed_tests.txt')
+  end
+
+  lane :retry_failed_tests do |options|
+    fail_build = options[:fail_build]
+    retry_attempt = options[:retry_attempt]
+    
+    failed_tests = File.read(failed_tests_path).split("\n")
+    
+    if failed_tests.empty?
+      UI.message('No failed tests to retry')
+    else
+      report_dir = "./test_output_retry_#{retry_attempt}/xctest/ios"
+      report_path = File.absolute_path(File.join(report_dir, "report.junit"))
+
+      scan(
+        scheme: "BackendIntegrationTests",
+        ensure_devices_found: true,
+        derived_data_path: "scan_derived_data",
+        output_types: 'junit',
+        output_style: 'raw',
+        result_bundle: true,
+        configuration: 'Debug',
+        output_directory: File.join('fastlane', report_dir),
+
+        only_testing: failed_tests,
+        fail_build: !!fail_build
+      )
+
+      retry_scan_save_failed_tests(
+        junit_report_path: report_path,
+        copy_path: File.join(test_artifact_path, "report.junit.retry.#{retry_attempt}"),
+        merge_path: File.join(test_artifact_path, "report.junit")
+      )
+    end
   end
 
   desc "Run LoadShedder tests"
@@ -631,6 +688,7 @@ platform :ios do
     scan(
       project: "./Tests/v3LoadShedderIntegration/v3LoadShedderIntegration.xcodeproj",
       scheme: "v3LoadShedderIntegration",
+      ensure_devices_found: true,
       derived_data_path: "scan_derived_data",
       output_types: 'junit',
       output_style: 'raw',

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -298,6 +298,14 @@ Export XCFramework
 
 Run BackendIntegrationTests
 
+### ios retry_failed_tests
+
+```sh
+[bundle exec] fastlane ios retry_failed_tests
+```
+
+
+
 ### ios v3_loadshedder_integration_tests
 
 ```sh

--- a/fastlane/actions/retry_scan_save_failed_tests.rb
+++ b/fastlane/actions/retry_scan_save_failed_tests.rb
@@ -1,0 +1,157 @@
+require 'nokogiri'
+
+module Fastlane
+  module Actions
+    module SharedValues
+      RETRY_SCAN_SAVE_FAILED_TESTS_CUSTOM_VALUE = :RETRY_SCAN_SAVE_FAILED_TESTS_CUSTOM_VALUE
+    end
+
+    class RetryScanSaveFailedTestsAction < Action
+      def self.run(params)
+        # './test_output/xctest/ios/report.junit'
+        report_path = params[:junit_report_path]
+        report_path = File.absolute_path(report_path)
+
+        # original
+        copy_path = params[:copy_path]
+        FileUtils.cp(report_path, copy_path)
+
+        save_failed_tests(report_path)
+
+        merge_path = params[:merge_path]
+        if merge_path
+          merge_and_replace_junit(report_path, merge_path)
+        end
+      end
+
+      def self.merge_and_replace_junit(retry_report_path, original_report)
+        merged_report = merge_reports(original_report, retry_report_path)
+        save_report(merged_report, original_report)
+    
+        FileUtils.rm_rf('./test_output/xctest/ios/retry')
+    
+        UI.message "Merged report saved to #{original_report}"
+      end
+
+      def self.parse_report(file_path)
+        Nokogiri::XML(File.open(file_path))
+      end
+      
+      def self.merge_reports(original_report, retry_report)
+        original_doc = parse_report(original_report)
+        retry_doc = parse_report(retry_report)
+      
+        original_testcases = original_doc.xpath('//testcase')
+        retry_testcases = retry_doc.xpath('//testcase')
+      
+        retry_count = 0
+      
+        retry_testcases.each do |retry_testcase|
+          suitename = retry_testcase.parent['name'] # Retrieve suitename
+          classname = retry_testcase['classname']
+          name = retry_testcase['name']
+      
+          original_testcase = original_testcases.find do |tc|
+            tc['classname'] == classname && tc['name'] == name && tc.parent['name'] == suitename
+          end
+      
+          if original_testcase
+            original_testcase.at('failure')&.remove # Remove failure from original
+      
+            # Add retry count attribute to the testcase
+            current_retry_count = original_testcase['retry_count'].to_i
+            original_testcase['retry_count'] = (current_retry_count + 1).to_s
+      
+            retry_count += 1
+          end
+        end
+      
+        # Add total retry count as a property in the testsuite
+        properties_node = original_doc.at('testsuite > properties') || Nokogiri::XML::Node.new('properties', original_doc.at('testsuite'))
+        original_doc.at('testsuite').add_child(properties_node) unless original_doc.at('testsuite > properties')
+      
+        retry_property = Nokogiri::XML::Node.new('property', original_doc)
+        retry_property['name'] = 'total_retries'
+        retry_property['value'] = retry_count.to_s
+      
+        properties_node.add_child(retry_property)
+      
+        original_doc
+      end
+      
+      def self.save_report(doc, output_path)
+        File.open(output_path, 'w') { |file| file.write(doc.to_xml) }
+      end
+
+      def self.failed_tests_path
+        File.absolute_path('./fastlane/test_output/xctest/ios/failed_tests.txt')
+      end
+
+      def self.save_failed_tests(report_path)
+        failed_tests = []
+        
+        if File.exist?(report_path)
+          doc = Nokogiri::XML(File.open(report_path))
+      
+          doc.xpath('//testcase[failure]').each do |test_case|
+            suitename = test_case.parent['name'] # Retrieve the suitename
+            classname = test_case['classname']
+            name = test_case['name']
+            failed_tests << "#{suitename}/#{classname}/#{name}"
+          end
+    
+          failed_tests = failed_tests.uniq
+      
+          File.open(failed_tests_path, 'w') do |file|
+            file.puts(failed_tests)
+          end
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'A short description with <= 80 characters of what this action does'
+      end
+
+      def self.details
+        # Optional:
+        # this is your chance to provide a more detailed description of this action
+        'You can use this action to do cool things...'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :junit_report_path,
+                                       description: 'Path of the junit report',
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :copy_path,
+                                       description: 'Path of copy the junit report too',
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :merge_path,
+                                       description: 'Path to merge the junit report into',
+                                       optional: true)
+        ]
+      end
+
+      def self.output
+        []
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.authors
+        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+        ['joshdholtz']
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
This was introduced in #3961 and reverted temporarily in #3974. This brings the changes back.
