### PR TITLE
temporarily disables purchasetester deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1325,10 +1325,12 @@ workflows:
           requires:
             - make-release
           <<: *release-tags
-      - deploy-purchase-tester:
-          requires:
-            - make-release
-          <<: *release-tags
+      # temporarily disabled since this won't work when building directly from its workspace.
+      # there's another PR to re-enable it
+      # - deploy-purchase-tester:
+      #     requires:
+      #       - make-release
+      #     <<: *release-tags
 
   snapshot-bump:
     when:


### PR DESCRIPTION
[The cleanup PR](https://github.com/RevenueCat/purchases-ios/pull/4111) would actually break the release process. 

This disables it for now, but it will get re-enabled in #4131. 

The reason is that one of the steps is to upload PurchaseTester to TestFlight, which is currently broken since it's set up to build from the PurchaseTester workspace.

And that workspace won't work correctly anymore since the dependency has been updated from Swift Package Manager as a pinned commit to a local dependency instead. 

This is a lot more convenient when developing, because it means that we can just run PurchaseTester from the main workspace and it all works, but it needs some updates to our fastlane stuff to be able to reploy purchaseTester again. 

