### PR TITLE
Fix crash on iOS 18 beta 5

### DIFF
--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -90,8 +90,6 @@ extension View {
         if enabled {
             if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
                 ViewThatFits(in: axis.scrollViewAxis) {
-                    self
-
                     ScrollView(axis.scrollViewAxis) {
                         self
                     }


### PR DESCRIPTION
Potential fix for https://github.com/RevenueCat/purchases-ios/issues/4150

The extra `self` seems unnecessary.