### PR TITLE
Return any cached CustomerInfo if we dont have an AppTransaction

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1129,6 +1129,13 @@ private extension PurchasesOrchestrator {
                         return
                     }
 
+                    // We dont have an AppTransactionJWS, return the cached CustomerInfo
+                    // even if it does not have originalPurchaseDate and originalApplicationVersion
+                    if let cachedCustomerInfo, appTransactionJWS == nil {
+                        completion?(.success(cachedCustomerInfo))
+                        return
+                    }
+
                     self.backend.post(receipt: .empty,
                                       productData: nil,
                                       transactionData: .init(appUserID: currentAppUserID,


### PR DESCRIPTION
To avoid making a request to /receipt without any transaction or app_transaction, return a cached customer info object if we don't have an app_transaction, even if the originalAppVersion and originalPurchaseDate are empty.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
