### PR TITLE
[Customer Center] Hide Contact Support button if URL can't be created

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
@@ -42,7 +42,7 @@ struct RestorePurchasesAlert: ViewModifier {
     private var localization
     @Environment(\.supportInformation)
     private var supportInformation: CustomerCenterConfigData.Support?
-    
+
     private var supportURL: URL? {
         guard let supportInformation = self.supportInformation else { return nil }
         let subject = self.localization.commonLocalizedString(for: .defaultSubject)
@@ -91,7 +91,9 @@ struct RestorePurchasesAlert: ViewModifier {
                     if let url = supportURL {
                         return Alert(title: Text(""),
                                      message: message,
-                                     primaryButton: .default(Text(localization.commonLocalizedString(for: .contactSupport))) {
+                                     primaryButton: .default(
+                                        Text(localization.commonLocalizedString(for: .contactSupport))
+                                     ) {
                                          Task {
                                              openURL(url)
                                          }


### PR DESCRIPTION
I noticed the Contact Support button wouldn't work in cases when the email URL is nil, like for example in simulators that don't have Mail app.

I improved the alert a little bit to hide the Contact Support button for those cases.