### PR TITLE
[StoreKit 2] Raise error if no AppTransaction and no Transaction present

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1129,6 +1129,14 @@ private extension PurchasesOrchestrator {
                         return
                     }
 
+                    // We dont have an AppTransactionJWS, and no transaction, return error
+                    if appTransactionJWS == nil {
+                        completion?(.failure(ErrorUtils.storeProblemError(
+                            withMessage: Strings.storeKit.sk2_app_transaction_unavailable.description
+                        )))
+                        return
+                    }
+
                     self.backend.post(receipt: .empty,
                                       productData: nil,
                                       transactionData: .init(appUserID: currentAppUserID,


### PR DESCRIPTION
When we don't have an AppTransaction, and the list of transactions is empty as well, this is likely an store issue, so we return an error and let the developer retry the operation.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
