### PR TITLE
Bring official `xcodes` back to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,23 +75,13 @@ commands:
       runtime-name:
         type: string
     steps:
-      # - install-brew-dependency:
-      #     dependency_name: 'xcodes'
-      # - run:
-      #     name: Install simulator
-      #     command: | # Print all available simulators and install required one
-      #         xcodes runtimes
-      #         sudo xcodes runtimes install "<< parameters.runtime-name >>"
-      # Xcodes got broken with latest iOS 18 betas. This is a temporary workaround. https://github.com/XcodesOrg/xcodes/issues/368
-      - run:
-          name: Install fixed xcodes version
-          command: |
-              mint install https://github.com/alvar-bolt/xcodes.git@alvar/ios-18-quickfix
-      - run:
-          name: Install simulator
-          command: | # Print all available simulators and install required one
-              $HOME/.mint/bin/xcodes runtimes
-              sudo $HOME/.mint/bin/xcodes runtimes install "<< parameters.runtime-name >>"
+       - install-brew-dependency:
+           dependency_name: 'xcodes'
+       - run:
+           name: Install simulator
+           command: | # Print all available simulators and install required one
+               xcodes runtimes
+               sudo xcodes runtimes install "<< parameters.runtime-name >>"
 
   install-bundle-dependencies:
     parameters:


### PR DESCRIPTION
This PR brings back the official xcode version since it looks like version 1.5.0 of xcodes fixed iOS 18 issues https://github.com/XcodesOrg/xcodes/releases/tag/1.5.0. We were relying on a fork that fixed the issues that arose with the release of iOS 18 betas