### PR TITLE
[Customer Center] UI polish for empty content

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/BackwardsCompatibleContentUnavailableView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/BackwardsCompatibleContentUnavailableView.swift
@@ -28,7 +28,7 @@ struct BackwardsCompatibleContentUnavailableView: View {
 
     var body: some View {
 
-        if #available(iOS 17.0, *) {
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
             ContentUnavailableView(
                 title,
                 systemImage: systemImage,

--- a/RevenueCatUI/CustomerCenter/Views/BackwardsCompatibleContentUnavailableView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/BackwardsCompatibleContentUnavailableView.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  BackwardsCompatibleContentUnavailableView.swift
+//
+//
+//  Created by Cody Kerns on 8/6/24.
+//
+
+import SwiftUI
+
+/// A SwiftUI view for displaying a message about unavailable content
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@available(visionOS, unavailable)
+struct BackwardsCompatibleContentUnavailableView: View {
+    @State var title: String
+    @State var description: String
+    @State var systemImage: String
+
+    var body: some View {
+
+        if #available(iOS 17.0, *) {
+            ContentUnavailableView(
+                title,
+                systemImage: systemImage,
+                description: Text(description)
+            )
+        } else {
+            VStack {
+                Image(systemName: systemImage)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 48, height: 48)
+                    .foregroundStyle(.secondary)
+                    .padding()
+
+                Text(title)
+                    .font(.title2)
+                    .bold()
+
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }.frame(maxHeight: .infinity)
+        }
+
+    }
+}

--- a/RevenueCatUI/CustomerCenter/Views/CompatibilityContentUnavailableView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CompatibilityContentUnavailableView.swift
@@ -15,6 +15,8 @@
 
 import SwiftUI
 
+#if os(iOS)
+
 /// A SwiftUI view for displaying a message about unavailable content
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable)
@@ -55,3 +57,5 @@ struct CompatibilityContentUnavailableView: View {
 
     }
 }
+
+#endif

--- a/RevenueCatUI/CustomerCenter/Views/CompatibilityContentUnavailableView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CompatibilityContentUnavailableView.swift
@@ -7,7 +7,7 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  BackwardsCompatibleContentUnavailableView.swift
+//  CompatibilityContentUnavailableView.swift
 //
 //
 //  Created by Cody Kerns on 8/6/24.
@@ -21,7 +21,7 @@ import SwiftUI
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 @available(visionOS, unavailable)
-struct BackwardsCompatibleContentUnavailableView: View {
+struct CompatibilityContentUnavailableView: View {
     @State var title: String
     @State var description: String
     @State var systemImage: String

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -54,13 +54,11 @@ struct NoSubscriptionsView: View {
                 background.edgesIgnoringSafeArea(.all)
             }
             VStack {
-                Text(self.configuration.screens[.noActive]?.title ?? "No Subscriptions found")
-                    .font(.title)
-                    .padding()
-                Text(self.configuration.screens[.noActive]?.subtitle ??
-                     "We can try checking your Apple account for any previous purchases")
-                .font(.body)
-                .padding()
+                BackwardsCompatibleContentUnavailableView(
+                    title: self.configuration.screens[.noActive]?.title ?? "No subscriptions found",
+                    description: self.configuration.screens[.noActive]?.subtitle ?? "We can try checking your Apple account for any previous purchases",
+                    systemImage: "exclamationmark.triangle.fill" // TODO: customize image
+                )
 
                 Spacer()
 

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -58,7 +58,7 @@ struct NoSubscriptionsView: View {
             VStack {
                 CompatibilityContentUnavailableView(
                     title: self.configuration.screens[.noActive]?.title ?? "No subscriptions found",
-                    description: 
+                    description:
                         self.configuration.screens[.noActive]?.subtitle ?? fallbackDescription,
                     systemImage: "exclamationmark.triangle.fill"
                 )

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -49,15 +49,18 @@ struct NoSubscriptionsView: View {
         let background = color(from: appearance.backgroundColor, for: colorScheme)
         let textColor = color(from: appearance.textColor, for: colorScheme)
 
+        let fallbackDescription = "We can try checking your Apple account for any previous purchases"
+
         ZStack {
             if background != nil {
                 background.edgesIgnoringSafeArea(.all)
             }
             VStack {
-                BackwardsCompatibleContentUnavailableView(
+                CompatibilityContentUnavailableView(
                     title: self.configuration.screens[.noActive]?.title ?? "No subscriptions found",
-                    description: self.configuration.screens[.noActive]?.subtitle ?? "We can try checking your Apple account for any previous purchases",
-                    systemImage: "exclamationmark.triangle.fill" // TODO: customize image
+                    description: 
+                        self.configuration.screens[.noActive]?.subtitle ?? fallbackDescription,
+                    systemImage: "exclamationmark.triangle.fill"
                 )
 
                 Spacer()
@@ -71,6 +74,7 @@ struct NoSubscriptionsView: View {
                 Button(localization.commonLocalizedString(for: .cancel)) {
                     dismiss()
                 }
+                .padding(.vertical)
             }
             .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
         }

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -49,20 +49,13 @@ struct WrongPlatformView: View {
             let textColor = color(from: appearance.textColor, for: colorScheme)
 
             VStack {
-                switch store {
-                case .appStore, .macAppStore, .playStore, .amazon:
-                    let platformName = humanReadablePlatformName(store: store!)
+                let platformInstructions = self.humanReadableInstructions(for: store)
 
-                    Text("Your subscription is a \(platformName) subscription.")
-                        .font(.title)
-                        .padding()
-                    Text("Go the app settings on \(platformName) to manage your subscription and billing.")
-                        .padding()
-                default:
-                    Text("Please contact support to manage your subscription")
-                        .font(.title)
-                        .padding()
-                }
+                BackwardsCompatibleContentUnavailableView(
+                    title: platformInstructions.0,
+                    description: platformInstructions.1,
+                    systemImage: "exclamationmark.triangle.fill" // TODO: customize image
+                )
 
             }
             .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
@@ -96,6 +89,40 @@ struct WrongPlatformView: View {
         }
     }
 
+    private func humanReadableInstructions(for store: Store?) -> (String, String) {
+        let defaultContactSupport = "Please contact support to manage your subscription."
+
+        if let store {
+            let platformName = humanReadablePlatformName(store: store)
+
+            switch store {
+            case .appStore, .macAppStore:
+                return (
+                    "You have an \(platformName) subscription.",
+                    "You can manage your subscription via the App Store app on an Apple device."
+                )
+            case .playStore:
+                return (
+                    "You have a \(platformName) subscription.",
+                    "You can manage your subscription via the Google Play app on an Android device."
+                )
+            case .stripe, .rcBilling, .external:
+                return ("Active \(platformName) Subscription", defaultContactSupport)
+            case .promotional:
+                return ("Active \(platformName) Subscription", defaultContactSupport)
+            case .amazon:
+                return (
+                    "You have an \(platformName) subscription.",
+                    "You can manage your subscription via the Amazon Appstore app."
+                )
+            case .unknownStore:
+                return ("Unknown Subscription", defaultContactSupport)
+            }
+        } else {
+            return ("Unknown Subscription", defaultContactSupport)
+        }
+    }
+
 }
 
 #if DEBUG
@@ -111,6 +138,9 @@ struct WrongPlatformView_Previews: PreviewProvider {
         Group {
             WrongPlatformView(store: .appStore)
                 .previewDisplayName("App Store")
+
+            WrongPlatformView(store: .amazon)
+                .previewDisplayName("Amazon")
 
             WrongPlatformView(store: .rcBilling)
                 .previewDisplayName("RCBilling")

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -51,10 +51,10 @@ struct WrongPlatformView: View {
             VStack {
                 let platformInstructions = self.humanReadableInstructions(for: store)
 
-                BackwardsCompatibleContentUnavailableView(
+                CompatibilityContentUnavailableView(
                     title: platformInstructions.0,
                     description: platformInstructions.1,
-                    systemImage: "exclamationmark.triangle.fill" // TODO: customize image
+                    systemImage: "exclamationmark.triangle.fill"
                 )
 
             }


### PR DESCRIPTION
Attempting some UI polish

- Implements `ContentUnavailableView` for the views that have 'empty' content (with a visually similar backwards compatible version)
- Improves instructions for each platform for wrong-platform subscription management

| New           | Old           |
|:-------------:|:-------------:|
| ![New Version](https://github.com/user-attachments/assets/866266ae-4996-4480-b990-17bc143641fa) | ![Old Version](https://github.com/user-attachments/assets/936e7892-2d60-4b86-889b-7b1b543d729c) |

