### PR TITLE
Use newer Alert API for showing customer restored alert

### DIFF
--- a/RevenueCatUI/Views/FooterView.swift
+++ b/RevenueCatUI/Views/FooterView.swift
@@ -184,6 +184,9 @@ private struct RestorePurchasesButton: View {
     @State
     private var restoredCustomerInfo: CustomerInfo?
 
+    @State
+    private var showRestoredCustomerInfoAlert: Bool = false
+
     var body: some View {
         AsyncButton {
             Logger.debug(Strings.restoring_purchases)
@@ -193,6 +196,7 @@ private struct RestorePurchasesButton: View {
             if success {
                 Logger.debug(Strings.restored_purchases)
                 self.restoredCustomerInfo = customerInfo
+                self.showRestoredCustomerInfoAlert = true
             } else {
                 Logger.debug(Strings.restore_purchases_with_empty_result)
             }
@@ -211,16 +215,16 @@ private struct RestorePurchasesButton: View {
         }
         .frame(minHeight: Constants.minimumButtonHeight)
         .buttonStyle(.plain)
-        .alert(item: self.$restoredCustomerInfo) { customerInfo in
-            Alert(
-                title: Text("Purchases restored successfully!", bundle: .module),
-                dismissButton: .default(Text("OK", bundle: .module)) {
+        .alert(Text("Purchases restored successfully!", bundle: .module),
+               isPresented: self.$showRestoredCustomerInfoAlert) {
+            Button(role: .cancel) {
+                if let restoredCustomerInfo = self.restoredCustomerInfo {
                     Logger.debug(Strings.setting_restored_customer_info)
-
+                    self.showRestoredCustomerInfoAlert = false
                     self.restoredCustomerInfo = nil
-                    self.purchaseHandler.setRestored(customerInfo)
+                    self.purchaseHandler.setRestored(restoredCustomerInfo)
                 }
-            )
+            } label: { Text("OK") }
         }
     }
 


### PR DESCRIPTION
This was causing issues for some developers, because the old, deprecated Alert API would fail silently if there was a view higher up in the view hierarchy which already had an Alert modifier

This in turn caused the `onRestoreCompleted` callback not to be called.

https://community.revenuecat.com/sdks-51/restore-completion-handlers-not-firing-in-presentpaywallifneeded-4674

The newer Alert API seems to not suffer from the same issue.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
