### PR TITLE
Speed up carthage installation tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1243,12 +1243,10 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      # - lint
-      # - run-test-ios-17
-      # - pod-lib-lint
-      # - run-revenuecat-ui-ios-17
-      # TODO: undo before merging, this is for testing only
-      - installation-tests-carthage
+      - lint
+      - run-test-ios-17
+      - pod-lib-lint
+      - run-revenuecat-ui-ios-17
 
   create-tag:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1243,10 +1243,12 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      - lint
-      - run-test-ios-17
-      - pod-lib-lint
-      - run-revenuecat-ui-ios-17
+      # - lint
+      # - run-test-ios-17
+      # - pod-lib-lint
+      # - run-revenuecat-ui-ios-17
+      # TODO: undo before merging, this is for testing only
+      - installation-tests-carthage
 
   create-tag:
     when:

--- a/Tests/InstallationTests/CarthageInstallation/fastlane/Fastfile
+++ b/Tests/InstallationTests/CarthageInstallation/fastlane/Fastfile
@@ -13,9 +13,11 @@ lane :installation_tests do
   
   Dir.chdir("..") do
     # install without building, then remove the tests and build, so that carthage
-    # doesn't try to build the other installation tests
+    # doesn't try to build the other installation tests and testing apps
     sh "carthage", "update", "--no-build"
     sh "rm", "-rf", "Carthage/Checkouts/purchases-root/Tests/InstallationTests/"
+    sh "rm", "-rf", "Carthage/Checkouts/purchases-root/Tests/APITesters/"
+    sh "rm", "-rf", "Carthage/Checkouts/purchases-root/Tests/TestingApps/"
 
     # Carthage builds all schemes including ones we don't need, so let's nuke them before proceeding
     schemes_directory = "Carthage/Checkouts/purchases-root/RevenueCat.xcodeproj/xcshareddata/xcschemes"


### PR DESCRIPTION
Speeds up carthage installation tests by reducing the amount of work that they do. 

It almost halves the execution time:

| Before | After |
| :-: | :-: |
| <img width="812" alt="Screenshot 2024-08-14 at 12 05 07 PM" src="https://github.com/user-attachments/assets/5d124805-feaa-46e4-b35a-a5ce1e30e0e1"> | <img width="512" alt="Screenshot 2024-08-14 at 12 30 54 PM" src="https://github.com/user-attachments/assets/535d2792-ae8c-4a1c-8158-c75f90f487c3"> |
