### PR TITLE
[Customer Center] Use system navigation titles

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -104,11 +104,11 @@ enum CustomerCenterConfigTestData {
     )
 
     static let standardAppearance = CustomerCenterConfigData.Appearance(
-        accentColor: .init(light: "#ffffff", dark: "#000000"),
+        accentColor: .init(light: "#007AFF", dark: "#007AFF"),
         textColor: .init(light: "#000000", dark: "#ffffff"),
-        backgroundColor: .init(light: "#000000", dark: "#ffffff"),
-        buttonTextColor: .init(light: "#000000", dark: "#ffffff"),
-        buttonBackgroundColor: .init(light: "#000000", dark: "#ffffff")
+        backgroundColor: .init(light: "#f5f5f7", dark: "#000000"),
+        buttonTextColor: .init(light: "#ffffff", dark: "#000000"),
+        buttonBackgroundColor: .init(light: "#287aff", dark: "#287aff")
     )
 
     static let subscriptionInformationMonthlyRenewing: SubscriptionInformation = .init(

--- a/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
@@ -48,10 +48,6 @@ struct FeedbackSurveyView: View {
             }
 
             VStack {
-                // swiftlint:disable:next todo
-                // TODO: enable the subtitle after data model changes
-                // SubtitleTextView(subtitle: self.viewModel.feedbackSurveyData.configuration.subtitle)
-
                 Spacer()
 
                 FeedbackSurveyButtonsView(options: self.viewModel.feedbackSurveyData.configuration.options,

--- a/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
@@ -46,13 +46,11 @@ struct FeedbackSurveyView: View {
             if let background = color(from: appearance.backgroundColor, for: colorScheme) {
                 background.edgesIgnoringSafeArea(.all)
             }
-            let textColor = color(from: appearance.textColor, for: colorScheme)
 
             VStack {
-                Text(self.viewModel.feedbackSurveyData.configuration.title)
-                    .font(.title)
-                    .padding()
-                    .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
+                // swiftlint:disable:next todo
+                // TODO: enable the subtitle after data model changes
+                // SubtitleTextView(subtitle: self.viewModel.feedbackSurveyData.configuration.subtitle)
 
                 Spacer()
 
@@ -69,6 +67,8 @@ struct FeedbackSurveyView: View {
                                          promoOfferDetails: promotionalOfferData.promoOfferDetails)
                 })
         }
+        .navigationTitle(self.viewModel.feedbackSurveyData.configuration.title)
+        .navigationBarTitleDisplayMode(.inline)
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -85,7 +85,7 @@ struct ManageSubscriptionsView: View {
             ScrollView {
                 VStack {
                     if self.viewModel.isLoaded {
-                        HeaderView(viewModel: self.viewModel)
+                        SubtitleTextView(subtitle: self.viewModel.screen.subtitle)
 
                         if let subscriptionInformation = self.viewModel.subscriptionInformation {
                             SubscriptionDetailsView(
@@ -108,6 +108,7 @@ struct ManageSubscriptionsView: View {
         .task {
             await loadInformationIfNeeded()
         }
+        .navigationTitle(self.viewModel.screen.title)
         .navigationBarTitleDisplayMode(.inline)
     }
 }
@@ -132,10 +133,9 @@ private extension ManageSubscriptionsView {
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 @available(visionOS, unavailable)
-struct HeaderView: View {
+struct SubtitleTextView: View {
 
-    @ObservedObject
-    private(set) var viewModel: ManageSubscriptionsViewModel
+    private(set) var subtitle: String?
     @Environment(\.appearance)
     private var appearance: CustomerCenterConfigData.Appearance
     @Environment(\.colorScheme)
@@ -144,10 +144,13 @@ struct HeaderView: View {
     var body: some View {
         let textColor = color(from: appearance.textColor, for: colorScheme)
 
-        Text(self.viewModel.screen.title)
-            .font(.title)
-            .padding()
-            .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
+        if let subtitle {
+            Text(subtitle)
+                .font(.subheadline)
+                .padding([.horizontal])
+                .multilineTextAlignment(.center)
+                .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
+        }
     }
 
 }
@@ -259,6 +262,7 @@ struct SubscriptionDetailsView: View {
         .background(Color(UIColor.tertiarySystemBackground))
         .cornerRadius(20)
         .shadow(color: .black.opacity(0.1), radius: 10, x: 0.0, y: 10)
+        .padding(.top)
         .padding(.bottom)
         .padding(.bottom)
     }

--- a/RevenueCatUI/CustomerCenter/Views/TintedProgressView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/TintedProgressView.swift
@@ -32,7 +32,7 @@ struct TintedProgressView: View {
     var body: some View {
         ProgressView()
             .controlSize(.regular)
-            .tint(colorScheme == .dark ? Color.black : Color.white)
+            .tint(colorScheme == .light ? Color.black : Color.white)
     }
 
 }


### PR DESCRIPTION
- Uses system navigation titles instead of text views for screen titles
- Display subtitle for the manage subscriptions screen
- improves preview test data with some standard default colors
- fixes progress view tint color

| New           | Old           |
|:-------------:|:-------------:|
| ![New Version](https://github.com/user-attachments/assets/2af439cf-a536-4930-bdd4-afc308bd100d) | ![Old Version](https://github.com/user-attachments/assets/5e53044c-e65d-4953-9faa-fd2217e6b84f) |
