### PR TITLE
[External] Add missing SwiftUI environment for previews

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppList.swift
@@ -49,4 +49,5 @@ struct AppList: View {
 
 #Preview {
     AppList()
+    .environment(ApplicationData())
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginWall.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginWall.swift
@@ -52,4 +52,5 @@ struct LoginWall<ContentView: View>: View {
             Text("Developer \(developer.name) is now signed in.")
         }
     }
+    .environment(ApplicationData())
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
These two previews were crashing due to expecting objects in the SwiftUI environments that were not added in the preview provider

### Description
Adds the two missing environment objects, tested by uploading to emerge and confirming the snapshots of these previews rendered without crashing
