### PR TITLE
Fix workflow permission check logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1424,7 +1424,9 @@ workflows:
         - equal:
             - "run-manual-tests"
             - << pipeline.parameters.action >>
-        - equal: [ "run-from-github-comments", << pipeline.parameters.GHA_Event >>]
+        - equal: 
+            - "run-from-github-comments"
+            - << pipeline.parameters.GHA_Meta >>
     jobs:
       - backend-integration-tests-SK1
       - backend-integration-tests-SK2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1397,7 +1397,6 @@ workflows:
     jobs:
       - release-train
 
-
   daily-loadshedder-integration-tests:
     when:
       and:

--- a/.github/workflows/trigger_all_tests.yml
+++ b/.github/workflows/trigger_all_tests.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       ${{ github.event.issue.pull_request }} &&
-      github.event.comment.body == '@RCGitBot please test'
+      github.event.comment.body == '@RCGitBot please test' &&
+      github.repository == 'RevenueCat/purchases-ios'
 
     steps:
       - name: Check membership in RevenueCat Org

--- a/.github/workflows/trigger_all_tests.yml
+++ b/.github/workflows/trigger_all_tests.yml
@@ -29,6 +29,6 @@ jobs:
 
         uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0
         with:
-          GHA_Action: "run-from-github-comments"
+          GHA_Meta: "run-from-github-comments"
         env:
           CCI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}

--- a/.github/workflows/trigger_all_tests.yml
+++ b/.github/workflows/trigger_all_tests.yml
@@ -13,11 +13,13 @@ jobs:
 
     steps:
       - name: Check membership in RevenueCat Org
+        env:
+          READ_ORG_GITHUB_TOKEN: ${{ secrets.READ_ORG_GITHUB_TOKEN }}
         id: verify
         # ensure that only RevenueCat members can trigger this
         run: |
-          RESPONSE=$(curl https://api.github.com/orgs/RevenueCat/members/${{ github.event.comment.user.login }})
-          if [[ "$RESPONSE" == *"Not Found"* ]]; then
+          RESPONSE=$(curl -s -o /dev/null --head -w "%{http_code}" -H "Authorization: Bearer $READ_ORG_GITHUB_TOKEN" https://api.github.com/orgs/RevenueCat/members/${{ github.event.comment.user.login }})
+          if [[ "$RESPONSE" != "204" ]]; then
             echo "User is not a member of the organization"
             exit 1
           fi


### PR DESCRIPTION
### Description
This improves the permission checking logic for running github actions. We also have it setup to only run actions by organization members, but this acts as an additional check.