### PR TITLE
[Customer Center] Updates the presentation of the refund status

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
@@ -66,10 +66,12 @@ class ManageSubscriptionsViewModel: ObservableObject {
     }
 
     init(screen: CustomerCenterConfigData.Screen,
-         subscriptionInformation: SubscriptionInformation) {
+         subscriptionInformation: SubscriptionInformation,
+         refundRequestStatusMessage: String? = nil) {
         self.screen = screen
         self.subscriptionInformation = subscriptionInformation
         self.purchasesProvider = ManageSubscriptionPurchases()
+        self.refundRequestStatusMessage = refundRequestStatusMessage
         state = .success
     }
 

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -194,11 +194,18 @@ struct SubscriptionDetailsView: View {
             }
 
             if let refundRequestStatusMessage = refundRequestStatusMessage {
-                Text("Refund request status: \(refundRequestStatusMessage)")
-                    .font(.caption)
-                    .bold()
-                    .foregroundColor(Color(UIColor.secondaryLabel))
-                    .padding([.horizontal, .bottom])
+                HStack(alignment: .center) {
+                    Image(systemName: "arrowshape.turn.up.backward")
+                        .accessibilityHidden(true)
+                        .frame(width: iconWidth)
+                    VStack(alignment: .leading) {
+                        Text("Refund status")
+                            .font(.caption2)
+                            .foregroundColor(Color(UIColor.secondaryLabel))
+                        Text("\(refundRequestStatusMessage)")
+                            .font(.caption)
+                    }
+                }
             }
         }.padding()
             .padding(.horizontal)

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -254,7 +254,8 @@ struct ManageSubscriptionsView_Previews: PreviewProvider {
     static var previews: some View {
         let viewModelMonthlyRenewing = ManageSubscriptionsViewModel(
             screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
-            subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing)
+            subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing,
+            refundRequestStatusMessage: "Refund granted successfully!")
         ManageSubscriptionsView(viewModel: viewModelMonthlyRenewing)
             .previewDisplayName("Monthly renewing")
 


### PR DESCRIPTION
As the title says. 

## Before
![Scherm­afbeelding 2024-07-18 om 15 49 00](https://github.com/user-attachments/assets/3d4b1e1e-f4cb-434e-9e6f-9859228dfd38)


## After
![Scherm­afbeelding 2024-07-18 om 15 50 56](https://github.com/user-attachments/assets/064d0298-8ade-4744-81b9-fc70e281ccb7)
