### PR TITLE
Re-added the RevenueCatUI tests job on every commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -569,7 +569,7 @@ jobs:
           name: RevenueCatUI API Tests
           command: bundle exec fastlane build_revenuecatui_api_tester
 
-  spm-revenuecat-ui-ios-17:
+  run-revenuecat-ui-ios-17:
     <<: *base-job
     parameters:
       xcode_version:
@@ -1269,7 +1269,7 @@ workflows:
     jobs:
       - spm-revenuecat-ui-ios-15
       - spm-revenuecat-ui-ios-16
-      - spm-revenuecat-ui-ios-17
+      - run-revenuecat-ui-ios-17
 
   build-test:
     when:
@@ -1279,14 +1279,10 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      - lint:
-          name: "swiftlint"
-      - run-test-ios-17:
-          name: "Unit tests"
-      - pod-lib-lint:
-          name: "Pod lib lint"
-      - spm-revenuecat-ui-ios-17:
-          name: "RevenueCatUI tests"
+      - lint
+      - run-test-ios-17
+      - pod-lib-lint
+      - run-revenuecat-ui-ios-17
 
   create-tag:
     when:
@@ -1411,7 +1407,7 @@ workflows:
       - spm-release-build-xcode-15
       - spm-revenuecat-ui-ios-15
       - spm-revenuecat-ui-ios-16
-      - spm-revenuecat-ui-ios-17
+      - run-revenuecat-ui-ios-17
       - spm-revenuecat-ui-watchos
       - installation-tests-cocoapods
       - installation-tests-swift-package-manager

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1279,9 +1279,14 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      - lint
-      - run-test-ios-17
-      - pod-lib-lint
+      - lint:
+          name: "swiftlint"
+      - run-test-ios-17:
+          name: "Unit tests"
+      - pod-lib-lint:
+          name: "Pod lib lint"
+      - spm-revenuecat-ui-ios-17:
+          name: "RevenueCatUI tests"
 
   create-tag:
     when:


### PR DESCRIPTION
I realized that we weren't running the suite of tests from RevenueCatUI in every commit. 

I missed this one because the name made it seem like it was a test specific to SPM, but it's just that it could only be run through SPM at the time. 

It can now be run from Xcode, but that's a separate story, so for now this just re-adds it and clarifies the naming a bit