### PR TITLE
Server Provided Backoff Interval Validation

### DIFF
--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -57,7 +57,7 @@ class OperationDispatcher {
         Self.dispatchOnMainActor(block)
     }
 
-    func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
+    func dispatchOnWorkerThread(delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
         if delay.hasDelay {
             self.workerQueue.asyncAfter(deadline: .now() + delay.random(), execute: block)
         } else {

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -676,7 +676,15 @@ extension HTTPClient {
         // Use the retry after value from the backend if present
         if let retryAfterHeaderValue = httpURLResponse.allHeaderFields[ResponseHeader.retryAfter.rawValue] as? String,
             let retryAfterMS = Double(retryAfterHeaderValue) {
-            return TimeInterval(milliseconds: retryAfterMS)
+
+            // Ensure that the retry interval is not negative or greater than 1 hour
+            let nonNegativeRetryAfterMS = max(0, retryAfterMS)
+            let cappedRetryInterval = min(
+                nonNegativeRetryAfterMS,
+                3_600_000   // 1 hour in milliseconds
+            )
+
+            return TimeInterval(milliseconds: cappedRetryInterval)
         }
 
         // Otherwise, use a default value

--- a/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
+++ b/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
@@ -60,7 +60,7 @@ class MockOperationDispatcher: OperationDispatcher {
     var invokedDispatchOnWorkerThreadDelayParam: JitterableDelay?
     var invokedDispatchOnWorkerThreadDelayParams: [JitterableDelay?] = []
 
-    override func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
+    override func dispatchOnWorkerThread(delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
         self.invokedDispatchOnWorkerThreadDelayParam = delay
         self.invokedDispatchOnWorkerThreadDelayParams.append(delay)
         self.invokedDispatchOnWorkerThread = true

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1775,6 +1775,49 @@ extension HTTPClientTests {
         expect(backoffPeriod).to(equal(TimeInterval(0.1)))  // 0.1s == 100ms
     }
 
+    func testUses0msBackoffIfServerProvidedBackoffIsNegative() {
+        let httpURLResponse = HTTPURLResponse(
+            url: URL(string: "api.revenuecat.com")!,
+            statusCode: HTTPStatusCode.tooManyRequests.rawValue,
+            httpVersion: nil,
+            headerFields: [
+                HTTPClient.ResponseHeader.retryAfter.rawValue: "-1"
+            ]
+        )!
+
+        let backoffPeriod = self.client.calculateRetryBackoffTime(forResponse: httpURLResponse, retryCount: 2)
+        expect(backoffPeriod).to(equal(TimeInterval(0)))
+    }
+
+    func testUses1hourBackoffIfServerProvidedBackoffIsGreaterThan1hour() {
+        let oneHourInMilliseconds = 3_600_000
+        let httpURLResponse = HTTPURLResponse(
+            url: URL(string: "api.revenuecat.com")!,
+            statusCode: HTTPStatusCode.tooManyRequests.rawValue,
+            httpVersion: nil,
+            headerFields: [
+                HTTPClient.ResponseHeader.retryAfter.rawValue: "\(oneHourInMilliseconds * 2)"
+            ]
+        )!
+
+        let backoffPeriod = self.client.calculateRetryBackoffTime(forResponse: httpURLResponse, retryCount: 2)
+        expect(backoffPeriod).to(equal(TimeInterval(milliseconds: Double(oneHourInMilliseconds))))
+    }
+
+    func testUsesDefaultBackoffIfServerProvidedBackoffIsEmptyString() {
+        let httpURLResponse = HTTPURLResponse(
+            url: URL(string: "api.revenuecat.com")!,
+            statusCode: HTTPStatusCode.tooManyRequests.rawValue,
+            httpVersion: nil,
+            headerFields: [
+                HTTPClient.ResponseHeader.retryAfter.rawValue: ""
+            ]
+        )!
+
+        let backoffPeriod = self.client.calculateRetryBackoffTime(forResponse: httpURLResponse, retryCount: 2)
+        expect(backoffPeriod).to(equal(TimeInterval(0.75)))
+    }
+
     func testUsesDefaultBackoffIfServerProvidedBackoffMissing() {
         let httpURLResponse = HTTPURLResponse(
             url: URL(string: "api.revenuecat.com")!,


### PR DESCRIPTION
This PR performs some validations on the server-provided retry backoff period. Specifically, it:
- Defaults to a backoff interval of 0ms if `Retry-After` is negative
- Caps the backoff interval from the `Retry-After` header at a maximum of 1 hour.
- Adds tests to verify the behavior
