### PR TITLE
replace `color(from colorInformation:)` global with extension

### DIFF
--- a/RevenueCatUI/CustomerCenter/ColorFromAppearance.swift
+++ b/RevenueCatUI/CustomerCenter/ColorFromAppearance.swift
@@ -18,9 +18,11 @@ import RevenueCat
 import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-func color(from colorInformation: CustomerCenterConfigData.Appearance.ColorInformation,
-           for colorScheme: ColorScheme) -> Color? {
-    return colorScheme == .dark ? colorInformation.dark?.underlyingColor : colorInformation.light?.underlyingColor
+extension Color {
+    static func from(colorInformation: CustomerCenterConfigData.Appearance.ColorInformation,
+                     for colorScheme: ColorScheme) -> Color? {
+        return colorScheme == .dark ? colorInformation.dark?.underlyingColor : colorInformation.light?.underlyingColor
+    }
 }
 
 #endif

--- a/RevenueCatUI/CustomerCenter/ManageSubscriptionsButtonStyle.swift
+++ b/RevenueCatUI/CustomerCenter/ManageSubscriptionsButtonStyle.swift
@@ -31,8 +31,8 @@ struct ManageSubscriptionsButtonStyle: PrimitiveButtonStyle {
     @Environment(\.colorScheme) private var colorScheme
 
     func makeBody(configuration: PrimitiveButtonStyleConfiguration) -> some View {
-        let background = color(from: appearance.buttonBackgroundColor, for: colorScheme)
-        let textColor = color(from: appearance.buttonTextColor, for: colorScheme)
+        let background = Color.from(colorInformation: appearance.buttonBackgroundColor, for: colorScheme)
+        let textColor = Color.from(colorInformation: appearance.buttonTextColor, for: colorScheme)
 
         Button(action: { configuration.trigger() }, label: {
             configuration.label.frame(maxWidth: .infinity)

--- a/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
@@ -42,7 +42,7 @@ struct FeedbackSurveyView: View {
 
     var body: some View {
         ZStack {
-            if let background = color(from: appearance.backgroundColor, for: colorScheme) {
+            if let background = Color.from(colorInformation: appearance.backgroundColor, for: colorScheme) {
                 background.edgesIgnoringSafeArea(.all)
             }
 

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -48,7 +48,7 @@ struct ManageSubscriptionsView: View {
     }
 
     var body: some View {
-        let accentColor = color(from: self.appearance.accentColor, for: self.colorScheme)
+        let accentColor = Color.from(colorInformation: self.appearance.accentColor, for: self.colorScheme)
 
         if #available(iOS 16.0, *) {
             NavigationStack {
@@ -77,7 +77,7 @@ struct ManageSubscriptionsView: View {
     @ViewBuilder
     var content: some View {
         ZStack {
-            if let background = color(from: appearance.backgroundColor, for: colorScheme) {
+            if let background = Color.from(colorInformation: appearance.backgroundColor, for: colorScheme) {
                 background.edgesIgnoringSafeArea(.all)
             }
 
@@ -139,7 +139,7 @@ struct SubtitleTextView: View {
     private var colorScheme
 
     var body: some View {
-        let textColor = color(from: appearance.textColor, for: colorScheme)
+        let textColor = Color.from(colorInformation: appearance.textColor, for: colorScheme)
 
         if let subtitle {
             Text(subtitle)

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -47,8 +47,8 @@ struct NoSubscriptionsView: View {
     }
 
     var body: some View {
-        let background = color(from: appearance.backgroundColor, for: colorScheme)
-        let textColor = color(from: appearance.textColor, for: colorScheme)
+        let background = Color.from(colorInformation: appearance.backgroundColor, for: colorScheme)
+        let textColor = Color.from(colorInformation: appearance.textColor, for: colorScheme)
 
         let fallbackDescription = "We can try checking your Apple account for any previous purchases"
 

--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -50,7 +50,7 @@ struct PromotionalOfferView: View {
 
     var body: some View {
         ZStack {
-            if let background = color(from: appearance.backgroundColor, for: colorScheme) {
+            if let background = Color.from(colorInformation: appearance.backgroundColor, for: colorScheme) {
                 background.edgesIgnoringSafeArea(.all)
             }
 
@@ -92,7 +92,7 @@ struct PromotionalOfferHeaderView: View {
     private(set) var viewModel: PromotionalOfferViewModel
 
     var body: some View {
-        let textColor = color(from: appearance.textColor, for: colorScheme)
+        let textColor = Color.from(colorInformation: appearance.textColor, for: colorScheme)
         if let details = self.viewModel.promotionalOfferData?.promoOfferDetails {
             VStack {
                 Text(details.title)

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -44,10 +44,10 @@ struct WrongPlatformView: View {
 
     var body: some View {
         ZStack {
-            if let background = color(from: appearance.backgroundColor, for: colorScheme) {
+            if let background = Color.from(colorInformation: appearance.backgroundColor, for: colorScheme) {
                 background.edgesIgnoringSafeArea(.all)
             }
-            let textColor = color(from: appearance.textColor, for: colorScheme)
+            let textColor = Color.from(colorInformation: appearance.textColor, for: colorScheme)
 
             VStack {
                 let platformInstructions = self.humanReadableInstructions(for: store)


### PR DESCRIPTION
Small refactor that replaces the color(from colorInformation:) global it with internal extension. 

The idea is to keep the global namespace cleaner. Also it feels a bit neater to be able to find it through Color. 