### PR TITLE
Update v5 migration guide to contain current latest version

### DIFF
--- a/scripts/docs/v5_api_migration_guide.html
+++ b/scripts/docs/v5_api_migration_guide.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="refresh" content="0; url=https://revenuecat.github.io/purchases-ios-docs/5.0.0-beta.2/documentation/revenuecat/v5_api_migration_guide"/>
+    <meta http-equiv="refresh" content="0; url=https://revenuecat.github.io/purchases-ios-docs/5.0.0/documentation/revenuecat/v5_api_migration_guide"/>
 </head>
 <body>
 </body>


### PR DESCRIPTION
### Description
This should be on the latest version so our automations perform the replacements correctly. Otherwise, the matching won't work correctly