### PR TITLE
Obsolete all observer mode configure functions

### DIFF
--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -57,56 +57,6 @@ public extension Purchases {
     func getEligiblePromotionalOffers(forProduct product: StoreProduct) async -> [PromotionalOffer] {
         return await eligiblePromotionalOffers(forProduct: product)
     }
-
-    @available(iOS, deprecated: 1, renamed: "configure(with:)")
-    @available(tvOS, deprecated: 1, renamed: "configure(with:)")
-    @available(watchOS, deprecated: 1, renamed: "configure(with:)")
-    @available(macOS, deprecated: 1, renamed: "configure(with:)")
-    @available(macCatalyst, deprecated: 1, renamed: "configure(with:)")
-    @objc(configureWithAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)
-    @discardableResult static func configure(withAPIKey apiKey: String,
-                                             appUserID: String?,
-                                             observerMode: Bool,
-                                             userDefaults: UserDefaults?,
-                                             useStoreKit2IfAvailable: Bool) -> Purchases {
-        configure(
-            withAPIKey: apiKey,
-            appUserID: appUserID,
-            observerMode: observerMode,
-            userDefaults: userDefaults,
-            useStoreKit2IfAvailable: useStoreKit2IfAvailable,
-            dangerousSettings: nil
-        )
-    }
-
-    @available(iOS, deprecated: 1, renamed: "configure(with:)")
-    @available(tvOS, deprecated: 1, renamed: "configure(with:)")
-    @available(watchOS, deprecated: 1, renamed: "configure(with:)")
-    @available(macOS, deprecated: 1, renamed: "configure(with:)")
-    @available(macCatalyst, deprecated: 1, renamed: "configure(with:)")
-    @objc(configureWithAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:dangerousSettings:)
-    // swiftlint:disable:next function_parameter_count
-    @discardableResult static func configure(withAPIKey apiKey: String,
-                                             appUserID: String?,
-                                             observerMode: Bool,
-                                             userDefaults: UserDefaults?,
-                                             useStoreKit2IfAvailable: Bool,
-                                             dangerousSettings: DangerousSettings?) -> Purchases {
-        return Self.configure(
-            withAPIKey: apiKey,
-            appUserID: appUserID,
-            observerMode: observerMode,
-            userDefaults: userDefaults,
-            platformInfo: nil,
-            responseVerificationMode: .default,
-            storeKitVersion: useStoreKit2IfAvailable ? .storeKit2 : .storeKit1,
-            storeKitTimeout: Configuration.storeKitRequestTimeoutDefault,
-            networkTimeout: Configuration.networkTimeoutDefault,
-            dangerousSettings: dangerousSettings,
-            showStoreMessagesAutomatically: true,
-            diagnosticsEnabled: false
-        )
-    }
 }
 
 public extension Purchases {

--- a/Sources/Misc/Obsoletions.swift
+++ b/Sources/Misc/Obsoletions.swift
@@ -623,6 +623,36 @@ custom UserDefaults.
 
     }
 
+    @available(iOS, obsoleted: 1, renamed: "configure(with:)")
+    @available(tvOS, obsoleted: 1, renamed: "configure(with:)")
+    @available(watchOS, obsoleted: 1, renamed: "configure(with:)")
+    @available(macOS, obsoleted: 1, renamed: "configure(with:)")
+    @available(macCatalyst, obsoleted: 1, renamed: "configure(with:)")
+    @objc(configureWithAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)
+    @discardableResult static func configure(withAPIKey apiKey: String,
+                                             appUserID: String?,
+                                             observerMode: Bool,
+                                             userDefaults: UserDefaults?,
+                                             useStoreKit2IfAvailable: Bool) -> Purchases {
+        fatalError()
+    }
+
+    @available(iOS, obsoleted: 1, renamed: "configure(with:)")
+    @available(tvOS, obsoleted: 1, renamed: "configure(with:)")
+    @available(watchOS, obsoleted: 1, renamed: "configure(with:)")
+    @available(macOS, obsoleted: 1, renamed: "configure(with:)")
+    @available(macCatalyst, obsoleted: 1, renamed: "configure(with:)")
+    @objc(configureWithAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:dangerousSettings:)
+    // swiftlint:disable:next function_parameter_count
+    @discardableResult static func configure(withAPIKey apiKey: String,
+                                             appUserID: String?,
+                                             observerMode: Bool,
+                                             userDefaults: UserDefaults?,
+                                             useStoreKit2IfAvailable: Bool,
+                                             dangerousSettings: DangerousSettings?) -> Purchases {
+        fatalError()
+    }
+
     /**
      * Enable automatic collection of Apple Search Ads attribution. Defaults to `false`.
      */

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -37,30 +37,6 @@ BOOL isAnonymous;
     [RCPurchases configureWithAPIKey:@"" appUserID:nil];
     [RCPurchases configureWithAPIKey:@"" appUserID:@"" purchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat storeKitVersion:RCStoreKitVersion2];
     [RCPurchases configureWithAPIKey:@"" appUserID:nil purchasesAreCompletedBy:RCPurchasesAreCompletedByMyApp storeKitVersion:RCStoreKitVersion1];
-    [RCPurchases configureWithAPIKey:@""
-                           appUserID:nil
-                        observerMode:false
-                        userDefaults:[[NSUserDefaults alloc] init]
-             useStoreKit2IfAvailable:true];
-    [RCPurchases configureWithAPIKey:@""
-                           appUserID:nil
-                        observerMode:false
-                        userDefaults:[[NSUserDefaults alloc] init]
-             useStoreKit2IfAvailable:true
-                   dangerousSettings:nil];
-    [RCPurchases configureWithAPIKey:@""
-                           appUserID:nil
-                        observerMode:false
-                        userDefaults:[[NSUserDefaults alloc] init]
-             useStoreKit2IfAvailable:true
-                   dangerousSettings:[[RCDangerousSettings alloc] init]];
-     [RCPurchases configureWithAPIKey:@""
-                            appUserID:nil
-                         observerMode:false
-                         userDefaults:[[NSUserDefaults alloc] init]
-              useStoreKit2IfAvailable:true
-                    dangerousSettings:[[RCDangerousSettings alloc] initWithAutoSyncPurchases:NO
-                                                                customEntitlementComputation:NO]];
 
     [RCPurchases setLogHandler:^(RCLogLevel l, NSString *i) {}];
     canI = [RCPurchases canMakePayments];

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -344,29 +344,6 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
     purchases.logIn("") { (_: CustomerInfo?, _: Bool, _: Error?) in }
 
     Purchases.configure(withAPIKey: "", appUserID: "")
-    Purchases.configure(withAPIKey: "",
-                        appUserID: nil,
-                        observerMode: true,
-                        userDefaults: UserDefaults(),
-                        useStoreKit2IfAvailable: true)
-    Purchases.configure(withAPIKey: "",
-                        appUserID: "",
-                        observerMode: true,
-                        userDefaults: UserDefaults(),
-                        useStoreKit2IfAvailable: true,
-                        dangerousSettings: nil)
-    Purchases.configure(withAPIKey: "",
-                        appUserID: "",
-                        observerMode: true,
-                        userDefaults: UserDefaults(),
-                        useStoreKit2IfAvailable: true,
-                        dangerousSettings: DangerousSettings())
-    Purchases.configure(withAPIKey: "",
-                        appUserID: "",
-                        observerMode: true,
-                        userDefaults: UserDefaults(),
-                        useStoreKit2IfAvailable: true,
-                        dangerousSettings: DangerousSettings(autoSyncPurchases: false))
 
     let _: Bool = purchases.finishTransactions
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -109,18 +109,6 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(Purchases.shared.purchasesAreCompletedBy) == .revenueCat
     }
 
-    @available(*, deprecated) // Ignore deprecation warnings
-    func testSharedInstanceIsSetWhenConfiguringWithAppUserIDAndUserDefaultsAndUseSK2() {
-        let purchases = Purchases.configure(withAPIKey: "",
-                                            appUserID: "",
-                                            observerMode: false,
-                                            userDefaults: nil,
-                                            useStoreKit2IfAvailable: true)
-        expect(Purchases.shared) === purchases
-        expect(Purchases.shared.finishTransactions) == true
-        expect(Purchases.shared.purchasesAreCompletedBy) == .revenueCat
-    }
-
     func testUserIdIsSetWhenConfiguringWithUserID() {
         let purchases = Purchases.configure(
             with: .init(withAPIKey: "")


### PR DESCRIPTION
I found two observer mode configure functions this morning that were deprecated but not obsoleted. This PR obsoletes them to match the obsoletion of the other observerMode configure functions.