### PR TITLE
Reduce CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1198,28 +1198,20 @@ workflows:
       - run-test-ios-16:
           xcode_version: '14.3.0'
           install_swiftlint: false
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - run-test-ios-15:
           xcode_version: '14.3.0'
           install_swiftlint: false
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - run-test-ios-14:
           xcode_version: '14.2.0'
           install_swiftlint: false
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - run-test-ios-13:
           xcode_version: '14.2.0'
           install_swiftlint: false
       - run-test-macos:
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
 
   generate_revenuecatui_snapshots:
     when: << pipeline.parameters.generate_revenuecatui_snapshots >>
@@ -1227,15 +1219,11 @@ workflows:
       - spm-revenuecat-ui-ios-15:
           xcode_version: '14.3.0'
           install_swiftlint: false
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - spm-revenuecat-ui-ios-16:
           xcode_version: '14.3.0'
           install_swiftlint: false
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - spm-revenuecat-ui-ios-17:
           xcode_version: "15.2"
 
@@ -1251,128 +1239,76 @@ workflows:
       - docs-build:
           xcode_version: '14.3.0'
           install_swiftlint: false
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - spm-release-build:
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - spm-custom-entitlement-computation-build:
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - spm-receipt-parser:
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - spm-release-build-xcode-14:
           xcode_version: '14.3.0'
           install_swiftlint: false
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - spm-release-build-xcode-15:
           xcode_version: '15.2'
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - spm-xcode-14-1:
           xcode_version: '14.1.0'
           install_swiftlint: false
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - spm-revenuecat-ui-ios-15:
           xcode_version: '14.3.0'
           install_swiftlint: false
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - spm-revenuecat-ui-ios-16:
           xcode_version: '14.3.0'
           install_swiftlint: false
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - spm-revenuecat-ui-ios-17:
           xcode_version: "15.2"
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - spm-revenuecat-ui-watchos:
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - run-test-macos:
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - run-test-ios-17:
           xcode_version: "15.2"
       - run-test-ios-16:
           xcode_version: '14.3.0'
           install_swiftlint: false
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - run-test-ios-15:
           xcode_version: '14.3.0'
           install_swiftlint: false
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - run-test-watchos:
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - run-test-tvos:
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       # Pre-iOS 15 requires macOS 12 which requires Xcode 14.2
       # See https://circleci.com/docs/using-macos/#supported-xcode-versions
       - run-test-ios-14:
           xcode_version: '14.2.0'
           install_swiftlint: false
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - run-test-ios-13:
           xcode_version: '14.2.0'
           install_swiftlint: false
       - build-tv-watch-and-macos:
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - build-visionos:
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - backend-integration-tests-SK1:
-          filters:
-            branches:
-              <<: *release-branches
-              ignore: *forked-pull-requests
+          <<: *release-branches
       - backend-integration-tests-SK2:
-          filters:
-            branches:
-              <<: *release-branches
-              ignore: *forked-pull-requests
+          <<: *release-branches
       - backend-integration-tests-other:
-          filters:
-            branches:
-              <<: *release-branches
-              ignore: *forked-pull-requests
+          <<: *release-branches
       - backend-integration-tests-offline:
-          filters:
-            branches:
-              <<: *release-branches
+          <<: *release-branches
       - backend-integration-tests-custom-entitlements:
-          filters:
-            branches:
-              <<: *release-branches
-              ignore: *forked-pull-requests
+          <<: *release-branches
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,12 @@ aliases:
       branches:
         only: /^release\/.*\.0$/
 
+  # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+  forked-pull-requests: &forked-pull-requests
+    filters:
+      tags:
+        ignore: /pull\/[0-9]+/
+
 commands:
   install-runtime:
     parameters:
@@ -1192,16 +1198,28 @@ workflows:
       - run-test-ios-16:
           xcode_version: '14.3.0'
           install_swiftlint: false
+          filters:
+            branches:
+              <<: *release-branches
       - run-test-ios-15:
           xcode_version: '14.3.0'
           install_swiftlint: false
+          filters:
+            branches:
+              <<: *release-branches
       - run-test-ios-14:
           xcode_version: '14.2.0'
           install_swiftlint: false
+          filters:
+            branches:
+              <<: *release-branches
       - run-test-ios-13:
           xcode_version: '14.2.0'
           install_swiftlint: false
-      - run-test-macos
+      - run-test-macos:
+          filters:
+            branches:
+              <<: *release-branches
 
   generate_revenuecatui_snapshots:
     when: << pipeline.parameters.generate_revenuecatui_snapshots >>
@@ -1209,9 +1227,15 @@ workflows:
       - spm-revenuecat-ui-ios-15:
           xcode_version: '14.3.0'
           install_swiftlint: false
+          filters:
+            branches:
+              <<: *release-branches
       - spm-revenuecat-ui-ios-16:
           xcode_version: '14.3.0'
           install_swiftlint: false
+          filters:
+            branches:
+              <<: *release-branches
       - spm-revenuecat-ui-ios-17:
           xcode_version: "15.2"
 
@@ -1227,71 +1251,128 @@ workflows:
       - docs-build:
           xcode_version: '14.3.0'
           install_swiftlint: false
-      - spm-release-build
-      - spm-custom-entitlement-computation-build
-      - spm-receipt-parser
+          filters:
+            branches:
+              <<: *release-branches
+      - spm-release-build:
+          filters:
+            branches:
+              <<: *release-branches
+      - spm-custom-entitlement-computation-build:
+          filters:
+            branches:
+              <<: *release-branches
+      - spm-receipt-parser:
+          filters:
+            branches:
+              <<: *release-branches
       - spm-release-build-xcode-14:
           xcode_version: '14.3.0'
           install_swiftlint: false
+          filters:
+            branches:
+              <<: *release-branches
       - spm-release-build-xcode-15:
           xcode_version: '15.2'
+          filters:
+            branches:
+              <<: *release-branches
       - spm-xcode-14-1:
           xcode_version: '14.1.0'
           install_swiftlint: false
+          filters:
+            branches:
+              <<: *release-branches
       - spm-revenuecat-ui-ios-15:
           xcode_version: '14.3.0'
           install_swiftlint: false
+          filters:
+            branches:
+              <<: *release-branches
       - spm-revenuecat-ui-ios-16:
           xcode_version: '14.3.0'
           install_swiftlint: false
+          filters:
+            branches:
+              <<: *release-branches
       - spm-revenuecat-ui-ios-17:
           xcode_version: "15.2"
-      - spm-revenuecat-ui-watchos
-      - run-test-macos
+          filters:
+            branches:
+              <<: *release-branches
+      - spm-revenuecat-ui-watchos:
+          filters:
+            branches:
+              <<: *release-branches
+      - run-test-macos:
+          filters:
+            branches:
+              <<: *release-branches
       - run-test-ios-17:
           xcode_version: "15.2"
       - run-test-ios-16:
           xcode_version: '14.3.0'
           install_swiftlint: false
+          filters:
+            branches:
+              <<: *release-branches
       - run-test-ios-15:
           xcode_version: '14.3.0'
           install_swiftlint: false
-      - run-test-watchos
-      - run-test-tvos
+          filters:
+            branches:
+              <<: *release-branches
+      - run-test-watchos:
+          filters:
+            branches:
+              <<: *release-branches
+      - run-test-tvos:
+          filters:
+            branches:
+              <<: *release-branches
       # Pre-iOS 15 requires macOS 12 which requires Xcode 14.2
       # See https://circleci.com/docs/using-macos/#supported-xcode-versions
       - run-test-ios-14:
           xcode_version: '14.2.0'
           install_swiftlint: false
+          filters:
+            branches:
+              <<: *release-branches
       - run-test-ios-13:
           xcode_version: '14.2.0'
           install_swiftlint: false
-          <<: *release-branches-and-main
-      - build-tv-watch-and-macos
-      - build-visionos
+      - build-tv-watch-and-macos:
+          filters:
+            branches:
+              <<: *release-branches
+      - build-visionos:
+          filters:
+            branches:
+              <<: *release-branches
       - backend-integration-tests-SK1:
           filters:
             branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+/
+              <<: *release-branches
+              ignore: *forked-pull-requests
       - backend-integration-tests-SK2:
           filters:
             branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+/
+              <<: *release-branches
+              ignore: *forked-pull-requests
       - backend-integration-tests-other:
           filters:
             branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+/
+              <<: *release-branches
+              ignore: *forked-pull-requests
       - backend-integration-tests-offline:
-          # These tests are flaky due to FB13133387 so we don't want the noise in every PR
-          <<: *release-branches-and-main
+          filters:
+            branches:
+              <<: *release-branches
       - backend-integration-tests-custom-entitlements:
           filters:
             branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+/
+              <<: *release-branches
+              ignore: *forked-pull-requests
 
   deploy:
     when:
@@ -1352,6 +1433,7 @@ workflows:
             - make-release
           <<: *non-patch-release-branches
           context: slack-secrets
+
   snapshot-bump:
     when:
       not:
@@ -1359,9 +1441,11 @@ workflows:
     jobs:
       - prepare-next-version:
           <<: *only-main-branch
+
   danger:
     jobs:
       - danger
+
   weekly-run-workflow:
     when:
       and:


### PR DESCRIPTION
Will reduce the number of CI jobs we're running so that we:

- run all jobs on release PRs
- have some trigger to manually run all non-essential jobs based on something (could be a comment, a tag, a webhook)
- then on regular commits run only essential jobs
