### PR TITLE
Fix docs deploy and add manual trigger on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2.1
 parameters:
   action:
     type: enum
-    enum: [default, bump, run-manual-tests]
+    enum: [default, bump, run-manual-tests, run-manual-docs-deploy]
     default: default
   generate_snapshots:
     default: false
@@ -1422,6 +1422,12 @@ workflows:
       equal: [bump, << pipeline.parameters.action >>]
     jobs:
       - release-train
+
+  manual-trigger-docs-deploy:
+    when:
+      equal: [run-manual-docs-deploy, << pipeline.parameters.action >>]
+    jobs:
+      - docs-deploy
 
   # to trigger tests manually, log into circleCI, select the project, a branch, and then click "Trigger Pipeline"
   # and add a parameter called "run-manual-tests"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -835,36 +835,34 @@ platform :ios do
 
     hosting_base_path = File.join(docs_repo_name, version_number)
 
-    docs_path = Dir.mktmpdir do |docs_generation_folder|
-      # swift package must be run from the dir that contains the Package.swift
-      # output is generated in docs_generation_folder
-      Dir.chdir("..") do
-        build_symbols_for_docs
+    docs_generation_folder = Dir.mktmpdir
 
-        sh("swift",
-           "package",
-           "--disable-sandbox",
-           "--allow-writing-to-directory",
-           docs_generation_folder,
-           "generate-documentation",
-           "--target",
-           "RevenueCat",
-           "--disable-indexing", # Produces a DocC archive that is best-suited for hosting online but incompatible with Xcode.
-           "--platform",
-           "name=iOS,version=#{ios_version}",
-           "--output-path",
-           docs_generation_folder,
-           "--hosting-base-path",
-           hosting_base_path,
-           "--transform-for-static-hosting",
-           "--enable-inherited-docs",
-           "--additional-symbol-graph-dir", ".build")
-      end
+    # swift package must be run from the dir that contains the Package.swift
+    # output is generated in docs_generation_folder
+    Dir.chdir("..") do
+      build_symbols_for_docs
 
-      docs_generation_folder # returning path from block
+      sh("swift",
+          "package",
+          "--disable-sandbox",
+          "--allow-writing-to-directory",
+          docs_generation_folder,
+          "generate-documentation",
+          "--target",
+          "RevenueCat",
+          "--disable-indexing", # Produces a DocC archive that is best-suited for hosting online but incompatible with Xcode.
+          "--platform",
+          "name=iOS,version=#{ios_version}",
+          "--output-path",
+          docs_generation_folder,
+          "--hosting-base-path",
+          hosting_base_path,
+          "--transform-for-static-hosting",
+          "--enable-inherited-docs",
+          "--additional-symbol-graph-dir", ".build")
     end
 
-    docs_path # returning path from lane
+    docs_generation_folder # returning path from lane
   end
 
   desc "Build and deploy PurchaseTesterSwiftUI"


### PR DESCRIPTION
### Motivation

Fix failing docs

### Description

When `Dir.mktmpdir` uses a block, the temp dir is deleted at the end of the block. Not using the block syntax anymore so the temp dir lives the entire process.

Also adds `run-manual-docs-deploy` action to trigger docs manually for easy testing since Xcode 14 can't be run on macOS Sonoma.

#### Proof

Docs build and published in https://github.com/RevenueCat/purchases-ios-docs/commit/56b09af83637a6e40450062e805849a04ade6043

<img width="1439" alt="Screenshot 2024-07-17 at 8 14 05 PM" src="https://github.com/user-attachments/assets/5b614b8e-1022-47bd-a412-27b7f35115d1">

