### PR TITLE
PaywallsTester: fix macOS build

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -93,6 +93,7 @@ struct APIKeyDashboardList: View {
                             NavigationLink(
                                 destination: PaywallPresenter(offering: offering,
                                                               mode: .default,
+                                                              introEligility: .eligible,
                                                               displayCloseButton: false),
                                 tag: PresentedPaywall(offering: offering, mode: .default),
                                 selection: self.$presentedPaywall


### PR DESCRIPTION
macOS builds were failing when archiving, this fixes a broken API call
<img width="756" alt="image" src="https://github.com/user-attachments/assets/1d6616a7-2334-4f55-bbcd-19d3142f8744">
