### PR TITLE
Fix release train deploy workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1353,24 +1353,23 @@ workflows:
           requires:
             - hold
       - make-release:
-          <<: *release-tags
+          requires:
+            - hold
       - push-revenuecat-pod:
           requires:
             - make-release
-          <<: *release-tags
       - push-revenuecatui-pod:
           requires:
-            - make-release
             - push-revenuecat-pod
-          <<: *release-tags
       - deploy-to-spm:
           requires:
             - make-release
-          <<: *release-tags
       - docs-deploy:
-          <<: *release-tags
+          requires:
+            - make-release
       - deploy-purchase-tester:
-          <<: *release-tags
+          requires:
+            - make-release
       - notify-on-non-patch-release-branches:
           requires:
             - make-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1335,7 +1335,7 @@ workflows:
       - run-test-ios-17
       - pod-lib-lint
 
-  deploy:
+  create-tag:
     when:
       and:
         - not:
@@ -1345,16 +1345,29 @@ workflows:
             value: << pipeline.git.branch >>
     jobs:
       - release-checks
-      - hold:
+      - hold-for-tag:
           type: approval
           requires:
             - release-checks
       - tag-release-branch:
           requires:
-            - hold
+            - hold-for-tag
+
+  deploy-tag:
+    when:
+      and:
+        - equal: [push, << pipeline.trigger_source >>]
+        - exists: << pipeline.git.tag >>
+        - not:
+          matches:
+            pattern: ".*-SNAPSHOT$"
+            value: << pipeline.git.tag >>
+    jobs:
+      - hold-for-release:
+          type: approval
       - make-release:
-          requires:
-            - hold
+            requires:
+              - hold-for-release
       - push-revenuecat-pod:
           requires:
             - make-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1345,13 +1345,13 @@ workflows:
             value: << pipeline.git.branch >>
     jobs:
       - release-checks
-      - hold-for-tag:
+      - hold:
           type: approval
           requires:
             - release-checks
       - tag-release-branch:
           requires:
-            - hold-for-tag
+            - hold
 
   deploy-tag:
     when:
@@ -1363,11 +1363,7 @@ workflows:
             pattern: ".*-SNAPSHOT$"
             value: << pipeline.git.tag >>
     jobs:
-      - hold-for-release:
-          type: approval
-      - make-release:
-            requires:
-              - hold-for-release
+      - make-release
       - push-revenuecat-pod:
           requires:
             - make-release


### PR DESCRIPTION
The deploy workflow didn't run correctly, because of a regression introduced in #4025 . 

The problem is that we replaced the tag filters with a `when` clause, but the job itself was relying on us using the filter and running the second part of the deploy workflow from the tag itself and not the branch. 

I.e.: it wasn't entirely a chain of jobs, rather, there were two separate chains, one for releases and one for tags, running in the same job. 

This PR splits the jobs into two parts: one that creates the tag, and one that fires when a new tag is pushed, to create a release for it