### PR TITLE
[Customer Center] Make cancel subscription less prominent

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -303,7 +303,9 @@ struct ManageSubscriptionButton: View {
                                  product: promotionalOfferData.product,
                                  promoOfferDetails: promotionalOfferData.promoOfferDetails)
         })
-        .buttonStyle(ManageSubscriptionsButtonStyle())
+        .applyIf(self.path.type != .cancel) {
+            $0.buttonStyle(ManageSubscriptionsButtonStyle())
+        }
         .disabled(self.viewModel.loadingPath != nil)
     }
 }

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -306,6 +306,9 @@ struct ManageSubscriptionButton: View {
         .applyIf(self.path.type != .cancel) {
             $0.buttonStyle(ManageSubscriptionsButtonStyle())
         }
+        .applyIf(self.path.type == .cancel) {
+            $0.foregroundColor(Color.red)
+        }
         .disabled(self.viewModel.loadingPath != nil)
     }
 }


### PR DESCRIPTION
Made the cancel subscription more destructive by removing the filling of the button and making it always red text

| Header | Header |
|--------|--------|
| ![simulator_screenshot_870B1F8E-5DC7-415A-AF46-B1B8A6767841](https://github.com/user-attachments/assets/458785b3-3576-4fd8-b6de-d0e9e24299b2) | ![simulator_screenshot_719D9495-A004-404E-84AC-1FF245457DBC](https://github.com/user-attachments/assets/512b4437-f424-4bac-a2dd-ebfe4674aa22) | 



