### PR TITLE
Only Retry POST Receipt Paths for 429

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -671,9 +671,11 @@ extension HTTPClient {
     internal func isResponseRetryable(_ urlResponse: HTTPURLResponse) -> Bool {
         let isStatusCodeRetryable = self.retriableStatusCodes.contains(urlResponse.httpStatusCode)
         let doesServerAllowRetryString = urlResponse.value(forHTTPHeaderField: ResponseHeader.isRetryable.rawValue)
-        var doesServerAllowRetry: Bool = true
+        let doesServerAllowRetry: Bool
         if let doesServerAllowRetryString = doesServerAllowRetryString {
             doesServerAllowRetry = Bool(doesServerAllowRetryString.lowercased()) ?? true
+        } else {
+            doesServerAllowRetry = true
         }
 
         return isStatusCodeRetryable && doesServerAllowRetry

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -626,8 +626,8 @@ extension HTTPClient {
         httpURLResponse: HTTPURLResponse?
     ) -> Bool {
 
-        guard let httpURLResponse = httpURLResponse,
-              request.httpRequest.isRetryable,
+        guard request.httpRequest.isRetryable,
+              let httpURLResponse = httpURLResponse,
               isResponseRetryable(httpURLResponse) else { return false }
 
         // At this point, retryCount hasn't been incremented yet, so we'll need to do it early here

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -22,7 +22,7 @@ struct HTTPRequest {
     var path: HTTPRequestPath
     /// If present, this will be used by the server to compute a checksum of the response signed with a private key.
     var nonce: Data?
-    /// Whether or not this reqeust should be retried by the HTTPClient for certain status codes.
+    /// Whether or not this request should be retried by the HTTPClient for certain status codes.
     var isRetryable: Bool
 
     init(

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -22,26 +22,49 @@ struct HTTPRequest {
     var path: HTTPRequestPath
     /// If present, this will be used by the server to compute a checksum of the response signed with a private key.
     var nonce: Data?
+    /// Whether or not this reqeust should be retried by the HTTPClient for certain status codes.
+    var isRetryable: Bool
 
-    init(method: Method, path: HTTPRequest.Path, nonce: Data? = nil) {
-        self.init(method: method, requestPath: path, nonce: nonce)
+    init(
+        method: Method,
+        path: HTTPRequest.Path,
+        nonce: Data? = nil,
+        isRetryable: Bool = false
+    ) {
+        self.init(method: method, requestPath: path, nonce: nonce, isRetryable: isRetryable)
     }
 
-    init(method: Method, path: HTTPRequest.PaywallPath, nonce: Data? = nil) {
-        self.init(method: method, requestPath: path, nonce: nonce)
+    init(
+        method: Method,
+        path: HTTPRequest.PaywallPath,
+        nonce: Data? = nil,
+        isRetryable: Bool = false
+    ) {
+        self.init(method: method, requestPath: path, nonce: nonce, isRetryable: isRetryable)
     }
 
-    init(method: Method, path: HTTPRequest.DiagnosticsPath, nonce: Data? = nil) {
-        self.init(method: method, requestPath: path, nonce: nonce)
+    init(
+        method: Method,
+        path: HTTPRequest.DiagnosticsPath,
+        nonce: Data? = nil,
+        isRetryable: Bool = false
+    ) {
+        self.init(method: method, requestPath: path, nonce: nonce, isRetryable: isRetryable)
     }
 
-    private init(method: Method, requestPath: HTTPRequestPath, nonce: Data? = nil) {
+    private init(
+        method: Method,
+        requestPath: HTTPRequestPath,
+        nonce: Data? = nil,
+        isRetryable: Bool = false
+    ) {
         assert(nonce == nil || nonce?.count == Data.nonceLength,
                "Invalid nonce: \(nonce?.description ?? "")")
 
         self.method = method
         self.path = requestPath
         self.nonce = nonce
+        self.isRetryable = isRetryable
     }
 
 }

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -97,7 +97,7 @@ final class PostReceiptDataOperation: CacheableNetworkOperation {
     }
 
     private func post(completion: @escaping () -> Void) {
-        let request = HTTPRequest(method: .post(self.postData), path: .postReceiptData)
+        let request = HTTPRequest(method: .post(self.postData), path: .postReceiptData, isRetryable: true)
 
         self.httpClient.perform(
             request

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -175,7 +175,7 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let result = try await self.purchases.productEntitlementMapping().entitlementsByProduct
-        expect(result).to(haveCount(18))
+        expect(result).to(haveCount(21))
         expect(result["com.revenuecat.monthly_4.99.1_week_intro"]) == ["premium"]
         expect(result["lifetime"]) == ["premium"]
         expect(result["com.revenuecat.intro_test.monthly.1_week_intro"]).to(beEmpty())
@@ -224,7 +224,8 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
     }
 
     func testDoesntRetryUnsupportedURLPaths() async throws {
-
+        defer { HTTPStubs.removeAllStubs() }
+        
         // Ensure that the each time POST /receipt is called, we mock a 429 error
         var stubbedRequestCount = 0
         let host = try XCTUnwrap(HTTPRequest.Path.serverHostURL.host)

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -225,7 +225,7 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
 
     func testDoesntRetryUnsupportedURLPaths() async throws {
         defer { HTTPStubs.removeAllStubs() }
-        
+
         // Ensure that the each time POST /receipt is called, we mock a 429 error
         var stubbedRequestCount = 0
         let host = try XCTUnwrap(HTTPRequest.Path.serverHostURL.host)

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -27,6 +27,12 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
         try await super.setUp()
     }
 
+    override func tearDown() async throws {
+        HTTPStubs.removeAllStubs()
+
+        try await super.tearDown()
+    }
+
     func testGetCustomerInfo() async throws {
         let info = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
         expect(info.entitlements.all).to(beEmpty())
@@ -224,8 +230,6 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
     }
 
     func testDoesntRetryUnsupportedURLPaths() async throws {
-        defer { HTTPStubs.removeAllStubs() }
-
         // Ensure that the each time POST /receipt is called, we mock a 429 error
         var stubbedRequestCount = 0
         let host = try XCTUnwrap(HTTPRequest.Path.serverHostURL.host)

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -12,11 +12,11 @@
 //  Created by Nacho Soto on 10/10/22.
 
 import Nimble
+import OHHTTPStubs
+import OHHTTPStubsSwift
 @testable import RevenueCat
 import StoreKitTest
 import XCTest
-import OHHTTPStubs
-import OHHTTPStubsSwift
 
 class OtherIntegrationTests: BaseBackendIntegrationTests {
 

--- a/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
@@ -17,7 +17,6 @@ import StoreKit
 import XCTest
 
 // swiftlint:disable type_name
-
 class BaseSignatureVerificationIntegrationTests: BaseStoreKitIntegrationTests {
 
     override var forceSignatureFailures: Bool { return self.invalidSignature }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -935,6 +935,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testVerifyPurchaseGrantsEntitlementsThroughOnRetryAfter429() async throws {
+        defer { HTTPStubs.removeAllStubs() }
 
         // Ensure that the first two times POST /receipt is called, we mock a 429 error
         // and then proceed normally with the backend on subsequent requests
@@ -966,6 +967,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testVerifyPurchaseDoesntGrantEntitlementsAfter429RetriesExhausted() async throws {
+        defer { HTTPStubs.removeAllStubs() }
 
         // Ensure that the each time POST /receipt is called, we mock a 429 error
         var stubbedRequestCount = 0
@@ -987,6 +989,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testVerifyPurchaseDoesntRetryIfIsRetryableHeaderIsFalse() async throws {
+        defer { HTTPStubs.removeAllStubs() }
 
         // Ensure that the each time POST /receipt is called, we mock a 429 error with the 
         // Is-Retryable header as "false"

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -120,6 +120,11 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
     override class var storeKitVersion: StoreKitVersion { .storeKit1 }
 
+    override func tearDown() async throws {
+        HTTPStubs.removeAllStubs()
+        try await super.tearDown()
+    }
+
     func testIsSandbox() throws {
         try expect(self.purchases.isSandbox) == true
     }
@@ -935,8 +940,6 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testVerifyPurchaseGrantsEntitlementsThroughOnRetryAfter429() async throws {
-        defer { HTTPStubs.removeAllStubs() }
-
         // Ensure that the first two times POST /receipt is called, we mock a 429 error
         // and then proceed normally with the backend on subsequent requests
         let host = try XCTUnwrap(HTTPRequest.Path.serverHostURL.host)
@@ -967,8 +970,6 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testVerifyPurchaseDoesntGrantEntitlementsAfter429RetriesExhausted() async throws {
-        defer { HTTPStubs.removeAllStubs() }
-
         // Ensure that the each time POST /receipt is called, we mock a 429 error
         var stubbedRequestCount = 0
         let host = try XCTUnwrap(HTTPRequest.Path.serverHostURL.host)
@@ -989,8 +990,6 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testVerifyPurchaseDoesntRetryIfIsRetryableHeaderIsFalse() async throws {
-        defer { HTTPStubs.removeAllStubs() }
-
         // Ensure that the each time POST /receipt is called, we mock a 429 error with the 
         // Is-Retryable header as "false"
         var stubbedRequestCount = 0

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1712,7 +1712,7 @@ extension HTTPClientTests {
     func testOnlyRetriesProvidedHTTPStatusCodesIfIsRetryableHeaderMissing() {
         expect(self.client.isRetryable(
             HTTPURLResponse(
-                url: URL(string: "api.revenuecat.com")!,
+                url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
                 statusCode: HTTPStatusCode.tooManyRequests.rawValue,
                 httpVersion: nil,
                 headerFields: nil
@@ -1720,7 +1720,7 @@ extension HTTPClientTests {
         )).to(beTrue())
         expect(self.client.isRetryable(
             HTTPURLResponse(
-                url: URL(string: "api.revenuecat.com")!,
+                url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
                 statusCode: HTTPStatusCode.invalidRequest.rawValue,
                 httpVersion: nil,
                 headerFields: nil
@@ -1731,7 +1731,7 @@ extension HTTPClientTests {
     func testWontRetryIfIsRetryableHeaderFalse() {
         expect(self.client.isRetryable(
             HTTPURLResponse(
-                url: URL(string: "api.revenuecat.com")!,
+                url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
                 statusCode: HTTPStatusCode.tooManyRequests.rawValue,
                 httpVersion: nil,
                 headerFields: [
@@ -1742,7 +1742,7 @@ extension HTTPClientTests {
 
         expect(self.client.isRetryable(
             HTTPURLResponse(
-                url: URL(string: "api.revenuecat.com")!,
+                url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
                 statusCode: HTTPStatusCode.tooManyRequests.rawValue,
                 httpVersion: nil,
                 headerFields: [
@@ -1753,7 +1753,7 @@ extension HTTPClientTests {
 
         expect(self.client.isRetryable(
             HTTPURLResponse(
-                url: URL(string: "api.revenuecat.com")!,
+                url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
                 statusCode: HTTPStatusCode.tooManyRequests.rawValue,
                 httpVersion: nil,
                 headerFields: [
@@ -1766,7 +1766,7 @@ extension HTTPClientTests {
     func testWillRetryIfIsRetryableHeaderTrue() {
         expect(self.client.isRetryable(
             HTTPURLResponse(
-                url: URL(string: "api.revenuecat.com")!,
+                url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
                 statusCode: HTTPStatusCode.tooManyRequests.rawValue,
                 httpVersion: nil,
                 headerFields: [
@@ -1777,7 +1777,7 @@ extension HTTPClientTests {
 
         expect(self.client.isRetryable(
             HTTPURLResponse(
-                url: URL(string: "api.revenuecat.com")!,
+                url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
                 statusCode: HTTPStatusCode.tooManyRequests.rawValue,
                 httpVersion: nil,
                 headerFields: [
@@ -1788,7 +1788,7 @@ extension HTTPClientTests {
 
         expect(self.client.isRetryable(
             HTTPURLResponse(
-                url: URL(string: "api.revenuecat.com")!,
+                url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
                 statusCode: HTTPStatusCode.tooManyRequests.rawValue,
                 httpVersion: nil,
                 headerFields: [
@@ -1801,7 +1801,7 @@ extension HTTPClientTests {
     func testWillNotRetryIfIsRetryableHeaderTrueButStatusCodeIsNotRetryable() {
         expect(self.client.isRetryable(
             HTTPURLResponse(
-                url: URL(string: "api.revenuecat.com")!,
+                url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
                 statusCode: HTTPStatusCode.success.rawValue,
                 httpVersion: nil,
                 headerFields: [
@@ -1814,7 +1814,7 @@ extension HTTPClientTests {
     // Backoff Time Tests
     func testUsesNoBackoffIfFirstRetryAndNoETagPresent() {
         var httpURLResponse = HTTPURLResponse(
-            url: URL(string: "api.revenuecat.com")!,
+            url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
             statusCode: HTTPStatusCode.tooManyRequests.rawValue,
             httpVersion: nil,
             headerFields: [:]
@@ -1824,7 +1824,7 @@ extension HTTPClientTests {
         expect(backoffPeriod).to(equal(TimeInterval(0)))
 
         httpURLResponse = HTTPURLResponse(
-            url: URL(string: "api.revenuecat.com")!,
+            url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
             statusCode: HTTPStatusCode.tooManyRequests.rawValue,
             httpVersion: nil,
             headerFields: [HTTPClient.ResponseHeader.eTag.rawValue: ""]
@@ -1836,7 +1836,7 @@ extension HTTPClientTests {
 
     func testUsesBackoffIfFirstRetryAndETagPresent() {
         var httpURLResponse = HTTPURLResponse(
-            url: URL(string: "api.revenuecat.com")!,
+            url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
             statusCode: HTTPStatusCode.tooManyRequests.rawValue,
             httpVersion: nil,
             headerFields: [:]
@@ -1846,7 +1846,7 @@ extension HTTPClientTests {
         expect(backoffPeriod).to(equal(TimeInterval(0)))
 
         httpURLResponse = HTTPURLResponse(
-            url: URL(string: "api.revenuecat.com")!,
+            url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
             statusCode: HTTPStatusCode.tooManyRequests.rawValue,
             httpVersion: nil,
             headerFields: [HTTPClient.ResponseHeader.eTag.rawValue: "some-etag-value"]
@@ -1860,7 +1860,7 @@ extension HTTPClientTests {
         let retryAfterSeconds = 100
 
         var httpURLResponse = HTTPURLResponse(
-            url: URL(string: "api.revenuecat.com")!,
+            url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
             statusCode: HTTPStatusCode.tooManyRequests.rawValue,
             httpVersion: nil,
             headerFields: [
@@ -1873,7 +1873,7 @@ extension HTTPClientTests {
 
         let retryAfterSecondsDecimal = 10.5
         httpURLResponse = HTTPURLResponse(
-            url: URL(string: "api.revenuecat.com")!,
+            url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
             statusCode: HTTPStatusCode.tooManyRequests.rawValue,
             httpVersion: nil,
             headerFields: [
@@ -1887,7 +1887,7 @@ extension HTTPClientTests {
 
     func testUses0msBackoffIfServerProvidedBackoffIsNegative() {
         let httpURLResponse = HTTPURLResponse(
-            url: URL(string: "api.revenuecat.com")!,
+            url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
             statusCode: HTTPStatusCode.tooManyRequests.rawValue,
             httpVersion: nil,
             headerFields: [
@@ -1902,7 +1902,7 @@ extension HTTPClientTests {
     func testUses1hourBackoffIfServerProvidedBackoffIsGreaterThan1hour() {
         let oneHourInSeconds = 3_600
         let httpURLResponse = HTTPURLResponse(
-            url: URL(string: "api.revenuecat.com")!,
+            url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
             statusCode: HTTPStatusCode.tooManyRequests.rawValue,
             httpVersion: nil,
             headerFields: [
@@ -1916,7 +1916,7 @@ extension HTTPClientTests {
 
     func testUsesDefaultBackoffIfServerProvidedBackoffIsEmptyString() {
         let httpURLResponse = HTTPURLResponse(
-            url: URL(string: "api.revenuecat.com")!,
+            url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
             statusCode: HTTPStatusCode.tooManyRequests.rawValue,
             httpVersion: nil,
             headerFields: [
@@ -1930,7 +1930,7 @@ extension HTTPClientTests {
 
     func testUsesDefaultBackoffIfServerProvidedBackoffMissing() {
         let httpURLResponse = HTTPURLResponse(
-            url: URL(string: "api.revenuecat.com")!,
+            url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
             statusCode: HTTPStatusCode.tooManyRequests.rawValue,
             httpVersion: nil,
             headerFields: [:]
@@ -1949,7 +1949,7 @@ extension HTTPClientTests {
             return .emptyTooManyRequestsResponse()
         }
 
-        let request = HTTPRequest(method: .get, path: .mockPath)
+        let request = HTTPRequest(method: .get, path: .receiptPath)
         let result = waitUntilValue { completion in
             self.client.perform(request) { (response: EmptyResponse) in
                 completion(response)
@@ -1980,7 +1980,7 @@ extension HTTPClientTests {
         let mockOperationDispatcher = MockOperationDispatcher()
         let client = self.createClient(self.systemInfo, operationDispatcher: mockOperationDispatcher)
 
-        let request = HTTPRequest(method: .get, path: .mockPath)
+        let request = HTTPRequest(method: .get, path: .receiptPath)
         _ = waitUntilValue { completion in
             client.perform(request) { (response: EmptyResponse) in
                 completion(response)
@@ -2004,22 +2004,22 @@ extension HTTPClientTests {
             return .emptyTooManyRequestsResponse()
         }
 
-        let request = HTTPRequest(method: .get, path: .mockPath)
+        let request = HTTPRequest(method: .get, path: .receiptPath)
         _ = waitUntilValue { completion in
             self.client.perform(request) { (response: EmptyResponse) in
                 completion(response)
             }
         }
         self.logger.verifyMessageWasLogged(
-            "Queued request GET /v1/subscribers/identify for retry number 1 in 0.0 seconds."
+            "Queued request GET /v1/receipts for retry number 1 in 0.0 seconds."
         )
         self.logger.verifyMessageWasLogged(
-            "Queued request GET /v1/subscribers/identify for retry number 2 in 0.75 seconds."
+            "Queued request GET /v1/receipts for retry number 2 in 0.75 seconds."
         )
         self.logger.verifyMessageWasLogged(
-            "Queued request GET /v1/subscribers/identify for retry number 3 in 3.0 seconds."
+            "Queued request GET /v1/receipts for retry number 3 in 3.0 seconds."
         )
-        self.logger.verifyMessageWasLogged("Request GET /v1/subscribers/identify failed all 3 retries.")
+        self.logger.verifyMessageWasLogged("Request GET /v1/receipts failed all 3 retries.")
     }
 
     func testRetryMessagesAreNotLoggedWhenNoRetriesOccur() throws {
@@ -2066,6 +2066,23 @@ extension HTTPClientTests {
         expect(retryCountHeaderValues).to(equal(["0"]))
     }
 
+    func testDoesNotRetryUnsupportedURLPaths() throws {
+        let host = try XCTUnwrap(HTTPRequest.Path.serverHostURL.host)
+        var requestCount = 0
+        stub(condition: isHost(host)) { _ in
+            requestCount += 1
+            return .emptyTooManyRequestsResponse()
+        }
+
+        let request = HTTPRequest(method: .get, path: .mockPath) // This is the logIn path
+        _ = waitUntilValue { completion in
+            self.client.perform(request) { (response: EmptyResponse) in
+                completion(response)
+            }
+        }
+        expect(requestCount).to(equal(1))
+    }
+
     func testRetryCountHeaderIsAccurateWithOnlyOneRetry() throws {
         var retryCountHeaderValues: [String?] = []
         var retryCount = 0
@@ -2084,7 +2101,7 @@ extension HTTPClientTests {
             }
         }
 
-        let request = HTTPRequest(method: .get, path: .mockPath)
+        let request = HTTPRequest(method: .get, path: .receiptPath)
         _ = waitUntilValue { completion in
             self.client.perform(request) { (response: EmptyResponse) in
                 completion(response)
@@ -2104,7 +2121,7 @@ extension HTTPClientTests {
             return .emptyTooManyRequestsResponse()
         }
 
-        let request = HTTPRequest(method: .get, path: .mockPath)
+        let request = HTTPRequest(method: .get, path: .receiptPath)
         _ = waitUntilValue { completion in
             self.client.perform(request) { (response: EmptyResponse) in
                 completion(response)
@@ -2127,7 +2144,7 @@ extension HTTPClientTests {
             }
         }
 
-        let request = HTTPRequest(method: .get, path: .mockPath)
+        let request = HTTPRequest(method: .get, path: .receiptPath)
         let result = waitUntilValue { completion in
             self.client.perform(request) { (response: EmptyResponse) in
                 completion(response)
@@ -2139,16 +2156,16 @@ extension HTTPClientTests {
         expect(result).to(beSuccess())
 
         self.logger.verifyMessageWasLogged(
-            "Queued request GET /v1/subscribers/identify for retry number 1 in 0.0 seconds."
+            "Queued request GET /v1/receipts for retry number 1 in 0.0 seconds."
         )
         self.logger.verifyMessageWasNotLogged(
-            "Queued request GET /v1/subscribers/identify for retry number 2 in 0.75 seconds."
+            "Queued request GET /v1/receipts for retry number 2 in 0.75 seconds."
         )
         self.logger.verifyMessageWasNotLogged(
-            "Queued request GET /v1/subscribers/identify for retry number 3 in 3.0 seconds."
+            "Queued request GET /v1/receipts for retry number 3 in 3.0 seconds."
         )
         self.logger.verifyMessageWasNotLogged(
-            "Request GET /v1/subscribers/identify failed all 3 retries."
+            "Request GET /v1/receipts failed all 3 retries."
         )
 
         expect(self.signing.requests).to(beEmpty())
@@ -2173,7 +2190,7 @@ extension HTTPClientTests {
         let didRetry = client.retryRequestIfNeeded(
             request: buildEmptyRequest(),
             httpURLResponse: HTTPURLResponse(
-                url: URL(string: "api.revenuecat.com")!,
+                url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
                 statusCode: HTTPStatusCode.success.rawValue,
                 httpVersion: nil,
                 headerFields: nil
@@ -2198,7 +2215,7 @@ extension HTTPClientTests {
         let didRetry = client.retryRequestIfNeeded(
             request: requestThatHasBeenRetriedManyTimes,
             httpURLResponse: HTTPURLResponse(
-                url: URL(string: "api.revenuecat.com")!,
+                url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
                 statusCode: HTTPStatusCode.tooManyRequests.rawValue,
                 httpVersion: nil,
                 headerFields: nil
@@ -2217,7 +2234,7 @@ extension HTTPClientTests {
         let didRetry = client.retryRequestIfNeeded(
             request: requestThatHasBeenRetriedManyTimes,
             httpURLResponse: HTTPURLResponse(
-                url: URL(string: "api.revenuecat.com")!,
+                url: URL(string: "https://api.revenuecat.com/v1/receipts")!,
                 statusCode: HTTPStatusCode.tooManyRequests.rawValue,
                 httpVersion: nil,
                 headerFields: nil
@@ -2337,6 +2354,7 @@ extension HTTPRequest.Path {
 
     // Doesn't matter which path this is, we stub requests to it.
     static let mockPath: Self = .logIn
+    static let receiptPath: Self = .postReceiptData
 
 }
 

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -250,4 +250,13 @@ class HTTPRequestTests: TestCase {
         expect(request.requestAddingNonceIfRequired(with: mode).nonce).toNot(beNil())
     }
 
+    func testRequestIsNotRetryableByDefault() {
+        let request: HTTPRequest = .init(method: .get, path: .getCustomerInfo(appUserID: "user"))
+        expect(request.isRetryable).to(beFalse())
+    }
+
+    func testRequestIsRetryableIfSet() {
+        let request: HTTPRequest = .init(method: .get, path: .getCustomerInfo(appUserID: "user"), isRetryable: true)
+        expect(request.isRetryable).to(beTrue())
+    }
 }


### PR DESCRIPTION
### Description
This PR modifies the HTTPClient's retry logic to only perform retries on requests to the `/v1/receipts` URL path that result in a 429 status code.

#### Testing
- Updated existing tests to set the `isRetryable` field correctly
- Added unit tests to `HTTPClient.Request` to ensure that the `isRetryable` field is being set properly
- Wrote new unit & integration tests to ensure that we don't retry requests to unsupported endpoints (like `/v1/subscribers/identify`)
