### PR TITLE
Deploy purchaserTester: clean up dry-run parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,6 @@ executors:
       xcode_version:
         type: string
         default: '15.3'
-      install_swiftlint:
-        type: boolean
-        default: true
     macos:
       xcode: << parameters.xcode_version >>
     resource_class: macos.m1.medium.gen1
@@ -405,7 +402,6 @@ jobs:
     executor:
       name: macos-executor
       xcode_version: '14.3.0'
-      install_swiftlint: false
 
     steps:
       - checkout
@@ -430,7 +426,6 @@ jobs:
     executor:
       name: macos-executor
       xcode_version: '14.1.0'
-      install_swiftlint: false
 
     steps:
       - checkout
@@ -491,7 +486,6 @@ jobs:
     executor:
       name: macos-executor
       xcode_version: '14.3.0'
-      install_swiftlint: false
 
     steps:
       - checkout
@@ -521,7 +515,6 @@ jobs:
     executor:
       name: macos-executor
       xcode_version: '14.3.0'
-      install_swiftlint: false
 
     steps:
       - checkout
@@ -555,7 +548,6 @@ jobs:
     executor:
       name: macos-executor
       xcode_version: '15.2.0'
-      install_swiftlint: false
 
     steps:
       - checkout
@@ -636,7 +628,6 @@ jobs:
     executor:
       name: macos-executor
       xcode_version: '15.2.0'
-      install_swiftlint: false
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,7 +478,8 @@ jobs:
           command: bundle exec fastlane run_api_tests
 
   spm-receipt-parser:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - run:
@@ -487,19 +488,15 @@ jobs:
           no_output_timeout: 30m
 
   spm-revenuecat-ui-ios-15:
-    <<: *base-job
-    parameters:
-      xcode_version:
-        type: string
-        default: '14.3.0'
-      install_swiftlint:
-        type: boolean
-        default: false
+    executor:
+      name: macos-executor
+      xcode_version: '14.3.0'
+      install_swiftlint: false
 
     steps:
       - checkout
       - install-dependencies:
-          install_swiftlint: << parameters.install_swiftlint >>
+          install_swiftlint: false
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Tests
@@ -521,19 +518,15 @@ jobs:
           destination: scan-test-output
 
   spm-revenuecat-ui-ios-16:
-    <<: *base-job
-    parameters:
-      xcode_version:
-        type: string
-        default: '14.3.0'
-      install_swiftlint:
-        type: boolean
-        default: false
+    executor:
+      name: macos-executor
+      xcode_version: '14.3.0'
+      install_swiftlint: false
 
     steps:
       - checkout
       - install-dependencies:
-          install_swiftlint: << parameters.install_swiftlint >>
+          install_swiftlint: false
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Release Build
@@ -559,19 +552,15 @@ jobs:
           destination: scan-test-output
 
   run-revenuecat-ui-ios-17:
-    <<: *base-job
-    parameters:
-      xcode_version:
-        type: string
-        default: '15.2.0'
-      install_swiftlint:
-        type: boolean
-        default: true
+    executor:
+      name: macos-executor
+      xcode_version: '15.2.0'
+      install_swiftlint: false
 
     steps:
       - checkout
       - install-dependencies:
-          install_swiftlint: << parameters.install_swiftlint >>
+          install_swiftlint: false
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Release Build
@@ -597,7 +586,8 @@ jobs:
           destination: scan-test-output
 
   spm-revenuecat-ui-watchos:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-dependencies
@@ -620,7 +610,8 @@ jobs:
           destination: scan-test-output
 
   run-test-macos:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-dependencies
@@ -642,19 +633,14 @@ jobs:
           destination: scan-test-output
 
   run-test-ios-17:
-    <<: *base-job
-    parameters:
-      xcode_version:
-        type: string
-        default: '15.2.0'
-      install_swiftlint:
-        type: boolean
-        default: false
+    executor:
+      name: macos-executor
+      xcode_version: '15.2.0'
+      install_swiftlint: false
 
     steps:
       - checkout
-      - install-dependencies:
-          install_swiftlint: << parameters.install_swiftlint >>
+      - install-dependencies
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,8 @@ parameters:
     type: string
     default: ""
 
-aliases:
-  base-job: &base-job
-    resource_class: macos.m1.medium.gen1
-    macos:
-      xcode: << parameters.xcode_version >>
+executors:
+  macos-executor:
     parameters:
       xcode_version:
         type: string
@@ -44,11 +41,20 @@ aliases:
       install_swiftlint:
         type: boolean
         default: true
+    macos:
+      xcode: << parameters.xcode_version >>
+    resource_class: macos.m1.medium.gen1
     environment:
       CIRCLECI_TESTS_GENERATE_SNAPSHOTS: << pipeline.parameters.generate_snapshots >>
       CIRCLECI_TESTS_GENERATE_REVENUECAT_UI_SNAPSHOTS: << pipeline.parameters.generate_revenuecatui_snapshots >>
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
+
+aliases:
+  # note: the base-job alias is being phased out in favor of the executor. This is because the executor allows us to have per-job parameters.
+  base-job: &base-job
+    executor:
+      name: macos-executor
   release-branches: &release-branches
     filters:
       tags:
@@ -1212,7 +1218,12 @@ jobs:
           bundle_name: v3LoadShedderIntegration
 
   deploy-purchase-tester:
-    <<: *base-job
+    executor:
+      name: macos-executor
+    parameters:
+      dry_run:
+        type: boolean
+        default: false
     steps:
       - checkout
       - setup-git-credentials
@@ -1222,18 +1233,6 @@ jobs:
       - run:
           name: Submit Purchase Tester
           command: bundle exec fastlane deploy_purchase_tester
-
-  deploy-purchase-tester-dry-run:
-    <<: *base-job
-    steps:
-      - checkout
-      - setup-git-credentials
-      - trust-github-key
-      - install-dependencies
-      - update-spm-installation-commit
-      - run:
-          name: Submit Purchase Tester
-          command: bundle exec fastlane deploy_purchase_tester dry_run:true
 
   deploy-to-spm:
     docker:
@@ -1327,6 +1326,7 @@ workflows:
             - make-release
           <<: *release-tags
       - deploy-purchase-tester:
+          dry_run: false
           requires:
             - make-release
           <<: *release-tags
@@ -1419,5 +1419,7 @@ workflows:
       - installation-tests-carthage
       - installation-tests-xcode-direct-integration
       - installation-tests-receipt-parser
-      - deploy-purchase-tester-dry-run
       - api-tests
+      - deploy-purchase-tester:
+          dry_run: true
+      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -627,7 +627,8 @@ jobs:
 
     steps:
       - checkout
-      - install-dependencies
+      - install-dependencies:
+          install_swiftlint: false
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,6 @@ executors:
     shell: /bin/bash --login -o pipefail
 
 aliases:
-  # note: the base-job alias is being phased out in favor of the executor. This is because the executor allows us to have per-job parameters.
-  base-job: &base-job
-    executor:
-      name: macos-executor
   release-branches: &release-branches
     filters:
       tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -830,7 +830,8 @@ jobs:
           destination: scan-test-output
 
   build-tv-watch-and-macos:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-dependencies
@@ -840,7 +841,8 @@ jobs:
           no_output_timeout: 30m
 
   build-visionos:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-dependencies
@@ -850,37 +852,43 @@ jobs:
           no_output_timeout: 30m
 
   backend-integration-tests-SK1:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-SK1"
 
   backend-integration-tests-SK2:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-SK2"
 
   backend-integration-tests-other:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-Other"
 
   backend-integration-tests-offline:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-Offline"
 
   backend-integration-tests-custom-entitlements:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-CustomEntitlements"
 
   release-checks:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - trust-github-key
@@ -908,16 +916,11 @@ jobs:
           destination: test_report.html
 
   docs-build:
-    <<: *base-job
-    parameters:
-      xcode_version:
-        type: string
-        # needs to be xcode 14 since we couldn't get xcode 15 to get along with --additional-symbol-graph-dir
-        # https://github.com/RevenueCat/purchases-ios/pull/1997
-        default: '14.3.0'
-      install_swiftlint:
-        type: boolean
-        default: true
+    executor:
+      name: macos-executor
+      # needs to be xcode 14 since we couldn't get xcode 15 to get along with --additional-symbol-graph-dir
+      # https://github.com/RevenueCat/purchases-ios/pull/1997
+      xcode_version: '14.3.0'
     steps:
       - setup-git-credentials
       - checkout
@@ -929,16 +932,11 @@ jobs:
             DOCS_IOS_VERSION: "17.4"
 
   docs-deploy:
-    <<: *base-job
-    parameters:
-      xcode_version:
-        type: string
-        # needs to be xcode 14 since we couldn't get xcode 15 to get along with --additional-symbol-graph-dir
-        # https://github.com/RevenueCat/purchases-ios/pull/1997
-        default: '14.3.0'
-      install_swiftlint:
-        type: boolean
-        default: true
+    executor:
+      name: macos-executor
+      # needs to be xcode 14 since we couldn't get xcode 15 to get along with --additional-symbol-graph-dir
+      # https://github.com/RevenueCat/purchases-ios/pull/1997
+      xcode_version: '14.3.0'
     steps:
       - setup-git-credentials
       - checkout
@@ -950,7 +948,8 @@ jobs:
             DOCS_IOS_VERSION: "17.4"
 
   make-release:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - trust-github-key
@@ -962,7 +961,8 @@ jobs:
           no_output_timeout: 30m
 
   push-revenuecat-pod:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-bundle-dependencies
@@ -973,7 +973,8 @@ jobs:
           no_output_timeout: 30m
 
   push-revenuecatui-pod:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-bundle-dependencies
@@ -984,7 +985,8 @@ jobs:
           no_output_timeout: 30m
 
   prepare-next-version:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-dependencies
@@ -995,7 +997,8 @@ jobs:
           command: bundle exec fastlane prepare_next_version
 
   installation-tests-cocoapods:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-dependencies
@@ -1010,7 +1013,8 @@ jobs:
           directory: Tests/InstallationTests/CocoapodsInstallation
 
   installation-tests-swift-package-manager:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - trust-github-key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -652,19 +652,14 @@ jobs:
           destination: scan-test-output
 
   run-test-ios-16:
-    <<: *base-job
-    parameters:
-      xcode_version:
-        type: string
-        default: '14.3.0'
-      install_swiftlint:
-        type: boolean
-        default: false
+    executor:
+      name: macos-executor
+      xcode_version: '14.3.0'
 
     steps:
       - checkout
       - install-dependencies:
-          install_swiftlint: << parameters.install_swiftlint >>
+          install_swiftlint: false
       - update-spm-installation-commit
       - run:
           name: Run tests
@@ -689,19 +684,14 @@ jobs:
           destination: scan-test-output
 
   run-test-ios-15:
-    <<: *base-job
-    parameters:
-      xcode_version:
-        type: string
-        default: '14.3.0'
-      install_swiftlint:
-        type: boolean
-        default: false
+    executor:
+      name: macos-executor
+      xcode_version: '14.3.0'
 
     steps:
       - checkout
       - install-dependencies:
-          install_swiftlint: << parameters.install_swiftlint >>
+          install_swiftlint: false
       - update-spm-installation-commit
       - run:
           name: Run tests
@@ -723,7 +713,8 @@ jobs:
           destination: scan-test-output
 
   run-test-tvos:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-dependencies
@@ -741,7 +732,8 @@ jobs:
           destination: scan-test-output
 
   run-test-watchos:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-dependencies
@@ -767,23 +759,18 @@ jobs:
           destination: scan-test-output
 
   run-test-ios-14:
-    <<: *base-job
+    executor:
+      name: macos-executor
     # Pre-iOS 15 requires macOS 12 which requires Xcode 14.2
     # See https://circleci.com/docs/using-macos/#supported-xcode-versions
-    parameters:
-      xcode_version:
-        type: string
-        default: '14.2.0'
-      install_swiftlint:
-        type: boolean
-        default: false
+      xcode_version: '14.2.0'
 
     steps:
       - checkout
       - install-dependencies:
           install_xcbeautify: false
           install_mint: true
-          install_swiftlint: << parameters.install_swiftlint >>
+          install_swiftlint: false
       - install-xcbeautify-for-xcode14
       - update-spm-installation-commit
       - install-runtime:
@@ -808,20 +795,16 @@ jobs:
           destination: scan-test-output
 
   run-test-ios-13:
-    <<: *base-job
-    parameters:
-      xcode_version:
-        type: string
-        default: '14.2.0'
-      install_swiftlint:
-        type: boolean
-        default: false
+    executor:
+      name: macos-executor
+      xcode_version: '14.2.0'
+
     steps:
       - checkout
       - install-dependencies:
           install_xcbeautify: false
           install_mint: true
-          install_swiftlint: << parameters.install_swiftlint >>
+          install_swiftlint: false
       - macos/install-rosetta
       - install-xcbeautify-for-xcode14
       - update-spm-installation-commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,14 +402,10 @@ commands:
 
 jobs:
   spm-release-build-xcode-14:
-    <<: *base-job
-    parameters:
-      xcode_version:
-        type: string
-        default: '14.3.0'
-      install_swiftlint:
-        type: boolean
-        default: false
+    executor:
+      name: macos-executor
+      xcode_version: '14.3.0'
+      install_swiftlint: false
 
     steps:
       - checkout
@@ -419,11 +415,9 @@ jobs:
           no_output_timeout: 30m
 
   spm-release-build-xcode-15:
-    <<: *base-job
-    parameters:
-      xcode_version:
-        type: string
-        default: '15.2.0'
+    executor:
+      name: macos-executor
+      xcode_version: '15.2.0'
 
     steps:
       - checkout
@@ -433,14 +427,10 @@ jobs:
           no_output_timeout: 30m
 
   spm-xcode-14-1:
-    <<: *base-job
-    parameters:
-      xcode_version:
-        type: string
-        default: '14.1.0'
-      install_swiftlint:
-        type: boolean
-        default: false
+    executor:
+      name: macos-executor
+      xcode_version: '14.1.0'
+      install_swiftlint: false
 
     steps:
       - checkout
@@ -454,7 +444,8 @@ jobs:
           no_output_timeout: 30m
 
   pod-lib-lint:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-dependencies
@@ -463,7 +454,8 @@ jobs:
           command: bundle exec fastlane check_pods
 
   spm-release-build:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - run:
@@ -476,7 +468,8 @@ jobs:
           no_output_timeout: 30m
 
   api-tests:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - install-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1026,7 +1026,8 @@ jobs:
           directory: Tests/InstallationTests/SPMInstallation/
 
   installation-tests-custom-entitlement-computation-swift-package-manager:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - trust-github-key
@@ -1038,7 +1039,8 @@ jobs:
           directory: Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/
 
   installation-tests-receipt-parser:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - trust-github-key
@@ -1050,7 +1052,8 @@ jobs:
           directory: Tests/InstallationTests/ReceiptParserInstallation/
 
   installation-tests-carthage:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - trust-github-key
@@ -1071,7 +1074,8 @@ jobs:
           directory: Tests/InstallationTests/CarthageInstallation/
 
   installation-tests-xcode-direct-integration:
-    <<: *base-job
+    executor:
+      name: macos-executor
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -1081,7 +1085,8 @@ jobs:
           directory: Tests/InstallationTests/XcodeDirectInstallation/
 
   lint:
-    <<: *base-job
+    executor:
+      name: macos-executor
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -1126,7 +1131,8 @@ jobs:
           command: bundle exec fastlane tag_current_branch
 
   release-train:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - setup-git-credentials
@@ -1137,7 +1143,8 @@ jobs:
           command: bundle exec fastlane automatic_bump github_rate_limit:10
 
   integration-tests-all:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - setup-git-credentials
@@ -1160,7 +1167,8 @@ jobs:
           destination: scan-test-output
 
   loadshedder-integration-tests-v3:
-    <<: *base-job
+    executor:
+      name: macos-executor
     steps:
       - checkout
       - setup-git-credentials
@@ -1189,7 +1197,7 @@ jobs:
       - update-spm-installation-commit
       - run:
           name: Submit Purchase Tester
-          command: bundle exec fastlane deploy_purchase_tester
+          command: bundle exec fastlane deploy_purchase_tester dry_run:<< parameters.dry_run >>
 
   deploy-to-spm:
     docker:


### PR DESCRIPTION
Cleans up the deploy purchase tester job's treatment of `dry-run`: it's now a parameter of the job instead of a separate job entirely. 

This is based off of @tonidero and @vegaro's feedback in #4131 