### PR TITLE
Fix Carthage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1370,6 +1370,9 @@ workflows:
   danger:
     jobs:
       - danger
+  carthage:
+    jobs:
+      - installation-tests-carthage
   weekly-run-workflow:
     when:
       and:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1370,9 +1370,6 @@ workflows:
   danger:
     jobs:
       - danger
-  carthage:
-    jobs:
-      - installation-tests-carthage
   weekly-run-workflow:
     when:
       and:

--- a/Tests/InstallationTests/CarthageInstallation/fastlane/Fastfile
+++ b/Tests/InstallationTests/CarthageInstallation/fastlane/Fastfile
@@ -16,7 +16,14 @@ lane :installation_tests do
     # doesn't try to build the other installation tests
     sh "carthage", "update", "--no-build"
     sh "rm", "-rf", "Carthage/Checkouts/purchases-root/Tests/InstallationTests/"
-    sh "rm", "-rf", "Carthage/Checkouts/purchases-root/RevenueCat.xcodeproj/xcshareddata/xcschemes/RevenueCatUIDev.xcscheme"
+
+    # Carthage builds all schemes including ones we don't need, so let's nuke them before proceeding
+    schemes_directory = "Carthage/Checkouts/purchases-root/RevenueCat.xcodeproj/xcshareddata/xcschemes"
+    Dir.glob("#{schemes_directory}/*.xcscheme").each do |file_path|
+      next if File.basename(file_path) == "RevenueCat.xcscheme"
+      sh "rm", "-f", file_path
+    end
+
     sh "carthage", "build", "--use-xcframeworks", "--verbose"
   end
 end

--- a/Tests/InstallationTests/CarthageInstallation/fastlane/Fastfile
+++ b/Tests/InstallationTests/CarthageInstallation/fastlane/Fastfile
@@ -16,6 +16,6 @@ lane :installation_tests do
     # doesn't try to build the other installation tests
     sh "carthage", "update", "--no-build"
     sh "rm", "-rf", "Carthage/Checkouts/purchases-root/Tests/InstallationTests/"
-    sh "carthage", "build", "--use-xcframeworks", "--scheme RevenueCat", "--verbose"
+    sh "carthage", "build", "--use-xcframeworks", "--verbose"
   end
 end

--- a/Tests/InstallationTests/CarthageInstallation/fastlane/Fastfile
+++ b/Tests/InstallationTests/CarthageInstallation/fastlane/Fastfile
@@ -16,6 +16,6 @@ lane :installation_tests do
     # doesn't try to build the other installation tests
     sh "carthage", "update", "--no-build"
     sh "rm", "-rf", "Carthage/Checkouts/purchases-root/Tests/InstallationTests/"
-    sh "carthage", "build", "--use-xcframeworks", "--verbose"
+    sh "carthage", "build", "--use-xcframeworks", "--scheme RevenueCat", "--verbose"
   end
 end

--- a/Tests/InstallationTests/CarthageInstallation/fastlane/Fastfile
+++ b/Tests/InstallationTests/CarthageInstallation/fastlane/Fastfile
@@ -16,6 +16,7 @@ lane :installation_tests do
     # doesn't try to build the other installation tests
     sh "carthage", "update", "--no-build"
     sh "rm", "-rf", "Carthage/Checkouts/purchases-root/Tests/InstallationTests/"
+    sh "rm", "-rf", "Carthage/Checkouts/purchases-root/RevenueCat.xcodeproj/xcshareddata/xcschemes/RevenueCatUIDev.xcscheme"
     sh "carthage", "build", "--use-xcframeworks", "--verbose"
   end
 end


### PR DESCRIPTION
It deletes all non-RevenueCat schemes which I assume are not needed by Carthage, so this should save a bit of time over what it was doing before too because it won't spend time on them.


https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/19899/workflows/a895e06e-305d-439d-9f99-3047a0375594

<img width="355" alt="image" src="https://github.com/RevenueCat/purchases-ios/assets/109382862/228528b8-4e19-4d99-8cf2-b7444bfd22ed">
