### PR TITLE
[Customer Center] Fix `BackendGetCustomerCenterConfigTests`

### DIFF
--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerCenterConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerCenterConfigTests.swift
@@ -37,7 +37,7 @@ class BackendGetCustomerCenterConfigTests: BaseBackendTests {
 
         expect(result).to(beSuccess())
         expect(self.httpClient.calls).to(haveCount(1))
-        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadDelayParam) == Delay.none
+        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadDelayParam) == JitterableDelay.none
     }
 
     func testGetCustomerCenterConfigPassesLocales() {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfig.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfig.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigCallsHTTPMethod.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigFailSendsNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigPassesLocales.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigPassesLocales.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN,es_ES",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfig.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfig.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigCachesForSameUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigCallsHTTPMethod.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigFailSendsNil.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigPassesLocales.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigPassesLocales.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN,es_ES",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfig.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfig.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigCachesForSameUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigCallsHTTPMethod.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigFailSendsNil.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigPassesLocales.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigPassesLocales.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN,es_ES",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testRepeatedRequestsLogDebugMessage.1.json
@@ -11,6 +11,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfig.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfig.1.json
@@ -1,0 +1,26 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/customercenter/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigCachesForSameUserID.1.json
@@ -1,0 +1,26 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/customercenter/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigCallsHTTPMethod.1.json
@@ -1,0 +1,26 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/customercenter/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
@@ -1,0 +1,26 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/customercenter/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigFailSendsNil.1.json
@@ -1,0 +1,26 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/customercenter/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,26 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/customercenter/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigPassesLocales.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigPassesLocales.1.json
@@ -1,0 +1,26 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN,es_ES",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/customercenter/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
@@ -1,0 +1,26 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/customercenter/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
@@ -1,0 +1,26 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/customercenter/user_id_2"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,26 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/customercenter/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS16-testPostDiagnosticsEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS16-testPostDiagnosticsEventsWithMultipleEvents.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS16-testPostDiagnosticsEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS16-testPostDiagnosticsEventsWithOneEvent.1.json
@@ -12,6 +12,7 @@
     "X-Platform-Flavor" : "native",
     "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
     "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
     "X-Storefront" : "USA",
     "X-StoreKit-Version" : "2",
     "X-StoreKit2-Enabled" : "true",


### PR DESCRIPTION
Fix `BackendGetCustomerCenterConfigTests` after a wrong merge. This was changed in #4048 