### PR TITLE
[Paywalls] Make iOS version calculation lazy

### DIFF
--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -30,7 +30,7 @@ extension View {
 }
 
 private var isIOSVersionWithCrash: Bool = {
-    // There is a bug in iOS 18 beta 5 (as of writing, future versions uncofirmed) that causes a crash.
+    // There is a bug in iOS 18 beta 5 (as of writing, future versions unconfirmed) that causes a crash.
     // This has been reporte to Apple as FB14699941.
     // Until this is fixed, we're rolling back to pre-iOS 16 behavior for this view.
     // More information and discussion here: https://github.com/RevenueCat/purchases-ios/issues/4150

--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -31,7 +31,7 @@ extension View {
 
 private var isIOSVersionWithCrash: Bool = {
     // There is a bug in iOS 18 beta 5 (as of writing, future versions unconfirmed) that causes a crash.
-    // This has been reporte to Apple as FB14699941.
+    // This has been reported to Apple as FB14699941.
     // Until this is fixed, we're rolling back to pre-iOS 16 behavior for this view.
     // More information and discussion here: https://github.com/RevenueCat/purchases-ios/issues/4150
     let iOSVersionWithCrash = OperatingSystemVersion(majorVersion: 18, minorVersion: 0, patchVersion: 0)

--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -29,6 +29,15 @@ extension View {
 
 }
 
+private var isIOSVersionWithCrash: Bool = {
+    // There is a bug in iOS 18 beta 5 (as of writing, future versions uncofirmed) that causes a crash.
+    // This has been reporte to Apple as FB14699941.
+    // Until this is fixed, we're rolling back to pre-iOS 16 behavior for this view.
+    // More information and discussion here: https://github.com/RevenueCat/purchases-ios/issues/4150
+    let iOSVersionWithCrash = OperatingSystemVersion(majorVersion: 18, minorVersion: 0, patchVersion: 0)
+    return ProcessInfo.processInfo.isOperatingSystemAtLeast(iOSVersionWithCrash)
+}()
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
@@ -84,20 +93,11 @@ extension View {
         #endif
     }
 
-    private static var isIOSVersionWithCrash: Bool {
-        // There is a bug in iOS 18 beta 5 (as of writing, future versions uncofirmed) that causes a crash.
-        // This has been reporte to Apple as FB14699941.
-        // Until this is fixed, we're rolling back to pre-iOS 16 behavior for this view.
-        // More information and discussion here: https://github.com/RevenueCat/purchases-ios/issues/4150
-        let iOSVersionWithCrash = OperatingSystemVersion(majorVersion: 18, minorVersion: 0, patchVersion: 0)
-        return ProcessInfo.processInfo.isOperatingSystemAtLeast(iOSVersionWithCrash)
-    }
-
     @ViewBuilder
     // @PublicForExternalTesting
     func scrollableIfNecessary(_ axis: Axis = .vertical, enabled: Bool = true) -> some View {
         if enabled {
-            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *), !Self.isIOSVersionWithCrash {
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *), !isIOSVersionWithCrash {
                 ViewThatFits(in: axis.scrollViewAxis) {
                     self
 
@@ -118,7 +118,7 @@ extension View {
     @ViewBuilder
     func scrollableIfNecessaryWhenAvailable(_ axis: Axis = .vertical, enabled: Bool = true) -> some View {
         if enabled {
-            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *), !Self.isIOSVersionWithCrash {
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *), !isIOSVersionWithCrash {
                 ViewThatFits(in: axis.scrollViewAxis) {
                     self
 


### PR DESCRIPTION
Since iOS version cannot change at runtime, we can make it a stored variable so we only compute it once.