### PR TITLE
Call AppTransaction.refresh() in certain scenarios if AppTransaction.shared is invalid

### DIFF
--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -106,7 +106,10 @@ final class TransactionPoster: TransactionPosterType {
             switch result {
             case .success(let encodedReceipt):
                 self.product(with: productIdentifier) { product in
-                    self.transactionFetcher.appTransactionJWS(refreshPolicy: .onlyIfEmpty) { appTransaction in
+                    // Only allow refreshing the AppTransaction if the source was a user action (e.g. purchase)
+                    let refreshPolicy: AppTransactionRefreshPolicy =
+                        data.source.initiationSource == .purchase ? .onlyIfEmpty : .never
+                    self.transactionFetcher.appTransactionJWS(refreshPolicy: refreshPolicy) { appTransaction in
                         self.postReceipt(transaction: transaction,
                                          purchasedTransactionData: data,
                                          receipt: encodedReceipt,

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -106,7 +106,7 @@ final class TransactionPoster: TransactionPosterType {
             switch result {
             case .success(let encodedReceipt):
                 self.product(with: productIdentifier) { product in
-                    self.transactionFetcher.appTransactionJWS { appTransaction in
+                    self.transactionFetcher.appTransactionJWS(refreshPolicy: .onlyIfEmpty) { appTransaction in
                         self.postReceipt(transaction: transaction,
                                          purchasedTransactionData: data,
                                          receipt: encodedReceipt,

--- a/Sources/Purchasing/StoreKit2/SK2AppTransaction.swift
+++ b/Sources/Purchasing/StoreKit2/SK2AppTransaction.swift
@@ -18,13 +18,15 @@ import StoreKit
 internal struct SK2AppTransaction {
 
     @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-    init(appTransaction: AppTransaction) {
+    init(appTransaction: AppTransaction, jwsRepresentation: String) {
         self.bundleId = appTransaction.bundleID
         self.originalApplicationVersion = appTransaction.originalAppVersion
         self.originalPurchaseDate = appTransaction.originalPurchaseDate
         self.environment = .init(environment: appTransaction.environment)
+        self.jwsRepresentation = jwsRepresentation
     }
 
+    let jwsRepresentation: String
     let bundleId: String
     let originalApplicationVersion: String?
     let originalPurchaseDate: Date?

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorCommonTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorCommonTests.swift
@@ -166,7 +166,7 @@ class PurchasesOrchestratorCommonTests: BasePurchasesOrchestratorTests {
     func testRestorePurchasesDoesNotLogWarningIfAllowSharingAppStoreAccountIsNotDefined() async throws {
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
 
-        _ = try? await self.orchestrator.syncPurchases(receiptRefreshPolicy: .never,
+        _ = try? await self.orchestrator.syncPurchases(receiptRefreshAllowed: false,
                                                        isRestore: false,
                                                        initiationSource: .restore)
 
@@ -182,7 +182,7 @@ class PurchasesOrchestratorCommonTests: BasePurchasesOrchestratorTests {
 
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
 
-        _ = try? await self.orchestrator.syncPurchases(receiptRefreshPolicy: .never,
+        _ = try? await self.orchestrator.syncPurchases(receiptRefreshAllowed: false,
                                                        isRestore: false,
                                                        initiationSource: .restore)
 
@@ -198,7 +198,7 @@ class PurchasesOrchestratorCommonTests: BasePurchasesOrchestratorTests {
 
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
 
-        _ = try? await self.orchestrator.syncPurchases(receiptRefreshPolicy: .never,
+        _ = try? await self.orchestrator.syncPurchases(receiptRefreshAllowed: false,
                                                        isRestore: false,
                                                        initiationSource: .restore)
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
@@ -582,7 +582,7 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
         self.customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         self.receiptParser.stubbedReceiptHasTransactionsResult = false
 
-        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                                      isRestore: false,
                                                                      initiationSource: .purchase)
         expect(self.backend.invokedPostReceiptData).to(beFalse())
@@ -596,7 +596,7 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
         self.customerInfoManager.stubbedCachedCustomerInfoResult = CustomerInfo.missingOriginalPurchaseDate
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
-        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                                      isRestore: true,
                                                                      initiationSource: .restore)
 
@@ -617,7 +617,7 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
     func testSyncPurchasesPostsReceipt() async throws {
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
-        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                                      isRestore: false,
                                                                      initiationSource: .purchase)
 
@@ -631,7 +631,7 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
         self.customerInfoManager.stubbedCachedCustomerInfoResult = nil
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
-        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                                      isRestore: true,
                                                                      initiationSource: .restore)
 
@@ -652,7 +652,7 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
     func testSyncPurchasesCallsSuccessDelegateMethod() async throws {
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
-        let receivedCustomerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+        let receivedCustomerInfo = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                                              isRestore: false,
                                                                              initiationSource: .purchase)
 
@@ -665,7 +665,7 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
         self.backend.stubbedPostReceiptResult = .failure(expectedError)
 
         do {
-            _ = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+            _ = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                           isRestore: false,
                                                           initiationSource: .purchase)
             fail("Expected error")

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -54,6 +54,7 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
                                             package: package,
                                             promotionalOffer: nil)
 
+        expect(self.mockTransactionFetcher.receivedRefreshPolicy) == .onlyIfEmpty
         expect(self.backend.invokedPostReceiptDataCount) == 1
         expect(self.backend.invokedPostReceiptData).to(beTrue())
         expect(self.backend.invokedPostReceiptDataParameters?.data) == .jws(transaction.jwsRepresentation!)
@@ -230,6 +231,7 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         self.productsManager.stubbedSk2StoreProductsResult = .success([product])
         let result = try await orchestrator.purchase(sk2Product: product, package: nil, promotionalOffer: nil)
 
+        expect(self.mockTransactionFetcher.receivedRefreshPolicy) == .onlyIfEmpty
         expect(result.transaction) == transaction.verifiedStoreTransaction
         expect(self.backend.invokedPostReceiptDataCount) == 1
         expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
@@ -468,6 +470,7 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
             updatedTransaction: transaction
         )
 
+        expect(self.mockTransactionFetcher.receivedRefreshPolicy) == .never
         expect(transaction.finishInvoked) == true
         expect(self.backend.invokedPostReceiptData) == true
         expect(self.backend.invokedPostReceiptDataParameters?.transactionData.source.isRestore) == false
@@ -543,6 +546,7 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
             updatedTransaction: transaction
         )
 
+        expect(self.mockTransactionFetcher.receivedRefreshPolicy) == .never
         expect(transaction.finishInvoked) == false
         expect(self.backend.invokedPostReceiptData) == true
         expect(self.backend.invokedPostReceiptDataParameters?.transactionData.source.isRestore) == false

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -570,9 +570,11 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         self.productsManager.stubbedSk2StoreProductsResult = .success([product])
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
-        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                                      isRestore: false,
                                                                      initiationSource: .purchase)
+
+        expect(self.mockTransactionFetcher.receivedRefreshPolicy) == .onlyIfEmpty
 
         expect(self.backend.invokedPostReceiptData).to(beTrue())
         expect(self.backend.invokedPostReceiptDataParameters?.data) == .jws(transaction.jwsRepresentation!)
@@ -620,9 +622,10 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         self.productsManager.stubbedSk2StoreProductsResult = .success([product])
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
-        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                                      isRestore: false,
                                                                      initiationSource: .purchase)
+        expect(self.mockTransactionFetcher.receivedRefreshPolicy) == .onlyIfEmpty
 
         expect(self.backend.invokedPostReceiptData).to(beTrue())
         expect(self.backend.invokedPostReceiptDataParameters?.data) == .sk2receipt(receipt)
@@ -634,11 +637,12 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = nil
         self.customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
 
-        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                                      isRestore: true,
                                                                      initiationSource: .restore)
 
         expect(self.backend.invokedPostReceiptData).to(beFalse())
+        expect(self.mockTransactionFetcher.receivedRefreshPolicy).to(beNil())
 
         expect(self.customerInfoManager.invokedCachedCustomerInfo).to(beTrue())
         expect(self.customerInfoManager.invokedCachedCustomerInfoCount) == 1
@@ -653,12 +657,13 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         self.customerInfoManager.stubbedCachedCustomerInfoResult = CustomerInfo.missingOriginalPurchaseDate
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
-        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                                      isRestore: true,
                                                                      initiationSource: .restore)
 
         expect(self.customerInfoManager.invokedCachedCustomerInfo).to(beTrue())
         expect(self.customerInfoManager.invokedCachedCustomerInfoCount) == 1
+        expect(self.mockTransactionFetcher.receivedRefreshPolicy) == .onlyIfEmpty
 
         expect(self.backend.invokedPostReceiptData).to(beTrue())
         expect(self.backend.invokedPostReceiptDataCount) == 1
@@ -680,12 +685,13 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         self.customerInfoManager.stubbedCachedCustomerInfoResult = CustomerInfo.missingOriginalApplicationVersion
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
-        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                                      isRestore: true,
                                                                      initiationSource: .restore)
 
         expect(self.customerInfoManager.invokedCachedCustomerInfo).to(beTrue())
         expect(self.customerInfoManager.invokedCachedCustomerInfoCount) == 1
+        expect(self.mockTransactionFetcher.receivedRefreshPolicy) == .onlyIfEmpty
 
         expect(self.backend.invokedPostReceiptData).to(beTrue())
         expect(self.backend.invokedPostReceiptDataCount) == 1
@@ -707,12 +713,13 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         self.customerInfoManager.stubbedCachedCustomerInfoResult = nil
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
-        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+        let customerInfo = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                                      isRestore: true,
                                                                      initiationSource: .restore)
 
         expect(self.customerInfoManager.invokedCachedCustomerInfo).to(beTrue())
         expect(self.customerInfoManager.invokedCachedCustomerInfoCount) == 1
+        expect(self.mockTransactionFetcher.receivedRefreshPolicy) == .onlyIfEmpty
 
         expect(self.backend.invokedPostReceiptData).to(beTrue())
         expect(self.backend.invokedPostReceiptDataCount) == 1
@@ -732,7 +739,7 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
 
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
-        let receivedCustomerInfo = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+        let receivedCustomerInfo = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                                              isRestore: false,
                                                                              initiationSource: .purchase)
 
@@ -748,7 +755,7 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         self.backend.stubbedPostReceiptResult = .failure(expectedError)
 
         do {
-            _ = try await self.orchestrator.syncPurchases(receiptRefreshPolicy: .always,
+            _ = try await self.orchestrator.syncPurchases(receiptRefreshAllowed: true,
                                                           isRestore: false,
                                                           initiationSource: .purchase)
             fail("Expected error")

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
@@ -22,6 +22,7 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
     private let _stubbedHasPendingConsumablePurchase: Atomic<Bool> = false
     private let _stubbedReceipt: Atomic<StoreKit2Receipt?> = .init(nil)
     private let _stubbedAppTransactionJWS: Atomic<String?> = .init(nil)
+    private let _receivedRefreshPolicy: Atomic<AppTransactionRefreshPolicy?> = .init(nil)
 
     var stubbedUnfinishedTransactions: [StoreTransaction] {
         get { return self._stubbedUnfinishedTransactions.value }
@@ -55,6 +56,11 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
         }
     }
 
+    var receivedRefreshPolicy: AppTransactionRefreshPolicy? {
+        get { return self._receivedRefreshPolicy.value }
+        set { self._receivedRefreshPolicy.value = newValue }
+    }
+
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func fetchReceipt(containing transaction: StoreTransactionType) async -> StoreKit2Receipt {
         return self.stubbedReceipt!
@@ -74,14 +80,17 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
         }
     }
 
-    var appTransactionJWS: String? {
-        get async {
-            return self.stubbedAppTransactionJWS
-        }
+    func appTransactionJWS(refreshPolicy: AppTransactionRefreshPolicy) async -> String? {
+        self.receivedRefreshPolicy = refreshPolicy
+        return self.stubbedAppTransactionJWS
     }
 
-    func appTransactionJWS(_ completion: @escaping (String?) -> Void) {
-        completion(self.stubbedAppTransactionJWS)
+    func appTransactionJWS(
+        refreshPolicy: AppTransactionRefreshPolicy,
+        _ completionHandler: @escaping (String?) -> Void
+    ) {
+        self.receivedRefreshPolicy = refreshPolicy
+        completionHandler(self.stubbedAppTransactionJWS)
     }
 
     // MARK: -


### PR DESCRIPTION
When `AppTransaction.shared` is empty or invalid, Apple recommends calling `AppTransaction.refresh().

https://developer.apple.com/documentation/storekit/apptransaction/4020517-refresh

Calling `refresh()` will always show an authentication prompt so we want to make sure we only call it in response to a user action

- After a purchase.
- When calling `restorePurchases`

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

`AppTransaction.shared` seems to be empty more often than expected. We're hoping refreshing it where applicable will improve the situation.

### Description
