### PR TITLE
[Customer Center] Make colors nullable

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		3551E39D2C4A6A1400D27C25 /* TintedProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3551E39C2C4A6A1400D27C25 /* TintedProgressView.swift */; };
 		35549323269E298B005F9AE9 /* OfferingsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35549322269E298B005F9AE9 /* OfferingsFactory.swift */; };
 		357349012C3BEB5C000EEB86 /* CustomerCenterConfigDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 357348FF2C3BEB0A000EEB86 /* CustomerCenterConfigDataTests.swift */; };
+		357CEC702C5940CE00A80837 /* ColorFromAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 357CEC6F2C5940CE00A80837 /* ColorFromAppearance.swift */; };
 		3592E8862C2ED51700D7F91D /* CustomerCenterConfigCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3592E8852C2ED51700D7F91D /* CustomerCenterConfigCallback.swift */; };
 		3592E88A2C2ED54A00D7F91D /* CustomerCenterConfigData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3592E8882C2ED54A00D7F91D /* CustomerCenterConfigData.swift */; };
 		3592E88C2C2ED58900D7F91D /* GetCustomerCenterConfigOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3592E88B2C2ED58900D7F91D /* GetCustomerCenterConfigOperation.swift */; };
@@ -1345,6 +1346,7 @@
 		35549322269E298B005F9AE9 /* OfferingsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingsFactory.swift; sourceTree = "<group>"; };
 		357348FF2C3BEB0A000EEB86 /* CustomerCenterConfigDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterConfigDataTests.swift; sourceTree = "<group>"; };
 		357C9BC022725CFA006BC624 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/iAd.framework; sourceTree = DEVELOPER_DIR; };
+		357CEC6F2C5940CE00A80837 /* ColorFromAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorFromAppearance.swift; sourceTree = "<group>"; };
 		3592E8852C2ED51700D7F91D /* CustomerCenterConfigCallback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerCenterConfigCallback.swift; sourceTree = "<group>"; };
 		3592E8882C2ED54A00D7F91D /* CustomerCenterConfigData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerCenterConfigData.swift; sourceTree = "<group>"; };
 		3592E88B2C2ED58900D7F91D /* GetCustomerCenterConfigOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GetCustomerCenterConfigOperation.swift; path = Sources/Networking/Operations/GetCustomerCenterConfigOperation.swift; sourceTree = SOURCE_ROOT; };
@@ -3132,6 +3134,7 @@
 				353756632C382C2800A1B8D6 /* URLUtilities.swift */,
 				1E5F8F6D2C4515430041EECD /* View+PresentCustomerCenter.swift */,
 				3511088E2C47F6DA0048C4D8 /* CustomerInfo+CurrentEntitlement.swift */,
+				357CEC6F2C5940CE00A80837 /* ColorFromAppearance.swift */,
 			);
 			path = CustomerCenter;
 			sourceTree = "<group>";
@@ -5822,6 +5825,7 @@
 				887A606E2C1D037000E1A461 /* LocalizedAlertError.swift in Sources */,
 				887A60802C1D037000E1A461 /* Package+VariableDataProvider.swift in Sources */,
 				887A60CE2C1D037000E1A461 /* View+PresentPaywall.swift in Sources */,
+				357CEC702C5940CE00A80837 /* ColorFromAppearance.swift in Sources */,
 				887A60832C1D037000E1A461 /* VersionDetector.swift in Sources */,
 				887A60872C1D037000E1A461 /* ViewExtensions.swift in Sources */,
 				353756712C382C2800A1B8D6 /* ManageSubscriptionsPurchaseType.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/ColorFromAppearance.swift
+++ b/RevenueCatUI/CustomerCenter/ColorFromAppearance.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  View+Appearance.swift
+//
+//  Created by Cesar de la Vega on 30/7/24.
+
+import Foundation
+import RevenueCat
+import SwiftUI
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+func color(from colorInformation: CustomerCenterConfigData.Appearance.ColorInformation,
+           for colorScheme: ColorScheme) -> Color? {
+    return colorScheme == .dark ? colorInformation.dark?.underlyingColor : colorInformation.light?.underlyingColor
+}

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -91,11 +91,11 @@ enum CustomerCenterConfigTestData {
                   )
         ],
         appearance: .init(
-            // swiftlint:disable force_try
-            mode: .custom(accentColor: try! .init(light: "#ffffff", dark: "#000000"),
-                          backgroundColor: try! .init(light: "#000000", dark: "#ffffff"),
-                          textColor: try! .init(light: "#000000", dark: "#ffffff"))
-            // swiftlint:enable force_try
+            accentColor: .init(light: "#ffffff", dark: "#000000"),
+            textColor: .init(light: "#000000", dark: "#ffffff"),
+            backgroundColor: .init(light: "#000000", dark: "#ffffff"),
+            buttonTextColor: .init(light: "#000000", dark: "#ffffff"),
+            buttonBackgroundColor: .init(light: "#000000", dark: "#ffffff")
         ),
         localization: .init(
             locale: "en_US",

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -90,13 +90,7 @@ enum CustomerCenterConfigTestData {
                     ]
                   )
         ],
-        appearance: .init(
-            accentColor: .init(light: "#ffffff", dark: "#000000"),
-            textColor: .init(light: "#000000", dark: "#ffffff"),
-            backgroundColor: .init(light: "#000000", dark: "#ffffff"),
-            buttonTextColor: .init(light: "#000000", dark: "#ffffff"),
-            buttonBackgroundColor: .init(light: "#000000", dark: "#ffffff")
-        ),
+        appearance: standardAppearance,
         localization: .init(
             locale: "en_US",
             localizedStrings: [
@@ -105,6 +99,14 @@ enum CustomerCenterConfigTestData {
             ]
         ),
         support: .init(email: "test-support@revenuecat.com")
+    )
+
+    static let standardAppearance = CustomerCenterConfigData.Appearance(
+        accentColor: .init(light: "#ffffff", dark: "#000000"),
+        textColor: .init(light: "#000000", dark: "#ffffff"),
+        backgroundColor: .init(light: "#000000", dark: "#ffffff"),
+        buttonTextColor: .init(light: "#000000", dark: "#ffffff"),
+        buttonBackgroundColor: .init(light: "#000000", dark: "#ffffff")
     )
 
     static let subscriptionInformationMonthlyRenewing: SubscriptionInformation = .init(

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterEnvironment.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterEnvironment.swift
@@ -43,7 +43,13 @@ extension CustomerCenterConfigData.Localization {
 extension CustomerCenterConfigData.Appearance {
 
     /// Default ``CustomerCenterConfigData.Appearance`` value for Environment usage
-    public static let `default` = CustomerCenterConfigData.Appearance(mode: .system)
+    public static let `default` = CustomerCenterConfigData.Appearance(
+        accentColor: .init(light: "#ffffff", dark: "#000000"),
+        textColor: .init(light: "#000000", dark: "#ffffff"),
+        backgroundColor: .init(light: "#000000", dark: "#ffffff"),
+        buttonTextColor: .init(light: "#000000", dark: "#ffffff"),
+        buttonBackgroundColor: .init(light: "#000000", dark: "#ffffff")
+    )
 
 }
 

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterEnvironment.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterEnvironment.swift
@@ -44,11 +44,11 @@ extension CustomerCenterConfigData.Appearance {
 
     /// Default ``CustomerCenterConfigData.Appearance`` value for Environment usage
     public static let `default` = CustomerCenterConfigData.Appearance(
-        accentColor: .init(light: "#ffffff", dark: "#000000"),
-        textColor: .init(light: "#000000", dark: "#ffffff"),
-        backgroundColor: .init(light: "#000000", dark: "#ffffff"),
-        buttonTextColor: .init(light: "#000000", dark: "#ffffff"),
-        buttonBackgroundColor: .init(light: "#000000", dark: "#ffffff")
+        accentColor: .init(),
+        textColor: .init(),
+        backgroundColor: .init(),
+        buttonTextColor: .init(),
+        buttonBackgroundColor: .init()
     )
 
 }

--- a/RevenueCatUI/CustomerCenter/ManageSubscriptionsButtonStyle.swift
+++ b/RevenueCatUI/CustomerCenter/ManageSubscriptionsButtonStyle.swift
@@ -27,11 +27,13 @@ struct ManageSubscriptionsButtonStyle: ButtonStyle {
     @Environment(\.colorScheme) private var colorScheme
 
     func makeBody(configuration: ButtonStyleConfiguration) -> some View {
+        let background = color(from: appearance.buttonBackgroundColor)
+        let textColor = color(from: appearance.buttonTextColor)
         configuration.label
             .padding()
             .frame(width: 300)
-            .background(color(from: appearance))
-            .foregroundColor(colorScheme == .dark ? Color.black : Color.white)
+            .applyIf(background != nil, apply: { $0.background(background) })
+            .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
             .cornerRadius(10)
             .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
             .opacity(configuration.isPressed ? 0.8 : 1.0)
@@ -46,13 +48,8 @@ struct ManageSubscriptionsButtonStyle: ButtonStyle {
 @available(watchOS, unavailable)
 private extension ManageSubscriptionsButtonStyle {
 
-    func color(from appearance: CustomerCenterConfigData.Appearance) -> Color {
-        switch appearance.mode {
-        case .system:
-            return Color.accentColor
-        case .custom(accentColor: let accentColor, backgroundColor: _, textColor: _):
-            return colorScheme == .dark ? accentColor.dark.underlyingColor : accentColor.light.underlyingColor
-        }
+    func color(from colorInformation: CustomerCenterConfigData.Appearance.ColorInformation) -> Color? {
+        return colorScheme == .dark ? colorInformation.dark?.underlyingColor : colorInformation.light?.underlyingColor
     }
 
 }
@@ -66,7 +63,13 @@ struct ManageSubscriptionsButtonStyle_Previews: PreviewProvider {
     static var previews: some View {
         Button("Didn't receive purchase") {}
             .buttonStyle(ManageSubscriptionsButtonStyle())
-            .environment(\.appearance, CustomerCenterConfigData.Appearance(mode: .system))
+            .environment(\.appearance, CustomerCenterConfigData.Appearance(
+                accentColor: .init(light: "#ffffff", dark: "#000000"),
+                textColor: .init(light: "#000000", dark: "#ffffff"),
+                backgroundColor: .init(light: "#000000", dark: "#ffffff"),
+                buttonTextColor: .init(light: "#ffffff", dark: "#000000"),
+                buttonBackgroundColor: .init(light: "#000000", dark: "#ffffff")
+            ))
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/ManageSubscriptionsButtonStyle.swift
+++ b/RevenueCatUI/CustomerCenter/ManageSubscriptionsButtonStyle.swift
@@ -17,6 +17,8 @@ import Foundation
 import RevenueCat
 import SwiftUI
 
+#if os(iOS)
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
@@ -60,3 +62,5 @@ struct ManageSubscriptionsButtonStyle_Previews: PreviewProvider {
     }
 
 }
+
+#endif

--- a/RevenueCatUI/CustomerCenter/ManageSubscriptionsButtonStyle.swift
+++ b/RevenueCatUI/CustomerCenter/ManageSubscriptionsButtonStyle.swift
@@ -52,13 +52,7 @@ struct ManageSubscriptionsButtonStyle_Previews: PreviewProvider {
     static var previews: some View {
         Button("Didn't receive purchase") {}
             .buttonStyle(ManageSubscriptionsButtonStyle())
-            .environment(\.appearance, CustomerCenterConfigData.Appearance(
-                accentColor: .init(light: "#ffffff", dark: "#000000"),
-                textColor: .init(light: "#000000", dark: "#ffffff"),
-                backgroundColor: .init(light: "#000000", dark: "#ffffff"),
-                buttonTextColor: .init(light: "#ffffff", dark: "#000000"),
-                buttonBackgroundColor: .init(light: "#000000", dark: "#ffffff")
-            ))
+            .environment(\.appearance, CustomerCenterConfigTestData.standardAppearance)
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/ManageSubscriptionsButtonStyle.swift
+++ b/RevenueCatUI/CustomerCenter/ManageSubscriptionsButtonStyle.swift
@@ -21,35 +21,22 @@ import SwiftUI
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-struct ManageSubscriptionsButtonStyle: ButtonStyle {
+struct ManageSubscriptionsButtonStyle: PrimitiveButtonStyle {
 
     @Environment(\.appearance) private var appearance: CustomerCenterConfigData.Appearance
     @Environment(\.colorScheme) private var colorScheme
 
-    func makeBody(configuration: ButtonStyleConfiguration) -> some View {
-        let background = color(from: appearance.buttonBackgroundColor)
-        let textColor = color(from: appearance.buttonTextColor)
-        configuration.label
-            .padding()
-            .frame(width: 300)
-            .applyIf(background != nil, apply: { $0.background(background) })
-            .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
-            .cornerRadius(10)
-            .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
-            .opacity(configuration.isPressed ? 0.8 : 1.0)
-            .animation(.easeInOut(duration: 0.2), value: configuration.isPressed)
-    }
+    func makeBody(configuration: PrimitiveButtonStyleConfiguration) -> some View {
+        let background = color(from: appearance.buttonBackgroundColor, for: colorScheme)
+        let textColor = color(from: appearance.buttonTextColor, for: colorScheme)
 
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(macOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
-private extension ManageSubscriptionsButtonStyle {
-
-    func color(from colorInformation: CustomerCenterConfigData.Appearance.ColorInformation) -> Color? {
-        return colorScheme == .dark ? colorInformation.dark?.underlyingColor : colorInformation.light?.underlyingColor
+        Button(action: { configuration.trigger() }, label: {
+            configuration.label.frame(width: 300)
+        })
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .applyIf(background != nil, apply: { $0.tint(background) })
+        .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/ViewModels/FeedbackSurveyViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/FeedbackSurveyViewModel.swift
@@ -58,6 +58,7 @@ class FeedbackSurveyViewModel: ObservableObject {
                 self.promotionalOfferData = promotionalOfferData
             case .failure:
                 self.feedbackSurveyData.onOptionSelected()
+                self.loadingState = nil
             }
         } else {
             self.feedbackSurveyData.onOptionSelected()

--- a/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
@@ -31,6 +31,8 @@ struct FeedbackSurveyView: View {
     private var localization: CustomerCenterConfigData.Localization
     @Environment(\.appearance)
     private var appearance: CustomerCenterConfigData.Appearance
+    @Environment(\.colorScheme)
+    private var colorScheme
 
     init(feedbackSurveyData: FeedbackSurveyData) {
         let viewModel = FeedbackSurveyViewModel(feedbackSurveyData: feedbackSurveyData)
@@ -38,25 +40,33 @@ struct FeedbackSurveyView: View {
     }
 
     var body: some View {
-        VStack {
-            Text(self.viewModel.feedbackSurveyData.configuration.title)
-                .font(.title)
-                .padding()
+        ZStack {
+            if let background = color(from: appearance.backgroundColor, for: colorScheme) {
+                background.edgesIgnoringSafeArea(.all)
+            }
+            let textColor = color(from: appearance.textColor, for: colorScheme)
 
-            Spacer()
+            VStack {
+                Text(self.viewModel.feedbackSurveyData.configuration.title)
+                    .font(.title)
+                    .padding()
+                    .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
 
-            FeedbackSurveyButtonsView(options: self.viewModel.feedbackSurveyData.configuration.options,
-                                      onOptionSelected: self.viewModel.handleAction(for:),
-                                      loadingState: self.$viewModel.loadingState)
+                Spacer()
+
+                FeedbackSurveyButtonsView(options: self.viewModel.feedbackSurveyData.configuration.options,
+                                          onOptionSelected: self.viewModel.handleAction(for:),
+                                          loadingState: self.$viewModel.loadingState)
+            }
+            .sheet(
+                item: self.$viewModel.promotionalOfferData,
+                onDismiss: { self.viewModel.handleSheetDismiss() },
+                content: { promotionalOfferData in
+                    PromotionalOfferView(promotionalOffer: promotionalOfferData.promotionalOffer,
+                                         product: promotionalOfferData.product,
+                                         promoOfferDetails: promotionalOfferData.promoOfferDetails)
+                })
         }
-        .sheet(
-            item: self.$viewModel.promotionalOfferData,
-            onDismiss: { self.viewModel.handleSheetDismiss() },
-            content: { promotionalOfferData in
-                PromotionalOfferView(promotionalOffer: promotionalOfferData.promotionalOffer,
-                                     product: promotionalOfferData.product,
-                                     promoOfferDetails: promotionalOfferData.promoOfferDetails)
-            })
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -29,6 +29,8 @@ struct ManageSubscriptionsView: View {
     private var appearance: CustomerCenterConfigData.Appearance
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
+    @Environment(\.colorScheme)
+    private var colorScheme
 
     @StateObject
     private var viewModel: ManageSubscriptionsViewModel
@@ -77,23 +79,29 @@ struct ManageSubscriptionsView: View {
 
     @ViewBuilder
     var content: some View {
-        VStack {
-            if self.viewModel.isLoaded {
-                HeaderView(viewModel: self.viewModel)
+        ZStack {
+            if let background = color(from: appearance.backgroundColor, for: colorScheme) {
+                background.edgesIgnoringSafeArea(.all)
+            }
 
-                if let subscriptionInformation = self.viewModel.subscriptionInformation {
-                    SubscriptionDetailsView(subscriptionInformation: subscriptionInformation,
-                                            localization: self.localization,
-                                            refundRequestStatusMessage: self.viewModel.refundRequestStatusMessage)
+            VStack {
+                if self.viewModel.isLoaded {
+                    HeaderView(viewModel: self.viewModel)
+
+                    if let subscriptionInformation = self.viewModel.subscriptionInformation {
+                        SubscriptionDetailsView(subscriptionInformation: subscriptionInformation,
+                                                localization: self.localization,
+                                                refundRequestStatusMessage: self.viewModel.refundRequestStatusMessage)
+                    }
+
+                    Spacer()
+
+                    ManageSubscriptionsButtonsView(viewModel: self.viewModel,
+                                                   loadingPath: self.$viewModel.loadingPath)
+                } else {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle())
                 }
-
-                Spacer()
-
-                ManageSubscriptionsButtonsView(viewModel: self.viewModel,
-                                               loadingPath: self.$viewModel.loadingPath)
-            } else {
-                ProgressView()
-                    .progressViewStyle(CircularProgressViewStyle())
             }
         }
         .task {
@@ -127,11 +135,18 @@ struct HeaderView: View {
 
     @ObservedObject
     private(set) var viewModel: ManageSubscriptionsViewModel
+    @Environment(\.appearance)
+    private var appearance: CustomerCenterConfigData.Appearance
+    @Environment(\.colorScheme)
+    private var colorScheme
 
     var body: some View {
+        let textColor = color(from: appearance.textColor, for: colorScheme)
+
         Text(self.viewModel.screen.title)
             .font(.title)
             .padding()
+            .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
     }
 
 }
@@ -140,6 +155,7 @@ struct HeaderView: View {
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
+@available(visionOS, unavailable)
 struct SubscriptionDetailsView: View {
 
     let iconWidth = 22.0

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -47,6 +47,8 @@ struct ManageSubscriptionsView: View {
     }
 
     var body: some View {
+        let accentColor = color(from: self.appearance.accentColor, for: self.colorScheme)
+
         if #available(iOS 16.0, *) {
             NavigationStack {
                 content
@@ -58,7 +60,7 @@ struct ManageSubscriptionsView: View {
                                 }
                         }
                     }
-            }
+            }.applyIf(accentColor != nil, apply: { $0.tint(accentColor) })
         } else {
             NavigationView {
                 content
@@ -73,7 +75,7 @@ struct ManageSubscriptionsView: View {
                     ) {
                         EmptyView()
                     })
-            }
+            }.applyIf(accentColor != nil, apply: { $0.tint(accentColor) })
         }
     }
 

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -34,7 +34,10 @@ struct NoSubscriptionsView: View {
 
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
-
+    @Environment(\.appearance)
+    private var appearance: CustomerCenterConfigData.Appearance
+    @Environment(\.colorScheme)
+    private var colorScheme
     @State
     private var showRestoreAlert: Bool = false
 
@@ -43,26 +46,35 @@ struct NoSubscriptionsView: View {
     }
 
     var body: some View {
-        VStack {
-            Text(self.configuration.screens[.noActive]?.title ?? "No Subscriptions found")
-                .font(.title)
-                .padding()
-            Text(self.configuration.screens[.noActive]?.subtitle ??
-                 "We can try checking your Apple account for any previous purchases")
+        let background = color(from: appearance.backgroundColor, for: colorScheme)
+        let textColor = color(from: appearance.textColor, for: colorScheme)
+
+        ZStack {
+            if background != nil {
+                background.edgesIgnoringSafeArea(.all)
+            }
+            VStack {
+                Text(self.configuration.screens[.noActive]?.title ?? "No Subscriptions found")
+                    .font(.title)
+                    .padding()
+                Text(self.configuration.screens[.noActive]?.subtitle ??
+                     "We can try checking your Apple account for any previous purchases")
                 .font(.body)
                 .padding()
 
-            Spacer()
+                Spacer()
 
-            Button(localization.commonLocalizedString(for: .restorePurchases)) {
-                showRestoreAlert = true
-            }
-            .restorePurchasesAlert(isPresented: $showRestoreAlert)
-            .buttonStyle(ManageSubscriptionsButtonStyle())
+                Button(localization.commonLocalizedString(for: .restorePurchases)) {
+                    showRestoreAlert = true
+                }
+                .restorePurchasesAlert(isPresented: $showRestoreAlert)
+                .buttonStyle(ManageSubscriptionsButtonStyle())
 
-            Button(localization.commonLocalizedString(for: .cancel)) {
-                dismiss()
+                Button(localization.commonLocalizedString(for: .cancel)) {
+                    dismiss()
+                }
             }
+            .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
         }
 
     }

--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -26,14 +26,16 @@ import SwiftUI
 @available(visionOS, unavailable)
 struct PromotionalOfferView: View {
 
-    @Environment(\.appearance) private var appearance: CustomerCenterConfigData.Appearance
-
     @StateObject
     private var viewModel: PromotionalOfferViewModel
     @Environment(\.dismiss)
     private var dismiss
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
+    @Environment(\.appearance)
+    private var appearance: CustomerCenterConfigData.Appearance
+    @Environment(\.colorScheme)
+    private var colorScheme
 
     init(promotionalOffer: PromotionalOffer,
          product: StoreProduct,
@@ -46,9 +48,53 @@ struct PromotionalOfferView: View {
     }
 
     var body: some View {
-        VStack {
-            if let details = self.viewModel.promotionalOfferData?.promoOfferDetails,
-               self.viewModel.error == nil {
+        ZStack {
+            if let background = color(from: appearance.backgroundColor, for: colorScheme) {
+                background.edgesIgnoringSafeArea(.all)
+            }
+
+            VStack {
+                if self.viewModel.error == nil {
+                    PromotionalOfferHeaderView(viewModel: self.viewModel)
+
+                    Spacer()
+
+                    PromoOfferButtonView(viewModel: self.viewModel, appearance: self.appearance)
+
+                    let dismissButtonTitle = self.localization.commonLocalizedString(for: .noThanks)
+                    Button(dismissButtonTitle) {
+                        dismiss()
+                    }
+                } else {
+                    EmptyView()
+                        .onAppear {
+                            dismiss()
+                        }
+                }
+            }
+        }
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@available(visionOS, unavailable)
+struct PromotionalOfferHeaderView: View {
+
+    @Environment(\.appearance)
+    private var appearance: CustomerCenterConfigData.Appearance
+    @Environment(\.colorScheme)
+    private var colorScheme
+    @ObservedObject
+    private(set) var viewModel: PromotionalOfferViewModel
+
+    var body: some View {
+        let textColor = color(from: appearance.textColor, for: colorScheme)
+        if let details = self.viewModel.promotionalOfferData?.promoOfferDetails {
+            VStack {
                 Text(details.title)
                     .font(.title)
                     .padding()
@@ -56,21 +102,7 @@ struct PromotionalOfferView: View {
                 Text(details.subtitle)
                     .font(.title3)
                     .padding()
-
-                Spacer()
-
-                PromoOfferButtonView(viewModel: self.viewModel, appearance: self.appearance)
-
-                let dismissButtonTitle = self.localization.commonLocalizedString(for: .noThanks)
-                Button(dismissButtonTitle) {
-                    dismiss()
-                }
-            } else {
-                EmptyView()
-                    .onAppear {
-                        dismiss()
-                    }
-            }
+            }.applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
         }
     }
 

--- a/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
@@ -71,7 +71,7 @@ struct RestorePurchasesAlert: ViewModifier {
                     return Alert(title: Text("Purchases recovered!"),
                                  message: Text("We applied the previously purchased items to your account. " +
                                                "Sorry for the inconvenience."),
-                                 dismissButton: .default(Text(localization.commonLocalizedString(for: .dismiss))) {
+                                 dismissButton: .cancel(Text(localization.commonLocalizedString(for: .dismiss))) {
                         dismiss()
                     })
 
@@ -92,7 +92,7 @@ struct RestorePurchasesAlert: ViewModifier {
                             }
                         }
                     }),
-                                 secondaryButton: .default(Text(localization.commonLocalizedString(for: .dismiss))) {
+                                 secondaryButton: .cancel(Text(localization.commonLocalizedString(for: .dismiss))) {
                         dismiss()
                     })
                 }

--- a/RevenueCatUI/CustomerCenter/Views/TintedProgressView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/TintedProgressView.swift
@@ -41,7 +41,13 @@ struct TintedProgressView_Previews: PreviewProvider {
 
     static var previews: some View {
         TintedProgressView()
-            .environment(\.appearance, CustomerCenterConfigData.Appearance(mode: .system))
+            .environment(\.appearance, CustomerCenterConfigData.Appearance(
+                accentColor: .init(light: "#ffffff", dark: "#000000"),
+                textColor: .init(light: "#000000", dark: "#ffffff"),
+                backgroundColor: .init(light: "#000000", dark: "#ffffff"),
+                buttonTextColor: .init(light: "#000000", dark: "#ffffff"),
+                buttonBackgroundColor: .init(light: "#000000", dark: "#ffffff")
+            ))
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/Views/TintedProgressView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/TintedProgressView.swift
@@ -27,6 +27,7 @@ struct TintedProgressView: View {
 
     var body: some View {
         ProgressView()
+            .controlSize(.regular)
             .tint(colorScheme == .dark ? Color.black : Color.white)
     }
 

--- a/RevenueCatUI/CustomerCenter/Views/TintedProgressView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/TintedProgressView.swift
@@ -15,6 +15,8 @@ import Foundation
 import RevenueCat
 import SwiftUI
 
+#if os(iOS)
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
@@ -52,3 +54,5 @@ struct TintedProgressView_Previews: PreviewProvider {
     }
 
 }
+
+#endif

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -29,8 +29,10 @@ struct WrongPlatformView: View {
     @State
     private var store: Store?
 
-    @Environment(\.openURL)
-    private var openURL
+    @Environment(\.appearance)
+    private var appearance: CustomerCenterConfigData.Appearance
+    @Environment(\.colorScheme)
+    private var colorScheme
 
     init() {
     }
@@ -40,23 +42,30 @@ struct WrongPlatformView: View {
     }
 
     var body: some View {
-        VStack {
-
-            switch store {
-            case .appStore, .macAppStore, .playStore, .amazon:
-                let platformName = humanReadablePlatformName(store: store!)
-
-                Text("Your subscription is a \(platformName) subscription.")
-                    .font(.title)
-                    .padding()
-                Text("Go the app settings on \(platformName) to manage your subscription and billing.")
-                    .padding()
-            default:
-                Text("Please contact support to manage your subscription")
-                    .font(.title)
-                    .padding()
+        ZStack {
+            if let background = color(from: appearance.backgroundColor, for: colorScheme) {
+                background.edgesIgnoringSafeArea(.all)
             }
+            let textColor = color(from: appearance.textColor, for: colorScheme)
 
+            VStack {
+                switch store {
+                case .appStore, .macAppStore, .playStore, .amazon:
+                    let platformName = humanReadablePlatformName(store: store!)
+
+                    Text("Your subscription is a \(platformName) subscription.")
+                        .font(.title)
+                        .padding()
+                    Text("Go the app settings on \(platformName) to manage your subscription and billing.")
+                        .padding()
+                default:
+                    Text("Please contact support to manage your subscription")
+                        .font(.title)
+                        .padding()
+                }
+
+            }
+            .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
         }
         .task {
             if store == nil {

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -242,6 +242,11 @@ public struct CustomerCenterConfigData {
             public var light: RCColor?
             public var dark: RCColor?
 
+            public init() {
+                self.light = nil
+                self.dark = nil
+            }
+
             public init(
                 light: String?,
                 dark: String?

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -221,7 +221,7 @@ public struct CustomerCenterConfigData {
 
         public let accentColor: ColorInformation
         public let textColor: ColorInformation
-        public let backgroundColor: ColorInformation        
+        public let backgroundColor: ColorInformation
         public let buttonTextColor: ColorInformation
         public let buttonBackgroundColor: ColorInformation
 
@@ -342,16 +342,16 @@ extension CustomerCenterConfigData.Screen {
 extension CustomerCenterConfigData.Appearance {
 
     init(from response: CustomerCenterConfigResponse.Appearance) {
-        self.accentColor = CustomerCenterConfigData.Appearance.ColorInformation(light: response.light.accentColor,
-                                                                                dark: response.dark.accentColor)
-        self.textColor = CustomerCenterConfigData.Appearance.ColorInformation(light: response.light.textColor,
-                                                                              dark: response.dark.textColor)
-        self.backgroundColor = CustomerCenterConfigData.Appearance.ColorInformation(light: response.light.backgroundColor,
-                                                                                    dark: response.dark.backgroundColor)
-        self.buttonTextColor = CustomerCenterConfigData.Appearance.ColorInformation(light: response.light.buttonTextColor,
-                                                                                    dark: response.dark.buttonTextColor)
-        self.buttonBackgroundColor = CustomerCenterConfigData.Appearance.ColorInformation(light: response.light.buttonBackgroundColor,
-                                                                                          dark: response.dark.buttonBackgroundColor)
+        self.accentColor = .init(light: response.light.accentColor,
+                                 dark: response.dark.accentColor)
+        self.textColor = .init(light: response.light.textColor,
+                               dark: response.dark.textColor)
+        self.backgroundColor = .init(light: response.light.backgroundColor,
+                                     dark: response.dark.backgroundColor)
+        self.buttonTextColor = .init(light: response.light.buttonTextColor,
+                                     dark: response.dark.buttonTextColor)
+        self.buttonBackgroundColor = .init(light: response.light.buttonBackgroundColor,
+                                           dark: response.dark.buttonBackgroundColor)
     }
 
 }

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -219,32 +219,47 @@ public struct CustomerCenterConfigData {
 
     public struct Appearance {
 
-        public let mode: AppearanceMode
+        public let accentColor: ColorInformation
+        public let textColor: ColorInformation
+        public let backgroundColor: ColorInformation        
+        public let buttonTextColor: ColorInformation
+        public let buttonBackgroundColor: ColorInformation
 
-        public init(mode: AppearanceMode) {
-            self.mode = mode
-        }
-
-        public enum AppearanceMode {
-
-            case system
-            case custom(accentColor: ColorInformation,
-                        backgroundColor: ColorInformation,
-                        textColor: ColorInformation)
-
+        public init(accentColor: ColorInformation,
+                    textColor: ColorInformation,
+                    backgroundColor: ColorInformation,
+                    buttonTextColor: ColorInformation,
+                    buttonBackgroundColor: ColorInformation) {
+            self.accentColor = accentColor
+            self.textColor = textColor
+            self.backgroundColor = backgroundColor
+            self.buttonTextColor = buttonTextColor
+            self.buttonBackgroundColor = buttonBackgroundColor
         }
 
         public struct ColorInformation {
 
-            public var light: RCColor
-            public var dark: RCColor
+            public var light: RCColor?
+            public var dark: RCColor?
 
             public init(
-                light: String,
-                dark: String
-            ) throws {
-                self.light = try RCColor(stringRepresentation: light)
-                self.dark = try RCColor(stringRepresentation: dark)
+                light: String?,
+                dark: String?
+            ) {
+                if let light = light {
+                    do {
+                        self.light = try RCColor(stringRepresentation: light)
+                    } catch {
+                        Logger.error("Failed to parse light color \(light)")
+                    }
+                }
+                if let dark = dark {
+                    do {
+                        self.dark = try RCColor(stringRepresentation: dark)
+                    } catch {
+                        Logger.error("Failed to parse dark color \(dark)")
+                    }
+                }
             }
         }
 
@@ -327,36 +342,16 @@ extension CustomerCenterConfigData.Screen {
 extension CustomerCenterConfigData.Appearance {
 
     init(from response: CustomerCenterConfigResponse.Appearance) {
-        self.mode = CustomerCenterConfigData.Appearance.AppearanceMode(from: response)
-    }
-
-}
-
-@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
-extension CustomerCenterConfigData.Appearance.AppearanceMode {
-
-    init(from response: CustomerCenterConfigResponse.Appearance) {
-        switch response.mode {
-        case .system:
-            self = .system
-        case .custom:
-            do {
-                let light = response.light
-                let dark = response.dark
-                let accent = try CustomerCenterConfigData.Appearance.ColorInformation(light: light.accentColor,
-                                                                                      dark: dark.accentColor)
-                let background = try CustomerCenterConfigData.Appearance.ColorInformation(light: light.backgroundColor,
-                                                                                          dark: dark.backgroundColor)
-                let text = try CustomerCenterConfigData.Appearance.ColorInformation(light: light.textColor,
-                                                                                    dark: dark.textColor)
-                self = .custom(accentColor: accent,
-                               backgroundColor: background,
-                               textColor: text)
-            } catch {
-                Logger.error("Failed to parse appearance colors")
-                self = .system
-            }
-        }
+        self.accentColor = CustomerCenterConfigData.Appearance.ColorInformation(light: response.light.accentColor,
+                                                                                dark: response.dark.accentColor)
+        self.textColor = CustomerCenterConfigData.Appearance.ColorInformation(light: response.light.textColor,
+                                                                              dark: response.dark.textColor)
+        self.backgroundColor = CustomerCenterConfigData.Appearance.ColorInformation(light: response.light.backgroundColor,
+                                                                                    dark: response.dark.backgroundColor)
+        self.buttonTextColor = CustomerCenterConfigData.Appearance.ColorInformation(light: response.light.buttonTextColor,
+                                                                                    dark: response.dark.buttonTextColor)
+        self.buttonBackgroundColor = CustomerCenterConfigData.Appearance.ColorInformation(light: response.light.buttonBackgroundColor,
+                                                                                          dark: response.dark.buttonBackgroundColor)
     }
 
 }

--- a/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
+++ b/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
@@ -83,22 +83,16 @@ struct CustomerCenterConfigResponse {
 
     struct Appearance {
 
-        let mode: AppearanceMode
         let light: AppearanceCustomColors
         let dark: AppearanceCustomColors
 
-        enum AppearanceMode: String {
-
-            case system = "SYSTEM"
-            case custom = "CUSTOM"
-
-        }
-
         struct AppearanceCustomColors {
 
-            let accentColor: String
-            let backgroundColor: String
-            let textColor: String
+            let accentColor: String?
+            let textColor: String?
+            let backgroundColor: String?
+            let buttonTextColor: String?
+            let buttonBackgroundColor: String?
 
         }
 
@@ -138,7 +132,6 @@ extension CustomerCenterConfigResponse.HelpPath.PromotionalOffer: Codable, Equat
 extension CustomerCenterConfigResponse.HelpPath.FeedbackSurvey: Codable, Equatable {}
 extension CustomerCenterConfigResponse.HelpPath.FeedbackSurvey.Option: Codable, Equatable {}
 extension CustomerCenterConfigResponse.Appearance: Codable, Equatable {}
-extension CustomerCenterConfigResponse.Appearance.AppearanceMode: Codable, Equatable {}
 extension CustomerCenterConfigResponse.Appearance.AppearanceCustomColors: Codable, Equatable {}
 extension CustomerCenterConfigResponse.Screen: Codable, Equatable {}
 extension CustomerCenterConfigResponse.Screen.ScreenType: Codable, Equatable {}

--- a/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
+++ b/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
@@ -26,9 +26,16 @@ class CustomerCenterConfigDataTests: TestCase {
         let mockResponse = CustomerCenterConfigResponse(
             customerCenter: .init(
                 appearance: .init(
-                    mode: .custom,
-                    light: .init(accentColor: "#FFFFFF", backgroundColor: "#000000", textColor: "#FF0000"),
-                    dark: .init(accentColor: "#000000", backgroundColor: "#FFFFFF", textColor: "#00FF00")
+                    light: .init(accentColor: "#A3F9B5",
+                                 textColor: "#7B2D26",
+                                 backgroundColor: "#E1C6FF",
+                                 buttonTextColor: "#0D3F4F",
+                                 buttonBackgroundColor: "#FFA07A"),
+                    dark: .init(accentColor: "#5D3FD3",
+                                textColor: "#98FB98",
+                                backgroundColor: "#2F4F4F",
+                                buttonTextColor: "#FFD700",
+                                buttonBackgroundColor: "#8B4513")
                 ),
                 screens: [
                     "MANAGEMENT": .init(
@@ -81,17 +88,16 @@ class CustomerCenterConfigDataTests: TestCase {
         expect(configData.localization.locale) == "en_US"
         expect(configData.localization.localizedStrings["key"]) == "value"
 
-        switch configData.appearance.mode {
-        case .system:
-            fatalError("appearance mode should be custom")
-        case .custom(accentColor: let accentColor, backgroundColor: let backgroundColor, textColor: let textColor):
-            expect(accentColor.light.stringRepresentation) == "#FFFFFF"
-            expect(accentColor.dark.stringRepresentation) == "#000000"
-            expect(backgroundColor.light.stringRepresentation) == "#000000"
-            expect(backgroundColor.dark.stringRepresentation) == "#FFFFFF"
-            expect(textColor.light.stringRepresentation) == "#FF0000"
-            expect(textColor.dark.stringRepresentation) == "#00FF00"
-        }
+        expect(configData.appearance.accentColor.light!.stringRepresentation) == "#A3F9B5"
+        expect(configData.appearance.accentColor.dark!.stringRepresentation) == "#5D3FD3"
+        expect(configData.appearance.backgroundColor.light!.stringRepresentation) == "#E1C6FF"
+        expect(configData.appearance.backgroundColor.dark!.stringRepresentation) == "#2F4F4F"
+        expect(configData.appearance.textColor.light!.stringRepresentation) == "#7B2D26"
+        expect(configData.appearance.textColor.dark!.stringRepresentation) == "#98FB98"
+        expect(configData.appearance.buttonTextColor.light!.stringRepresentation) == "#0D3F4F"
+        expect(configData.appearance.buttonTextColor.dark!.stringRepresentation) == "#FFD700"
+        expect(configData.appearance.buttonBackgroundColor.light!.stringRepresentation) == "#FFA07A"
+        expect(configData.appearance.buttonBackgroundColor.dark!.stringRepresentation) == "#8B4513"
 
         expect(configData.screens.count) == 1
         let managementScreen = try XCTUnwrap(configData.screens[.management])

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerCenterConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerCenterConfigTests.swift
@@ -151,7 +151,6 @@ class BackendGetCustomerCenterConfigTests: BaseBackendTests {
         expect(appearance.light.accentColor) == "#000000"
         expect(appearance.light.backgroundColor) == "#ffffff"
         expect(appearance.light.textColor) == "#ffffff"
-        expect(appearance.mode) == .custom
 
         let screens = try XCTUnwrap(customerCenter.screens)
         expect(screens).to(haveCount(2))


### PR DESCRIPTION
- Adapt changes from https://github.com/RevenueCat/khepri/pull/9707/ which makes colors nullable and adds new colors for buttons
- Change background and text color in all screens
- Modified buttons to use `.buttonStyle(.borderedProminent)` so they look native by default
- Applied accent color to back button in navigation view