### PR TITLE
Fixes trigger_all_tests.yml triggering on every issue comment

### DIFF
--- a/.github/workflows/trigger_all_tests.yml
+++ b/.github/workflows/trigger_all_tests.yml
@@ -8,7 +8,7 @@ jobs:
   trigger-circleci:
     runs-on: ubuntu-latest
     if: |
-      ${{ github.event.issue.pull_request }} &&
+      github.event.issue.pull_request &&
       github.event.comment.body == '@RCGitBot please test' &&
       github.repository == 'RevenueCat/purchases-ios'
 


### PR DESCRIPTION
## Bug
The `trigger_all_tests.yml` workflow triggers for every issue comment. It doesn't check that the comment body matches "\@RCGitBot please test". 

You can see this if you check [the latest workflow runs](https://github.com/RevenueCat/purchases-ios/actions/workflows/trigger_all_tests.yml), and click a few of the comments in that list.

For example, [this run](https://github.com/RevenueCat/purchases-ios/actions/runs/10083907383) was triggered by this comment:
> This does add noise to the overall schemes in Xcode, let me know if that feels like a bit too much

Also, these workflow runs all fail. 

## Fix
Checking [rhysd.github.io/actionlint](https://rhysd.github.io/actionlint/#eJx9VNtu2kAQffdXTF2ai1TbSdQnV0ghLiKobYgIeUojy6wHvI3ZdfcCpSn/3rGxCRDSN3t2zpnZM2dHJDMMYaT4dIoKOnkOI9RGO44UoQPAtbYYMzmboTBlAMAsC9QhPDCFicH00XF+yrEuz8yaxWNcsRwZX+crK7RHbGDHVhjr5YTSpjrikxD+Vl8ArednmHKT2bGPcyrmV6X9wuZ5rPCXJQysVnB0VOfv5NYN+mOZLqHdhuPLYdTj5koaKHJMNEJZ8/gVWmEhNTdSrVHDks1ilJigsIplBNQel/rYqWDaYKHDmsEDUUkXZcieYIazMSqd8QK4gBceGKhpDQBAMQ83PwDDbudLPBj24l5/dH1/FY8GX7s3YSWERlLXaP9gCsmwYeFpCHNUfLLchN5THW0VXTmj+lLky+1+6kaBJaKZFyVy7UOHMalSLqZgJPQqfSCVTH9cc1ycfdoqoVAXUpCuTKZIbFKtI2kJbmrICVEjSDVNBP+TGC6Fv+EgW7wMfy3H3e3g5q7bbp0wq3LwNHgSghTngSATwI+tXJLfyzBJ94MLcD88Z8YUcdnXyt0/vwa3Y00mVd1OCFeYKJKgdVDpfXzJrMMgSAru1w4i5wV0QR1seae+f/DK0o1NrUbl53JKVlmtTrdK8Ak8PIDbarRw4V0bXJLehcfHz6WaYqchZJkE957o6KWCILsntfqHxHd3sb+5gfOt0IQ7bzH/n3XvRTTLJKrWQNSHhVRPk1wudlxbmy9ulkX8Oou2g7aModYnp84mTOLR+mnIvVs7zjkL9nePV/ACcy7QS1jZ5eX83L/wzzYsC5rL9mPsXXfi72iSEFxypjdRcuatZ+fVU9PuWw85ivqHHm/UH0bfus0ZTfofBySdhg==) for the `trigger_all_tests.yml` file at [68ac257](https://github.com/RevenueCat/purchases-ios/tree/68ac25722987f318bc6dd93c9fae5eb90e270f3d) (HEAD of `main` at the time of writing) shows this error: 

>if: condition "${{ github.event.issue.pull_request }} &&\ngithub.event.comment.body == '@RCGitBot please test' &&\ngithub.repository == 'RevenueCat/purchases-ios'\n" **is always evaluated to true** because extra characters are around ${{ }} 

The fix is to remove the curly braces altogether. Omitting the curly braces is okay in `if` conditions, according to [the GitHub Actions docs](https://docs.github.com/en/actions/learn-github-actions/expressions):
>The exception to this rule is when you are using expressions in an if clause, where, optionally, you can usually omit `${{` and `}}`.
 
(I tried moving the closing curly braces (`}}`) to the end of the last condition, but that didn't please the linter.)