### PR TITLE
XCFramework artifacts in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -913,6 +913,12 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/report.html
           destination: test_report.html
+      - store_artifacts:
+          path: RevenueCat.xcframework.zip
+          destination: RevenueCat.xcframework.zip
+      - store_artifacts:
+          path: RevenueCatUI.xcframework.zip
+          destination: RevenueCatUI.xcframework.zip
 
   docs-build:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1249,12 +1249,10 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      # todo: undo, temporarily commenting out to test xcframework output
-      # - lint
-      # - run-test-ios-17
-      # - pod-lib-lint
-      # - run-revenuecat-ui-ios-17
-      - release-checks
+      - lint
+      - run-test-ios-17
+      - pod-lib-lint
+      - run-revenuecat-ui-ios-17
 
   create-tag:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1249,10 +1249,12 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      - lint
-      - run-test-ios-17
-      - pod-lib-lint
-      - run-revenuecat-ui-ios-17
+      # todo: undo, temporarily commenting out to test xcframework output
+      # - lint
+      # - run-test-ios-17
+      # - pod-lib-lint
+      # - run-revenuecat-ui-ios-17
+      - release-checks
 
   create-tag:
     when:

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -7125,7 +7125,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.RevenueCatUIDev;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.RevenueCatUI;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = NO;
@@ -7148,10 +7148,10 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 8SXR2327BM;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -7175,9 +7175,10 @@
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.RevenueCatUIDev;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.RevenueCatUI;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -243,11 +243,12 @@ platform :ios do
 
   desc "Release checks"
   lane :release_checks do |options|
-    version_number = current_version_number
-    check_no_git_tag_exists(version_number)
-    check_pods
+    # todo: undo, temporarily commenting out to test xcframework output
+    # version_number = current_version_number
+    # check_no_git_tag_exists(version_number)
+    # check_pods
     export_xcframeworks
-    check_no_github_release_exists(version_number)
+    # check_no_github_release_exists(version_number)
   end
 
   desc "build tvOS, watchOS, macOS"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -243,12 +243,11 @@ platform :ios do
 
   desc "Release checks"
   lane :release_checks do |options|
-    # todo: undo, temporarily commenting out to test xcframework output
-    # version_number = current_version_number
-    # check_no_git_tag_exists(version_number)
-    # check_pods
+    version_number = current_version_number
+    check_no_git_tag_exists(version_number)
+    check_pods
     export_xcframeworks
-    # check_no_github_release_exists(version_number)
+    check_no_github_release_exists(version_number)
   end
 
   desc "build tvOS, watchOS, macOS"
@@ -547,17 +546,17 @@ platform :ios do
       app_identifier: "com.revenuecat.CarthageIntegration"
     )
 
-    # create_and_sign_xcframework(
-    #   scheme: 'RevenueCat',
-    #   product_name: 'RevenueCat',
-    #   platforms: [
-    #   'iOS',
-    #   'macOS',
-    #   'maccatalyst',
-    #   'tvOS',
-    #   'watchOS',
-    #   'visionOS'
-    # ])
+    create_and_sign_xcframework(
+      scheme: 'RevenueCat',
+      product_name: 'RevenueCat',
+      platforms: [
+      'iOS',
+      'macOS',
+      'maccatalyst',
+      'tvOS',
+      'watchOS',
+      'visionOS'
+    ])
     create_and_sign_xcframework(
       scheme: 'RevenueCatUIDev',
       product_name: 'RevenueCatUI',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -538,17 +538,26 @@ platform :ios do
   end
 
   lane :export_xcframeworks do |options|
-    create_and_sign_xcframework(
-      scheme: 'RevenueCat',
-      product_name: 'RevenueCat',
-      platforms: [
-      'iOS',
-      'macOS',
-      'maccatalyst',
-      'tvOS',
-      'watchOS',
-      'visionOS'
-    ])
+    match(
+      readonly: true,
+      git_url: ENV['CERTS_REPO_URL'],
+      type: 'appstore',
+      skip_provisioning_profiles: true,
+      # This isn't important, we just need to fetch the certificate
+      app_identifier: "com.revenuecat.CarthageIntegration"
+    )
+
+    # create_and_sign_xcframework(
+    #   scheme: 'RevenueCat',
+    #   product_name: 'RevenueCat',
+    #   platforms: [
+    #   'iOS',
+    #   'macOS',
+    #   'maccatalyst',
+    #   'tvOS',
+    #   'watchOS',
+    #   'visionOS'
+    # ])
     create_and_sign_xcframework(
       scheme: 'RevenueCatUIDev',
       product_name: 'RevenueCatUI',
@@ -563,6 +572,7 @@ platform :ios do
     scheme = options[:scheme]
     product_name = options[:product_name]
     platforms = options[:platforms]
+    match()
 
     output_directory = "build/xcframeworks/#{product_name}"
 
@@ -714,15 +724,6 @@ platform :ios do
   end
 
   private_lane :sign_xcframework do |options|
-    match(
-      readonly: true,
-      git_url: ENV['CERTS_REPO_URL'],
-      type: 'appstore',
-      skip_provisioning_profiles: true,
-      # This isn't important, we just need to fetch the certificate
-      app_identifier: "com.revenuecat.CarthageIntegration"
-    )
-
     sh(
       "codesign",
       "--timestamp",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -537,15 +537,6 @@ platform :ios do
   end
 
   lane :export_xcframeworks do |options|
-    match(
-      readonly: true,
-      git_url: ENV['CERTS_REPO_URL'],
-      type: 'appstore',
-      skip_provisioning_profiles: true,
-      # This isn't important, we just need to fetch the certificate
-      app_identifier: "com.revenuecat.CarthageIntegration"
-    )
-
     create_and_sign_xcframework(
       scheme: 'RevenueCat',
       product_name: 'RevenueCat',
@@ -722,6 +713,15 @@ platform :ios do
   end
 
   private_lane :sign_xcframework do |options|
+    match(
+      readonly: true,
+      git_url: ENV['CERTS_REPO_URL'],
+      type: 'appstore',
+      skip_provisioning_profiles: true,
+      # This isn't important, we just need to fetch the certificate
+      app_identifier: "com.revenuecat.CarthageIntegration"
+    )
+
     sh(
       "codesign",
       "--timestamp",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -572,7 +572,6 @@ platform :ios do
     scheme = options[:scheme]
     product_name = options[:product_name]
     platforms = options[:platforms]
-    match()
 
     output_directory = "build/xcframeworks/#{product_name}"
 


### PR DESCRIPTION
Follow up to https://github.com/RevenueCat/purchases-ios/pull/4172
Adds the xcframework as a circleci artifact

Also fixes a code signing issue when archiving `RevenueCatUI.xcframework`

linear ticket: SDK-3555