### PR TITLE
Support OriginalApplicationVersion & OriginalPurchaseDate with SK2

### DIFF
--- a/Sources/Misc/StoreKitVersion.swift
+++ b/Sources/Misc/StoreKitVersion.swift
@@ -52,7 +52,7 @@ extension StoreKitVersion {
 
     /// - Returns: `true` if SK2 is available in this device.
     static var isStoreKit2Available: Bool {
-        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             return true
         } else {
             return false

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -114,11 +114,13 @@ class Backend {
               productData: ProductRequestData?,
               transactionData: PurchasedTransactionData,
               observerMode: Bool,
+              appTransaction: String? = nil,
               completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         self.customer.post(receipt: receipt,
                            productData: productData,
                            transactionData: transactionData,
                            observerMode: observerMode,
+                           appTransaction: appTransaction,
                            completion: completion)
     }
 

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -87,10 +87,12 @@ final class CustomerAPI {
         self.backendConfig.operationQueue.addOperation(postAttributionDataOperation)
     }
 
+    // swiftlint:disable function_parameter_count
     func post(receipt: EncodedAppleReceipt,
               productData: ProductRequestData?,
               transactionData: PurchasedTransactionData,
               observerMode: Bool,
+              appTransaction: String?,
               completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         var subscriberAttributesToPost: SubscriberAttribute.Dictionary?
 
@@ -111,7 +113,8 @@ final class CustomerAPI {
             productData: productData,
             receipt: receipt,
             observerMode: observerMode,
-            testReceiptIdentifier: self.backendConfig.systemInfo.testReceiptIdentifier
+            testReceiptIdentifier: self.backendConfig.systemInfo.testReceiptIdentifier,
+            appTransaction: appTransaction
         )
         let factory = PostReceiptDataOperation.createFactory(
             configuration: config,

--- a/Sources/Networking/HTTPClient/HTTPRequestBody.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestBody.swift
@@ -18,14 +18,14 @@ protocol HTTPRequestBody: Encodable {
 
     /// The keys and values that will be included in the signature.
     /// - Note: this is not `[String: String]` because we need to preserve ordering.
-    var contentForSignature: [(key: String, value: String)] { get }
+    var contentForSignature: [(key: String, value: String?)] { get }
 
 }
 
 extension HTTPRequestBody {
 
     // Default implementation for endpoints which don't support signing.
-    var contentForSignature: [(key: String, value: String)] {
+    var contentForSignature: [(key: String, value: String?)] {
         return []
     }
 

--- a/Sources/Networking/Operations/LogInOperation.swift
+++ b/Sources/Networking/Operations/LogInOperation.swift
@@ -117,7 +117,7 @@ extension LogInOperation {
 
 extension LogInOperation.Body: HTTPRequestBody {
 
-    var contentForSignature: [(key: String, value: String)] {
+    var contentForSignature: [(key: String, value: String?)] {
         return [
             (Self.CodingKeys.appUserID.stringValue, self.appUserID),
             (Self.CodingKeys.newAppUserID.stringValue, self.newAppUserID)

--- a/Sources/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Sources/Networking/Operations/PostOfferForSigningOperation.swift
@@ -122,7 +122,7 @@ private extension PostOfferForSigningOperation {
         }
 
         let appUserID: String
-        let fetchToken: String
+        let fetchToken: String?
         let generateOffers: [Offer]
 
         init(appUserID: String, data: PostOfferForSigningData) {

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -134,6 +134,9 @@ extension PostReceiptDataOperation {
         /// - Note: this is only used for the backend to disambiguate receipts created in `SKTestSession`s.
         let testReceiptIdentifier: String?
 
+        /// The [AppTransaction](https://developer.apple.com/documentation/storekit/apptransaction) JWS token
+        /// retrieved from StoreKit 2.
+        let appTransaction: String?
     }
 
     struct Paywall {
@@ -162,7 +165,8 @@ extension PostReceiptDataOperation.PostData {
         productData: ProductRequestData?,
         receipt: EncodedAppleReceipt,
         observerMode: Bool,
-        testReceiptIdentifier: String?
+        testReceiptIdentifier: String?,
+        appTransaction: String?
     ) {
         self.init(
             appUserID: data.appUserID,
@@ -179,7 +183,8 @@ extension PostReceiptDataOperation.PostData {
             initiationSource: data.source.initiationSource,
             subscriberAttributesByKey: data.unsyncedAttributes,
             aadAttributionToken: data.aadAttributionToken,
-            testReceiptIdentifier: testReceiptIdentifier
+            testReceiptIdentifier: testReceiptIdentifier,
+            appTransaction: appTransaction
         )
     }
 
@@ -257,6 +262,7 @@ extension PostReceiptDataOperation.PostData: Encodable {
         case appliedTargetingRule
         case paywall
         case testReceiptIdentifier = "test_receipt_identifier"
+        case appTransaction = "app_transaction"
 
     }
 
@@ -273,6 +279,7 @@ extension PostReceiptDataOperation.PostData: Encodable {
             try productData.encode(to: encoder)
         }
 
+        try container.encodeIfPresent(self.appTransaction, forKey: .appTransaction)
         try container.encodeIfPresent(self.presentedOfferingIdentifier, forKey: .presentedOfferingIdentifier)
         try container.encodeIfPresent(self.presentedPlacementIdentifier, forKey: .presentedPlacementIdentifier)
         try container.encodeIfPresent(self.appliedTargetingRule, forKey: .appliedTargetingRule)

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -333,10 +333,11 @@ extension PostReceiptDataOperation.AppliedTargetingRule: Codable {
 
 extension PostReceiptDataOperation.PostData: HTTPRequestBody {
 
-    var contentForSignature: [(key: String, value: String)] {
+    var contentForSignature: [(key: String, value: String?)] {
         return [
             (Self.CodingKeys.appUserID.stringValue, self.appUserID),
-            (Self.CodingKeys.fetchToken.stringValue, self.fetchToken ?? "")
+            (Self.CodingKeys.fetchToken.stringValue, self.fetchToken),
+            (Self.CodingKeys.appTransaction.stringValue, self.appTransaction)
         ]
     }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1126,6 +1126,13 @@ private extension PurchasesOrchestrator {
 
                 let receipt = await self.encodedReceipt(transaction: transaction, jwsRepresentation: jwsRepresentation)
 
+                let appTransactionJWS: String?
+                if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                    appTransactionJWS = await self.transactionFetcher.appTransactionJWS
+                } else {
+                    appTransactionJWS = nil
+                }
+
                 self.createProductRequestData(with: transaction.productIdentifier) { productRequestData in
                     let transactionData: PurchasedTransactionData = .init(
                         appUserID: currentAppUserID,
@@ -1138,7 +1145,8 @@ private extension PurchasesOrchestrator {
                     self.backend.post(receipt: receipt,
                                       productData: productRequestData,
                                       transactionData: transactionData,
-                                      observerMode: self.observerMode) { result in
+                                      observerMode: self.observerMode,
+                                      appTransaction: appTransactionJWS) { result in
                         self.handleReceiptPost(result: result,
                                                transactionData: transactionData,
                                                subscriberAttributes: unsyncedAttributes,

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
@@ -31,6 +31,10 @@ protocol StoreKit2TransactionFetcherType: Sendable {
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     var firstVerifiedTransaction: StoreTransaction? { get async }
 
+    var appTransactionJWS: String? { get async }
+
+    func appTransactionJWS(_ completionHandler: @escaping (String?) -> Void)
+
 }
 
 final class StoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
@@ -99,6 +103,38 @@ final class StoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
         )
     }
 
+    /// A computed property that retrieves the JWS (JSON Web Signature) representation of the app transaction asynchronously.
+    ///
+    /// If the OS does not support AppTransaction (available in iOS16+), it returns `nil`.
+    ///
+    /// - Returns: A `String` containing the JWS representation of the app transaction, or `nil` if the feature is unavailable on the current platform version.
+    var appTransactionJWS: String? {
+        get async {
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                return try? await AppTransaction.shared.jwsRepresentation
+            } else {
+                return nil
+            }
+        }
+    }
+
+    /// Retrieves the JWS (JSON Web Signature) representation of the AppTransaction asynchronously and
+    /// passes it to the provided completion handler.
+    ///
+    /// If the OS does not support AppTransaction (available in iOS16+), it returns `nil` through the completion handler.
+    ///
+    /// - Parameter completion: A closure that is called with the JWS representation of the app transaction, or `nil`
+    /// if the feature is unavailable on the current platform version.
+    /// - Parameter result: A `String?` containing the JWS representation of the app transaction, or `nil` if unavailable.
+    func appTransactionJWS(_ completion: @escaping (String?) -> Void) {
+        Async.call(with: completion) {
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                return try? await AppTransaction.shared.jwsRepresentation
+            } else {
+                return nil
+            }
+        }
+    }
 }
 
 // MARK: -

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
@@ -103,11 +103,13 @@ final class StoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
         )
     }
 
-    /// A computed property that retrieves the JWS (JSON Web Signature) representation of the app transaction asynchronously.
+    /// A computed property that retrieves the JWS (JSON Web Signature) representation 
+    /// of the app transaction asynchronously.
     ///
     /// If the OS does not support AppTransaction (available in iOS16+), it returns `nil`.
     ///
-    /// - Returns: A `String` containing the JWS representation of the app transaction, or `nil` if the feature is unavailable on the current platform version.
+    /// - Returns: A `String` containing the JWS representation of the app transaction, 
+    /// or `nil` if the feature is unavailable on the current platform version.
     var appTransactionJWS: String? {
         get async {
             if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
@@ -121,11 +123,13 @@ final class StoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
     /// Retrieves the JWS (JSON Web Signature) representation of the AppTransaction asynchronously and
     /// passes it to the provided completion handler.
     ///
-    /// If the OS does not support AppTransaction (available in iOS16+), it returns `nil` through the completion handler.
+    /// If the OS does not support AppTransaction (available in iOS16+), it returns `nil` through the 
+    /// completion handler.
     ///
     /// - Parameter completion: A closure that is called with the JWS representation of the app transaction, or `nil`
     /// if the feature is unavailable on the current platform version.
-    /// - Parameter result: A `String?` containing the JWS representation of the app transaction, or `nil` if unavailable.
+    /// - Parameter result: A `String?` containing the JWS representation of the app transaction, 
+    /// or `nil` if unavailable.
     func appTransactionJWS(_ completion: @escaping (String?) -> Void) {
         Async.call(with: completion) {
             if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {

--- a/Sources/Purchasing/StoreKitAbstractions/EncodedAppleReceipt.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/EncodedAppleReceipt.swift
@@ -20,12 +20,13 @@ enum EncodedAppleReceipt: Equatable {
   case jws(String)
   case receipt(Data)
   case sk2receipt(StoreKit2Receipt)
+  case empty
 
 }
 
 extension EncodedAppleReceipt {
 
-    func serialized() -> String {
+    func serialized() -> String? {
         switch self {
         case .jws(let jws):
             return jws
@@ -38,6 +39,8 @@ extension EncodedAppleReceipt {
                 Logger.warn(Strings.storeKit.sk2_error_encoding_receipt(error))
                 return ""
             }
+        case .empty:
+            return nil
         }
     }
 

--- a/Sources/Security/HTTPRequestBody+Signing.swift
+++ b/Sources/Security/HTTPRequestBody+Signing.swift
@@ -25,7 +25,8 @@ extension HTTPRequestBody {
     }
 
     private var postParameterHash: String {
-        return HTTPRequest.signingParameterHash(self.contentForSignature.map(\.value))
+        let nonNilValues = self.contentForSignature.compactMap { $0.value }
+        return HTTPRequest.signingParameterHash(nonNilValues)
     }
 
 }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -33,6 +33,85 @@ class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
         }
     }
 
+    @available(iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, *)
+    func testOriginalPurchaseDateAvailableAfterPurchase() async throws {
+        // In this scenario, the AppTransaction should be posted with the SK2 transaction JWT
+
+        try await self.signInAsNewAppUserID()
+        try await self.purchaseMonthlyProduct()
+
+        let originalPurchaseDate = try await Purchases.shared.customerInfo().originalPurchaseDate
+        expect(originalPurchaseDate).toNot(beNil())
+    }
+
+    @available(iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, *)
+    func testOriginalApplicationVersionAvailableAfterPurchase() async throws {
+        // In this scenario, the AppTransaction should be posted with the SK2 transaction JWT
+
+        try await self.signInAsNewAppUserID()
+        try await self.purchaseMonthlyProduct()
+
+        let originalApplicationVersion = try await Purchases.shared.customerInfo().originalApplicationVersion
+        expect(originalApplicationVersion).toNot(beNil())
+    }
+
+    @available(iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, *)
+    func testOriginalPurchaseDateAvailableAfterSyncPurchasesWithoutPurchase() async throws {
+        // In this scenario, the AppTransaction should be posted without a SK2 transaction JWT when syncPurchases is
+        // called
+
+        try await self.signInAsNewAppUserID()
+        _ = try await Purchases.shared.syncPurchases()
+
+        let customerInfo = try await Purchases.shared.customerInfo()
+        expect(customerInfo.originalPurchaseDate).toNot(beNil())
+    }
+
+    @available(iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, *)
+    func testOriginalApplicationVersionAvailableAfterSyncPurchasesWithoutPurchase() async throws {
+        // In this scenario, the AppTransaction should be posted without a SK2 transaction JWT when syncPurchases is
+        // called
+
+        try await self.signInAsNewAppUserID()
+        _ = try await Purchases.shared.syncPurchases()
+
+        let customerInfo = try await Purchases.shared.customerInfo()
+        expect(customerInfo.originalApplicationVersion).toNot(beNil())
+    }
+
+    @available(iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, *)
+    func testOriginalPurchaseDateAvailableAfterSyncPurchasesWithPreviousPurchase() async throws {
+        // In this scenario, the AppTransaction should be posted with a SK2 transaction JWT when syncPurchases is
+        // called
+        guard let product = try await self.monthlyPackage.storeProduct.sk2Product else {
+            fail("SK2 product missing.")
+            return
+        }
+
+        _ = try await Purchases.shared.syncPurchases()
+
+        let originalPurchaseDate = try await Purchases.shared.customerInfo().originalPurchaseDate
+        expect(originalPurchaseDate).toNot(beNil())
+    }
+
+    @available(iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, *)
+    func testOriginalApplicationVersionAvailableAfterSyncPurchasesWithPreviousPurchase() async throws {
+        // In this scenario, the AppTransaction should be posted with a SK2 transaction JWT when syncPurchases is
+        // called
+        guard let product = try await self.monthlyPackage.storeProduct.sk2Product else {
+            fail("SK2 product missing.")
+            return
+        }
+        _ = try await product.purchase()
+        _ = try await Purchases.shared.syncPurchases()
+
+        let originalApplicationVersion = try await Purchases.shared.customerInfo().originalApplicationVersion
+        expect(originalApplicationVersion).toNot(beNil())
+    }
+
+    private func signInAsNewAppUserID() async throws {
+        _ = try await Purchases.shared.logIn("integration-test-user-\(UUID().uuidString)")
+    }
 }
 
 class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -41,7 +41,7 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTes
     override func setUp() async throws {
         try await super.setUp()
 
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/StoreKitUnitTests/CachingProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/CachingProductsManagerTests.swift
@@ -40,7 +40,7 @@ class CachingProductsManagerIntegrationTests: StoreKitConfigTestCase {
     }
 
     func testFetchProductsWithIdentifiersSK2() throws {
-        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
+        guard #available(iOS 16.0, tvOS 16.0, macOS 13.0, watchOS 9.0, *) else {
             throw XCTSkip("Required API is not available for this test.")
         }
 
@@ -92,7 +92,7 @@ class CachingProductsManagerIntegrationTests: StoreKitConfigTestCase {
     }
 
     func testFetchCachedSK2Products() throws {
-        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
+        guard #available(iOS 16.0, tvOS 16.0, macOS 13.0, watchOS 9.0, *) else {
             throw XCTSkip("Required API is not available for this test.")
         }
 

--- a/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
@@ -66,7 +66,7 @@ class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testReceiptParserParsesReceiptWithSingleIAP() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
         let product = try await fetchSk2Product()
         let purchaseTime = Date()
 

--- a/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
+++ b/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
@@ -74,7 +74,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSk2PriceFormatterUsesCurrentStorefront() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         self.testSession.locale = Locale(identifier: "es_ES")
         try await self.changeStorefront("ESP")

--- a/Tests/StoreKitUnitTests/ProductsFetcherSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/ProductsFetcherSK2Tests.swift
@@ -24,7 +24,7 @@ class ProductsFetcherSK2Tests: StoreKitConfigTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         self.productsFetcherSK2 = ProductsFetcherSK2()
     }

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -36,6 +36,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
     }
 
     func testFetchProductsWithIdentifiersSK2() throws {
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
             throw XCTSkip("Required API is not available for this test.")
         }
@@ -84,7 +85,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testInvalidateAndReFetchCachedProductsAfterStorefrontChangesSK2() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let manager = self.createManager(storeKitVersion: .storeKit2)
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
@@ -560,7 +560,7 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testSK1DoesNotListenForSK2Transactions() throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let transactionListener = MockStoreKit2TransactionListener()
         let storeKit2ObserverModePurchaseDetector = MockStoreKit2ObserverModePurchaseDetector()

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -629,15 +629,100 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         expect(customerInfo) == mockCustomerInfo
     }
 
-    func testSyncPurchasesDoesntPostReceiptAndReturnsCustomerInfoIfNoTransaction() async throws {
+    func testSyncPurchasesDoesntPostReceiptAndReturnsCustomerInfoIfNoTransactionsAndOriginalPurchaseDatePresent()
+    async throws {
         self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = nil
-        self.customerInfoManager.stubbedCustomerInfoResult = .success(mockCustomerInfo)
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
 
         let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
-                                                                     isRestore: false,
-                                                                     initiationSource: .purchase)
+                                                                     isRestore: true,
+                                                                     initiationSource: .restore)
+
         expect(self.backend.invokedPostReceiptData).to(beFalse())
-        expect(self.customerInfoManager.invokedCustomerInfo).to(beTrue())
+
+        expect(self.customerInfoManager.invokedCachedCustomerInfo).to(beTrue())
+        expect(self.customerInfoManager.invokedCachedCustomerInfoCount) == 1
+        expect(customerInfo) == mockCustomerInfo
+    }
+
+    func testSyncPurchasesPostsReceiptIfNoTransactionsAndEmptyOriginalPurchaseDate() async throws {
+        let appTransactionJWS = "some_jws"
+
+        self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = nil
+        self.mockTransactionFetcher.stubbedAppTransactionJWS = appTransactionJWS
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = CustomerInfo.missingOriginalPurchaseDate
+        self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
+
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+                                                                     isRestore: true,
+                                                                     initiationSource: .restore)
+
+        expect(self.customerInfoManager.invokedCachedCustomerInfo).to(beTrue())
+        expect(self.customerInfoManager.invokedCachedCustomerInfoCount) == 1
+
+        expect(self.backend.invokedPostReceiptData).to(beTrue())
+        expect(self.backend.invokedPostReceiptDataCount) == 1
+        expect(self.backend.invokedPostReceiptDataParameters?.appTransaction) == appTransactionJWS
+        expect(self.backend.invokedPostReceiptDataParameters?.data) == .empty // No fetch_token
+        expect(
+            self.backend.invokedPostReceiptDataParameters?.transactionData.appUserID
+        ) == Self.mockUserID
+
+        expect(self.customerInfoManager.invokedCustomerInfo).to(beFalse())
+        expect(customerInfo) == mockCustomerInfo
+    }
+
+    func testSyncPurchasesPostsReceiptIfNoTransactionsAndEmptyOriginalApplicationVersionSK2() async throws {
+        let appTransactionJWS = "some_jws"
+
+        self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = nil
+        self.mockTransactionFetcher.stubbedAppTransactionJWS = appTransactionJWS
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = CustomerInfo.missingOriginalApplicationVersion
+        self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
+
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+                                                                     isRestore: true,
+                                                                     initiationSource: .restore)
+
+        expect(self.customerInfoManager.invokedCachedCustomerInfo).to(beTrue())
+        expect(self.customerInfoManager.invokedCachedCustomerInfoCount) == 1
+
+        expect(self.backend.invokedPostReceiptData).to(beTrue())
+        expect(self.backend.invokedPostReceiptDataCount) == 1
+        expect(self.backend.invokedPostReceiptDataParameters?.appTransaction) == appTransactionJWS
+        expect(self.backend.invokedPostReceiptDataParameters?.data) == .empty // No fetch_token
+        expect(
+            self.backend.invokedPostReceiptDataParameters?.transactionData.appUserID
+        ) == Self.mockUserID
+
+        expect(self.customerInfoManager.invokedCustomerInfo).to(beFalse())
+        expect(customerInfo) == mockCustomerInfo
+    }
+
+    func testSyncPurchasesPostsReceiptIfNoTransactionsAndNoCachedCustomerInfo() async throws {
+        let appTransactionJWS = "some_jws"
+
+        self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = nil
+        self.mockTransactionFetcher.stubbedAppTransactionJWS = appTransactionJWS
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = nil
+        self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
+
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+                                                                     isRestore: true,
+                                                                     initiationSource: .restore)
+
+        expect(self.customerInfoManager.invokedCachedCustomerInfo).to(beTrue())
+        expect(self.customerInfoManager.invokedCachedCustomerInfoCount) == 1
+
+        expect(self.backend.invokedPostReceiptData).to(beTrue())
+        expect(self.backend.invokedPostReceiptDataCount) == 1
+        expect(self.backend.invokedPostReceiptDataParameters?.appTransaction) == appTransactionJWS
+        expect(self.backend.invokedPostReceiptDataParameters?.data) == .empty // No fetch_token
+        expect(
+            self.backend.invokedPostReceiptDataParameters?.transactionData.appUserID
+        ) == Self.mockUserID
+
+        expect(self.customerInfoManager.invokedCustomerInfo).to(beFalse())
         expect(customerInfo) == mockCustomerInfo
     }
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -22,11 +22,14 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
 
     override class var storeKitVersion: StoreKitVersion { .storeKit2 }
 
+    override func setUp() async throws {
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
+        try await super.setUp()
+    }
+
     // MARK: - StoreFront Changes
 
     func testClearCachedProductsAndOfferingsAfterStorefrontChanges() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         self.orchestrator.storefrontDidUpdate(with: MockStorefront(countryCode: "ESP"))
 
         expect(self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateCount) == 1
@@ -36,8 +39,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     // MARK: - Purchasing
 
     func testPurchasePostsReceipt() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
         let transaction = try await createTransaction(finished: true)
@@ -64,8 +65,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     }
 
     func testPurchaseReturnsCorrectValues() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
         let mockTransaction = try await self.simulateAnyPurchase()
         mockStoreKit2TransactionListener?.mockTransaction = .init(mockTransaction.underlyingTransaction)
@@ -86,8 +85,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     }
 
     func testPurchaseDoesNotPostReceiptIfPurchaseFailed() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         // As of Xcode 15.2 this makes purchases fail with `StoreKitError.unknown`
         testSession.failTransactionsEnabled = true
         let product = try await fetchSk2Product()
@@ -104,14 +101,10 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     }
 
     func testPurchaseWithPromotionalOfferPostsReceiptIfSuccessful() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         throw XCTSkip("Purchasing with a promo offer in SK2 using a StoreKit Config file returns an unknown error")
     }
 
     func testPurchaseWithInvalidPromotionalOfferSignatureFails() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         let product = try await self.fetchSk2Product()
         let offer = PromotionalOffer.SignedData(
             identifier: "identifier \(Int.random(in: 0..<1000))",
@@ -133,8 +126,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     }
 
     func testPurchaseCancelled() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         self.customerInfoManager.stubbedCustomerInfoResult = .success(self.mockCustomerInfo)
         self.mockStoreKit2TransactionListener?.mockResult = .init(.userCancelled)
 
@@ -153,8 +144,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     #if swift(>=5.9)
     @available(iOS 17.0, tvOS 17.0, watchOS 10.0, macOS 14.0, *)
     func testPurchaseSK2CancelledWithSimulatedError() async throws {
-        try AvailabilityChecks.iOS17APIAvailableOrSkipTest()
-
         try await self.testSession.setSimulatedError(.generic(.userCancelled), forAPI: .purchase)
 
         self.customerInfoManager.stubbedCustomerInfoResult = .success(self.mockCustomerInfo)
@@ -189,8 +178,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     // MARK: - Purchasing, StoreKit 2 only
 
     func testPurchaseSK2IncludesAppUserIdIfUUID() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         let uuid = UUID()
         self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: uuid.uuidString)
         self.setUpOrchestrator()
@@ -205,8 +192,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     }
 
     func testPurchaseSK2DoesNotIncludeAppUserIdIfNotUUID() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: "not_a_uuid")
         self.setUpOrchestrator()
         self.setUpStoreKit2Listener()
@@ -258,8 +243,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     // MARK: - Paywalls
 
     func testPurchaseWithPresentedPaywall() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
         self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
         self.orchestrator.track(paywallEvent: .impression(Self.paywallEventCreationData, Self.paywallEvent))
@@ -284,8 +267,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     }
 
     func testPurchaseFailureRemembersPresentedPaywall() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         let mockListener = try XCTUnwrap(
             self.orchestrator.storeKit2TransactionListener as? MockStoreKit2TransactionListener
         )
@@ -314,7 +295,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     // MARK: - AdServices and Attributes
 
     func testPurchaseDoesNotPostAdServicesTokenIfNotEnabled() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
         try AvailabilityChecks.skipIfTVOrWatchOSOrMacOS()
 
         let mockListener = try XCTUnwrap(
@@ -335,7 +315,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
 
     #if !os(tvOS) && !os(watchOS)
     func testPurchasePostsAdServicesTokenAndSubscriberAttributes() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
         try AvailabilityChecks.skipIfTVOrWatchOSOrMacOS()
 
         // Test for custom entitlement computation mode.
@@ -477,8 +456,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     // MARK: - TransactionListenerDelegate
 
     func testSK2TransactionListenerDelegate() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         self.setUpStoreKit2Listener()
 
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
@@ -501,8 +478,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     }
 
     func testSK2TransactionListenerDoesNotFinishTransactionIfPostingReceiptFails() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         self.setUpStoreKit2Listener()
 
         let expectedError: BackendError = .missingReceiptFile(nil)
@@ -528,8 +503,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     }
 
     func testSK2TransactionListenerOnlyFinishesTransactionsAfterPostingReceipt() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         enum Operation {
             case receiptPost
             case finishTransaction
@@ -556,8 +529,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     }
 
     func testSK2TransactionListenerDelegateWithObserverMode() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         self.setUpSystemInfo(finishTransactions: false)
         self.setUpOrchestrator()
         self.setUpStoreKit2Listener()
@@ -579,8 +550,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     }
 
     func testSK2ListensForSK2Transactions() throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         let transactionListener = MockStoreKit2TransactionListener()
         let storeKit2ObserverModePurchasesDetector = MockStoreKit2ObserverModePurchaseDetector()
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -55,10 +55,15 @@ protocol PurchasesOrchestratorTests {
 
     func testSyncPurchasesPostsReceipt() async throws
 
-    func testSyncPurchasesDoesntPostReceiptAndReturnsCustomerInfoIfNoTransaction() async throws
-
     func testSyncPurchasesCallsSuccessDelegateMethod() async throws
 
     func testSyncPurchasesPassesErrorOnFailure() async throws
+
+    func testSyncPurchasesDoesntPostReceiptAndReturnsCustomerInfoIfNoTransactionsAndOriginalPurchaseDatePresent()
+    async throws
+
+    func testSyncPurchasesPostsReceiptIfNoTransactionsAndEmptyOriginalPurchaseDate() async throws
+
+    func testSyncPurchasesPostsReceiptIfNoTransactionsAndNoCachedCustomerInfo() async throws
 
 }

--- a/Tests/StoreKitUnitTests/StoreKit2/StoreKit2CachingProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/StoreKit2CachingProductsManagerTests.swift
@@ -26,7 +26,7 @@ class StoreKit2CachingProductsManagerTests: StoreKitConfigTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let systemInfo = MockSystemInfo(finishTransactions: false)
 

--- a/Tests/StoreKitUnitTests/StoreKit2/StoreKit2ObserverModePurchaseDetectorTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/StoreKit2ObserverModePurchaseDetectorTests.swift
@@ -28,7 +28,7 @@ class StoreKit2ObserverModePurchaseDetectorTests: StoreKitConfigTestCase {
     private var observerModePurchaseDetector: StoreKit2ObserverModePurchaseDetector!
 
     override func setUp() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
         deviceCache = .init()
     }
 

--- a/Tests/StoreKitUnitTests/StoreKit2/StoreKit2StorefrontListenerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/StoreKit2StorefrontListenerTests.swift
@@ -31,7 +31,7 @@ class StoreKit2StorefrontListenerTests: TestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         self.delegate = .init()
         self.listener = .init(delegate: self.delegate,

--- a/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionFetcherTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionFetcherTests.swift
@@ -23,7 +23,7 @@ class StoreKit2TransactionFetcherTests: StoreKitConfigTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         self.fetcher = .init()
     }

--- a/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionListenerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionListenerTests.swift
@@ -36,7 +36,7 @@ class StoreKit2TransactionListenerBaseTests: StoreKitConfigTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         // Unfinished transactions before beginning the test might lead to false positives / negatives
         await self.verifyNoUnfinishedTransactions()
@@ -51,7 +51,7 @@ class StoreKit2TransactionListenerBaseTests: StoreKitConfigTestCase {
 class StoreKit2TransactionListenerTests: StoreKit2TransactionListenerBaseTests {
 
     func testStopsListeningToTransactions() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         var handle: Task<Void, Never>?
 
@@ -71,7 +71,7 @@ class StoreKit2TransactionListenerTests: StoreKit2TransactionListenerBaseTests {
     // MARK: -
 
     func testVerifiedTransactionReturnsOriginalTransaction() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let fakeTransaction = try await self.simulateAnyPurchase()
 
@@ -83,7 +83,7 @@ class StoreKit2TransactionListenerTests: StoreKit2TransactionListenerBaseTests {
     }
 
     func testIsCancelledIsTrueWhenPurchaseIsCancelled() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let (isCancelled, transaction) = try await self.listener.handle(purchaseResult: .userCancelled)
         expect(isCancelled) == true
@@ -91,7 +91,7 @@ class StoreKit2TransactionListenerTests: StoreKit2TransactionListenerBaseTests {
     }
 
     func testPendingTransactionsReturnPaymentPendingError() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         // Note: can't use `expect().to(throwError)` or `XCTAssertThrowsError`
         // because neither of them accept `async`
@@ -104,7 +104,7 @@ class StoreKit2TransactionListenerTests: StoreKit2TransactionListenerBaseTests {
     }
 
     func testUnverifiedTransactionsReturnStoreProblemError() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let transaction = try await self.simulateAnyPurchase()
         let error: StoreKit.VerificationResult<Transaction>.VerificationError = .invalidSignature

--- a/Tests/StoreKitUnitTests/StoreTransactionTests.swift
+++ b/Tests/StoreKitUnitTests/StoreTransactionTests.swift
@@ -70,7 +70,7 @@ class StoreTransactionTests: StoreKitConfigTestCase {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSK2DetailsWrapCorrectly() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let sk2Transaction = try await self.createTransactionWithPurchase()
         let jwsRepresentation = UUID().uuidString

--- a/Tests/StoreKitUnitTests/StorefrontTests.swift
+++ b/Tests/StoreKitUnitTests/StorefrontTests.swift
@@ -22,7 +22,7 @@ class StorefrontTests: StoreKitConfigTestCase {
     @MainActor
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testCurrentStorefrontSK2() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let expectedStorefront = try await XCTAsyncUnwrap(await StoreKit.Storefront.current)
         let currentStorefront = try await XCTAsyncUnwrap(await Storefront.currentStorefront)

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -59,7 +59,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     @MainActor
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSK2CheckEligibilityAsync() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let products: Set<String> = ["product_id",
                                      "com.revenuecat.monthly_4.99.1_week_intro",
@@ -82,7 +82,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testCheckEligibilityNoAsync() throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let products: Set<String> = ["product_id",
                                      "com.revenuecat.monthly_4.99.1_week_intro",
@@ -111,7 +111,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testCheckEligibilityNoAsyncWithFailure() throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let products: Set<String> = ["product_id",
                                      "com.revenuecat.monthly_4.99.1_week_intro",
@@ -142,7 +142,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testCheckEligibilityForProductIsEligibleForEligibleSubscription() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let storeProduct = try await self.fetchSk2StoreProduct()
 
@@ -157,7 +157,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testCheckEligibilityForLifetimeProductIsNoIntroOfferExists() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let storeProduct = try await self.fetchSk2StoreProduct("lifetime")
 
@@ -172,7 +172,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testCheckEligibilityForProductIsIneligibleAfterPurchasing() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let sk2Product = try await self.fetchSk2Product()
         let storeProduct = StoreProduct(sk2Product: sk2Product)
@@ -198,7 +198,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testCheckEligibilityForInvalidProductIsUnknown() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let storeProduct = try await self.fetchSk2StoreProduct()
 

--- a/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
+++ b/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
@@ -43,6 +43,30 @@ extension CustomerInfo {
         ] as [String: Any]
     ])
 
+    // swiftlint:disable:next force_try
+    static let missingOriginalPurchaseDate: CustomerInfo = try! .init(data: [
+        "request_date": "2019-08-16T10:30:42Z",
+        "subscriber": [
+            "first_seen": "2019-07-17T00:05:54Z",
+            "original_app_user_id": "app_user_id",
+            "subscriptions": [:] as [String: Any],
+            "other_purchases": [:] as [String: Any],
+            "original_application_version": "1.0"
+        ] as [String: Any]
+    ])
+
+    // swiftlint:disable:next force_try
+    static let missingOriginalApplicationVersion: CustomerInfo = try! .init(data: [
+        "request_date": "2019-08-16T10:30:42Z",
+        "subscriber": [
+            "first_seen": "2019-07-17T00:05:54Z",
+            "original_app_user_id": "app_user_id",
+            "subscriptions": [:] as [String: Any],
+            "other_purchases": [:] as [String: Any],
+            "original_purchase_date": "2019-07-17T00:05:54Z"
+        ] as [String: Any]
+    ])
+
 }
 
 extension CustomerInfo {

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -12,6 +12,7 @@ class MockBackend: Backend {
                                        productData: ProductRequestData?,
                                        transactionData: PurchasedTransactionData,
                                        observerMode: Bool,
+                                       appTransaction: String?,
                                        completion: CustomerAPI.CustomerInfoResponseHandler?)
 
     var invokedPostReceiptData = false
@@ -45,6 +46,7 @@ class MockBackend: Backend {
                        productData: ProductRequestData?,
                        transactionData: PurchasedTransactionData,
                        observerMode: Bool,
+                       appTransaction: String? = nil,
                        completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         invokedPostReceiptData = true
         invokedPostReceiptDataCount += 1
@@ -52,11 +54,13 @@ class MockBackend: Backend {
                                             productData,
                                             transactionData,
                                             observerMode,
+                                            appTransaction,
                                             completion)
         invokedPostReceiptDataParametersList.append((receipt,
                                                      productData,
                                                      transactionData,
                                                      observerMode,
+                                                     appTransaction,
                                                      completion))
 
         self.onPostReceipt?()

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
@@ -74,14 +74,12 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
     var appTransactionJWS: String? {
         get async {
             return self.stubbedAppTransactionJWS
         }
     }
 
-    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
     func appTransactionJWS(_ completion: @escaping (String?) -> Void) {
         completion(self.stubbedAppTransactionJWS)
     }

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
@@ -21,6 +21,7 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
     private let _stubbedFirstVerifiedAutoRenewableTransaction: Atomic<StoreTransaction?> = .init(nil)
     private let _stubbedHasPendingConsumablePurchase: Atomic<Bool> = false
     private let _stubbedReceipt: Atomic<StoreKit2Receipt?> = .init(nil)
+    private let _stubbedAppTransactionJWS: Atomic<String?> = .init(nil)
 
     var stubbedUnfinishedTransactions: [StoreTransaction] {
         get { return self._stubbedUnfinishedTransactions.value }
@@ -40,6 +41,11 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
     var stubbedFirstVerifiedAutoRenewableTransaction: StoreTransaction? {
         get { return self._stubbedFirstVerifiedAutoRenewableTransaction.value }
         set { self._stubbedFirstVerifiedAutoRenewableTransaction.value = newValue }
+    }
+
+    var stubbedAppTransactionJWS: String? {
+        get { return self._stubbedAppTransactionJWS.value }
+        set { self._stubbedAppTransactionJWS.value = newValue }
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -66,6 +72,18 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
         get async {
             self.stubbedFirstVerifiedAutoRenewableTransaction
         }
+    }
+
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+    var appTransactionJWS: String? {
+        get async {
+            return self.stubbedAppTransactionJWS
+        }
+    }
+
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+    func appTransactionJWS(_ completion: @escaping (String?) -> Void) {
+        completion(self.stubbedAppTransactionJWS)
     }
 
     // MARK: -

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -89,6 +89,8 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
     }
 
     func testPostsReceiptDataWithAppTransactionCorrectly() throws {
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
+
         let path: HTTPRequest.Path = .postReceiptData
 
         httpClient.mock(
@@ -104,6 +106,40 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
         waitUntil { completed in
             self.backend.post(receipt: Self.receipt,
                               productData: productData,
+                              transactionData: .init(
+                                 appUserID: Self.userID,
+                                 presentedOfferingContext: nil,
+                                 unsyncedAttributes: nil,
+                                 storefront: nil,
+                                 source: .init(isRestore: isRestore, initiationSource: .purchase)
+                              ),
+                              observerMode: observerMode,
+                              appTransaction: appTransaction,
+                              completion: { _ in
+                completed()
+            })
+        }
+
+        expect(self.httpClient.calls).to(haveCount(1))
+    }
+
+    func testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly() throws {
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
+
+        let path: HTTPRequest.Path = .postReceiptData
+
+        httpClient.mock(
+            requestPath: path,
+            response: .init(statusCode: .success, response: Self.validCustomerResponse)
+        )
+
+        let isRestore = false
+        let observerMode = true
+        let appTransaction = "some_jws_token"
+
+        waitUntil { completed in
+            self.backend.post(receipt: .empty,
+                              productData: nil,
                               transactionData: .init(
                                  appUserID: Self.userID,
                                  presentedOfferingContext: nil,

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -88,6 +88,39 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
         expect(self.httpClient.calls).to(haveCount(1))
     }
 
+    func testPostsReceiptDataWithAppTransactionCorrectly() throws {
+        let path: HTTPRequest.Path = .postReceiptData
+
+        httpClient.mock(
+            requestPath: path,
+            response: .init(statusCode: .success, response: Self.validCustomerResponse)
+        )
+
+        let isRestore = false
+        let observerMode = true
+        let appTransaction = "some_jws_token"
+        let productData: ProductRequestData = .createMockProductData(currencyCode: "USD")
+
+        waitUntil { completed in
+            self.backend.post(receipt: Self.receipt,
+                              productData: productData,
+                              transactionData: .init(
+                                 appUserID: Self.userID,
+                                 presentedOfferingContext: nil,
+                                 unsyncedAttributes: nil,
+                                 storefront: nil,
+                                 source: .init(isRestore: isRestore, initiationSource: .purchase)
+                              ),
+                              observerMode: observerMode,
+                              appTransaction: appTransaction,
+                              completion: { _ in
+                completed()
+            })
+        }
+
+        expect(self.httpClient.calls).to(haveCount(1))
+    }
+
     func testPostsReceiptDataWithTestReceiptIdentifier() throws {
         let identifier = try XCTUnwrap(UUID(uuidString: "12345678-1234-1234-1234-C2C35AE34D09")).uuidString
 

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testCachesCustomerGetsForSameCustomer.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerCallsBackendProperly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithFailedVerification.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetsCustomerInfo.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesGetCustomerInfoErrors.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesInvalidJSON.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
@@ -14,8 +14,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testUpdatesRequestDateFromResponseHeader.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfUnknownError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testPostsProductIdentifiers.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCachesForSameUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethod.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsFailSendsNil.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsNetworkErrorSendsError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsOneOffering.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestIsNotAuthenticated.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithFailure.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithSuccess.1.json
@@ -11,8 +11,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCachesForSameUserIDs.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginMakesRightCalls.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMapping.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS15-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS15-testPostAdServicesCallsHttpClient.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS15-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS15-testPostAttributesPutsDataInDataKey.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS15-testPostDiagnosticsEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS15-testPostDiagnosticsEventsWithMultipleEvents.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS15-testPostDiagnosticsEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS15-testPostDiagnosticsEventsWithOneEvent.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningEmptyOffersResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNetworkError.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningSignatureErrorResponse.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
@@ -13,7 +13,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -13,7 +13,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
@@ -13,7 +13,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -13,7 +13,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testCachesRequestsForSameReceipt.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesNotPostConsentStatus.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testFreeTrialPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
@@ -13,7 +13,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -15,8 +15,8 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -13,7 +13,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testIndividualParamsCanBeNil.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayAsYouGoPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayUpFrontPostsCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
@@ -13,7 +13,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -13,7 +13,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -1,0 +1,36 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : {
+      "app_transaction" : "some_jws_token",
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "initiation_source" : "purchase",
+      "is_restore" : false,
+      "observer_mode" : true
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionCorrectly.1.json
@@ -12,12 +12,13 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {
+      "app_transaction" : "some_jws_token",
       "app_user_id" : "user",
       "attributes" : {
         "$attConsentStatus" : {
@@ -26,7 +27,7 @@
         }
       },
       "currency" : "USD",
-      "fetch_token" : "YW4gYXdlc29tZWVyIHJlY2VpcHQ=",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
       "initiation_source" : "purchase",
       "is_restore" : false,
       "observer_mode" : true,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
@@ -13,7 +13,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -13,7 +13,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -1,0 +1,36 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : {
+      "app_transaction" : "some_jws_token",
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "initiation_source" : "purchase",
+      "is_restore" : false,
+      "observer_mode" : true
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionCorrectly.1.json
@@ -12,12 +12,13 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {
+      "app_transaction" : "some_jws_token",
       "app_user_id" : "user",
       "attributes" : {
         "$attConsentStatus" : {
@@ -26,7 +27,7 @@
         }
       },
       "currency" : "USD",
-      "fetch_token" : "YW4gYXdlc29tZWVyIHJlY2VpcHQ=",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
       "initiation_source" : "purchase",
       "is_restore" : false,
       "observer_mode" : true,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithFailedVerification.1.json
@@ -12,7 +12,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -12,7 +12,7 @@
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -1,0 +1,35 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : {
+      "app_transaction" : "some_jws_token",
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "initiation_source" : "purchase",
+      "is_restore" : false,
+      "observer_mode" : true
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionCorrectly.1.json
@@ -2,22 +2,22 @@
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
     "content-type" : "application/json",
-    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
-    "X-Is-Sandbox" : "true",
+    "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "1",
-    "X-StoreKit2-Enabled" : "false",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
     "X-Version" : "4.0.0"
   },
   "request" : {
     "body" : {
+      "app_transaction" : "some_jws_token",
       "app_user_id" : "user",
       "attributes" : {
         "$attConsentStatus" : {
@@ -26,7 +26,7 @@
         }
       },
       "currency" : "USD",
-      "fetch_token" : "YW4gYXdlc29tZWVyIHJlY2VpcHQ=",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
       "initiation_source" : "purchase",
       "is_restore" : false,
       "observer_mode" : true,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestContainsSignatureHeader.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestFailsIfSignatureVerificationFails.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1660,7 +1660,7 @@ extension BaseHTTPClientTests {
         var key1: String
         var key2: String
 
-        var contentForSignature: [(key: String, value: String)] {
+        var contentForSignature: [(key: String, value: String?)] {
             return [
                 ("key1", self.key1),
                 ("key2", self.key2)
@@ -1707,6 +1707,6 @@ private struct AnyEncodableRequestBody: HTTPRequestBody, Decodable {
         self.body = .init(body)
     }
 
-    var contentForSignature: [(key: String, value: String)] { [] }
+    var contentForSignature: [(key: String, value: String?)] { [] }
 
 }

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
@@ -12,8 +12,8 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -446,6 +446,7 @@ extension BasePurchasesTests {
                            productData: ProductRequestData?,
                            transactionData: PurchasedTransactionData,
                            observerMode: Bool,
+                           appTransaction: String? = nil,
                            completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
             self.postReceiptDataCalled = true
             self.postedReceiptData = receipt

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -356,7 +356,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
     }
 
     func testDoesNotInitializeSK1IfSK2Enabled() throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let configurationBuilder = Configuration.Builder(withAPIKey: "")
             .with(storeKitVersion: .storeKit2)
@@ -375,7 +375,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
     }
 
     func testSetsPaymentQueueWrapperDelegateToPaymentQueueWrapperIfSK1IsNotEnabled() throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         self.systemInfo = MockSystemInfo(finishTransactions: false,
                                          storeKitVersion: .storeKit2)

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
@@ -161,7 +161,7 @@ class PurchaseDeferredPurchasesSK2Tests: BasePurchasesTests {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         self.setupPurchases()
 

--- a/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
@@ -101,7 +101,7 @@ class TransactionPosterTests: TestCase {
     }
 
     func testHandlePurchasedTransactionSendsJWS() throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         self.setUp(observerMode: false, storeKitVersion: .storeKit2)
         let jwsRepresentation = UUID().uuidString
@@ -130,7 +130,7 @@ class TransactionPosterTests: TestCase {
     }
 
     func testHandlePurchasedTransactionSendsSK2Receipt() throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         self.setUp(observerMode: false, storeKitVersion: .storeKit2)
         let jwsRepresentation = UUID().uuidString

--- a/Tests/UnitTests/StoreKitExtensions/StoreKitErrorTests.swift
+++ b/Tests/UnitTests/StoreKitExtensions/StoreKitErrorTests.swift
@@ -22,7 +22,7 @@ class StoreKitErrorTests: BaseErrorTests {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
     }
 
     func testErrorUtilsCreation() {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithAdServicesToken.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -13,8 +13,8 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Storefront" : "USA",
-    "X-StoreKit-Version" : "2",
-    "X-StoreKit2-Enabled" : "true",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
     "X-Version" : "4.0.0"
   },
   "request" : {


### PR DESCRIPTION
### Description
This PR enables support for `OriginalApplicationVersion` and `OriginalPurchaseDate` with StoreKit 2 via SK2's `AppTransaction`.