### PR TITLE
CI Build Docs Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ aliases:
       tags:
         ignore: /.*/
       branches:
-        only: /^release\/.*\.0$/    
+        only: /^release\/.*\.0$/
 
 commands:
   install-runtime:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,8 @@ aliases:
         ignore: /.*/
       branches:
         only: /^release\/.*\.0$/
+  docs: &docs
+    xcode_version: '14.3.0'
 
 commands:
   install-runtime:
@@ -861,8 +863,9 @@ jobs:
           path: fastlane/test_output/report.html
           destination: test_report.html
 
-  docs-deploy:
+  docs-build:
     <<: *base-job
+    <<: *docs
     steps:
       - setup-git-credentials
       - checkout
@@ -871,7 +874,20 @@ jobs:
           name: Build docs
           command: bundle exec fastlane generate_docs
           environment:
-            DOCS_IOS_VERSION: "16.1"
+            DOCS_IOS_VERSION: "17.4"
+
+  docs-deploy:
+    <<: *base-job
+    <<: *docs
+    steps:
+      - setup-git-credentials
+      - checkout
+      - install-bundle-dependencies
+      - run:
+          name: Build docs
+          command: bundle exec fastlane generate_and_publish_docs
+          environment:
+            DOCS_IOS_VERSION: "17.4"
 
   make-release:
     <<: *base-job
@@ -1212,6 +1228,7 @@ workflows:
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
       - lint
+      - docs-build
       - spm-release-build
       - spm-custom-entitlement-computation-build
       - spm-receipt-parser
@@ -1328,6 +1345,7 @@ workflows:
             - make-release
           <<: *release-tags
       - docs-deploy:
+          <<: *docs
           <<: *release-tags
       - deploy-purchase-tester:
           <<: *release-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,7 @@ aliases:
       tags:
         ignore: /.*/
       branches:
-        only: /^release\/.*\.0$/
-  docs: &docs
-    xcode_version: '14.3.0'
+        only: /^release\/.*\.0$/    
 
 commands:
   install-runtime:
@@ -865,7 +863,6 @@ jobs:
 
   docs-build:
     <<: *base-job
-    <<: *docs
     steps:
       - setup-git-credentials
       - checkout
@@ -878,7 +875,6 @@ jobs:
 
   docs-deploy:
     <<: *base-job
-    <<: *docs
     steps:
       - setup-git-credentials
       - checkout
@@ -1228,7 +1224,9 @@ workflows:
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
       - lint
-      - docs-build
+      - docs-build:
+          xcode_version: '14.3.0'
+          install_swiftlint: false
       - spm-release-build
       - spm-custom-entitlement-computation-build
       - spm-receipt-parser
@@ -1345,8 +1343,8 @@ workflows:
             - make-release
           <<: *release-tags
       - docs-deploy:
-          <<: *docs
           <<: *release-tags
+          xcode_version: '14.3.0'
       - deploy-purchase-tester:
           <<: *release-tags
       - notify-on-non-patch-release-branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -869,7 +869,7 @@ jobs:
       - install-bundle-dependencies
       - run:
           name: Build docs
-          command: bundle exec fastlane generate_docs
+          command: bundle exec fastlane build_docs
           environment:
             DOCS_IOS_VERSION: "17.4"
 
@@ -881,7 +881,7 @@ jobs:
       - install-bundle-dependencies
       - run:
           name: Build docs
-          command: bundle exec fastlane generate_and_publish_docs
+          command: bundle exec fastlane build_and_publish_docs
           environment:
             DOCS_IOS_VERSION: "17.4"
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -774,13 +774,13 @@ platform :ios do
   end
 
   desc "Generate docs without publishing"
-  lane :generate_docs do
-    generate_docs_shared
+  lane :build_docs do
+    build_docs_shared
   end
 
   desc "Generate & publish docs"
-  lane :generate_and_publish_docs do
-    generate_docs_shared
+  lane :build_and_publish_docs do
+    build_docs_shared
 
     version_number = current_version_number
     docs_repo_base_url = ENV["DOCS_REPO_BASE_URL"]
@@ -817,7 +817,7 @@ platform :ios do
   end
 
   desc "Builds the docs"
-  private_lane :generate_docs_shared do
+  private_lane :build_docs_shared do
     ENV["INCLUDE_DOCC_PLUGIN"] = "true"
 
     version_number = current_version_number

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -780,7 +780,7 @@ platform :ios do
 
   desc "Generate & publish docs"
   lane :build_and_publish_docs do
-    build_docs_shared
+    docs_generation_folder = build_docs_shared
 
     version_number = current_version_number
     docs_repo_base_url = ENV["DOCS_REPO_BASE_URL"]
@@ -800,7 +800,7 @@ platform :ios do
           # copy docs generated in the previous step into the docs folder
           # and push the changes
           docs_destination_folder = "docs/#{version_number}"
-          FileUtils.cp_r @docs_generation_folder + "/.", docs_destination_folder
+          FileUtils.cp_r docs_generation_folder + "/.", docs_destination_folder
           docs_files.each do |file|
             FileUtils.cp file, "docs/"
           end
@@ -828,8 +828,7 @@ platform :ios do
 
     hosting_base_path = File.join(docs_repo_name, version_number)
 
-    Dir.mktmpdir do |docs_generation_folder|
-      @docs_generation_folder = docs_generation_folder
+    docs_path = Dir.mktmpdir do |docs_generation_folder|
       # swift package must be run from the dir that contains the Package.swift
       # output is generated in docs_generation_folder
       Dir.chdir("..") do
@@ -854,7 +853,11 @@ platform :ios do
            "--enable-inherited-docs",
            "--additional-symbol-graph-dir", ".build")
       end
+
+      docs_generation_folder # returning path from block
     end
+
+    docs_path # returning path from lane
   end
 
   desc "Build and deploy PurchaseTesterSwiftUI"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -773,22 +773,63 @@ platform :ios do
     end
   end
 
-  desc "Generate docs"
+  desc "Generate docs without publishing"
   lane :generate_docs do
-    ENV["INCLUDE_DOCC_PLUGIN"] = "true"
+    generate_docs_shared
+  end
+
+  desc "Generate & publish docs"
+  lane :generate_and_publish_docs do
+    generate_docs_shared
 
     version_number = current_version_number
     docs_repo_base_url = ENV["DOCS_REPO_BASE_URL"]
     docs_repo_name = ENV["DOCS_REPO_NAME"]
-    ios_version = ENV['DOCS_IOS_VERSION'] || "16.1"
 
     UI.user_error!("Missing environment variable: DOCS_REPO_BASE_URL") unless docs_repo_base_url
     UI.user_error!("Missing environment variable: DOCS_REPO_NAME") unless docs_repo_name
 
     docs_repo_url = File.join(docs_repo_base_url, docs_repo_name)
+
+    docs_files = Dir.glob("scripts/docs/*.html").map { |file| File.realpath(file) }
+    # clone docs repo
+    Dir.mktmpdir do |docs_repo_clone_dir|
+      Dir.chdir(docs_repo_clone_dir) do
+        sh("git", "clone", docs_repo_url)
+        Dir.chdir(docs_repo_name) do
+          # copy docs generated in the previous step into the docs folder
+          # and push the changes
+          docs_destination_folder = "docs/#{version_number}"
+          FileUtils.cp_r @docs_generation_folder + "/.", docs_destination_folder
+          docs_files.each do |file|
+            FileUtils.cp file, "docs/"
+          end
+
+          # using sh instead of fastlane commands because fastlane would run
+          # from the repo root
+          sh("git", "add", docs_destination_folder)
+          sh("git", "add", "docs/*.html")
+          sh("git", "commit", "-m", "Update documentation for #{version_number}")
+          sh("git", "push")
+        end
+      end
+    end
+  end
+
+  desc "Builds the docs"
+  private_lane :generate_docs_shared do
+    ENV["INCLUDE_DOCC_PLUGIN"] = "true"
+
+    version_number = current_version_number
+    docs_repo_name = ENV["DOCS_REPO_NAME"]
+    ios_version = ENV['DOCS_IOS_VERSION'] || "16.1"
+
+    UI.user_error!("Missing environment variable: DOCS_REPO_NAME") unless docs_repo_name
+
     hosting_base_path = File.join(docs_repo_name, version_number)
 
     Dir.mktmpdir do |docs_generation_folder|
+      @docs_generation_folder = docs_generation_folder
       # swift package must be run from the dir that contains the Package.swift
       # output is generated in docs_generation_folder
       Dir.chdir("..") do
@@ -812,30 +853,6 @@ platform :ios do
            "--transform-for-static-hosting",
            "--enable-inherited-docs",
            "--additional-symbol-graph-dir", ".build")
-
-        docs_files = Dir.glob("scripts/docs/*.html").map { |file| File.realpath(file) }
-        # clone docs repo
-        Dir.mktmpdir do |docs_repo_clone_dir|
-          Dir.chdir(docs_repo_clone_dir) do
-            sh("git", "clone", docs_repo_url)
-            Dir.chdir(docs_repo_name) do
-              # copy docs generated in the previous step into the docs folder
-              # and push the changes
-              docs_destination_folder = "docs/#{version_number}"
-              FileUtils.cp_r docs_generation_folder + "/.", docs_destination_folder
-              docs_files.each do |file|
-                FileUtils.cp file, "docs/"
-              end
-
-              # using sh instead of fastlane commands because fastlane would run
-              # from the repo root
-              sh("git", "add", docs_destination_folder)
-              sh("git", "add", "docs/*.html")
-              sh("git", "commit", "-m", "Update documentation for #{version_number}")
-              sh("git", "push")
-            end
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
### Motivation
The doc building process can be fragile at times, and since we only build the docs when we make a deployment, we can be unaware when changes in individual PRs can break our docs' build. This PR aims to make changes that break the docs building process visible earlier in the development cycle to help avoid tricky failures during deployments.

### Description
This PR makes two main changes to how docs are built in the CI process:
- Fixes the existing docs job in the deploy pipeline by having it run on Xcode 14.3.0. This fix comes from an [earlier commit](https://github.com/RevenueCat/purchases-ios/commit/f05f0cf14aaf061d7d8f17d2f4f6ac1fec9200a2) by @vegaro that likely got overridden when `5.0-dev` was merged into `main` recently.
- Introduces a job to build the docs on each PR instead of only during the deploy pipeline
   - It splits the existing `docs-build` into two separate jobs:
      - `docs-build`: Only builds the docs, and is run on each build.
      - `docs-deploy`: Builds and deploys the docs. Replaces the old `docs-build` job and is only run in the deploy pipeline.
  - In Fastlane, we've split the existing `generate_docs` lane into two separate lanes and one private lane:
     - `generate_docs`: This now only builds the docs by running the `generate_docs_shared` lane
     - `generate_and_publish_docs`: Builds the docs by running the `generate_docs_shared` lane and then publishing the docs

### Testing
I've been able to test the `docs-build` job in this PR, but haven't been able to fully test the `generate_and_publish_docs` job since we haven't executed another deployment since 5.0.0. If anyone has any ideas to test `generate_and_publish_docs`, let me know! 😄

