### PR TITLE
Treat Retry-After Header As Seconds

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -685,16 +685,16 @@ extension HTTPClient {
     ) -> TimeInterval {
         // Use the retry after value from the backend if present
         if let retryAfterHeaderValue = httpURLResponse.allHeaderFields[ResponseHeader.retryAfter.rawValue] as? String,
-            let retryAfterMS = Double(retryAfterHeaderValue) {
+            let retryAfterSeconds = Double(retryAfterHeaderValue) {
 
             // Ensure that the retry interval is not negative or greater than 1 hour
-            let nonNegativeRetryAfterMS = max(0, retryAfterMS)
+            let nonNegativeRetryAfterSeconds = max(0, retryAfterSeconds)
             let cappedRetryInterval = min(
-                nonNegativeRetryAfterMS,
-                3_600_000   // 1 hour in milliseconds
+                nonNegativeRetryAfterSeconds,
+                3_600   // 1 hour in seconds
             )
 
-            return TimeInterval(milliseconds: cappedRetryInterval)
+            return TimeInterval(cappedRetryInterval)
         }
 
         // Otherwise, use a default value

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1869,7 +1869,7 @@ extension HTTPClientTests {
         )!
 
         let backoffPeriod = self.client.calculateRetryBackoffTime(forResponse: httpURLResponse, retryCount: 2)
-        expect(backoffPeriod).to(equal(TimeInterval(retryAfterSeconds)))  // 0.1s == 100ms
+        expect(backoffPeriod).to(equal(TimeInterval(retryAfterSeconds)))
     }
 
     func testUses0msBackoffIfServerProvidedBackoffIsNegative() {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1859,7 +1859,7 @@ extension HTTPClientTests {
     func testUsesServerProvidedBackoffIfPresent() {
         let retryAfterSeconds = 100
 
-        let httpURLResponse = HTTPURLResponse(
+        var httpURLResponse = HTTPURLResponse(
             url: URL(string: "api.revenuecat.com")!,
             statusCode: HTTPStatusCode.tooManyRequests.rawValue,
             httpVersion: nil,
@@ -1868,8 +1868,21 @@ extension HTTPClientTests {
             ]
         )!
 
-        let backoffPeriod = self.client.calculateRetryBackoffTime(forResponse: httpURLResponse, retryCount: 2)
+        var backoffPeriod = self.client.calculateRetryBackoffTime(forResponse: httpURLResponse, retryCount: 2)
         expect(backoffPeriod).to(equal(TimeInterval(retryAfterSeconds)))
+
+        let retryAfterSecondsDecimal = 10.5
+        httpURLResponse = HTTPURLResponse(
+            url: URL(string: "api.revenuecat.com")!,
+            statusCode: HTTPStatusCode.tooManyRequests.rawValue,
+            httpVersion: nil,
+            headerFields: [
+                HTTPClient.ResponseHeader.retryAfter.rawValue: "\(retryAfterSecondsDecimal)"
+            ]
+        )!
+
+        backoffPeriod = self.client.calculateRetryBackoffTime(forResponse: httpURLResponse, retryCount: 2)
+        expect(backoffPeriod).to(equal(TimeInterval(retryAfterSecondsDecimal)))
     }
 
     func testUses0msBackoffIfServerProvidedBackoffIsNegative() {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1857,19 +1857,19 @@ extension HTTPClientTests {
     }
 
     func testUsesServerProvidedBackoffIfPresent() {
-        let retryAfterMilliseconds = 100
+        let retryAfterSeconds = 100
 
         let httpURLResponse = HTTPURLResponse(
             url: URL(string: "api.revenuecat.com")!,
             statusCode: HTTPStatusCode.tooManyRequests.rawValue,
             httpVersion: nil,
             headerFields: [
-                HTTPClient.ResponseHeader.retryAfter.rawValue: "\(retryAfterMilliseconds)"
+                HTTPClient.ResponseHeader.retryAfter.rawValue: "\(retryAfterSeconds)"
             ]
         )!
 
         let backoffPeriod = self.client.calculateRetryBackoffTime(forResponse: httpURLResponse, retryCount: 2)
-        expect(backoffPeriod).to(equal(TimeInterval(0.1)))  // 0.1s == 100ms
+        expect(backoffPeriod).to(equal(TimeInterval(retryAfterSeconds)))  // 0.1s == 100ms
     }
 
     func testUses0msBackoffIfServerProvidedBackoffIsNegative() {
@@ -1887,18 +1887,18 @@ extension HTTPClientTests {
     }
 
     func testUses1hourBackoffIfServerProvidedBackoffIsGreaterThan1hour() {
-        let oneHourInMilliseconds = 3_600_000
+        let oneHourInSeconds = 3_600
         let httpURLResponse = HTTPURLResponse(
             url: URL(string: "api.revenuecat.com")!,
             statusCode: HTTPStatusCode.tooManyRequests.rawValue,
             httpVersion: nil,
             headerFields: [
-                HTTPClient.ResponseHeader.retryAfter.rawValue: "\(oneHourInMilliseconds * 2)"
+                HTTPClient.ResponseHeader.retryAfter.rawValue: "\(oneHourInSeconds * 2)"
             ]
         )!
 
         let backoffPeriod = self.client.calculateRetryBackoffTime(forResponse: httpURLResponse, retryCount: 2)
-        expect(backoffPeriod).to(equal(TimeInterval(milliseconds: Double(oneHourInMilliseconds))))
+        expect(backoffPeriod).to(equal(TimeInterval(Double(oneHourInSeconds))))
     }
 
     func testUsesDefaultBackoffIfServerProvidedBackoffIsEmptyString() {


### PR DESCRIPTION
### Motivation
The RevenueCat REST API v2's `Retry-After` header uses seconds instead of milliseconds, so we've decided to treat it as seconds to maintain consistency.

### Description
Adjusts the SDK to treat the `Retry-After` header's value as seconds instead of milliseconds.
