### PR TITLE
Fix cocoapods installation tests

### DIFF
--- a/Tests/InstallationTests/CocoapodsInstallation/Gemfile
+++ b/Tests/InstallationTests/CocoapodsInstallation/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "fastlane"
 gem "cocoapods"
+gem "nokogiri"


### PR DESCRIPTION
### Description
With #3976, we added a new dependency, but we need to also add it to the gemfile for the cocoapods installation tests