### PR TITLE
Use available resource class for backend-integration-tests-offline-job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1271,7 +1271,7 @@ workflows:
               ignore: /pull\/[0-9]+/
       - backend-integration-tests-offline:
           # These tests are flaky due to FB13133387 so we don't want the noise in every PR
-          <<: *release-branches-and-main
+          # <<: *release-branches-and-main
       - backend-integration-tests-custom-entitlements:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1270,7 +1270,7 @@ workflows:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
       - backend-integration-tests-offline:
-          xcode_version: "15.2"
+          xcode_version: "15.3"
           install_swiftlint: false
           # These tests are flaky due to FB13133387 so we don't want the noise in every PR
           # <<: *release-branches-and-main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1270,6 +1270,8 @@ workflows:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
       - backend-integration-tests-offline:
+          xcode_version: "15.2"
+          install_swiftlint: false
           # These tests are flaky due to FB13133387 so we don't want the noise in every PR
           # <<: *release-branches-and-main
       - backend-integration-tests-custom-entitlements:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -823,8 +823,6 @@ jobs:
 
   backend-integration-tests-offline:
     <<: *base-job
-    # These tests are even flakier running on M1
-    resource_class: macos.x86.medium.gen2
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-Offline"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1270,10 +1270,8 @@ workflows:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
       - backend-integration-tests-offline:
-          xcode_version: "15.3"
-          install_swiftlint: false
           # These tests are flaky due to FB13133387 so we don't want the noise in every PR
-          # <<: *release-branches-and-main
+          <<: *release-branches-and-main
       - backend-integration-tests-custom-entitlements:
           filters:
             branches:


### PR DESCRIPTION
### Description
The `5.0-dev` branch was using the `macos.x86.medium.gen2` resource class for the `backend-integration-tests-offline-job`, but that resource class was removed from CircleCI on June 28, 2024 ([source](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718)). Since the resource class is now unavailable, this job currently fails 100% of the time on `main`.

This PR brings the job onto the same M1 resource as most other jobs. While the tests may be more flaky on M1 machines, the job retry mechanism we have in place now should help counter this.
