### PR TITLE
Fix trigger all tests branch

### DIFF
--- a/.github/workflows/trigger_all_tests.yml
+++ b/.github/workflows/trigger_all_tests.yml
@@ -41,7 +41,7 @@ jobs:
       # As of writing, this is installed in ubuntu-latest
       # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#cli-tools
       
-      - name: 'Get PR branch'
+      - id: 'get-branch' # the id here is important since it gets reused in the next step
         run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
         env:
           REPO: ${{ github.repository }}


### PR DESCRIPTION
Fix trigger all tests branch (again). 

This was a pretty obvious bug - I was using the output of the `get-branch` step, but I never set the id of the step to that. 

This setup now more closely matches the [solution laid out as a github comment](https://github.com/CircleCI-Public/trigger-circleci-pipeline-action/issues/61#issuecomment-1662021882)