### PR TITLE
[Customer Center] Fixes an extra blank screen after popping FeedbackSurveyView on iOS 18.

### DIFF
--- a/RevenueCatUI/Binding+Extensions.swift
+++ b/RevenueCatUI/Binding+Extensions.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Binding+Extensions.swift
+//
+//  Created by JayShortway on 05/08/2024.
+
+import SwiftUI
+
+extension Binding where Value == Bool {
+    static func isNotNil<T>(_ value: Binding<T?>) -> Binding<Bool> {
+        Binding(
+            get: { value.wrappedValue != nil },
+            set: { if !$0 { value.wrappedValue = nil } }
+        )
+    }
+}

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -52,10 +52,7 @@ struct ManageSubscriptionsView: View {
         if #available(iOS 16.0, *) {
             NavigationStack {
                 content
-                    .navigationDestination(isPresented: Binding(
-                        get: { self.viewModel.feedbackSurveyData != nil },
-                        set: { if !$0 { self.viewModel.feedbackSurveyData = nil } }
-                    )) {
+                    .navigationDestination(isPresented: .isNotNil(self.$viewModel.feedbackSurveyData)) {
                         if let feedbackSurveyData = self.viewModel.feedbackSurveyData {
                             FeedbackSurveyView(feedbackSurveyData: feedbackSurveyData)
                                 .onDisappear {
@@ -74,7 +71,7 @@ struct ManageSubscriptionsView: View {
                                     self.viewModel.feedbackSurveyData = nil
                                 }
                         },
-                        isActive: .constant(self.viewModel.feedbackSurveyData != nil)
+                        isActive: .isNotNil(self.$viewModel.feedbackSurveyData)
                     ) {
                         EmptyView()
                     })

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -52,7 +52,10 @@ struct ManageSubscriptionsView: View {
         if #available(iOS 16.0, *) {
             NavigationStack {
                 content
-                    .navigationDestination(isPresented: .constant(self.viewModel.feedbackSurveyData != nil)) {
+                    .navigationDestination(isPresented: Binding(
+                        get: { self.viewModel.feedbackSurveyData != nil },
+                        set: { if !$0 { self.viewModel.feedbackSurveyData = nil } }
+                    )) {
                         if let feedbackSurveyData = self.viewModel.feedbackSurveyData {
                             FeedbackSurveyView(feedbackSurveyData: feedbackSurveyData)
                                 .onDisappear {

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -55,9 +55,6 @@ struct ManageSubscriptionsView: View {
                     .navigationDestination(isPresented: .isNotNil(self.$viewModel.feedbackSurveyData)) {
                         if let feedbackSurveyData = self.viewModel.feedbackSurveyData {
                             FeedbackSurveyView(feedbackSurveyData: feedbackSurveyData)
-                                .onDisappear {
-                                    self.viewModel.feedbackSurveyData = nil
-                                }
                         }
                     }
             }.applyIf(accentColor != nil, apply: { $0.tint(accentColor) })
@@ -67,9 +64,6 @@ struct ManageSubscriptionsView: View {
                     .background(NavigationLink(
                         destination: self.viewModel.feedbackSurveyData.map { data in
                             FeedbackSurveyView(feedbackSurveyData: data)
-                                .onDisappear {
-                                    self.viewModel.feedbackSurveyData = nil
-                                }
                         },
                         isActive: .isNotNil(self.$viewModel.feedbackSurveyData)
                     ) {


### PR DESCRIPTION
## Cause
The issue in the [ticket](https://linear.app/revenuecat/issue/SDK-3519/extra-blank-screen-after-back-button-on-cancel-subscription) is caused by the use of `.constant` and `.onDisappear`, which probably resulted in a timing issue where the `feedbackSurveyData` is not set to `nil` quickly enough after pressing the Back button. 

## Fix
The fix in this PR is to bind directly to the `.feedbackSurveyData` property. I've added an `.isNotNil` Binding extension for this, as it seemed useful to reuse in other parts of RevenueCatUI. Let me know if the `Binding+Extensions.swift` file should be placed somewhere else instead.  

---
Closes SDK-3519 