### PR TITLE
Observe `PurchaseHandler` when owned externally

### DIFF
--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -20,7 +20,7 @@ struct PaywallViewConfiguration {
     var fonts: PaywallFontProvider
     var displayCloseButton: Bool
     var introEligibility: TrialOrIntroEligibilityChecker?
-    var purchaseHandler: PurchaseHandler?
+    var purchaseHandler: PurchaseHandler
 
     init(
         content: Content,
@@ -29,7 +29,7 @@ struct PaywallViewConfiguration {
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
-        purchaseHandler: PurchaseHandler? = nil
+        purchaseHandler: PurchaseHandler
     ) {
         self.content = content
         self.customerInfo = customerInfo


### PR DESCRIPTION
Josh kindly [fixed a problem](https://github.com/RevenueCat/purchases-ios/pull/4035) while I was away where the purchase handler would get clobbered when the paywall was re-rendered. This PR restores avoiding having one struct owned by two @StateObjects at the same time.