### PR TITLE
tests triggrer: add target-branch parameter to trigger from the right branch

### DIFF
--- a/.github/workflows/trigger_all_tests.yml
+++ b/.github/workflows/trigger_all_tests.yml
@@ -32,7 +32,7 @@ jobs:
           echo "User is a member of the organization"
 
 
-      - name: 'Get github branch'
+      - name: 'Get GitHub branch'
         run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
         env:
           REPO: ${{ github.repository }}

--- a/.github/workflows/trigger_all_tests.yml
+++ b/.github/workflows/trigger_all_tests.yml
@@ -31,12 +31,21 @@ jobs:
           fi
           echo "User is a member of the organization"
 
+
+      - name: 'Get github branch'
+        run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
+        env:
+          REPO: ${{ github.repository }}
+          PR_NO: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Trigger CircleCI workflow
         id: trigger_circleci_workflow
         if: success()
 
         uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0
         with:
+          target-branch: ${{ steps.get-branch.outputs.branch }}
           GHA_Meta: "run-from-github-comments"
         env:
           CCI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}

--- a/.github/workflows/trigger_all_tests.yml
+++ b/.github/workflows/trigger_all_tests.yml
@@ -32,6 +32,12 @@ jobs:
           echo "User is a member of the organization"
 
 
+      # Note: actions based on issue comments always trigger from the main branch. So we need to tell CircleCI to use a specific branch. 
+      # We can do that by passing in the target-branch. 
+      # This solution is based on this comment: https://github.com/CircleCI-Public/trigger-circleci-pipeline-action/issues/61#issuecomment-1662021882
+      # But we can also see that the following code reads from this parameter: https://github.com/CircleCI-Public/trigger-circleci-pipeline-action/blob/a81cd720792a6088debd7f182b552845abb86f1b/src/lib/CircleCIPipelineTrigger.ts#L66
+      # Even though it seems to be undocumented as of writing. 
+      
       - name: 'Get GitHub branch'
         run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
         env:


### PR DESCRIPTION
Fix the `@RCGitBot please test` issue where tests would always get triggered from the `main` branch. 

This solution is based on this comment: https://github.com/CircleCI-Public/trigger-circleci-pipeline-action/issues/61#issuecomment-1662021882

But you can also see in the code that this is indeed how the branch name is determined, and that that [logic looks the same as the one for `GHA_action` and `target-slug`](https://github.com/CircleCI-Public/trigger-circleci-pipeline-action/blob/a81cd720792a6088debd7f182b552845abb86f1b/src/lib/CircleCIPipelineTrigger.ts#L66), so it's just undocumented. 

We're using a fixed version, 1.2.0, so it shouldn't just randomly break. 