### PR TITLE
[Customer Center] Fix for disabled promo offer button

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -310,6 +310,8 @@ struct ManageSubscriptionButton: View {
                 Text(path.title)
             }
         })
+        .buttonStyle(ManageSubscriptionsButtonStyle())
+        .disabled(self.viewModel.loadingPath != nil)
         .restorePurchasesAlert(isPresented: self.$viewModel.showRestoreAlert)
         .sheet(item: self.$viewModel.promotionalOfferData,
                onDismiss: {
@@ -322,8 +324,6 @@ struct ManageSubscriptionButton: View {
                                  product: promotionalOfferData.product,
                                  promoOfferDetails: promotionalOfferData.promoOfferDetails)
         })
-        .buttonStyle(ManageSubscriptionsButtonStyle())
-        .disabled(self.viewModel.loadingPath != nil)
     }
 }
 


### PR DESCRIPTION
I noticed the purchase button for the promo offers is always disabled. Changing the order of the modifiers fixes it