### PR TITLE
Server Provided Backoff Interval Validation

### DIFF
--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -57,7 +57,7 @@ class OperationDispatcher {
         Self.dispatchOnMainActor(block)
     }
 
-    func dispatchOnWorkerThread(delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
+    func dispatchOnWorkerThread(jitterableDelay delay: JitterableDelay = .none, block: @escaping @Sendable () -> Void) {
         if delay.hasDelay {
             self.workerQueue.asyncAfter(deadline: .now() + delay.random(), execute: block)
         } else {

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -686,7 +686,15 @@ extension HTTPClient {
         // Use the retry after value from the backend if present
         if let retryAfterHeaderValue = httpURLResponse.allHeaderFields[ResponseHeader.retryAfter.rawValue] as? String,
             let retryAfterMS = Double(retryAfterHeaderValue) {
-            return TimeInterval(milliseconds: retryAfterMS)
+
+            // Ensure that the retry interval is not negative or greater than 1 hour
+            let nonNegativeRetryAfterMS = max(0, retryAfterMS)
+            let cappedRetryInterval = min(
+                nonNegativeRetryAfterMS,
+                3_600_000   // 1 hour in milliseconds
+            )
+
+            return TimeInterval(milliseconds: cappedRetryInterval)
         }
 
         // Otherwise, use a default value


### PR DESCRIPTION
This PR performs some validations on the server-provided retry backoff period. Specifically, it:

- Defaults to a backoff interval of 0ms if Retry-After is negative
- Caps the backoff interval from the Retry-After header at a maximum of 1 hour.
- Adds tests to verify the behavior