### PR TITLE
Allow user to set the paywall content max width

### DIFF
--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -142,8 +142,10 @@ struct BackgroundedTemplateView: ViewModifier {
     let configuration: TemplateViewConfiguration
 
     func body(content: Content) -> some View {
-        content
-            .background(configuration.backgroundView)
+        ZStack {
+            configuration.backgroundView
+            content
+        }
     }
 }
 

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -141,11 +141,15 @@ extension PaywallData {
 struct BackgroundedTemplateView: ViewModifier {
     let configuration: TemplateViewConfiguration
 
+    @Environment(\.contentMaxWidth)
+    private var contentMaxWidth
+
     func body(content: Content) -> some View {
         ZStack {
             configuration.backgroundView
                 .frame(minWidth: 0, maxWidth: .infinity)
             content
+                .frame(maxWidth: contentMaxWidth)
         }
     }
 }

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -235,3 +235,18 @@ private extension TemplateViewConfiguration {
     }
 
 }
+
+// MARK: -
+
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
+private struct ContentMaxWidthKey: EnvironmentKey {
+    static let defaultValue: CGFloat = .infinity
+}
+
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
+extension EnvironmentValues {
+    var contentMaxWidth: CGFloat {
+        get { self[ContentMaxWidthKey.self] }
+        set { self[ContentMaxWidthKey.self] = newValue }
+    }
+}

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -144,6 +144,7 @@ struct BackgroundedTemplateView: ViewModifier {
     func body(content: Content) -> some View {
         ZStack {
             configuration.backgroundView
+                .frame(minWidth: 0, maxWidth: .infinity)
             content
         }
     }

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -138,6 +138,16 @@ extension PaywallData {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct BackgroundedTemplateView: ViewModifier {
+    let configuration: TemplateViewConfiguration
+
+    func body(content: Content) -> some View {
+        content
+            .background(configuration.backgroundView)
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
     func adaptTemplateView(with configuration: TemplateViewConfiguration) -> some View {

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -152,7 +152,7 @@ extension View {
 
     func adaptTemplateView(with configuration: TemplateViewConfiguration) -> some View {
         self
-            .background(configuration.backgroundView)
+            .modifier(BackgroundedTemplateView(configuration: configuration))
             .adjustColorScheme(with: configuration)
             .adjustSize(with: configuration.mode)
     }

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -251,7 +251,7 @@ private struct ContentMaxWidthKey: EnvironmentKey {
 }
 
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
-extension EnvironmentValues {
+public extension EnvironmentValues {
     var contentMaxWidth: CGFloat {
         get { self[ContentMaxWidthKey.self] }
         set { self[ContentMaxWidthKey.self] = newValue }

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -141,7 +141,7 @@ extension PaywallData {
 struct BackgroundedTemplateView: ViewModifier {
     let configuration: TemplateViewConfiguration
 
-    @Environment(\.contentMaxWidth)
+    @Environment(\.paywallContentMaxWidth)
     private var contentMaxWidth
 
     func body(content: Content) -> some View {
@@ -252,7 +252,7 @@ private struct ContentMaxWidthKey: EnvironmentKey {
 
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
 public extension EnvironmentValues {
-    var contentMaxWidth: CGFloat {
+    var paywallContentMaxWidth: CGFloat {
         get { self[ContentMaxWidthKey.self] }
         set { self[ContentMaxWidthKey.self] = newValue }
     }


### PR DESCRIPTION
## Motivation

Sometimes, it's not ideal to use the entire width of the screen for the paywall.

## ↔️ Default Look
For example, a fullscreen paywall on an iPad looks like this by default:
![old](https://github.com/user-attachments/assets/a4a3b086-609f-48b2-b3e2-335afaf7e9a9)
<sub>☝️ This is a 10-inch iPad, but imagine a 13-inch!</sub>

This extremely wide content looks off, doesn't it? Who needs a button that's `2752 px` (or `1376 pt`) wide?! 😱

---

## ✅ Customized with the New API
By limiting it to a more readable size, it looks like this:
![new](https://github.com/user-attachments/assets/f147f2d3-9baf-4b3b-9bef-982cd5e60dc9)

Much better, right?

### 💡 Usage
```swift
PaywallView()
    .environment(\.paywallContentMaxWidth, UIViewController().view.readableContentGuide.layoutFrame.size.width)
```
<sub>☝️ I used the native `readableContentGuide` as Apple suggested for the device here, but the user can pass any value that suits them.</sub>