### PR TITLE
added new workflow to trigger all tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,20 @@ parameters:
     default: false
     type: boolean
 
+# params used by the trigger CircleCI Pipeline GitHub Action: https://github.com/marketplace/actions/trigger-circleci-pipeline
+  GHA_Event:
+    type: string
+    default: ""
+  GHA_Actor:
+    type: string
+    default: ""
+  GHA_Action:
+    type: string
+    default: ""
+  GHA_Meta:
+    type: string
+    default: ""
+
 aliases:
   base-job: &base-job
     resource_class: macos.m1.medium.gen1
@@ -1410,6 +1424,7 @@ workflows:
         - equal:
             - "run-manual-tests"
             - << pipeline.parameters.action >>
+         - equal: [ "run-from-github-comments", << pipeline.parameters.GHA_Event >>]
     jobs:
       - backend-integration-tests-SK1
       - backend-integration-tests-SK2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1424,7 +1424,7 @@ workflows:
         - equal:
             - "run-manual-tests"
             - << pipeline.parameters.action >>
-         - equal: [ "run-from-github-comments", << pipeline.parameters.GHA_Event >>]
+        - equal: [ "run-from-github-comments", << pipeline.parameters.GHA_Event >>]
     jobs:
       - backend-integration-tests-SK1
       - backend-integration-tests-SK2

--- a/.github/workflows/trigger_all_tests.yml
+++ b/.github/workflows/trigger_all_tests.yml
@@ -1,0 +1,34 @@
+name: Trigger All Tests
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    if: |
+      ${{ github.event.issue.pull_request }} &&
+      github.event.comment.body == '@RCGitBot please test'
+
+    steps:
+      - name: Check membership in RevenueCat Org
+        id: verify
+        # ensure that only RevenueCat members can trigger this
+        run: |
+          RESPONSE=$(curl https://api.github.com/orgs/RevenueCat/members/${{ github.event.comment.user.login }})
+          if [[ "$RESPONSE" == *"Not Found"* ]]; then
+            echo "User is not a member of the organization"
+            exit 1
+          fi
+          echo "User is a member of the organization"
+
+      - name: Trigger CircleCI workflow
+        id: trigger_circleci_workflow
+        if: success()
+
+        uses: circleci/trigger_circleci_pipeline@v1.2
+        with:
+          GHA_Action: "run-from-github-comments"
+        env:
+          CCI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}


### PR DESCRIPTION
Follow up to #4025 

Adds a github action to trigger all tests based on a github PR comment. 

Annoyingly, this can only be [tested once the action is in the default branch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only), the docs state: 

> Note: This event will only trigger a workflow run if the workflow file is on the default branch.

(I commented on this PR like 10 times before seeing this and didn't understand why it wouldn't fire)

This uses [CircleCI's Marketplace action for it](https://github.com/marketplace/actions/trigger-circleci-pipeline). 

I also considered [triggering via API](https://circleci.com/docs/triggers-overview/#run-a-pipeline-using-the-api), but that has one big disadvantage in that the branch that the action receives is `main`, so we'd have to do extra work to get the branch name. This takes care of that automatically. 
