### PR TITLE
[Customer Center] Improves the UI of the current subscription

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -104,12 +104,22 @@ enum CustomerCenterConfigTestData {
         )
     )
 
-    static let subscriptionInformation: SubscriptionInformation = .init(
+    static let subscriptionInformationMonthlyRenewing: SubscriptionInformation = .init(
         title: "Basic",
         durationTitle: "Monthly",
         price: "$4.99 / month",
         nextRenewalString: "June 1st, 2024",
         willRenew: true,
+        productIdentifier: "product_id",
+        active: true
+    )
+
+    static let subscriptionInformationYearlyExpiring: SubscriptionInformation = .init(
+        title: "Basic",
+        durationTitle: "Yearly",
+        price: "$4.99 / year",
+        nextRenewalString: "June 1st, 2024",
+        willRenew: false,
         productIdentifier: "product_id",
         active: true
     )

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -108,7 +108,7 @@ enum CustomerCenterConfigTestData {
         title: "Basic",
         durationTitle: "Monthly",
         price: "$4.99 / month",
-        nextRenewalString: "June 1st, 2024",
+        expirationDateString: "June 1st, 2024",
         willRenew: true,
         productIdentifier: "product_id",
         active: true
@@ -118,7 +118,7 @@ enum CustomerCenterConfigTestData {
         title: "Basic",
         durationTitle: "Yearly",
         price: "$4.99 / year",
-        nextRenewalString: "June 1st, 2024",
+        expirationDateString: "June 1st, 2024",
         willRenew: false,
         productIdentifier: "product_id",
         active: true

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -107,7 +107,7 @@ enum CustomerCenterConfigTestData {
     static let subscriptionInformationMonthlyRenewing: SubscriptionInformation = .init(
         title: "Basic",
         durationTitle: "Monthly",
-        price: "$4.99 / month",
+        price: "$4.99",
         expirationDateString: "June 1st, 2024",
         willRenew: true,
         productIdentifier: "product_id",
@@ -117,7 +117,7 @@ enum CustomerCenterConfigTestData {
     static let subscriptionInformationYearlyExpiring: SubscriptionInformation = .init(
         title: "Basic",
         durationTitle: "Yearly",
-        price: "$4.99 / year",
+        price: "$49.99",
         expirationDateString: "June 1st, 2024",
         willRenew: false,
         productIdentifier: "product_id",

--- a/RevenueCatUI/CustomerCenter/Data/SubscriptionInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/SubscriptionInformation.swift
@@ -20,11 +20,11 @@ struct SubscriptionInformation {
     let title: String
     let durationTitle: String
     let price: String
-    let nextRenewalString: String?
+    let expirationDateString: String?
     let productIdentifier: String
 
-    var renewalString: String {
-        return active ? (willRenew ? "Renews" : "Expires") : "Expired"
+    var expirationString: String {
+        return active ? (willRenew ? "Next billing date" : "Expires") : "Expired"
     }
 
     private let willRenew: Bool
@@ -33,7 +33,7 @@ struct SubscriptionInformation {
     init(title: String,
          durationTitle: String,
          price: String,
-         nextRenewalString: String?,
+         expirationDateString: String?,
          willRenew: Bool,
          productIdentifier: String,
          active: Bool
@@ -41,7 +41,7 @@ struct SubscriptionInformation {
         self.title = title
         self.durationTitle = durationTitle
         self.price = price
-        self.nextRenewalString = nextRenewalString
+        self.expirationDateString = expirationDateString
         self.productIdentifier = productIdentifier
         self.willRenew = willRenew
         self.active = active

--- a/RevenueCatUI/CustomerCenter/Data/SubscriptionInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/SubscriptionInformation.swift
@@ -30,8 +30,8 @@ struct SubscriptionInformation {
     var explanation: String {
         return active ? (
             willRenew ?
-                "This is your subscription with the soonest billing date." :
-                "This is your subscription with the soonest expiration date."
+                "This is your subscription with the earliest billing date." :
+                "This is your subscription with the earliest expiration date."
         ) : "This subscription has expired."
     }
 

--- a/RevenueCatUI/CustomerCenter/Data/SubscriptionInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/SubscriptionInformation.swift
@@ -27,6 +27,14 @@ struct SubscriptionInformation {
         return active ? (willRenew ? "Next billing date" : "Expires") : "Expired"
     }
 
+    var explanation: String {
+        return active ? (
+            willRenew ?
+                "This is your subscription with the soonest billing date." :
+                "This is your subscription with the soonest expiration date."
+        ) : "This subscription has expired."
+    }
+
     private let willRenew: Bool
     private let active: Bool
 

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
@@ -111,7 +111,7 @@ class ManageSubscriptionsViewModel: ObservableObject {
             title: subscribedProduct.localizedTitle,
             durationTitle: subscribedProduct.subscriptionPeriod?.durationTitle ?? "",
             price: subscribedProduct.localizedPriceString,
-            nextRenewalString: currentEntitlement.expirationDate.map { dateFormatter.string(from: $0) } ?? nil,
+            expirationDateString: currentEntitlement.expirationDate.map { dateFormatter.string(from: $0) } ?? nil,
             willRenew: currentEntitlement.willRenew,
             productIdentifier: currentEntitlement.productIdentifier,
             active: currentEntitlement.isActive

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -243,10 +243,18 @@ struct ManageSubscriptionsButtonsView: View {
 struct ManageSubscriptionsView_Previews: PreviewProvider {
 
     static var previews: some View {
-        let viewModel = ManageSubscriptionsViewModel(
+        let viewModelMonthlyRenewing = ManageSubscriptionsViewModel(
             screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
-            subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformation)
-        ManageSubscriptionsView(viewModel: viewModel)
+            subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing)
+        ManageSubscriptionsView(viewModel: viewModelMonthlyRenewing)
+            .previewDisplayName("Monthly renewing")
+
+        let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
+            screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
+            subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationYearlyExpiring)
+
+        ManageSubscriptionsView(viewModel: viewModelYearlyExpiring)
+            .previewDisplayName("Yearly expiring")
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -137,6 +137,7 @@ struct HeaderView: View {
 @available(watchOS, unavailable)
 struct SubscriptionDetailsView: View {
 
+    let iconWidth = 22.0
     let subscriptionInformation: SubscriptionInformation
     let refundRequestStatusMessage: String?
 
@@ -154,7 +155,7 @@ struct SubscriptionDetailsView: View {
             HStack(alignment: .center) {
                 Image(systemName: "coloncurrencysign.arrow.circlepath")
                     .accessibilityHidden(true)
-                    .frame(width: 22)
+                    .frame(width: iconWidth)
                 VStack(alignment: .leading) {
                     Text("Billing cycle")
                         .font(.caption2)
@@ -167,7 +168,7 @@ struct SubscriptionDetailsView: View {
             HStack(alignment: .center) {
                 Image(systemName: "coloncurrencysign")
                     .accessibilityHidden(true)
-                    .frame(width: 22)
+                    .frame(width: iconWidth)
                 VStack(alignment: .leading) {
                     Text("Current price")
                         .font(.caption2)
@@ -181,7 +182,7 @@ struct SubscriptionDetailsView: View {
                 HStack(alignment: .center) {
                     Image(systemName: "calendar")
                         .accessibilityHidden(true)
-                        .frame(width: 22)
+                        .frame(width: iconWidth)
                     VStack(alignment: .leading) {
                         Text("\(subscriptionInformation.expirationString)")
                             .font(.caption2)

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -142,20 +142,46 @@ struct SubscriptionDetailsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("\(subscriptionInformation.title) - \(subscriptionInformation.durationTitle)")
-                .font(.subheadline)
-                .padding([.horizontal, .top])
+            Text("\(subscriptionInformation.title)")
+                .font(.headline)
+                .padding([.bottom])
 
-            Text("\(subscriptionInformation.price)")
-                .font(.caption)
-                .foregroundColor(Color.gray)
-                .padding(.horizontal)
+            HStack(alignment: .center) {
+                Image(systemName: "coloncurrencysign.arrow.circlepath")
+                    .frame(width: 22)
+                VStack(alignment: .leading) {
+                    Text("Billing cycle")
+                        .font(.caption2)
+                        .foregroundColor(Color.gray)
+                    Text("\(subscriptionInformation.durationTitle)")
+                        .font(.caption)
+                }
+            }
+
+            HStack(alignment: .center) {
+                Image(systemName: "coloncurrencysign")
+                    .frame(width: 22)
+                VStack(alignment: .leading) {
+                    Text("Price")
+                        .font(.caption2)
+                        .foregroundColor(Color.gray)
+                    Text("\(subscriptionInformation.price)")
+                        .font(.caption)
+                }
+            }
 
             if let nextRenewal =  subscriptionInformation.nextRenewalString {
-                Text("\(subscriptionInformation.renewalString): \(String(describing: nextRenewal))")
-                    .font(.caption)
-                    .foregroundColor(Color.gray)
-                    .padding([.horizontal, .bottom])
+                HStack(alignment: .center) {
+                    Image(systemName: "calendar")
+                        .frame(width: 22)
+                    VStack(alignment: .leading) {
+                        Text("Next billing date")
+                            .font(.caption2)
+                            .foregroundColor(Color.gray)
+                        Text("\(subscriptionInformation.renewalString): \(String(describing: nextRenewal))")
+                            .font(.caption)
+                    }
+                }
             }
 
             if let refundRequestStatusMessage = refundRequestStatusMessage {
@@ -165,7 +191,11 @@ struct SubscriptionDetailsView: View {
                     .foregroundColor(Color.gray)
                     .padding([.horizontal, .bottom])
             }
-        }
+        }.padding()
+            .padding(.horizontal)
+            .background(Color.white)
+            .cornerRadius(20)
+            .shadow(color: Color.black.opacity(0.2), radius: 4)
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -149,7 +149,7 @@ struct SubscriptionDetailsView: View {
                 Text("\(subscriptionInformation.explanation)")
                     .frame(maxWidth: 200, alignment: .leading)
                     .font(.caption)
-                    .foregroundColor(Color.gray)
+                    .foregroundColor(Color(UIColor.secondaryLabel))
             }.padding([.bottom], 10)
 
             HStack(alignment: .center) {
@@ -159,7 +159,7 @@ struct SubscriptionDetailsView: View {
                 VStack(alignment: .leading) {
                     Text("Billing cycle")
                         .font(.caption2)
-                        .foregroundColor(Color.gray)
+                        .foregroundColor(Color(UIColor.secondaryLabel))
                     Text("\(subscriptionInformation.durationTitle)")
                         .font(.caption)
                 }
@@ -172,7 +172,7 @@ struct SubscriptionDetailsView: View {
                 VStack(alignment: .leading) {
                     Text("Current price")
                         .font(.caption2)
-                        .foregroundColor(Color.gray)
+                        .foregroundColor(Color(UIColor.secondaryLabel))
                     Text("\(subscriptionInformation.price)")
                         .font(.caption)
                 }
@@ -186,7 +186,7 @@ struct SubscriptionDetailsView: View {
                     VStack(alignment: .leading) {
                         Text("\(subscriptionInformation.expirationString)")
                             .font(.caption2)
-                            .foregroundColor(Color.gray)
+                            .foregroundColor(Color(UIColor.secondaryLabel))
                         Text("\(String(describing: nextRenewal))")
                             .font(.caption)
                     }
@@ -197,12 +197,12 @@ struct SubscriptionDetailsView: View {
                 Text("Refund request status: \(refundRequestStatusMessage)")
                     .font(.caption)
                     .bold()
-                    .foregroundColor(Color.gray)
+                    .foregroundColor(Color(UIColor.secondaryLabel))
                     .padding([.horizontal, .bottom])
             }
         }.padding()
             .padding(.horizontal)
-            .background(Color.white)
+            .background(Color(UIColor.tertiarySystemBackground))
             .cornerRadius(20)
             .shadow(color: Color.black.opacity(0.2), radius: 4)
     }

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -167,7 +167,7 @@ struct SubscriptionDetailsView: View {
                 Image(systemName: "coloncurrencysign")
                     .frame(width: 22)
                 VStack(alignment: .leading) {
-                    Text("Price")
+                    Text("Current price")
                         .font(.caption2)
                         .foregroundColor(Color.gray)
                     Text("\(subscriptionInformation.price)")

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -153,6 +153,7 @@ struct SubscriptionDetailsView: View {
 
             HStack(alignment: .center) {
                 Image(systemName: "coloncurrencysign.arrow.circlepath")
+                    .accessibilityHidden(true)
                     .frame(width: 22)
                 VStack(alignment: .leading) {
                     Text("Billing cycle")
@@ -165,6 +166,7 @@ struct SubscriptionDetailsView: View {
 
             HStack(alignment: .center) {
                 Image(systemName: "coloncurrencysign")
+                    .accessibilityHidden(true)
                     .frame(width: 22)
                 VStack(alignment: .leading) {
                     Text("Current price")
@@ -178,6 +180,7 @@ struct SubscriptionDetailsView: View {
             if let nextRenewal =  subscriptionInformation.expirationDateString {
                 HStack(alignment: .center) {
                     Image(systemName: "calendar")
+                        .accessibilityHidden(true)
                         .frame(width: 22)
                     VStack(alignment: .leading) {
                         Text("\(subscriptionInformation.expirationString)")

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -142,9 +142,14 @@ struct SubscriptionDetailsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("\(subscriptionInformation.title)")
-                .font(.headline)
-                .padding([.bottom], 10)
+            VStack(alignment: .leading) {
+                Text("\(subscriptionInformation.title)")
+                    .font(.headline)
+                Text("\(subscriptionInformation.explanation)")
+                    .frame(maxWidth: 200, alignment: .leading)
+                    .font(.caption)
+                    .foregroundColor(Color.gray)
+            }.padding([.bottom], 10)
 
             HStack(alignment: .center) {
                 Image(systemName: "coloncurrencysign.arrow.circlepath")

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -170,15 +170,15 @@ struct SubscriptionDetailsView: View {
                 }
             }
 
-            if let nextRenewal =  subscriptionInformation.nextRenewalString {
+            if let nextRenewal =  subscriptionInformation.expirationDateString {
                 HStack(alignment: .center) {
                     Image(systemName: "calendar")
                         .frame(width: 22)
                     VStack(alignment: .leading) {
-                        Text("Next billing date")
+                        Text("\(subscriptionInformation.expirationString)")
                             .font(.caption2)
                             .foregroundColor(Color.gray)
-                        Text("\(subscriptionInformation.renewalString): \(String(describing: nextRenewal))")
+                        Text("\(String(describing: nextRenewal))")
                             .font(.caption)
                     }
                 }

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -144,7 +144,7 @@ struct SubscriptionDetailsView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("\(subscriptionInformation.title)")
                 .font(.headline)
-                .padding([.bottom])
+                .padding([.bottom], 10)
 
             HStack(alignment: .center) {
                 Image(systemName: "coloncurrencysign.arrow.circlepath")

--- a/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
@@ -115,7 +115,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
         expect(subscriptionInformation.title) == "title"
         expect(subscriptionInformation.durationTitle) == "month"
         expect(subscriptionInformation.price) == "$2.99"
-        expect(subscriptionInformation.nextRenewalString) == reformat(ISO8601Date: expirationDate)
+        expect(subscriptionInformation.expirationDateString) == reformat(ISO8601Date: expirationDate)
         expect(subscriptionInformation.productIdentifier) == productId
     }
 
@@ -172,7 +172,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
         expect(subscriptionInformation.title) == "yearly"
         expect(subscriptionInformation.durationTitle) == "year"
         expect(subscriptionInformation.price) == "$29.99"
-        expect(subscriptionInformation.nextRenewalString) == reformat(ISO8601Date: expirationDateFirst)
+        expect(subscriptionInformation.expirationDateString) == reformat(ISO8601Date: expirationDateFirst)
         expect(subscriptionInformation.productIdentifier) == productIdOne
     }
 
@@ -235,7 +235,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
         expect(subscriptionInformation.title) == "yearly"
         expect(subscriptionInformation.durationTitle) == "year"
         expect(subscriptionInformation.price) == "$29.99"
-        expect(subscriptionInformation.nextRenewalString) == reformat(ISO8601Date: expirationDateFirst)
+        expect(subscriptionInformation.expirationDateString) == reformat(ISO8601Date: expirationDateFirst)
         expect(subscriptionInformation.productIdentifier) == productIdOne
     }
 
@@ -299,7 +299,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
         expect(subscriptionInformation.title) == "monthly"
         expect(subscriptionInformation.durationTitle) == "month"
         expect(subscriptionInformation.price) == "$2.99"
-        expect(subscriptionInformation.nextRenewalString) == reformat(ISO8601Date: expirationDateSecond)
+        expect(subscriptionInformation.expirationDateString) == reformat(ISO8601Date: expirationDateSecond)
         expect(subscriptionInformation.productIdentifier) == productIdTwo
     }
 


### PR DESCRIPTION
## Summary
This PR improves the presentation of the current subscription.
- Adds hierarchy to the various texts.
- Uses padding to indicate which texts belong together and which do not.
- Adds some descriptive icons.
- Adds a short explanation as to which subscription we're showing. 
- Describes the date as the "next billing date" (or date of expiry, if applicable). 
- Wraps it in a card.

This PR can be seen as a proposal. Feel free to add any suggestions! 

## Before

![image](https://github.com/user-attachments/assets/5d721636-827c-4d1c-a067-869aaf48da26)


## After

![image](https://github.com/user-attachments/assets/f5241dd6-bbf2-4b1c-9486-4ce366579a99)

