### PR TITLE
Enable customer center tests

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -163,7 +163,7 @@ platform :ios do
       output_directory: "fastlane/test_output/xctest/ios",
       number_of_retries: generate_snapshots ? 0 : 5,
       fail_build: !generate_snapshots,
-      xcargs: "OTHER_SWIFT_FLAGS='-DCUSTOMER_CENTER_ENABLED'"
+      xcargs: "OTHER_SWIFT_FLAGS='-DCUSTOMER_CENTER_ENABLED'" # todo: remove once Customer Center is released
     )
   end
 
@@ -232,7 +232,8 @@ platform :ios do
         report_formats: [:junit],
         report_path: 'fastlane/test_output/revenuecatui/tests.xml',
         test: true,
-        xcargs: generate_snapshots ? "-testPlan CI-Snapshots" : "-testPlan CI-RevenueCatUI"
+        # todo: remove CUSTOMER_CENTER_ENABLED once Customer Center is released
+        xcargs: "#{generate_snapshots ? '-testPlan CI-Snapshots' : '-testPlan CI-RevenueCatUI'} OTHER_SWIFT_FLAGS='-DCUSTOMER_CENTER_ENABLED'"
       )
     rescue => e
       # Equivalent to `fail_build: !generate_snapshots`

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -304,7 +304,7 @@ platform :ios do
       scheme: 'All API Tests',
       destination: 'generic/platform=iOS Simulator',
       configuration: 'release',
-      xcargs: "-DCUSTOMER_CENTER_ENABLED=YES"
+      xcargs: "OTHER_SWIFT_FLAGS='-DCUSTOMER_CENTER_ENABLED'" # todo: remove once Customer Center is released
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -163,7 +163,7 @@ platform :ios do
       output_directory: "fastlane/test_output/xctest/ios",
       number_of_retries: generate_snapshots ? 0 : 5,
       fail_build: !generate_snapshots,
-      xcargs: "-DCUSTOMER_CENTER_ENABLED=YES"
+      xcargs: "OTHER_SWIFT_FLAGS='-DCUSTOMER_CENTER_ENABLED'"
     )
   end
 
@@ -303,6 +303,7 @@ platform :ios do
       scheme: 'All API Tests',
       destination: 'generic/platform=iOS Simulator',
       configuration: 'release',
+      xcargs: "-DCUSTOMER_CENTER_ENABLED=YES"
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -162,7 +162,8 @@ platform :ios do
       configuration: 'Debug',
       output_directory: "fastlane/test_output/xctest/ios",
       number_of_retries: generate_snapshots ? 0 : 5,
-      fail_build: !generate_snapshots
+      fail_build: !generate_snapshots,
+      xcargs: "-DCUSTOMER_CENTER_ENABLED=YES"
     )
   end
 


### PR DESCRIPTION
Customer Center is currently `#ifdef`ed out via `CUSTOMER_CENTER_ENABLED` while it is under development, but we want to run its tests during development.  This defines `CUSTOMER_CENTER_ENABLED` for `OTHER_SWIFT_FLAGS` via the command line build arguments for test lanes, which will override the project settings, so the tests are run.

This PR can be reverted when the customer centre is released.

‼️This PR is not needed if we go for the [source-processing method](https://github.com/RevenueCat/purchases-ios/pull/4170) instead.