### PR TITLE
Fix the setting for SKIP_INSTALL in Xcode project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1249,12 +1249,10 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      # todo: undo the change after confirming that things work
-      - installation-tests-xcode-direct-integration
-      # - lint
-      # - run-test-ios-17
-      # - pod-lib-lint
-      # - run-revenuecat-ui-ios-17
+      - lint
+      - run-test-ios-17
+      - pod-lib-lint
+      - run-revenuecat-ui-ios-17
 
   create-tag:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1249,10 +1249,12 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      - lint
-      - run-test-ios-17
-      - pod-lib-lint
-      - run-revenuecat-ui-ios-17
+      # todo: undo the change after confirming that things work
+      - installation-tests-xcode-direct-integration
+      # - lint
+      # - run-test-ios-17
+      # - pod-lib-lint
+      # - run-revenuecat-ui-ios-17
 
   create-tag:
     when:

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -6507,7 +6507,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				RUN_DOCUMENTATION_COMPILER = YES;
 				SDKROOT = "";
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -7089,7 +7089,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = "";
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -7187,7 +7187,7 @@
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
The official docs don't say a lot about `SKIP_INSTALL`, but I missed the mark during the #4172 PR, where the ideal setup is  NO for debug, YES for release. I spent a lot of time figuring this out a couple of years back but the other day I completely forgot about it 🤦 


<img width="1128" alt="image" src="https://github.com/user-attachments/assets/4256ec42-00c2-4de2-a622-9a151b849781">

<img width="747" alt="image" src="https://github.com/user-attachments/assets/c8cdf454-0558-489b-bb24-b3006a4ebacb">

Here's ChatGPT's far better explanation than Apple's: 
```
	•	Debug Configuration:
	•	SKIP_INSTALL = YES
	•	During development, you typically don’t need to install (or include) the product (e.g., .framework, .app) in the final build output. The focus is on quick builds, so setting SKIP_INSTALL = YES can help speed up the process by skipping unnecessary steps.
	•	Release Configuration:
	•	SKIP_INSTALL = NO
	•	In the Release configuration, you usually want to include everything in the final build output. This is particularly important when archiving for distribution or creating .xcframeworks, as you need the final product to be available in the archive.

Example Scenario

If you are building a framework that is used by other targets in your project:

	•	Debug Configuration:
	•	Set SKIP_INSTALL = YES so that intermediate builds are faster, and the framework isn’t unnecessarily copied to the install location.
	•	Release Configuration:
	•	Set SKIP_INSTALL = NO so that when you archive the framework, it is included in the final archive, making it available for distribution or further use.

```
