### PR TITLE
Fix prepare next version job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1045,6 +1045,7 @@ jobs:
     steps:
       - checkout
       - install-dependencies
+      - setup-git-credentials
       - trust-github-key
       - run:
           name: Prepare next version


### PR DESCRIPTION
### Description
I noticed the `prepare-next-version` job was failing due to missing github credentials. This should fix that.
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
