### PR TITLE
Only checks staged files for leftover API keys.

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -41,16 +41,20 @@ verify_no_included_apikeys() {
     "${SCRIPT_DIR}/../Tests/TestingApps/PurchaseTester/PurchaseTester/Constants.swift"
     "${SCRIPT_DIR}/../Tests/TestingApps/PaywallsTester/PaywallsTester/Config/LocalConfigItems.swift"
   )
+  FILES_STAGED=$(git diff --cached --name-only)
   PATTERN="\"REVENUECAT_API_KEY\""
 
-  for i in "${FILES_TO_CHECK[@]}" 
+  for staged_file in $FILES_STAGED
   do
-    grep -q $PATTERN $i
-    FOUND=$?
-    if [ $FOUND -ne 0 ]; then
-      echo "Leftover API Key found in '$(basename $i)'. Please remove."
-      exit $FOUND
-    fi
+    absolute_staged_file=$(realpath "$staged_file")
+    for api_file in "${FILES_TO_CHECK[@]}"
+    do
+      absolute_api_file=$(realpath "$api_file")
+      if [ $absolute_staged_file = $absolute_api_file ] && ! grep -q $PATTERN $absolute_staged_file; then
+        echo "Leftover API Key found in '$(basename $absolute_staged_file)'. Please remove."
+        exit 1
+      fi
+    done
   done
 }
 


### PR DESCRIPTION
## What
As the title says. It does a rudimentary intersect of the existing `FILES_TO_CHECK` and the staged files, and checks _those_ files for leftover API keys. 

## Why
This allows you to set API keys in any of the `FILES_TO_CHECK` files, as long as you're not trying to commit them. Otherwise you'd have to revert your local API key every time you'd want to commit anything. 