### PR TITLE
Move No subscriptions page strings to Localization

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -32,6 +32,9 @@ struct NoSubscriptionsView: View {
     @Environment(\.dismiss)
     var dismiss
 
+    @Environment(\.localization)
+    private var localization: CustomerCenterConfigData.Localization
+
     @State
     private var showRestoreAlert: Bool = false
 
@@ -41,25 +44,24 @@ struct NoSubscriptionsView: View {
 
     var body: some View {
         VStack {
-            Text("No Subscriptions found")
+            Text(localization.commonLocalizedString(for: .noSubscriptionsFound))
                 .font(.title)
                 .padding()
-            Text("We can try checking your Apple account for any previous purchases")
+            Text(localization.commonLocalizedString(for: .tryCheckRestore))
                 .font(.body)
                 .padding()
 
             Spacer()
 
-            Button("Restore purchases") {
+            Button(localization.commonLocalizedString(for: .restorePurchases)) {
                 showRestoreAlert = true
             }
             .restorePurchasesAlert(isPresented: $showRestoreAlert)
             .buttonStyle(ManageSubscriptionsButtonStyle())
 
-            Button("Cancel") {
+            Button(localization.commonLocalizedString(for: .cancel)) {
                 dismiss()
             }
-
         }
 
     }

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -42,18 +42,30 @@ public struct CustomerCenterConfigData {
         public enum CommonLocalizedString: String {
 
             case noThanks = "no_thanks"
+            case noSubscriptionsFound = "no_subscriptions_found"
+            case tryCheckRestore = "try_check_restore"
+            case restorePurchases = "restore_purchases"
+            case cancel = "cancel"
 
             var defaultValue: String {
                 switch self {
                 case .noThanks:
                     return "No, thanks"
+                case .noSubscriptionsFound:
+                    return "No Subscriptions found"
+                case .tryCheckRestore:
+                    return "We can try checking your Apple account for any previous purchases"
+                case .restorePurchases:
+                    return "Restore purchases"
+                case .cancel:
+                    return "Cancel"
                 }
             }
 
         }
 
         public func commonLocalizedString(for key: CommonLocalizedString) -> String {
-            return self.localizedStrings["common_\(key.rawValue)"] ?? key.defaultValue
+            return self.localizedStrings[key.rawValue] ?? key.defaultValue
         }
 
     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -215,8 +215,6 @@ extension SamplePaywallsList {
         switch action {
         case .restoreCompleted(_):
             print("CustomerCenter: restoreCompleted")
-        case .purchaseCompleted(_):
-            print("CustomerCenter: purchaseCompleted")
         case .restoreStarted:
             print("CustomerCenter: restoreStarted")
         case .restoreFailed(_):


### PR DESCRIPTION
### Description
This is based on the changes in #3968 

This PR:
- Moves the strings currently hardcode into the `CustomerCenterConfigData.Localization` object.
- Fixes an issue compiling paywall tester introduced in a previous PR
- Modifies how we read backend strings to not account for the `common_` prefix, which is already removed by the backend.
