### PR TITLE
Fix release release trains part 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1354,9 +1354,12 @@ workflows:
             - hold
 
   deploy-tag:
+    when:
+      not:
+        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - make-release:
-        <<: *release-tags
+          <<: *release-tags
       - push-revenuecat-pod:
           requires:
             - make-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1354,31 +1354,29 @@ workflows:
             - hold
 
   deploy-tag:
-    when:
-      and:
-        - equal: [push, << pipeline.trigger_source >>]
-        - exists: << pipeline.git.tag >>
-        - not:
-          matches:
-            pattern: ".*-SNAPSHOT$"
-            value: << pipeline.git.tag >>
     jobs:
-      - make-release
+      - make-release:
+        <<: *release-tags
       - push-revenuecat-pod:
           requires:
             - make-release
+          <<: *release-tags
       - push-revenuecatui-pod:
           requires:
             - push-revenuecat-pod
+          <<: *release-tags
       - deploy-to-spm:
           requires:
             - make-release
+          <<: *release-tags
       - docs-deploy:
           requires:
             - make-release
+          <<: *release-tags
       - deploy-purchase-tester:
           requires:
             - make-release
+          <<: *release-tags
       - notify-on-non-patch-release-branches:
           requires:
             - make-release


### PR DESCRIPTION
Follow-up to https://github.com/RevenueCat/purchases-ios/pull/4079, removes the `when` and re-introduces filters as the way to trigger the job since `when` doesn't seem to work for tags