### PR TITLE
Retry Requests with HTTP Status 429

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -893,6 +893,8 @@
 		F5FCD3EA27DA0D0B003BDC04 /* PriceFormatterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FCD3E927DA0D0B003BDC04 /* PriceFormatterProvider.swift */; };
 		F5FCD3FC27DA2034003BDC04 /* PriceFormatterProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FCD3FB27DA2034003BDC04 /* PriceFormatterProviderTests.swift */; };
 		FD18ED4E2837F89200C5AA4F /* StoreKitWorkaroundsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD18ED4D2837F89200C5AA4F /* StoreKitWorkaroundsTests.swift */; };
+		FD43D2FC2C41864000077235 /* TimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD43D2FA2C4185B700077235 /* TimeInterval+Extensions.swift */; };
+		FD43D2FE2C41867600077235 /* TimeInterval+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD43D2FD2C41867600077235 /* TimeInterval+ExtensionsTests.swift */; };
 		FD9F982D2BE28A7F0091A5BF /* MockNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B515526D44B2300BD2BD7 /* MockNotificationCenter.swift */; };
 		FDAADFCB2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAADFCA2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift */; };
 		FDAADFCC2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAADFCA2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift */; };
@@ -1822,6 +1824,8 @@
 		F5FCD3E927DA0D0B003BDC04 /* PriceFormatterProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatterProvider.swift; sourceTree = "<group>"; };
 		F5FCD3FB27DA2034003BDC04 /* PriceFormatterProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatterProviderTests.swift; sourceTree = "<group>"; };
 		FD18ED4D2837F89200C5AA4F /* StoreKitWorkaroundsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitWorkaroundsTests.swift; sourceTree = "<group>"; };
+		FD43D2FA2C4185B700077235 /* TimeInterval+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Extensions.swift"; sourceTree = "<group>"; };
+		FD43D2FD2C41867600077235 /* TimeInterval+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		FDAADFCA2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAllTransactionsProvider.swift; sourceTree = "<group>"; };
 		FDAADFCE2BE2B84500BD1659 /* StoreKit2ObserverModePurchaseDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2ObserverModePurchaseDetector.swift; sourceTree = "<group>"; };
 		FDAADFD22BE2B99900BD1659 /* MockStoreKit2ObserverModePurchaseDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreKit2ObserverModePurchaseDetector.swift; sourceTree = "<group>"; };
@@ -1968,6 +1972,7 @@
 				57CD86D9291C1E2300768DE1 /* UserDefaults+Extensions.swift */,
 				4FC883802AA7A2BD00A3DE03 /* ProcessInfo+Extensions.swift */,
 				4F5C05BC2A43A21A00651C7D /* Locale+Extensions.swift */,
+				FD43D2FA2C4185B700077235 /* TimeInterval+Extensions.swift */,
 			);
 			path = FoundationExtensions;
 			sourceTree = "<group>";
@@ -2668,6 +2673,7 @@
 				5796A3BF27D7D64500653165 /* ResultExtensionsTests.swift */,
 				57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */,
 				57D56FC92853C005009E8E1E /* StringExtensionsTests.swift */,
+				FD43D2FD2C41867600077235 /* TimeInterval+ExtensionsTests.swift */,
 			);
 			path = FoundationExtensions;
 			sourceTree = "<group>";
@@ -4481,6 +4487,7 @@
 				578D79742936A36B0042E434 /* LoggerType.swift in Sources */,
 				B34605EB279A766C0031CA74 /* OperationQueue+Extensions.swift in Sources */,
 				57E6C2C72975AAE1001AFE98 /* FileReader.swift in Sources */,
+				FD43D2FC2C41864000077235 /* TimeInterval+Extensions.swift in Sources */,
 				4F7DBFBD2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift in Sources */,
 				5766AB4728401B8400FA6091 /* PackageType.swift in Sources */,
 				358C756C2C332BE800ECCA12 /* PreferredLocalesProvider.swift in Sources */,
@@ -4720,6 +4727,7 @@
 				57488B8B29CB756A0000EE7E /* ProductEntitlementMappingTests.swift in Sources */,
 				57ACB12428174B9F000DCC9F /* CustomerInfo+TestExtensions.swift in Sources */,
 				351B51B926D450E800BD2BD7 /* TransactionsFactoryTests.swift in Sources */,
+				FD43D2FE2C41867600077235 /* TimeInterval+ExtensionsTests.swift in Sources */,
 				351B51BB26D450E800BD2BD7 /* ProductRequestDataInitializationTests.swift in Sources */,
 				351B515426D44B0A00BD2BD7 /* MockStoreKit1Wrapper.swift in Sources */,
 				4F0BBAAC2A1D253D000E75AB /* OfflineCustomerInfoCreatorTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -893,6 +893,8 @@
 		F5FCD3EA27DA0D0B003BDC04 /* PriceFormatterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FCD3E927DA0D0B003BDC04 /* PriceFormatterProvider.swift */; };
 		F5FCD3FC27DA2034003BDC04 /* PriceFormatterProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FCD3FB27DA2034003BDC04 /* PriceFormatterProviderTests.swift */; };
 		FD18ED4E2837F89200C5AA4F /* StoreKitWorkaroundsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD18ED4D2837F89200C5AA4F /* StoreKitWorkaroundsTests.swift */; };
+		FD2E6C9F2C480FF000CB4BD7 /* OHHTTPStubs in Frameworks */ = {isa = PBXBuildFile; productRef = FD2E6C9E2C480FF000CB4BD7 /* OHHTTPStubs */; };
+		FD2E6CA12C48100900CB4BD7 /* OHHTTPStubsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = FD2E6CA02C48100900CB4BD7 /* OHHTTPStubsSwift */; };
 		FD43D2FC2C41864000077235 /* TimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD43D2FA2C4185B700077235 /* TimeInterval+Extensions.swift */; };
 		FD43D2FE2C41867600077235 /* TimeInterval+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD43D2FD2C41867600077235 /* TimeInterval+ExtensionsTests.swift */; };
 		FD9F982D2BE28A7F0091A5BF /* MockNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B515526D44B2300BD2BD7 /* MockNotificationCenter.swift */; };
@@ -1871,6 +1873,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FD2E6C9F2C480FF000CB4BD7 /* OHHTTPStubs in Frameworks */,
+				FD2E6CA12C48100900CB4BD7 /* OHHTTPStubsSwift in Frameworks */,
 				2D803F6626F144BF0069D717 /* Nimble in Frameworks */,
 				4FCBA8512A153940004134BD /* SnapshotTesting in Frameworks */,
 				2DA85A8C26DEA7FB00F1136D /* RevenueCat.framework in Frameworks */,
@@ -3795,6 +3799,8 @@
 			packageProductDependencies = (
 				2D803F6526F144BF0069D717 /* Nimble */,
 				4FCBA8502A153940004134BD /* SnapshotTesting */,
+				FD2E6C9E2C480FF000CB4BD7 /* OHHTTPStubs */,
+				FD2E6CA02C48100900CB4BD7 /* OHHTTPStubsSwift */,
 			);
 			productName = BackendIntegrationTests;
 			productReference = 2DE20B6C264087FB004C597D /* BackendIntegrationTests.xctest */;
@@ -6606,6 +6612,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 57E04739277260DE0082FE91 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
 			productName = SnapshotTesting;
+		};
+		FD2E6C9E2C480FF000CB4BD7 /* OHHTTPStubs */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
+			productName = OHHTTPStubs;
+		};
+		FD2E6CA02C48100900CB4BD7 /* OHHTTPStubsSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
+			productName = OHHTTPStubsSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Sources/FoundationExtensions/TimeInterval+Extensions.swift
+++ b/Sources/FoundationExtensions/TimeInterval+Extensions.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TimeInterval+Extensions.swift
+//
+//  Created by Will Taylor on 7/12/24.
+
+import Foundation
+
+extension TimeInterval {
+
+    init(milliseconds: Double) {
+        self = milliseconds / 1000.0
+    }
+
+}

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -28,7 +28,7 @@ enum NetworkStrings {
                             error: NetworkError,
                             metadata: HTTPClient.ResponseMetadata?)
     case api_request_failed_status_code(HTTPStatusCode)
-    case api_request_queued_for_retry(httpMethod: String, path: String, backoffInterval: TimeInterval)
+    case api_request_queued_for_retry(httpMethod: String, retryNumber: UInt, path: String, backoffInterval: TimeInterval)
     case api_request_failed_all_retries(httpMethod: String, path: String, retryCount: UInt)
     case reusing_existing_request_for_operation(CacheableNetworkOperation.Type, String)
     case enqueing_operation(CacheableNetworkOperation.Type, cacheKey: String)
@@ -48,7 +48,6 @@ enum NetworkStrings {
 
     #if DEBUG
     case api_request_forcing_server_error(HTTPRequest)
-    case api_request_forcing_network_error(HTTPRequest, NetworkError)
     case api_request_forcing_signature_failure(HTTPRequest)
     case api_request_disabling_header_parameter_signature_verification(HTTPRequest)
     #endif
@@ -134,8 +133,8 @@ extension NetworkStrings: LogMessage {
         case let .request_handled_by_load_shedder(path):
             return "Request was handled by load shedder: \(path.relativePath)"
 
-        case let .api_request_queued_for_retry(httpMethod, path, backoffInterval):
-            return "Queued request \(httpMethod) \(path) for retry in \(backoffInterval) seconds."
+        case let .api_request_queued_for_retry(httpMethod, retryNumber, path, backoffInterval):
+            return "Queued request \(httpMethod) \(path) for retry number \(retryNumber) in \(backoffInterval) seconds."
 
         case let .api_request_failed_all_retries(httpMethod, path, retryCount):
             return "Request \(httpMethod) \(path) failed all \(retryCount) retries."
@@ -143,15 +142,6 @@ extension NetworkStrings: LogMessage {
         #if DEBUG
         case let .api_request_forcing_server_error(request):
             return "Returning fake HTTP 500 error for \(request.description)"
-
-        case let .api_request_forcing_network_error(request, networkError):
-            var simulatedHTTPStatusCode: HTTPStatusCode
-            if case .errorResponse(_, let statusCode, _) = networkError {
-                simulatedHTTPStatusCode = statusCode
-            } else {
-                simulatedHTTPStatusCode = .internalServerError
-            }
-            return "Returning fake HTTP \(simulatedHTTPStatusCode.rawValue) error for \(request.description)"
 
         case let .api_request_forcing_signature_failure(request):
             return "Returning fake signature verification failure for '\(request.description)'"

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -29,6 +29,7 @@ enum NetworkStrings {
                             metadata: HTTPClient.ResponseMetadata?)
     case api_request_failed_status_code(HTTPStatusCode)
     case api_request_queued_for_retry(httpMethod: String, path: String, backoffInterval: TimeInterval)
+    case api_request_failed_all_retries(httpMethod: String, path: String, retryCount: UInt)
     case reusing_existing_request_for_operation(CacheableNetworkOperation.Type, String)
     case enqueing_operation(CacheableNetworkOperation.Type, cacheKey: String)
     case creating_json_error(error: String)
@@ -133,7 +134,10 @@ extension NetworkStrings: LogMessage {
             return "Request was handled by load shedder: \(path.relativePath)"
 
         case let .api_request_queued_for_retry(httpMethod, path, backoffInterval):
-            return "Queued request \(httpMethod) to \(path) for retry in \(backoffInterval) seconds."
+            return "Queued request \(httpMethod) \(path) for retry in \(backoffInterval) seconds."
+
+        case let .api_request_failed_all_retries(httpMethod, path, retryCount):
+            return "Request \(httpMethod) \(path) failed all \(retryCount) retries."
 
         #if DEBUG
         case let .api_request_forcing_server_error(request):

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -48,6 +48,7 @@ enum NetworkStrings {
 
     #if DEBUG
     case api_request_forcing_server_error(HTTPRequest)
+    case api_request_forcing_network_error(HTTPRequest, NetworkError)
     case api_request_forcing_signature_failure(HTTPRequest)
     case api_request_disabling_header_parameter_signature_verification(HTTPRequest)
     #endif
@@ -142,6 +143,15 @@ extension NetworkStrings: LogMessage {
         #if DEBUG
         case let .api_request_forcing_server_error(request):
             return "Returning fake HTTP 500 error for \(request.description)"
+
+        case let .api_request_forcing_network_error(request, networkError):
+            var simulatedHTTPStatusCode: HTTPStatusCode
+            if case .errorResponse(_, let statusCode, _) = networkError {
+                simulatedHTTPStatusCode = statusCode
+            } else {
+                simulatedHTTPStatusCode = .internalServerError
+            }
+            return "Returning fake HTTP \(simulatedHTTPStatusCode.rawValue) error for \(request.description)"
 
         case let .api_request_forcing_signature_failure(request):
             return "Returning fake signature verification failure for '\(request.description)'"

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -28,7 +28,7 @@ enum NetworkStrings {
                             error: NetworkError,
                             metadata: HTTPClient.ResponseMetadata?)
     case api_request_failed_status_code(HTTPStatusCode)
-    case api_request_queued_for_retry(httpMethod: String, 
+    case api_request_queued_for_retry(httpMethod: String,
                                       retryNumber: UInt,
                                       path: String,
                                       backoffInterval: TimeInterval)

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -28,7 +28,10 @@ enum NetworkStrings {
                             error: NetworkError,
                             metadata: HTTPClient.ResponseMetadata?)
     case api_request_failed_status_code(HTTPStatusCode)
-    case api_request_queued_for_retry(httpMethod: String, retryNumber: UInt, path: String, backoffInterval: TimeInterval)
+    case api_request_queued_for_retry(httpMethod: String, 
+                                      retryNumber: UInt,
+                                      path: String,
+                                      backoffInterval: TimeInterval)
     case api_request_failed_all_retries(httpMethod: String, path: String, retryCount: UInt)
     case reusing_existing_request_for_operation(CacheableNetworkOperation.Type, String)
     case enqueing_operation(CacheableNetworkOperation.Type, cacheKey: String)

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -28,6 +28,7 @@ enum NetworkStrings {
                             error: NetworkError,
                             metadata: HTTPClient.ResponseMetadata?)
     case api_request_failed_status_code(HTTPStatusCode)
+    case api_request_queued_for_retry(httpMethod: String, path: String, backoffInterval: TimeInterval)
     case reusing_existing_request_for_operation(CacheableNetworkOperation.Type, String)
     case enqueing_operation(CacheableNetworkOperation.Type, cacheKey: String)
     case creating_json_error(error: String)
@@ -130,6 +131,9 @@ extension NetworkStrings: LogMessage {
 
         case let .request_handled_by_load_shedder(path):
             return "Request was handled by load shedder: \(path.relativePath)"
+
+        case let .api_request_queued_for_retry(httpMethod, path, backoffInterval):
+            return "Queued request \(httpMethod) to \(path) for retry in \(backoffInterval) seconds."
 
         #if DEBUG
         case let .api_request_forcing_server_error(request):

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -57,7 +57,7 @@ class OperationDispatcher {
         Self.dispatchOnMainActor(block)
     }
 
-    func dispatchOnWorkerThread(delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
+    func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
         if delay.hasDelay {
             self.workerQueue.asyncAfter(deadline: .now() + delay.random(), execute: block)
         } else {
@@ -65,11 +65,7 @@ class OperationDispatcher {
         }
     }
 
-    func dispatchOnWorkerThread(after timeInterval: TimeInterval, block: @escaping @Sendable () -> Void) {
-        self.workerQueue.asyncAfter(deadline: .now() + timeInterval, execute: block)
-    }
-
-    func dispatchOnWorkerThread(delay: JitterableDelay = .none, block: @escaping @Sendable () async -> Void) {
+    func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, block: @escaping @Sendable () async -> Void) {
         Task.detached(priority: .background) {
             if delay.hasDelay {
                 try? await Task.sleep(nanoseconds: DispatchTimeInterval(delay.random()).nanoseconds)
@@ -77,6 +73,10 @@ class OperationDispatcher {
 
             await block()
         }
+    }
+
+    func dispatchOnWorkerThread(after timeInterval: TimeInterval, block: @escaping @Sendable () -> Void) {
+        self.workerQueue.asyncAfter(deadline: .now() + timeInterval, execute: block)
     }
 
 }

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -57,7 +57,7 @@ class OperationDispatcher {
         Self.dispatchOnMainActor(block)
     }
 
-    func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
+    func dispatchOnWorkerThread(delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
         if delay.hasDelay {
             self.workerQueue.asyncAfter(deadline: .now() + delay.random(), execute: block)
         } else {

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -23,6 +23,7 @@ enum Delay {
     case none
     case `default`
     case long
+    case timeInterval(TimeInterval)
 
     static func `default`(forBackgroundedApp inBackground: Bool) -> Self {
         return inBackground ? .default : .none
@@ -108,6 +109,8 @@ private extension Delay {
         case .none: return 0
         case .`default`: return 0
         case .long: return Self.maxJitter
+        case .timeInterval(let timeInterval):
+            return max(timeInterval - 0.1, 0)
         }
     }
 
@@ -116,6 +119,8 @@ private extension Delay {
         case .none: return 0
         case .`default`: return Self.maxJitter
         case .long: return Self.maxJitter * 2
+        case .timeInterval(let timeInterval):
+            return max(timeInterval + 0.1, 0)
         }
     }
 

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -18,7 +18,7 @@ import Foundation
 ///
 /// These delays prevent DDOS if a notification leads to many users opening an app at the same time,
 /// by spreading asynchronous operations over time.
-enum Delay {
+enum Delay: Equatable {
 
     case none
     case `default`

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -110,7 +110,7 @@ private extension Delay {
         case .`default`: return 0
         case .long: return Self.maxJitter
         case .timeInterval(let timeInterval):
-            return max(timeInterval - 0.1, 0)
+            return max(timeInterval, 0)
         }
     }
 
@@ -120,7 +120,7 @@ private extension Delay {
         case .`default`: return Self.maxJitter
         case .long: return Self.maxJitter * 2
         case .timeInterval(let timeInterval):
-            return max(timeInterval + 0.1, 0)
+            return max(timeInterval, 0)
         }
     }
 

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -65,7 +65,7 @@ class OperationDispatcher {
         }
     }
 
-    func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, 
+    func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none,
                                 block: @escaping @Sendable () async -> Void) {
         Task.detached(priority: .background) {
             if delay.hasDelay {

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -65,7 +65,8 @@ class OperationDispatcher {
         }
     }
 
-    func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, block: @escaping @Sendable () async -> Void) {
+    func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, 
+                                block: @escaping @Sendable () async -> Void) {
         Task.detached(priority: .background) {
             if delay.hasDelay {
                 try? await Task.sleep(nanoseconds: DispatchTimeInterval(delay.random()).nanoseconds)

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -57,7 +57,7 @@ class OperationDispatcher {
         Self.dispatchOnMainActor(block)
     }
 
-    func dispatchOnWorkerThread(delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
+    func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
         if delay.hasDelay {
             self.workerQueue.asyncAfter(deadline: .now() + delay.random(), execute: block)
         } else {

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -19,7 +19,6 @@ import Foundation
 
         #if DEBUG
         let forceServerErrors: Bool
-        let forcedServerErrors: [String: [NetworkError]]?
         let forceSignatureFailures: Bool
         let disableHeaderSignatureVerification: Bool
         let testReceiptIdentifier: String?
@@ -27,14 +26,12 @@ import Foundation
         init(
             enableReceiptFetchRetry: Bool = false,
             forceServerErrors: Bool = false,
-            forcedServerErrors: [String: [NetworkError]]? = nil,
             forceSignatureFailures: Bool = false,
             disableHeaderSignatureVerification: Bool = false,
             testReceiptIdentifier: String? = nil
         ) {
             self.enableReceiptFetchRetry = enableReceiptFetchRetry
             self.forceServerErrors = forceServerErrors
-            self.forcedServerErrors = forcedServerErrors
             self.forceSignatureFailures = forceSignatureFailures
             self.disableHeaderSignatureVerification = disableHeaderSignatureVerification
             self.testReceiptIdentifier = testReceiptIdentifier
@@ -126,8 +123,6 @@ internal protocol InternalDangerousSettingsType: Sendable {
     #if DEBUG
     /// Whether `HTTPClient` will fake server errors
     var forceServerErrors: Bool { get }
-
-    var forcedServerErrors: [String: [NetworkError]]? { get }
 
     /// Whether `HTTPClient` will fake invalid signatures.
     var forceSignatureFailures: Bool { get }

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -19,6 +19,7 @@ import Foundation
 
         #if DEBUG
         let forceServerErrors: Bool
+        let forcedServerErrors: [String: [NetworkError]]?
         let forceSignatureFailures: Bool
         let disableHeaderSignatureVerification: Bool
         let testReceiptIdentifier: String?
@@ -26,12 +27,14 @@ import Foundation
         init(
             enableReceiptFetchRetry: Bool = false,
             forceServerErrors: Bool = false,
+            forcedServerErrors: [String: [NetworkError]]? = nil,
             forceSignatureFailures: Bool = false,
             disableHeaderSignatureVerification: Bool = false,
             testReceiptIdentifier: String? = nil
         ) {
             self.enableReceiptFetchRetry = enableReceiptFetchRetry
             self.forceServerErrors = forceServerErrors
+            self.forcedServerErrors = forcedServerErrors
             self.forceSignatureFailures = forceSignatureFailures
             self.disableHeaderSignatureVerification = disableHeaderSignatureVerification
             self.testReceiptIdentifier = testReceiptIdentifier
@@ -123,6 +126,8 @@ internal protocol InternalDangerousSettingsType: Sendable {
     #if DEBUG
     /// Whether `HTTPClient` will fake server errors
     var forceServerErrors: Bool { get }
+
+    var forcedServerErrors: [String: [NetworkError]]? { get }
 
     /// Whether `HTTPClient` will fake invalid signatures.
     var forceSignatureFailures: Bool { get }

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -39,7 +39,8 @@ class Backend {
                                     eTagManager: eTagManager,
                                     signing: Signing(apiKey: apiKey, clock: systemInfo.clock),
                                     diagnosticsTracker: diagnosticsTracker,
-                                    requestTimeout: httpClientTimeout)
+                                    requestTimeout: httpClientTimeout, 
+                                    operationDispatcher: OperationDispatcher.default)
         let config = BackendConfiguration(httpClient: httpClient,
                                           operationDispatcher: operationDispatcher,
                                           operationQueue: QueueProvider.createBackendQueue(),

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -39,7 +39,7 @@ class Backend {
                                     eTagManager: eTagManager,
                                     signing: Signing(apiKey: apiKey, clock: systemInfo.clock),
                                     diagnosticsTracker: diagnosticsTracker,
-                                    requestTimeout: httpClientTimeout, 
+                                    requestTimeout: httpClientTimeout,
                                     operationDispatcher: OperationDispatcher.default)
         let config = BackendConfiguration(httpClient: httpClient,
                                           operationDispatcher: operationDispatcher,

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -56,7 +56,7 @@ extension BackendConfiguration {
         delay: JitterableDelay,
         cacheStatus: CallbackCacheStatus
     ) {
-        self.operationDispatcher.dispatchOnWorkerThread(delay: delay) {
+        self.operationDispatcher.dispatchOnWorkerThread(jitterableDelay: delay) {
             self.operationQueue.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
         }
     }
@@ -66,7 +66,7 @@ extension BackendConfiguration {
         _ operation: NetworkOperation,
         delay: JitterableDelay = .long
     ) {
-        self.operationDispatcher.dispatchOnWorkerThread(delay: delay) {
+        self.operationDispatcher.dispatchOnWorkerThread(jitterableDelay: delay) {
             self.diagnosticsQueue.addOperation(operation)
         }
     }

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -53,7 +53,7 @@ extension BackendConfiguration {
     /// Adds the `operation` to the `OperationQueue` (based on `CallbackCacheStatus`) potentially adding a random delay.
     func addCacheableOperation<T: CacheableNetworkOperation>(
         with factory: CacheableNetworkOperationFactory<T>,
-        delay: Delay,
+        delay: JitterableDelay,
         cacheStatus: CallbackCacheStatus
     ) {
         self.operationDispatcher.dispatchOnWorkerThread(delay: delay) {
@@ -64,7 +64,7 @@ extension BackendConfiguration {
     /// Adds the `operation` to the diagnostics `OperationQueue` potentially adding a random delay.
     func addDiagnosticsOperation(
         _ operation: NetworkOperation,
-        delay: Delay = .long
+        delay: JitterableDelay = .long
     ) {
         self.operationDispatcher.dispatchOnWorkerThread(delay: delay) {
             self.diagnosticsQueue.addOperation(operation)

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -670,10 +670,9 @@ extension HTTPClient {
         retryCount: UInt
     ) -> TimeInterval {
         // Use the retry after value from the backend if present
-        if let retryAfterHeaderValue = httpURLResponse.allHeaderFields[ResponseHeader.retryAfter.rawValue] as? String {
-            if let retryAfterMS = Double(retryAfterHeaderValue) {
-                return TimeInterval(milliseconds: retryAfterMS)
-            }
+        if let retryAfterHeaderValue = httpURLResponse.allHeaderFields[ResponseHeader.retryAfter.rawValue] as? String,
+            let retryAfterMS = Double(retryAfterHeaderValue) {
+            return TimeInterval(milliseconds: retryAfterMS)
         }
 
         // Otherwise, use a default value
@@ -689,9 +688,9 @@ extension HTTPClient {
     /// - Returns: The backoff time interval for the given retry count. If the retry count exceeds
     ///   the predefined list of backoff intervals, it returns 0.
     internal func defaultExponentialBackoffTimeInterval(withRetryCount retryCount: UInt) -> TimeInterval {
-        return retryCount - 1 < self.retryBackoffIntervals.count
-        ? self.retryBackoffIntervals[Int(max(retryCount - 1, 0))]
-        : 0
+        let backoffIntervalIndex = Int(max(retryCount - 1, 0))
+        let backoffIntervalIndexIsWithinBounds = backoffIntervalIndex < self.retryBackoffIntervals.count
+        return backoffIntervalIndexIsWithinBounds ? self.retryBackoffIntervals[backoffIntervalIndex] : 0
     }
 }
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -686,7 +686,15 @@ extension HTTPClient {
         // Use the retry after value from the backend if present
         if let retryAfterHeaderValue = httpURLResponse.allHeaderFields[ResponseHeader.retryAfter.rawValue] as? String,
             let retryAfterMS = Double(retryAfterHeaderValue) {
-            return TimeInterval(milliseconds: retryAfterMS)
+
+            // Ensure that the retry interval is not negative or greater than 1 hour
+            let nonNegativeRetryAfterMS = max(0, retryAfterMS)
+            let cappedRetryInterval = min(
+                nonNegativeRetryAfterMS,
+                3_600_000   // 1 hour in milliseconds
+            )
+
+            return TimeInterval(milliseconds: cappedRetryInterval)
         }
 
         // Otherwise, use a default value

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -36,10 +36,6 @@ class HTTPClient {
     private let retriableStatusCodes: Set<HTTPStatusCode>
     private let operationDispatcher: OperationDispatcher
 
-    #if DEBUG
-    private var pathRequestCounts: [String: Int] = [:]
-    #endif
-
     private let retryBackoffIntervals: [TimeInterval] = [
         TimeInterval(0),
         TimeInterval(0.75),

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -632,7 +632,7 @@ extension HTTPClient {
     ) {
         // retryCount is incremented before the retry is executed, so don't stop retries if
         // retryCount == self.retryOptions.maxNumberOfRetries
-        guard request.retryCount > self.retryOptions.maxNumberOfRetries else { return }
+        guard request.retryCount <= self.retryOptions.maxNumberOfRetries else { return }
         guard let httpURLResponse = httpURLResponse else { return }
         guard shouldRetryRequest(withStatusCode: httpURLResponse.httpStatusCode) else { return }
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -633,7 +633,11 @@ extension HTTPClient {
 
         // TODO:
 //        refactor the current etag usage to the new way of doing things
-//        for first retry with no header, make sure that there’s no delay to preserve the exact behavior we currently have
+
+        // If this is our first retry and there's no eTag header, ensure there's no delay
+        if httpURLResponse.allHeaderFields[ResponseHeader.eTag] == nil && retryCount == 1 {
+            return TimeInterval(0)
+        }
 
         // Use the retry after value from the backend if present
         if let retryAfterHeaderValue = httpURLResponse.allHeaderFields[ResponseHeader.retryAfter.rawValue] as? String {

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -685,16 +685,16 @@ extension HTTPClient {
     ) -> TimeInterval {
         // Use the retry after value from the backend if present
         if let retryAfterHeaderValue = httpURLResponse.allHeaderFields[ResponseHeader.retryAfter.rawValue] as? String,
-            let retryAfterMS = Double(retryAfterHeaderValue) {
+            let retryAfterSeconds = Double(retryAfterHeaderValue) {
 
             // Ensure that the retry interval is not negative or greater than 1 hour
-            let nonNegativeRetryAfterMS = max(0, retryAfterMS)
+            let nonNegativeRetryAfterSeconds = max(0, retryAfterSeconds)
             let cappedRetryInterval = min(
-                nonNegativeRetryAfterMS,
-                3_600_000   // 1 hour in milliseconds
+                nonNegativeRetryAfterSeconds,
+                3_600   // 1 hour in seconds
             )
 
-            return TimeInterval(milliseconds: cappedRetryInterval)
+            return TimeInterval(cappedRetryInterval)
         }
 
         // Otherwise, use a default value

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -625,7 +625,7 @@ extension HTTPClient {
         httpURLResponse: HTTPURLResponse?
     ) -> Bool {
         guard let httpURLResponse = httpURLResponse,
-              shouldRetryRequest(withStatusCode: httpURLResponse.httpStatusCode) else { return false }
+              isStatusCodeRetryable(httpURLResponse.httpStatusCode) else { return false }
 
         // At this point, retryCount hasn't been incremented yet, so we'll need to do it early here
         // to determine if another retry is appropriate.
@@ -665,7 +665,7 @@ extension HTTPClient {
         return true
     }
 
-    internal func shouldRetryRequest(withStatusCode statusCode: HTTPStatusCode) -> Bool {
+    internal func isStatusCodeRetryable(_ statusCode: HTTPStatusCode) -> Bool {
         return self.retriableStatusCodes.contains(statusCode)
     }
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -679,18 +679,6 @@ extension HTTPClient {
         }
 
         // Otherwise, use a default value
-        return defaultExponentialBackoffTimeInterval(withRetryCount: retryCount)
-    }
-
-    /// Returns the exponential backoff time interval for a given retry count.
-    ///
-    /// This function calculates the backoff time interval for a given retry count based on a predefined
-    /// list of backoff intervals. The `retryCount` is not 0-indexed and should start with 1.
-    ///
-    /// - Parameter retryCount: The count of the retry attempt, starting from 1.
-    /// - Returns: The backoff time interval for the given retry count. If the retry count exceeds
-    ///   the predefined list of backoff intervals, it returns 0.
-    internal func defaultExponentialBackoffTimeInterval(withRetryCount retryCount: UInt) -> TimeInterval {
         let backoffIntervalIndex = Int(max(retryCount - 1, 0))
         let backoffIntervalIndexIsWithinBounds = backoffIntervalIndex < self.retryBackoffIntervals.count
         return backoffIntervalIndexIsWithinBounds ? self.retryBackoffIntervals[backoffIntervalIndex] : 0

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -524,11 +524,13 @@ private extension HTTPClient {
         let requestStartTime = self.dateProvider.now()
 
         #if DEBUG
-        failIfForcedErrorPresentForPath(
+        let didForceFailure = failIfForcedErrorPresentForPath(
             request: request,
             urlRequest: urlRequest,
             requestStartTime: requestStartTime
         )
+        // If we forced a failure, don't run the actual request
+        if didForceFailure { return }
         #endif
 
         // swiftlint:disable:next redundant_void_return
@@ -624,7 +626,7 @@ private extension HTTPClient {
         request: Request,
         urlRequest: URLRequest,
         requestStartTime: Date
-    ) {
+    ) -> Bool {
         // If we're running tests, allow for the forcing of certain error responses from the backend
         if ProcessInfo.isRunningUnitTests
             || ProcessInfo.isRunningIntegrationTests
@@ -658,9 +660,10 @@ private extension HTTPClient {
                     requestStartTime: requestStartTime
                 )
 
-                return
+                return true
             }
         }
+        return false
     }
     #endif
 }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -38,8 +38,8 @@ class HTTPClient {
 
     private let retryBackoffIntervals: [TimeInterval] = [
         TimeInterval(0),
-        TimeInterval(0.25),
-        TimeInterval(0.5)
+        TimeInterval(0.75),
+        TimeInterval(3)
     ]
 
     init(apiKey: String,

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -508,7 +508,6 @@ private extension HTTPClient {
         }
     }
 
-    // swiftlint:disable:next
     func start(request: Request) {
         let urlRequest = self.convert(request: request)
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -130,6 +130,7 @@ class HTTPClient {
             "X-StoreKit2-Enabled": "\(self.systemInfo.storeKitVersion.isStoreKit2EnabledAndAvailable)",
             "X-StoreKit-Version": "\(self.systemInfo.storeKitVersion.effectiveVersion)",
             "X-Observer-Mode-Enabled": "\(self.systemInfo.observerMode)",
+            RequestHeader.retryCount.rawValue: "0",
             RequestHeader.sandbox.rawValue: "\(self.systemInfo.isSandbox)"
         ]
 
@@ -195,6 +196,7 @@ extension HTTPClient {
         case postParameters = "X-Post-Params-Hash"
         case headerParametersForSignature = "X-Headers-Hash"
         case sandbox = "X-Is-Sandbox"
+        case retryCount = "X-Retry-Count"
 
     }
 
@@ -274,6 +276,7 @@ internal extension HTTPClient {
         func retriedRequest() -> Self {
             var copy = self
             copy.retryCount += 1
+            copy.headers[RequestHeader.retryCount.rawValue] = "\(copy.retryCount)"
 
             return copy
         }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -650,6 +650,7 @@ extension HTTPClient {
         Logger.debug(
             NetworkStrings.api_request_queued_for_retry(
                 httpMethod: request.method.httpMethod,
+                retryNumber: nextRetryCount,
                 path: request.path,
                 backoffInterval: retryBackoffInterval
             )

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -630,10 +630,6 @@ extension HTTPClient {
         forResponse httpURLResponse: HTTPURLResponse,
         retryCount: UInt
     ) -> TimeInterval {
-
-        // TODO:
-//        refactor the current etag usage to the new way of doing things
-
         // If this is our first retry and there's no eTag header, ensure there's no delay
         if httpURLResponse.allHeaderFields[ResponseHeader.eTag] == nil && retryCount == 1 {
             return TimeInterval(0)

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -646,6 +646,7 @@ private extension HTTPClient {
                     simulatedHTTPStatusCode = .internalServerError
                 }
 
+                Logger.warn(NetworkStrings.api_request_forcing_network_error(request.httpRequest, forcedError))
                 self.handle(
                     urlResponse: HTTPURLResponse(
                         url: urlRequest.url ?? URL(string: "api.revenuecat.com")!,

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -612,6 +612,8 @@ extension HTTPClient {
             self.state.modify {
                 $0.queuedRequests.insert(retriedRequest, at: 0)
             }
+
+            self.beginNextRequest()
         }
     }
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -508,6 +508,7 @@ private extension HTTPClient {
         }
     }
 
+    // swiftlint:disable:next function_body_length
     func start(request: Request) {
         let urlRequest = self.convert(request: request)
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -211,6 +211,7 @@ extension HTTPClient {
         case requestID = "X-Request-ID"
         case amazonTraceID = "X-Amzn-Trace-ID"
         case retryAfter = "Retry-After"
+        case isRetryable = "Is-Retryable"
 
     }
 
@@ -625,7 +626,7 @@ extension HTTPClient {
         httpURLResponse: HTTPURLResponse?
     ) -> Bool {
         guard let httpURLResponse = httpURLResponse,
-              isStatusCodeRetryable(httpURLResponse.httpStatusCode) else { return false }
+              isRetryable(httpURLResponse) else { return false }
 
         // At this point, retryCount hasn't been incremented yet, so we'll need to do it early here
         // to determine if another retry is appropriate.
@@ -665,8 +666,17 @@ extension HTTPClient {
         return true
     }
 
-    internal func isStatusCodeRetryable(_ statusCode: HTTPStatusCode) -> Bool {
-        return self.retriableStatusCodes.contains(statusCode)
+    internal func isRetryable(_ urlResponse: HTTPURLResponse) -> Bool {
+        let isStatusCodeRetryable = self.retriableStatusCodes.contains(urlResponse.httpStatusCode)
+        let isRetryableString = urlResponse.value(forHTTPHeaderField: ResponseHeader.isRetryable.rawValue)
+        let isRetryable: Bool
+        if let isRetryableString {
+            isRetryable = Bool(isRetryableString.lowercased()) ?? true
+        } else {
+            isRetryable = true
+        }
+
+        return isStatusCodeRetryable && isRetryable
     }
 
     internal func calculateRetryBackoffTime(

--- a/Sources/Networking/HTTPClient/HTTPStatusCode.swift
+++ b/Sources/Networking/HTTPClient/HTTPStatusCode.swift
@@ -24,6 +24,7 @@ enum HTTPStatusCode {
     case invalidRequest
     case unauthorized
     case notFoundError
+    case tooManyRequests
     case internalServerError
     case networkConnectTimeoutError
 
@@ -60,6 +61,7 @@ extension HTTPStatusCode: RawRepresentable {
         case .invalidRequest: return 400
         case .unauthorized: return 401
         case .notFoundError: return 404
+        case .tooManyRequests: return 429
         case .internalServerError: return 500
         case .networkConnectTimeoutError: return 599
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1891,7 +1891,7 @@ private extension Purchases {
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *),
               let manager = self.paywallEventsManager else { return }
 
-        self.operationDispatcher.dispatchOnWorkerThread(delay: .long) {
+        self.operationDispatcher.dispatchOnWorkerThread(jitterableDelay: .long) {
             _ = try? await manager.flushEvents(count: PaywallEventsManager.defaultEventFlushCount)
         }
     }

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -48,7 +48,6 @@ class BaseBackendIntegrationTests: TestCase {
     private var mainThreadMonitor: MainThreadMonitor!
 
     fileprivate var serverIsDown: Bool = false
-    fileprivate var serverErrors: [String: [NetworkError]]?
 
     static var isSandbox: Bool = true {
         didSet {
@@ -240,15 +239,11 @@ private extension BaseBackendIntegrationTests {
 extension BaseBackendIntegrationTests: InternalDangerousSettingsType {
 
     var forceServerErrors: Bool { return self.serverIsDown }
-    var forcedServerErrors: [String: [NetworkError]]? { return self.serverErrors }
     var forceSignatureFailures: Bool { return false }
     var disableHeaderSignatureVerification: Bool { return false }
     var testReceiptIdentifier: String? { return self.testUUID.uuidString }
 
     final func serverDown() { self.serverIsDown = true }
     final func serverUp() { self.serverIsDown = false }
-    final func setForcedServerErrors(_ errors: [String: [NetworkError]]?) {
-        self.serverErrors = errors
-    }
 
 }

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -48,6 +48,7 @@ class BaseBackendIntegrationTests: TestCase {
     private var mainThreadMonitor: MainThreadMonitor!
 
     fileprivate var serverIsDown: Bool = false
+    fileprivate var serverErrors: [String: [NetworkError]]?
 
     static var isSandbox: Bool = true {
         didSet {
@@ -239,11 +240,15 @@ private extension BaseBackendIntegrationTests {
 extension BaseBackendIntegrationTests: InternalDangerousSettingsType {
 
     var forceServerErrors: Bool { return self.serverIsDown }
+    var forcedServerErrors: [String: [NetworkError]]? { return self.serverErrors }
     var forceSignatureFailures: Bool { return false }
     var disableHeaderSignatureVerification: Bool { return false }
     var testReceiptIdentifier: String? { return self.testUUID.uuidString }
 
     final func serverDown() { self.serverIsDown = true }
     final func serverUp() { self.serverIsDown = false }
+    final func setForcedServerErrors(_ errors: [String: [NetworkError]]?) {
+        self.serverErrors = errors
+    }
 
 }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -13,7 +13,6 @@ import StoreKit
 import StoreKitTest
 import UniformTypeIdentifiers
 import XCTest
-
 import OHHTTPStubs
 import OHHTTPStubsSwift
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -7,14 +7,14 @@
 //
 
 import Nimble
+import OHHTTPStubs
+import OHHTTPStubsSwift
 @testable import RevenueCat
 import SnapshotTesting
 import StoreKit
 import StoreKitTest
 import UniformTypeIdentifiers
 import XCTest
-import OHHTTPStubs
-import OHHTTPStubsSwift
 
 // swiftlint:disable file_length type_body_length
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -985,6 +985,30 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         expect(stubbedRequestCount).to(equal(4)) // 1 original request + 3 retries
     }
+
+    func testVerifyPurchaseDoesntRetryIfIsRetryableHeaderIsFalse() async throws {
+
+        // Ensure that the each time POST /receipt is called, we mock a 429 error with the 
+        // Is-Retryable header as "false"
+        var stubbedRequestCount = 0
+        let host = try XCTUnwrap(HTTPRequest.Path.serverHostURL.host)
+        stub(condition: isHost(host) && isPath("/v1/receipts")) { _ in
+            stubbedRequestCount += 1
+            return Self.emptyTooManyRequestsResponse(
+                headers: [HTTPClient.ResponseHeader.isRetryable.rawValue: "false"]
+            )
+        }
+
+        let product = try await self.monthlyPackage.storeProduct
+        do {
+            _ = try await self.purchases.purchase(product: product)
+            fail("Expected purchases.purchase to fail with no retries when the Is-Retryable response header is false.")
+        } catch {
+            expect(error).to(matchError(ErrorCode.unknownError))
+        }
+
+        expect(stubbedRequestCount).to(equal(1)) // 1 original request + 0 retries
+    }
 }
 
 private extension BaseStoreKitIntegrationTests {
@@ -997,11 +1021,13 @@ private extension BaseStoreKitIntegrationTests {
         }
     }
 
-    static func emptyTooManyRequestsResponse() -> HTTPStubsResponse {
+    static func emptyTooManyRequestsResponse(
+        headers: [String: String]? = nil
+    ) -> HTTPStubsResponse {
         // `HTTPStubsResponse` doesn't have value semantics, it's a mutable class!
         // This creates a new response each time so modifications in one test don't affect others.
         return .init(data: Data(),
                      statusCode: 429,
-                     headers: nil)
+                     headers: headers)
     }
 }

--- a/Tests/UnitTests/FoundationExtensions/TimeInterval+ExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/TimeInterval+ExtensionsTests.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TimeInterval+ExtensionsTests.swift
+//
+//  Created by Will Taylor on 7/12/24.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class TimeIntervalExtensionsTests: TestCase {
+
+    func testTimeIntervalMillisecondsInitializerOneSecond() {
+        let timeInterval = TimeInterval(milliseconds: 1000)
+        expect(timeInterval).to(equal(1))
+    }
+
+    func testTimeIntervalMillisecondsInitializerHalfSecond() {
+        let timeInterval = TimeInterval(milliseconds: 500)
+        expect(timeInterval).to(equal(0.5))
+    }
+}

--- a/Tests/UnitTests/Misc/OperationDispatcherTests.swift
+++ b/Tests/UnitTests/Misc/OperationDispatcherTests.swift
@@ -19,26 +19,26 @@ import XCTest
 class OperationDispatcherTests: TestCase {
 
     func testDelayForBackgroundedApp() {
-        expect(Delay.default(forBackgroundedApp: true)) == .default
+        expect(JitterableDelay.default(forBackgroundedApp: true)) == .default
     }
 
     func testDelayForForegroundedApp() {
-        expect(Delay.default(forBackgroundedApp: false)) == Delay.none
+        expect(JitterableDelay.default(forBackgroundedApp: false)) == JitterableDelay.none
     }
 
     func testNoDelay() {
-        expect(Delay.none.hasDelay) == false
-        expect(Delay.none.range) == 0..<0
+        expect(JitterableDelay.none.hasDelay) == false
+        expect(JitterableDelay.none.range) == 0..<0
     }
 
     func testDefaultDelay() {
-        expect(Delay.default.hasDelay) == true
-        expect(Delay.default.range) == 0..<5
+        expect(JitterableDelay.default.hasDelay) == true
+        expect(JitterableDelay.default.range) == 0..<5
     }
 
     func testLongDelay() {
-        expect(Delay.long.hasDelay) == true
-        expect(Delay.long.range) == 5..<10
+        expect(JitterableDelay.long.hasDelay) == true
+        expect(JitterableDelay.long.range) == 5..<10
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -69,7 +69,8 @@ class MockHTTPClient: HTTPClient {
                    signing: FakeSigning.default,
                    diagnosticsTracker: diagnosticsTracker,
                    dnsChecker: dnsChecker,
-                   requestTimeout: requestTimeout)
+                   requestTimeout: requestTimeout,
+                   operationDispatcher: MockOperationDispatcher())
     }
 
     private let sourceTestFile: StaticString

--- a/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
+++ b/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
@@ -58,9 +58,11 @@ class MockOperationDispatcher: OperationDispatcher {
     var shouldInvokeDispatchOnWorkerThreadBlock = true
     var forwardToOriginalDispatchOnWorkerThread = false
     var invokedDispatchOnWorkerThreadDelayParam: Delay?
+    var invokedDispatchOnWorkerThreadDelayParams: [Delay?] = []
 
     override func dispatchOnWorkerThread(delay: Delay = .none, block: @escaping @Sendable () -> Void) {
         self.invokedDispatchOnWorkerThreadDelayParam = delay
+        self.invokedDispatchOnWorkerThreadDelayParams.append(delay)
         self.invokedDispatchOnWorkerThread = true
         self.invokedDispatchOnWorkerThreadCount += 1
         if self.forwardToOriginalDispatchOnWorkerThread {

--- a/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
+++ b/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
@@ -60,7 +60,7 @@ class MockOperationDispatcher: OperationDispatcher {
     var invokedDispatchOnWorkerThreadDelayParam: JitterableDelay?
     var invokedDispatchOnWorkerThreadDelayParams: [JitterableDelay?] = []
 
-    override func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
+    override func dispatchOnWorkerThread(delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
         self.invokedDispatchOnWorkerThreadDelayParam = delay
         self.invokedDispatchOnWorkerThreadDelayParams.append(delay)
         self.invokedDispatchOnWorkerThread = true

--- a/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
+++ b/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
@@ -60,7 +60,8 @@ class MockOperationDispatcher: OperationDispatcher {
     var invokedDispatchOnWorkerThreadDelayParam: JitterableDelay?
     var invokedDispatchOnWorkerThreadDelayParams: [JitterableDelay?] = []
 
-    override func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
+    override func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, 
+                                         block: @escaping @Sendable () -> Void) {
         self.invokedDispatchOnWorkerThreadDelayParam = delay
         self.invokedDispatchOnWorkerThreadDelayParams.append(delay)
         self.invokedDispatchOnWorkerThread = true

--- a/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
+++ b/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
@@ -60,7 +60,7 @@ class MockOperationDispatcher: OperationDispatcher {
     var invokedDispatchOnWorkerThreadDelayParam: JitterableDelay?
     var invokedDispatchOnWorkerThreadDelayParams: [JitterableDelay?] = []
 
-    override func dispatchOnWorkerThread(delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
+    override func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
         self.invokedDispatchOnWorkerThreadDelayParam = delay
         self.invokedDispatchOnWorkerThreadDelayParams.append(delay)
         self.invokedDispatchOnWorkerThread = true

--- a/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
+++ b/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
@@ -60,7 +60,7 @@ class MockOperationDispatcher: OperationDispatcher {
     var invokedDispatchOnWorkerThreadDelayParam: JitterableDelay?
     var invokedDispatchOnWorkerThreadDelayParams: [JitterableDelay?] = []
 
-    override func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, 
+    override func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none,
                                          block: @escaping @Sendable () -> Void) {
         self.invokedDispatchOnWorkerThreadDelayParam = delay
         self.invokedDispatchOnWorkerThreadDelayParams.append(delay)

--- a/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
+++ b/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
@@ -57,10 +57,10 @@ class MockOperationDispatcher: OperationDispatcher {
     var invokedDispatchOnWorkerThreadCount = 0
     var shouldInvokeDispatchOnWorkerThreadBlock = true
     var forwardToOriginalDispatchOnWorkerThread = false
-    var invokedDispatchOnWorkerThreadDelayParam: Delay?
-    var invokedDispatchOnWorkerThreadDelayParams: [Delay?] = []
+    var invokedDispatchOnWorkerThreadDelayParam: JitterableDelay?
+    var invokedDispatchOnWorkerThreadDelayParams: [JitterableDelay?] = []
 
-    override func dispatchOnWorkerThread(delay: Delay = .none, block: @escaping @Sendable () -> Void) {
+    override func dispatchOnWorkerThread(delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
         self.invokedDispatchOnWorkerThreadDelayParam = delay
         self.invokedDispatchOnWorkerThreadDelayParams.append(delay)
         self.invokedDispatchOnWorkerThread = true
@@ -76,10 +76,10 @@ class MockOperationDispatcher: OperationDispatcher {
 
     var invokedDispatchAsyncOnWorkerThread = false
     var invokedDispatchAsyncOnWorkerThreadCount = 0
-    var invokedDispatchAsyncOnWorkerThreadDelayParam: Delay?
+    var invokedDispatchAsyncOnWorkerThreadDelayParam: JitterableDelay?
 
     override func dispatchOnWorkerThread(
-        delay: Delay = .none,
+        delay: JitterableDelay = .none,
         block: @escaping @Sendable () async -> Void
     ) {
         self.invokedDispatchAsyncOnWorkerThreadDelayParam = delay
@@ -92,6 +92,27 @@ class MockOperationDispatcher: OperationDispatcher {
             Task<Void, Never> {
                 await block()
             }
+        }
+    }
+
+    var invokedDispatchOnWorkerThreadWithTimeInterval = false
+    var invokedDispatchOnWorkerThreadWithTimeIntervalCount = 0
+    var shouldInvokeDispatchOnWorkerThreadBlockWithTimeInterval = true
+    var forwardToOriginalDispatchOnWorkerThreadWithTimeInterval = false
+    var invokedDispatchOnWorkerThreadWithTimeIntervalParam: TimeInterval?
+    var invokedDispatchOnWorkerThreadWithTimeIntervalParams: [TimeInterval?] = []
+    override func dispatchOnWorkerThread(after timeInterval: TimeInterval, block: @escaping @Sendable () -> Void) {
+        self.invokedDispatchOnWorkerThreadWithTimeIntervalParam = timeInterval
+        self.invokedDispatchOnWorkerThreadWithTimeIntervalParams.append(timeInterval)
+        self.invokedDispatchOnWorkerThreadWithTimeInterval = true
+        self.invokedDispatchOnWorkerThreadWithTimeIntervalCount += 1
+
+        if self.forwardToOriginalDispatchOnWorkerThread {
+            super.dispatchOnWorkerThread(after: timeInterval, block: block)
+            return
+        }
+        if self.shouldInvokeDispatchOnWorkerThreadBlock {
+            block()
         }
     }
 

--- a/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
+++ b/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
@@ -60,13 +60,13 @@ class MockOperationDispatcher: OperationDispatcher {
     var invokedDispatchOnWorkerThreadDelayParam: JitterableDelay?
     var invokedDispatchOnWorkerThreadDelayParams: [JitterableDelay?] = []
 
-    override func dispatchOnWorkerThread(delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
+    override func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
         self.invokedDispatchOnWorkerThreadDelayParam = delay
         self.invokedDispatchOnWorkerThreadDelayParams.append(delay)
         self.invokedDispatchOnWorkerThread = true
         self.invokedDispatchOnWorkerThreadCount += 1
         if self.forwardToOriginalDispatchOnWorkerThread {
-            super.dispatchOnWorkerThread(delay: delay, block: block)
+            super.dispatchOnWorkerThread(jitterableDelay: delay, block: block)
             return
         }
         if self.shouldInvokeDispatchOnWorkerThreadBlock {
@@ -79,7 +79,7 @@ class MockOperationDispatcher: OperationDispatcher {
     var invokedDispatchAsyncOnWorkerThreadDelayParam: JitterableDelay?
 
     override func dispatchOnWorkerThread(
-        delay: JitterableDelay = .none,
+        jitterableDelay delay: JitterableDelay = .none,
         block: @escaping @Sendable () async -> Void
     ) {
         self.invokedDispatchAsyncOnWorkerThreadDelayParam = delay
@@ -87,7 +87,7 @@ class MockOperationDispatcher: OperationDispatcher {
         self.invokedDispatchAsyncOnWorkerThreadCount += 1
 
         if self.forwardToOriginalDispatchOnWorkerThread {
-            super.dispatchOnWorkerThread(delay: delay, block: block)
+            super.dispatchOnWorkerThread(jitterableDelay: delay, block: block)
         } else if self.shouldInvokeDispatchOnWorkerThreadBlock {
             Task<Void, Never> {
                 await block()

--- a/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
@@ -35,7 +35,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
 
         expect(result).to(beSuccess())
         expect(self.httpClient.calls).to(haveCount(1))
-        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadDelayParam) == Delay.none
+        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadDelayParam) == JitterableDelay.none
     }
 
     func testGetOfferingsCallsHTTPMethodWithRandomDelay() {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testCachesCustomerGetsForSameCustomer.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerCallsBackendProperly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithFailedVerification.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetsCustomerInfo.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesGetCustomerInfoErrors.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesInvalidJSON.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
@@ -14,6 +14,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testUpdatesRequestDateFromResponseHeader.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testCachesCustomerGetsForSameCustomer.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerCallsBackendProperly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithFailedVerification.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetsCustomerInfo.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesGetCustomerInfoErrors.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesInvalidJSON.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testSendsNonceWhenEnabled.1.json
@@ -14,6 +14,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testUpdatesRequestDateFromResponseHeader.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testCachesCustomerGetsForSameCustomer.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerCallsBackendProperly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithFailedVerification.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetsCustomerInfo.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesGetCustomerInfoErrors.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesInvalidJSON.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
@@ -14,6 +14,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testUpdatesRequestDateFromResponseHeader.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testCachesCustomerGetsForSameCustomer.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerCallsBackendProperly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithFailedVerification.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetsCustomerInfo.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesGetCustomerInfoErrors.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesInvalidJSON.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testSendsNonceWhenEnabled.1.json
@@ -14,6 +14,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testUpdatesRequestDateFromResponseHeader.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testCachesCustomerGetsForSameCustomer.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerCallsBackendProperly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithFailedVerification.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetsCustomerInfo.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesGetCustomerInfoErrors.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesInvalidJSON.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testSendsNonceWhenEnabled.1.json
@@ -14,6 +14,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testUpdatesRequestDateFromResponseHeader.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testCachesCustomerGetsForSameCustomer.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerCallsBackendProperly.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoWithFailedVerification.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetsCustomerInfo.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testHandlesGetCustomerInfoErrors.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testHandlesInvalidJSON.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testSendsNonceWhenEnabled.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testUpdatesRequestDateFromResponseHeader.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testCachesCustomerGetsForSameCustomer.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerCallsBackendProperly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerInfoWithFailedVerification.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetsCustomerInfo.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testHandlesGetCustomerInfoErrors.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testHandlesInvalidJSON.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testSendsNonceWhenEnabled.1.json
@@ -14,6 +14,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testUpdatesRequestDateFromResponseHeader.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfUnknownError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testPostsProductIdentifiers.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfUnknownError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testPostsProductIdentifiers.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfUnknownError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testPostsProductIdentifiers.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfUnknownError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testPostsProductIdentifiers.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfUnknownError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testPostsProductIdentifiers.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testEligibilityUnknownIfError.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testEligibilityUnknownIfUnknownError.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testPostsProductIdentifiers.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/watchOS-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/watchOS-testEligibilityUnknownIfError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/watchOS-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/watchOS-testEligibilityUnknownIfUnknownError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/watchOS-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/watchOS-testPostsProductIdentifiers.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethod.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsFailSendsNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsNetworkErrorSendsError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsOneOffering.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethod.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsFailSendsNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsNetworkErrorSendsError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsOneOffering.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethod.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsFailSendsNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsNetworkErrorSendsError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsOneOffering.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethod.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsFailSendsNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsNetworkErrorSendsError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsOneOffering.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethod.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsFailSendsNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsNetworkErrorSendsError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsOneOffering.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCachesForSameUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCallsHTTPMethod.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsFailSendsNil.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsNetworkErrorSendsError.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsOneOffering.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testRepeatedRequestsLogDebugMessage.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsCallsHTTPMethod.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsFailSendsNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsNetworkErrorSendsError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsOneOffering.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestIsNotAuthenticated.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithFailure.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithSuccess.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestIsNotAuthenticated.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithFailure.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithSuccess.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestIsNotAuthenticated.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithFailure.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithSuccess.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestIsNotAuthenticated.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithFailure.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithSuccess.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestIsNotAuthenticated.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithFailure.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithSuccess.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestIsNotAuthenticated.1.json
@@ -10,6 +10,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestWithFailure.1.json
@@ -10,6 +10,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestWithSuccess.1.json
@@ -10,6 +10,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/watchOS-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/watchOS-testHealthRequestIsNotAuthenticated.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/watchOS-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/watchOS-testHealthRequestWithFailure.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/watchOS-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/watchOS-testHealthRequestWithSuccess.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCachesForSameUserIDs.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginMakesRightCalls.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCachesForSameUserIDs.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginMakesRightCalls.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithFailedVerification.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCachesForSameUserIDs.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginMakesRightCalls.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCachesForSameUserIDs.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginMakesRightCalls.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithFailedVerification.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithVerifiedResponse.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCachesForSameUserIDs.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginMakesRightCalls.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithFailedVerification.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithVerifiedResponse.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCachesForSameUserIDs.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginMakesRightCalls.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginWithFailedVerification.1.json
@@ -14,6 +14,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginWithVerifiedResponse.1.json
@@ -14,6 +14,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCachesForSameUserIDs.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginMakesRightCalls.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginWithFailedVerification.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginWithVerifiedResponse.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMapping.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMapping.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMapping.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMapping.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMapping.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/macOS-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/macOS-testGetProductEntitlementMapping.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/macOS-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/macOS-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/watchOS-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/watchOS-testGetProductEntitlementMapping.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/watchOS-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/watchOS-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS13-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS13-testPostAdServicesCallsHttpClient.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS14-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS14-testPostAdServicesCallsHttpClient.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS15-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS15-testPostAdServicesCallsHttpClient.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS16-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS16-testPostAdServicesCallsHttpClient.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS17-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS17-testPostAdServicesCallsHttpClient.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/macOS-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/macOS-testPostAdServicesCallsHttpClient.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/watchOS-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/watchOS-testPostAdServicesCallsHttpClient.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS13-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS13-testPostAttributesPutsDataInDataKey.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS14-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS14-testPostAttributesPutsDataInDataKey.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS15-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS15-testPostAttributesPutsDataInDataKey.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS16-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS16-testPostAttributesPutsDataInDataKey.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS17-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS17-testPostAttributesPutsDataInDataKey.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/macOS-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/macOS-testPostAttributesPutsDataInDataKey.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/watchOS-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/watchOS-testPostAttributesPutsDataInDataKey.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS15-testPostDiagnosticsEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS15-testPostDiagnosticsEventsWithMultipleEvents.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS15-testPostDiagnosticsEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS15-testPostDiagnosticsEventsWithOneEvent.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS17-testPostDiagnosticsEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS17-testPostDiagnosticsEventsWithMultipleEvents.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS17-testPostDiagnosticsEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS17-testPostDiagnosticsEventsWithOneEvent.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/macOS-testPostDiagnosticsEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/macOS-testPostDiagnosticsEventsWithMultipleEvents.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/macOS-testPostDiagnosticsEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/macOS-testPostDiagnosticsEventsWithOneEvent.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/watchOS-testPostDiagnosticsEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/watchOS-testPostDiagnosticsEventsWithMultipleEvents.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/watchOS-testPostDiagnosticsEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/watchOS-testPostDiagnosticsEventsWithOneEvent.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningEmptyOffersResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNetworkError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningSignatureErrorResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningEmptyOffersResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNetworkError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningSignatureErrorResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningEmptyOffersResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNetworkError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningSignatureErrorResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningEmptyOffersResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNetworkError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningSignatureErrorResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningEmptyOffersResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNetworkError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningSignatureErrorResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningEmptyOffersResponse.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningNetworkError.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningSignatureErrorResponse.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningEmptyOffersResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningNetworkError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningSignatureErrorResponse.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testCachesRequestsForSameReceipt.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesNotPostConsentStatus.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testFreeTrialPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testIndividualParamsCanBeNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayAsYouGoPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayUpFrontPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testCachesRequestsForSameReceipt.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesNotPostConsentStatus.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testFreeTrialPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testIndividualParamsCanBeNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayAsYouGoPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayUpFrontPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testCachesRequestsForSameReceipt.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesNotPostConsentStatus.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testFreeTrialPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testIndividualParamsCanBeNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayAsYouGoPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayUpFrontPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testCachesRequestsForSameReceipt.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesNotPostConsentStatus.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testFreeTrialPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testIndividualParamsCanBeNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayAsYouGoPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayUpFrontPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testCachesRequestsForSameReceipt.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesNotPostConsentStatus.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testFreeTrialPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testIndividualParamsCanBeNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayAsYouGoPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayUpFrontPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testCachesRequestsForSameReceipt.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesNotPostConsentStatus.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentCurrency.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentCurrency.2.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentDiscounts.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentDiscounts.2.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOffering.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOffering.2.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOfferings.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOfferings.2.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentReceipts.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentReceipts.2.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentRestore.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentRestore.2.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testFreeTrialPostsCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithFailedVerification.1.json
@@ -14,6 +14,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -14,6 +14,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testIndividualParamsCanBeNil.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPayAsYouGoPostsCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPayUpFrontPostsCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testCachesRequestsForSameReceipt.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesNotPostConsentStatus.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentCurrency.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentCurrency.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentDiscounts.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentDiscounts.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOffering.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOffering.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOfferings.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOfferings.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentReceipts.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentReceipts.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentRestore.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentRestore.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testFreeTrialPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsEntitlementsWithFailedVerification.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -15,6 +15,7 @@
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Post-Params-Hash" : "app_user_id,fetch_token,app_transaction:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testIndividualParamsCanBeNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPayAsYouGoPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPayUpFrontPostsCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithAppTransactionCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithAppTransactionCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestContainsSignatureHeader.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestFailsIfSignatureVerificationFails.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestContainsSignatureHeader.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestFailsIfSignatureVerificationFails.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestContainsSignatureHeader.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestFailsIfSignatureVerificationFails.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestContainsSignatureHeader.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestFailsIfSignatureVerificationFails.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestContainsSignatureHeader.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestFailsIfSignatureVerificationFails.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/macOS-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/macOS-testRequestContainsSignatureHeader.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/macOS-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/macOS-testRequestFailsIfSignatureVerificationFails.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/watchOS-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/watchOS-testRequestContainsSignatureHeader.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/watchOS-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/watchOS-testRequestFailsIfSignatureVerificationFails.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1711,6 +1711,8 @@ extension HTTPClientTests {
         expect(self.client.shouldRetryRequest(withStatusCode: .invalidRequest)).to(beFalse())
     }
 
+    
+
     // Backoff Time Tests
     func testUsesNoBackoffIfFirstRetryAndNoETagPresent() {
         var httpURLResponse = HTTPURLResponse(

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1857,9 +1857,15 @@ extension HTTPClientTests {
                 completion(response)
             }
         }
-        self.logger.verifyMessageWasLogged("Queued request GET /v1/subscribers/identify for retry in 0.0 seconds.")
-        self.logger.verifyMessageWasLogged("Queued request GET /v1/subscribers/identify for retry in 0.75 seconds.")
-        self.logger.verifyMessageWasLogged("Queued request GET /v1/subscribers/identify for retry in 3.0 seconds.")
+        self.logger.verifyMessageWasLogged(
+            "Queued request GET /v1/subscribers/identify for retry number 1 in 0.0 seconds."
+        )
+        self.logger.verifyMessageWasLogged(
+            "Queued request GET /v1/subscribers/identify for retry number 2 in 0.75 seconds."
+        )
+        self.logger.verifyMessageWasLogged(
+            "Queued request GET /v1/subscribers/identify for retry number 3 in 3.0 seconds."
+        )
         self.logger.verifyMessageWasLogged("Request GET /v1/subscribers/identify failed all 3 retries.")
     }
 
@@ -1875,9 +1881,15 @@ extension HTTPClientTests {
                 completion(response)
             }
         }
-        self.logger.verifyMessageWasNotLogged("Queued request GET /v1/subscribers/identify for retry in 0.0 seconds.")
-        self.logger.verifyMessageWasNotLogged("Queued request GET /v1/subscribers/identify for retry in 0.75 seconds.")
-        self.logger.verifyMessageWasNotLogged("Queued request GET /v1/subscribers/identify for retry in 3.0 seconds.")
+        self.logger.verifyMessageWasNotLogged(
+            "Queued request GET /v1/subscribers/identify for retry number 1 in 0.0 seconds."
+        )
+        self.logger.verifyMessageWasNotLogged(
+            "Queued request GET /v1/subscribers/identify for retry number 2 in 0.75 seconds."
+        )
+        self.logger.verifyMessageWasNotLogged(
+            "Queued request GET /v1/subscribers/identify for retry number 3 in 3.0 seconds."
+        )
         self.logger.verifyMessageWasNotLogged("Request GET /v1/subscribers/identify failed all 3 retries.")
     }
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1834,11 +1834,11 @@ extension HTTPClientTests {
             }
         }
 
-        expect(mockOperationDispatcher.invokedDispatchOnWorkerThreadCount).to(equal(3))
-        expect(mockOperationDispatcher.invokedDispatchOnWorkerThreadDelayParams).to(equal([
-            .timeInterval(0),
-            .timeInterval(0.75),
-            .timeInterval(3)
+        expect(mockOperationDispatcher.invokedDispatchOnWorkerThreadWithTimeIntervalCount).to(equal(3))
+        expect(mockOperationDispatcher.invokedDispatchOnWorkerThreadWithTimeIntervalParams).to(equal([
+            TimeInterval(0),
+            TimeInterval(0.75),
+            TimeInterval(3)
         ]))
     }
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1710,8 +1710,8 @@ extension HTTPClientTests {
 extension HTTPClientTests {
 
     func testOnlyRetriesProvidedHTTPStatusCodes() {
-        expect(self.client.shouldRetryRequest(withStatusCode: .tooManyRequests)).to(beTrue())
-        expect(self.client.shouldRetryRequest(withStatusCode: .invalidRequest)).to(beFalse())
+        expect(self.client.isStatusCodeRetryable(.tooManyRequests)).to(beTrue())
+        expect(self.client.isStatusCodeRetryable(.invalidRequest)).to(beFalse())
     }
 
     // Backoff Time Tests

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1985,11 +1985,18 @@ extension HTTPClientTests {
         expect(result).toNot(beNil())
         expect(result).to(beSuccess())
 
-        self.logger.verifyMessageWasLogged("Queued request GET /v1/subscribers/identify for retry in 0.0 seconds.")
-
-        self.logger.verifyMessageWasNotLogged("Queued request GET /v1/subscribers/identify for retry in 0.25 seconds.")
-        self.logger.verifyMessageWasNotLogged("Queued request GET /v1/subscribers/identify for retry in 0.5 seconds.")
-        self.logger.verifyMessageWasNotLogged("Request GET /v1/subscribers/identify failed all 3 retries.")
+        self.logger.verifyMessageWasLogged(
+            "Queued request GET /v1/subscribers/identify for retry number 1 in 0.0 seconds."
+        )
+        self.logger.verifyMessageWasNotLogged(
+            "Queued request GET /v1/subscribers/identify for retry number 2 in 0.75 seconds."
+        )
+        self.logger.verifyMessageWasNotLogged(
+            "Queued request GET /v1/subscribers/identify for retry number 3 in 3.0 seconds."
+        )
+        self.logger.verifyMessageWasNotLogged(
+            "Request GET /v1/subscribers/identify failed all 3 retries."
+        )
 
         expect(self.signing.requests).to(beEmpty())
     }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1787,10 +1787,6 @@ extension HTTPClientTests {
 
     func testDefaultRetryBackoffPeriods() {
         expect(
-            self.client.defaultExponentialBackoffTimeInterval(withRetryCount: 0)
-        ).to(equal(0))
-
-        expect(
             self.client.defaultExponentialBackoffTimeInterval(withRetryCount: 1)
         ).to(equal(0))
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1709,9 +1709,106 @@ extension HTTPClientTests {
 // MARK: - HttpClient Retry Tests
 extension HTTPClientTests {
 
-    func testOnlyRetriesProvidedHTTPStatusCodes() {
-        expect(self.client.isStatusCodeRetryable(.tooManyRequests)).to(beTrue())
-        expect(self.client.isStatusCodeRetryable(.invalidRequest)).to(beFalse())
+    func testOnlyRetriesProvidedHTTPStatusCodesIfIsRetryableHeaderMissing() {
+        expect(self.client.isRetryable(
+            HTTPURLResponse(
+                url: URL(string: "api.revenuecat.com")!,
+                statusCode: HTTPStatusCode.tooManyRequests.rawValue,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+        )).to(beTrue())
+        expect(self.client.isRetryable(
+            HTTPURLResponse(
+                url: URL(string: "api.revenuecat.com")!,
+                statusCode: HTTPStatusCode.invalidRequest.rawValue,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+        )).to(beFalse())
+    }
+
+    func testWontRetryIfIsRetryableHeaderFalse() {
+        expect(self.client.isRetryable(
+            HTTPURLResponse(
+                url: URL(string: "api.revenuecat.com")!,
+                statusCode: HTTPStatusCode.tooManyRequests.rawValue,
+                httpVersion: nil,
+                headerFields: [
+                    HTTPClient.ResponseHeader.isRetryable.rawValue: "false"
+                ]
+            )!
+        )).to(beFalse())
+
+        expect(self.client.isRetryable(
+            HTTPURLResponse(
+                url: URL(string: "api.revenuecat.com")!,
+                statusCode: HTTPStatusCode.tooManyRequests.rawValue,
+                httpVersion: nil,
+                headerFields: [
+                    HTTPClient.ResponseHeader.isRetryable.rawValue: "False"
+                ]
+            )!
+        )).to(beFalse())
+
+        expect(self.client.isRetryable(
+            HTTPURLResponse(
+                url: URL(string: "api.revenuecat.com")!,
+                statusCode: HTTPStatusCode.tooManyRequests.rawValue,
+                httpVersion: nil,
+                headerFields: [
+                    HTTPClient.ResponseHeader.isRetryable.rawValue: "FALSE"
+                ]
+            )!
+        )).to(beFalse())
+    }
+
+    func testWillRetryIfIsRetryableHeaderTrue() {
+        expect(self.client.isRetryable(
+            HTTPURLResponse(
+                url: URL(string: "api.revenuecat.com")!,
+                statusCode: HTTPStatusCode.tooManyRequests.rawValue,
+                httpVersion: nil,
+                headerFields: [
+                    HTTPClient.ResponseHeader.isRetryable.rawValue: "true"
+                ]
+            )!
+        )).to(beTrue())
+
+        expect(self.client.isRetryable(
+            HTTPURLResponse(
+                url: URL(string: "api.revenuecat.com")!,
+                statusCode: HTTPStatusCode.tooManyRequests.rawValue,
+                httpVersion: nil,
+                headerFields: [
+                    HTTPClient.ResponseHeader.isRetryable.rawValue: "True"
+                ]
+            )!
+        )).to(beTrue())
+
+        expect(self.client.isRetryable(
+            HTTPURLResponse(
+                url: URL(string: "api.revenuecat.com")!,
+                statusCode: HTTPStatusCode.tooManyRequests.rawValue,
+                httpVersion: nil,
+                headerFields: [
+                    HTTPClient.ResponseHeader.isRetryable.rawValue: "TRUE"
+                ]
+            )!
+        )).to(beTrue())
+    }
+
+    func testWillNotRetryIfIsRetryableHeaderTrueButStatusCodeIsNotRetryable() {
+        expect(self.client.isRetryable(
+            HTTPURLResponse(
+                url: URL(string: "api.revenuecat.com")!,
+                statusCode: HTTPStatusCode.success.rawValue,
+                httpVersion: nil,
+                headerFields: [
+                    HTTPClient.ResponseHeader.isRetryable.rawValue: "true"
+                ]
+            )!
+        )).to(beFalse())
     }
 
     // Backoff Time Tests

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1664,6 +1664,44 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
 
 }
 
+// MARK: - HttpClient.Request Tests
+extension HTTPClientTests {
+    func testNewRequestHasNoRetries() {
+        let request = buildEmptyRequest()
+
+        expect(request.retried).to(beFalse())
+        expect(request.retryCount).to(equal(0))
+    }
+
+    func testRetryingRequestIncrementsRetryCount() {
+        let request = buildEmptyRequest()
+
+        let retriedRequest = request.retriedRequest()
+        let secondRetriedRequest = retriedRequest.retriedRequest()
+
+        expect(retriedRequest.retried).to(beTrue())
+        expect(retriedRequest.retryCount).to(equal(1))
+
+        expect(secondRetriedRequest.retried).to(beTrue())
+        expect(secondRetriedRequest.retryCount).to(equal(2))
+    }
+
+    private func buildEmptyRequest() -> HTTPClient.Request {
+        let completionHandler: HTTPClient.Completion<CustomerInfo> = { _ in return }
+
+        let request: HTTPClient.Request = .init(
+            httpRequest: .init(method: .get, path: .getCustomerInfo(appUserID: "abc123")),
+            authHeaders: .init(),
+            defaultHeaders: .init(),
+            verificationMode: .default,
+            internalSettings: DangerousSettings.Internal.default,
+            completionHandler: completionHandler
+        )
+
+        return request
+    }
+}
+
 // swiftlint:disable large_tuple
 
 private func matchTrackParams(

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1711,8 +1711,6 @@ extension HTTPClientTests {
         expect(self.client.shouldRetryRequest(withStatusCode: .invalidRequest)).to(beFalse())
     }
 
-    
-
     // Backoff Time Tests
     func testUsesNoBackoffIfFirstRetryAndNoETagPresent() {
         var httpURLResponse = HTTPURLResponse(

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1782,7 +1782,7 @@ extension HTTPClientTests {
         )!
 
         let backoffPeriod = self.client.calculateRetryBackoffTime(forResponse: httpURLResponse, retryCount: 2)
-        expect(backoffPeriod).to(equal(TimeInterval(0.25)))
+        expect(backoffPeriod).to(equal(TimeInterval(0.75)))
     }
 
     func testDefaultRetryBackoffPeriods() {
@@ -1792,11 +1792,11 @@ extension HTTPClientTests {
 
         expect(
             self.client.defaultExponentialBackoffTimeInterval(withRetryCount: 2)
-        ).to(equal(0.25))
+        ).to(equal(0.75))
 
         expect(
             self.client.defaultExponentialBackoffTimeInterval(withRetryCount: 3)
-        ).to(equal(0.5))
+        ).to(equal(3))
     }
 
     func testPerformsAllRetriesIfAlwaysGetsRetryableStatusCode() throws {
@@ -1828,8 +1828,8 @@ extension HTTPClientTests {
         )
         expect(error.isServerDown) == false
         self.logger.verifyMessageWasLogged("Queued request GET /v1/subscribers/identify for retry in 0.0 seconds.")
-        self.logger.verifyMessageWasLogged("Queued request GET /v1/subscribers/identify for retry in 0.25 seconds.")
-        self.logger.verifyMessageWasLogged("Queued request GET /v1/subscribers/identify for retry in 0.5 seconds.")
+        self.logger.verifyMessageWasLogged("Queued request GET /v1/subscribers/identify for retry in 0.75 seconds.")
+        self.logger.verifyMessageWasLogged("Queued request GET /v1/subscribers/identify for retry in 3.0 seconds.")
         self.logger.verifyMessageWasLogged("Request GET /v1/subscribers/identify failed all 3 retries.")
 
         expect(self.signing.requests).to(beEmpty())

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -69,7 +69,8 @@ class BaseHTTPClientTests<ETag: ETagManager>: TestCase {
                           signing: self.signing,
                           diagnosticsTracker: self.diagnosticsTracker,
                           dnsChecker: MockDNSChecker.self,
-                          requestTimeout: defaultTimeout.seconds)
+                          requestTimeout: defaultTimeout.seconds,
+                          operationDispatcher: MockOperationDispatcher())
     }
 
 }

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithMultipleEvents.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithOneEvent.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/macOS-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/macOS-testPostPaywallEventsWithMultipleEvents.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/macOS-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/macOS-testPostPaywallEventsWithOneEvent.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/watchOS-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/watchOS-testPostPaywallEventsWithMultipleEvents.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/watchOS-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/watchOS-testPostPaywallEventsWithOneEvent.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithAdServicesToken.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithAdServicesToken.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithAdServicesToken.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithAdServicesToken.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithAdServicesToken.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithAdServicesToken.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithAdServicesToken.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -13,6 +13,7 @@
     "X-Platform-Flavor-Version" : "2.3.3",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_US",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "1",
     "X-StoreKit2-Enabled" : "false",


### PR DESCRIPTION
### Motivation
In the past, the SDK has ignored HTTP Status 429s. This PR introduces a retry ability with an exponential backoff policy to the SDK's HTTPClient so that 429s can be retried.

### Description
#### Configuration
The implementation allows consumers of the HTTP client to specify which HTTP status codes to retry for. The exponential backoff policy will retry requests up to three times, with the following backoff times:
- First retry: 0sec
- Second retry: 0.75sec
- Third retry: 3sec

#### Server-Defined Backoff Durations
If the server returns the `Retry-After` header with an integer value, the SDK will use that integer as the number of milliseconds to wait before retrying again instead of computing a backoff duration.

#### New `X-Retry-After` Header For Outbound Network Requests
This PR introduces a new `X-Retry-After` header for all outbound network requests, whose value is an integer. For the initial request (with no retries), the value is 0. For the first retry, the value is 1. For the second retry, the value is 2, and so on.

#### Etag Management
To keep our etag behavior consistent, the backoff duration for a first retry will always be 0 seconds.

#### Logging
A debug message in the format `"Queued request \(httpMethod) \(path) for retry number \(retryNumber) in \(backoffInterval) seconds."` is logged when a request is queued for retry. If a request fails all retries, a message with the format `"Request \(httpMethod) \(path) failed all \(retryCount) retries."` will be logged.

#### Testing
A good number of unit tests have been written, for both the individual parts of the HTTP client introduced in this PR and for testing the entire request flow through the HTTPClient.



