### PR TITLE
[CustomerCenter] Add `presentCustomerCenter` modifier

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1E473B662AC42D34008B07F9 /* StoreMessagesHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E473B652AC42D34008B07F9 /* StoreMessagesHelper.swift */; };
 		1E473B682AC43254008B07F9 /* StoreMessageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E473B672AC43254008B07F9 /* StoreMessageType.swift */; };
 		1E568B512ACC6A8300D3C12F /* StoreMessageTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E568B502ACC6A8300D3C12F /* StoreMessageTypeTests.swift */; };
+		1E5F8F6E2C4515430041EECD /* View+PresentCustomerCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E5F8F6D2C4515430041EECD /* View+PresentCustomerCenter.swift */; };
 		1E99F81F2AC5917F0023E26E /* StoreMessagesHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E99F81D2AC5917F0023E26E /* StoreMessagesHelperTests.swift */; };
 		2C0B98CD2797070B00C5874F /* PromotionalOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */; };
 		2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */; };
@@ -1047,6 +1048,7 @@
 		1E473B672AC43254008B07F9 /* StoreMessageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessageType.swift; sourceTree = "<group>"; };
 		1E473B692AC46908008B07F9 /* MockStoreMessagesHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreMessagesHelper.swift; sourceTree = "<group>"; };
 		1E568B502ACC6A8300D3C12F /* StoreMessageTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessageTypeTests.swift; sourceTree = "<group>"; };
+		1E5F8F6D2C4515430041EECD /* View+PresentCustomerCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+PresentCustomerCenter.swift"; sourceTree = "<group>"; };
 		1E99F81D2AC5917F0023E26E /* StoreMessagesHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessagesHelperTests.swift; sourceTree = "<group>"; };
 		2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOffer.swift; sourceTree = "<group>"; };
 		2C646C282A0EBD0300E5936E /* CI-Snapshots.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = "CI-Snapshots.xctestplan"; path = "Tests/TestPlans/CI-Snapshots.xctestplan"; sourceTree = "<group>"; };
@@ -2591,6 +2593,7 @@
 				353756612C382C2800A1B8D6 /* ManageSubscriptionsButtonStyle.swift */,
 				353756622C382C2800A1B8D6 /* ManageSubscriptionsPurchaseType.swift */,
 				353756632C382C2800A1B8D6 /* URLUtilities.swift */,
+				1E5F8F6D2C4515430041EECD /* View+PresentCustomerCenter.swift */,
 			);
 			path = CustomerCenter;
 			sourceTree = "<group>";
@@ -5212,6 +5215,7 @@
 				887A60C82C1D037000E1A461 /* ProgressView.swift in Sources */,
 				887A60D02C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift in Sources */,
 				887A60CD2C1D037000E1A461 /* PaywallView.swift in Sources */,
+				1E5F8F6E2C4515430041EECD /* View+PresentCustomerCenter.swift in Sources */,
 				887A60C12C1D037000E1A461 /* DebugErrorView.swift in Sources */,
 				887A607C2C1D037000E1A461 /* ColorInformation+MultiScheme.swift in Sources */,
 				887A60782C1D037000E1A461 /* TestData.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
+++ b/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
@@ -53,17 +53,15 @@ extension View {
     /// - Parameter onDismiss: Callback executed when the customer center wants to be dismissed.
     /// Make sure you stop presenting the customer center when this is called
     /// - Parameter presentationMode: The desired presentation mode of the customer center. Defaults to `.sheet`.
-    /// - Parameter myAppPurchaseLogic: Use this if you are handling purchases/restores on your own instead of through RevenueCat.
     public func presentCustomerCenter(
         isPresented: Binding<Bool>,
         onDismiss: @escaping () -> Void,
-        presentationMode: CustomerCenterPresentationMode = .default,
-        myAppPurchaseLogic: MyAppPurchaseLogic? = nil
+        presentationMode: CustomerCenterPresentationMode = .default
     ) -> some View {
         return self.modifier(PresentingCustomerCenterModifier(
             isPresented: isPresented,
             onDismiss: onDismiss,
-            myAppPurchaseLogic: myAppPurchaseLogic,
+            myAppPurchaseLogic: nil,
             presentationMode: presentationMode
         ))
     }

--- a/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
+++ b/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
@@ -49,7 +49,6 @@ extension View {
     ///      .presentCustomerCenter()
     /// }
     /// ```
-
     /// - Parameter isPresented: Binding indicating whether the customer center should be displayed
     /// - Parameter onDismiss: Callback executed when the customer center wants to be dismissed.
     /// Make sure you stop presenting the customer center when this is called

--- a/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
+++ b/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
@@ -34,7 +34,6 @@ extension CustomerCenterPresentationMode {
 
 }
 
-// swiftlint:disable file_length
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
 @available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")

--- a/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
+++ b/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
@@ -14,7 +14,7 @@
 import RevenueCat
 import SwiftUI
 
-#if !os(macOS) && !os(tvOS)
+#if os(iOS)
 
 /// Presentation options to use with the [presentCustomerCenter](x-source-tag://presentCustomerCenter) View modifiers.
 public enum CustomerCenterPresentationMode {
@@ -37,6 +37,8 @@ extension CustomerCenterPresentationMode {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
 @available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
+@available(watchOS, unavailable, message: "CustomerCenterView does not support watchOS yet")
+@available(visionOS, unavailable, message: "CustomerCenterView does not support visionOS yet")
 extension View {
 
     /// Presents the ``CustomerCenter``.
@@ -70,6 +72,8 @@ extension View {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@available(visionOS, unavailable)
 private struct PresentingCustomerCenterModifier: ViewModifier {
 
     var presentationMode: CustomerCenterPresentationMode

--- a/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
+++ b/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
@@ -1,0 +1,126 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  View+PresentCustomerCenter.swift
+//
+//  Created by Toni Rico Diez on 2024-07-15.
+
+import RevenueCat
+import SwiftUI
+
+#if !os(macOS) && !os(tvOS)
+
+/// Presentation options to use with the [presentCustomerCenter](x-source-tag://presentCustomerCenter) View modifiers.
+public enum CustomerCenterPresentationMode {
+
+    /// Customer center presented using SwiftUI's `.sheet`.
+    case sheet
+
+    /// Customer center presented using SwiftUI's `.fullScreenCover`.
+    case fullScreen
+
+}
+
+extension CustomerCenterPresentationMode {
+
+    // swiftlint:disable:next missing_docs
+    public static let `default`: Self = .sheet
+
+}
+
+// swiftlint:disable file_length
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
+@available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
+extension View {
+
+    /// Presents the ``CustomerCenter``.
+    /// Example:
+    /// ```swift
+    /// var body: some View {
+    ///    YourApp()
+    ///      .presentCustomerCenter()
+    /// }
+    /// ```
+
+    /// - Parameter isPresented: Binding indicating whether the customer center should be displayed
+    /// - Parameter onDismiss: Callback executed when the customer center wants to be dismissed.
+    /// Make sure you stop presenting the customer center when this is called
+    /// - Parameter presentationMode: The desired presentation mode of the customer center. Defaults to `.sheet`.
+    /// - Parameter myAppPurchaseLogic: Use this if you are handling purchases/restores on your own instead of through RevenueCat.
+    public func presentCustomerCenter(
+        isPresented: Binding<Bool>,
+        onDismiss: @escaping () -> Void,
+        presentationMode: CustomerCenterPresentationMode = .default,
+        myAppPurchaseLogic: MyAppPurchaseLogic? = nil
+    ) -> some View {
+        return self.modifier(PresentingCustomerCenterModifier(
+            isPresented: isPresented,
+            onDismiss: onDismiss,
+            myAppPurchaseLogic: myAppPurchaseLogic,
+            presentationMode: presentationMode
+        ))
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+private struct PresentingCustomerCenterModifier: ViewModifier {
+
+    var presentationMode: CustomerCenterPresentationMode
+    var onDismiss: (() -> Void)
+
+    init(
+        isPresented: Binding<Bool>,
+        onDismiss: @escaping () -> Void,
+        myAppPurchaseLogic: MyAppPurchaseLogic?,
+        presentationMode: CustomerCenterPresentationMode,
+        purchaseHandler: PurchaseHandler? = nil
+    ) {
+        self._isPresented = isPresented
+        self.presentationMode = presentationMode
+        self.onDismiss = onDismiss
+        self._purchaseHandler = .init(wrappedValue: purchaseHandler ??
+                                      PurchaseHandler.default(performPurchase: myAppPurchaseLogic?.performPurchase,
+                                                              performRestore: myAppPurchaseLogic?.performRestore))
+    }
+
+    @StateObject
+    private var purchaseHandler: PurchaseHandler
+
+    @Binding
+    var isPresented: Bool
+
+    func body(content: Content) -> some View {
+        Group {
+            switch presentationMode {
+            case .sheet:
+                content
+                    .sheet(isPresented: self.$isPresented, onDismiss: self.onDismiss) {
+                        self.customerCenterView()
+                    }
+            case .fullScreen:
+                content
+                    .fullScreenCover(isPresented: self.$isPresented, onDismiss: self.onDismiss) {
+                        self.customerCenterView()
+                    }
+            }
+        }
+    }
+
+    private func customerCenterView() -> some View {
+        CustomerCenterView()
+            .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
+    }
+
+}
+
+#endif

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -144,7 +144,7 @@ struct SamplePaywallsList: View {
                 Button {
                     self.presentingCustomerCenter = true
                 } label: {
-                    TemplateLabel(name: "Customer center", icon: "person.fill")
+                    TemplateLabel(name: "Customer center (sheet)", icon: "person.fill")
                 }
                 #endif
             }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -140,7 +140,7 @@ struct SamplePaywallsList: View {
                     TemplateLabel(name: "Unrecognized paywall", icon: "exclamationmark.triangle")
                 }
 
-                #if !os(watchOS)
+                #if os(iOS)
                 Button {
                     self.presentingCustomerCenter = true
                 } label: {
@@ -151,9 +151,11 @@ struct SamplePaywallsList: View {
         }
         .frame(maxWidth: .infinity)
         .buttonStyle(.plain)
+        #if os(iOS)
         .presentCustomerCenter(isPresented: self.$presentingCustomerCenter) {
             self.presentingCustomerCenter = false
         }
+        #endif
     }
 
     #if os(watchOS)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -16,6 +16,9 @@ struct SamplePaywallsList: View {
     @State
     private var display: Display?
 
+    @State
+    private var presentingCustomerCenter: Bool = false
+
     var body: some View {
         NavigationView {
             self.list(with: Self.loader)
@@ -136,10 +139,21 @@ struct SamplePaywallsList: View {
                 } label: {
                     TemplateLabel(name: "Unrecognized paywall", icon: "exclamationmark.triangle")
                 }
+
+                #if !os(watchOS)
+                Button {
+                    self.presentingCustomerCenter = true
+                } label: {
+                    TemplateLabel(name: "Customer center", icon: "person.fill")
+                }
+                #endif
             }
         }
         .frame(maxWidth: .infinity)
         .buttonStyle(.plain)
+        .presentCustomerCenter(isPresented: self.$presentingCustomerCenter) {
+            self.presentingCustomerCenter = false
+        }
     }
 
     #if os(watchOS)


### PR DESCRIPTION
### Description
This adds a modifier, `presentCustomerCenter` that can be used to more simply display the customer center. The API looks like:
```
.presentCustomerCenter(isPresented: self.$presentingCustomerCenter) {
    self.presentingCustomerCenter = false
}
```