### PR TITLE
Revert workaround for iOS 18 beta 5 SwiftUI crash

### DIFF
--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -29,15 +29,6 @@ extension View {
 
 }
 
-private var isIOSVersionWithCrash: Bool = {
-    // There is a bug in iOS 18 beta 5 (as of writing, future versions unconfirmed) that causes a crash.
-    // This has been reported to Apple as FB14699941.
-    // Until this is fixed, we're rolling back to pre-iOS 16 behavior for this view.
-    // More information and discussion here: https://github.com/RevenueCat/purchases-ios/issues/4150
-    let iOSVersionWithCrash = OperatingSystemVersion(majorVersion: 18, minorVersion: 0, patchVersion: 0)
-    return ProcessInfo.processInfo.isOperatingSystemAtLeast(iOSVersionWithCrash)
-}()
-
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
@@ -97,7 +88,7 @@ extension View {
     // @PublicForExternalTesting
     func scrollableIfNecessary(_ axis: Axis = .vertical, enabled: Bool = true) -> some View {
         if enabled {
-            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *), !isIOSVersionWithCrash {
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
                 ViewThatFits(in: axis.scrollViewAxis) {
                     self
 
@@ -118,7 +109,7 @@ extension View {
     @ViewBuilder
     func scrollableIfNecessaryWhenAvailable(_ axis: Axis = .vertical, enabled: Bool = true) -> some View {
         if enabled {
-            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *), !isIOSVersionWithCrash {
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
                 ViewThatFits(in: axis.scrollViewAxis) {
                     self
 


### PR DESCRIPTION
The issue has been fixed in iOS 18.1 beta 2 / iOS 18 beta 6.

Original PR: https://github.com/RevenueCat/purchases-ios/pull/4154