### PR TITLE
re-enable customer center tests in main

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -132,6 +132,10 @@ platform :ios do
 
   desc "Runs all the iOS tests"
   lane :test_ios do |options|
+
+    # todo: remove once Customer Center is released
+    enable_customer_center
+
     generate_snapshots = ENV["CIRCLECI_TESTS_GENERATE_SNAPSHOTS"] == "true"
 
     # For platforms that fail to run StoreKit tests.
@@ -216,6 +220,9 @@ platform :ios do
     platform = ENV['PLATFORM'] || 'iOS Simulator'
     destination = ENV['DEVICE'] || "iPhone 14,OS=16.4"
     sdk = ENV['BUILD_SDK'] || 'iphonesimulator'
+
+    # todo: remove once Customer Center is released
+    enable_customer_center
 
     fetch_snapshots
 
@@ -470,6 +477,27 @@ platform :ios do
       files_to_add: "."
      )
     }
+  end
+
+  desc "Enable Customer Center"
+  lane :enable_customer_center do
+    # This enables the customer center by replacing CUSTOMER_CENTER_ENABLED with true in all files. 
+    # This lane should be removed once Customer Center is released.
+    require 'find'
+
+    project_root = File.expand_path("../", __dir__)
+
+    Find.find(project_root) do |path|
+      next unless File.file?(path) # Process only files
+
+      content = File.read(path)
+
+      updated_content = content.gsub('CUSTOMER_CENTER_ENABLED', 'true')
+
+      File.write(path, updated_content) if content != updated_content
+    end
+
+    UI.success("Customer Center enabled.")
   end
 
   private_lane :push_snapshot_pr do |options|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -488,7 +488,8 @@ platform :ios do
     project_root = File.expand_path("../", __dir__)
 
     Find.find(project_root) do |path|
-      next unless File.file?(path) # Process only files
+      # process only Swift files
+      next unless File.file?(path) && File.extname(path) == ".swift"
 
       content = File.read(path)
 


### PR DESCRIPTION
We weren't running tests for Customer Center in PRs, since the `CUSTOMER_CENTER_ENABLED` flag is disabled. 

This could be dangerous, so this PR enables the flag in the absolutely dumbest way I could think of: just replace the instances where the flag is used with `true`, before running tests, i.e.: 
```swift
// before
#if CUSTOMER_CENTER_ENABLED

// after
#if true
```

It's easy to extend to other test suites. It could also have been its own test suite but I felt like it wouldn't have added much, we would have ended up most tests twice for no real gain. 