### PR TITLE
Create lane to enable customer center

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -998,6 +998,32 @@ platform :ios do
     end
   end
 
+  desc "Enable customer center development by cherry-picking a specific commit"
+  lane :enable_customer_center do |options|
+    commit_hash = options[:commit_hash] || "517ad0bf5"
+
+    UI.message("Preparing to enable customer center development...")
+    UI.message("Checking git status...")
+    
+    ensure_git_status_clean
+
+    UI.message("Git working directory is clean. Proceeding with customer center enablement.")
+    UI.message("Cherry-picking commit to enable customer center: #{commit_hash}")
+
+    begin
+      sh("git", "cherry-pick", commit_hash)
+      UI.success("Successfully enabled customer center development by cherry-picking commit #{commit_hash}")
+    rescue => ex
+      UI.error("Failed to enable customer center. Error while cherry-picking commit #{commit_hash}")
+      UI.error(ex.message)
+      
+      if UI.confirm("Do you want to abort the customer center enablement?")
+        sh("git", "cherry-pick", "--abort")
+        UI.message("Customer center enablement aborted")
+      end
+    end
+  end
+
   private_lane :sandbox_testers_delete do |options|
     email_pattern = options[:email_pattern]
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1008,13 +1008,14 @@ platform :ios do
     ensure_git_status_clean
 
     UI.message("Git working directory is clean. Proceeding with customer center enablement.")
-    UI.message("Cherry-picking commit to enable customer center: #{commit_hash}")
+    UI.message("Applying changes from commit to enable customer center: #{commit_hash}")
 
     begin
-      sh("git", "cherry-pick", commit_hash)
-      UI.success("Successfully enabled customer center development by cherry-picking commit #{commit_hash}")
+      sh("git", "cherry-pick", "--no-commit", commit_hash)
+      UI.success("Successfully applied changes for customer center development from commit #{commit_hash}")
+      UI.important("Changes are now in your working directory. Review and stage/commit as needed.")
     rescue => ex
-      UI.error("Failed to enable customer center. Error while cherry-picking commit #{commit_hash}")
+      UI.error("Failed to enable customer center. Error while applying changes from commit #{commit_hash}")
       UI.error(ex.message)
       
       if UI.confirm("Do you want to abort the customer center enablement?")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1002,12 +1002,6 @@ platform :ios do
   lane :enable_customer_center do |options|
     commit_hash = options[:commit_hash] || "517ad0bf5"
 
-    UI.message("Preparing to enable customer center development...")
-    UI.message("Checking git status...")
-    
-    ensure_git_status_clean
-
-    UI.message("Git working directory is clean. Proceeding with customer center enablement.")
     UI.message("Applying changes from commit to enable customer center: #{commit_hash}")
 
     begin

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -354,6 +354,14 @@ Updates purchases-ios-snapshots-commit to point to latest commit on main
 
 Create or delete sandbox testers
 
+### ios enable_customer_center
+
+```sh
+[bundle exec] fastlane ios enable_customer_center
+```
+
+Enable customer center development by cherry-picking a specific commit
+
 ----
 
 


### PR DESCRIPTION
This lane will do the cherry pick command that enables the customer center, without the need to check the commit hash