### PR TITLE
Set Paywalls Tester deployment target to iOS 15

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		4FCA01FB2A3A1CBD00B262C0 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FCA01FA2A3A1CBD00B262C0 /* StoreKit.framework */; };
 		4FDF11202A7270F3004F3680 /* SamplePaywallsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF111F2A7270F3004F3680 /* SamplePaywallsList.swift */; };
 		880B2AF22BEC2D62006B9393 /* Preprocessor.sh in Resources */ = {isa = PBXBuildFile; fileRef = 880B2AF12BEC2D62006B9393 /* Preprocessor.sh */; };
+		884A4DDE2C701F4100BD6B90 /* CompatibilityContentUnavailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884A4DDD2C701F4100BD6B90 /* CompatibilityContentUnavailableView.swift */; };
 		88A543E92C387DB00039C6A5 /* APIKeyDashboardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A543E82C387DB00039C6A5 /* APIKeyDashboardList.swift */; };
 		88B2F9882BE1943C00B43E0B /* ManagePaywallButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B2F9872BE1943C00B43E0B /* ManagePaywallButton.swift */; };
 		88B2F98B2BE19B1200B43E0B /* OfferingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B2F98A2BE19B1200B43E0B /* OfferingButton.swift */; };
@@ -96,6 +97,7 @@
 		4FFD2A602AA154B4001F4B0C /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
 		880B2AF12BEC2D62006B9393 /* Preprocessor.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = Preprocessor.sh; sourceTree = SOURCE_ROOT; };
 		880B2AF32BEC35AA006B9393 /* Postprocessor.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Postprocessor.sh; sourceTree = SOURCE_ROOT; };
+		884A4DDD2C701F4100BD6B90 /* CompatibilityContentUnavailableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompatibilityContentUnavailableView.swift; sourceTree = "<group>"; };
 		88A543E82C387DB00039C6A5 /* APIKeyDashboardList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIKeyDashboardList.swift; sourceTree = "<group>"; };
 		88B2F9872BE1943C00B43E0B /* ManagePaywallButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagePaywallButton.swift; sourceTree = "<group>"; };
 		88B2F98A2BE19B1200B43E0B /* OfferingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingButton.swift; sourceTree = "<group>"; };
@@ -255,6 +257,7 @@
 				4FC046C32A572E3700A28BCF /* DebugView.swift */,
 				88B2F9892BE1944200B43E0B /* OfferingList */,
 				88B4380B2BDB0FCB000AF27C /* PaywallPresenter.swift */,
+				884A4DDD2C701F4100BD6B90 /* CompatibilityContentUnavailableView.swift */,
 				4FDF111F2A7270F3004F3680 /* SamplePaywallsList.swift */,
 				4F102E262A840ECC0059EED6 /* CustomPaywall.swift */,
 				4F71CDD12A992292001B9BEF /* CustomPaywallContent.swift */,
@@ -420,6 +423,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				884A4DDE2C701F4100BD6B90 /* CompatibilityContentUnavailableView.swift in Sources */,
 				88DFC1972BCF4A5100273B6D /* MockData.swift in Sources */,
 				88BEB9282BF537F200A3D05F /* SamplePaywalls.swift in Sources */,
 				88DFC18D2BCF3AD100273B6D /* AsyncButton.swift in Sources */,

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -624,7 +624,7 @@
 				INFOPLIST_KEY_WKWatchOnly = NO;
 				"INFOPLIST_KEY_WKWatchOnly[sdk=watchos*]" = YES;
 				"INFOPLIST_KEY_WKWatchOnly[sdk=watchsimulator*]" = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
@@ -674,7 +674,7 @@
 				INFOPLIST_KEY_WKWatchOnly = NO;
 				"INFOPLIST_KEY_WKWatchOnly[sdk=watchos*]" = YES;
 				"INFOPLIST_KEY_WKWatchOnly[sdk=watchsimulator*]" = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/ApplicationData.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/ApplicationData.swift
@@ -9,16 +9,16 @@ import Foundation
 
 import OSLog
 
-@Observable
-final class ApplicationData {
+@MainActor
+final class ApplicationData: ObservableObject {
 
+    @Published
     private(set) var authenticationStatus: AuthenticationStatus = .unknown {
         didSet {
             Self.logger.info("Changed authentication: \(String(describing: self.authenticationStatus))")
         }
     }
 
-    @MainActor
     func loadApplicationData() async throws {
         do {
             self.authenticationStatus = .signedIn(try await self.manager.loadApplicationData())
@@ -32,7 +32,7 @@ final class ApplicationData {
         self.manager.signOut()
         self.authenticationStatus = .signedOut
     }
-    
+
     var isSignedIn: Bool {
         if case .signedIn = self.authenticationStatus {
             return true
@@ -40,7 +40,6 @@ final class ApplicationData {
         return false
     }
 
-    @ObservationIgnored
     private var manager: ApplicationManagerType = ApplicationManager()
     private static let logger = Logging.shared.logger(category: "ApplicationData")
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -26,7 +26,7 @@ struct PresentedPaywall: Hashable {
     var responseOfferingID: String
 }
 
-
+@MainActor
 final class OfferingsPaywallsViewModel: ObservableObject {
 
     enum State {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import RevenueCat
+import Combine
 
 struct PaywallsData: Hashable {
     let offeringsAndPaywalls: [OfferingPaywall]
@@ -25,8 +26,8 @@ struct PresentedPaywall: Hashable {
     var responseOfferingID: String
 }
 
-@Observable
-final class OfferingsPaywallsViewModel {
+
+final class OfferingsPaywallsViewModel: ObservableObject {
 
     enum State {
         case notloaded
@@ -34,8 +35,10 @@ final class OfferingsPaywallsViewModel {
         case error(Error)
     }
 
+    @Published
     var error: Error?
 
+    @Published
     private(set) var state: State {
         didSet {
             if case let .error(stateError) = state {
@@ -43,10 +46,17 @@ final class OfferingsPaywallsViewModel {
             }
         }
     }
+
+    @Published
     private(set) var hasMultipleTemplates = false
+
+    @Published
     private(set) var hasMultipleOfferingsWithPaywalls = false
+
+    @Published
     var presentedPaywall: PresentedPaywall?
 
+    @Published
     var listData: PaywallsData? {
         didSet {
             Task { @MainActor in
@@ -55,6 +65,7 @@ final class OfferingsPaywallsViewModel {
         }
     }
 
+    //@Published
     var singleApp: DeveloperResponse.App? {
         guard apps.count == 1 else { return nil }
         return apps.first
@@ -88,19 +99,17 @@ final class OfferingsPaywallsViewModel {
             self.state = .error(error)
         }
     }
-    
-    @MainActor
+
     func getAndShowPaywallForID(id: String, mode: PaywallViewMode = .default) async {
 
-        showPaywallForID(id, mode: mode)
+        await showPaywallForID(id, mode: mode)
 
         // in case data has changed since last fetch
         await updateOfferingsAndPaywalls()
 
-        showPaywallForID(id, mode: mode)
+        await showPaywallForID(id, mode: mode)
     }
 
-    @MainActor
     func dismissPaywall() {
         self.presentedPaywall = nil
     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Data/OfferingsPaywallsViewModel.swift
@@ -65,7 +65,6 @@ final class OfferingsPaywallsViewModel: ObservableObject {
         }
     }
 
-    //@Published
     var singleApp: DeveloperResponse.App? {
         guard apps.count == 1 else { return nil }
         return apps.first
@@ -116,7 +115,7 @@ final class OfferingsPaywallsViewModel: ObservableObject {
 
     private static var logger = Logging.shared.logger(category: "Paywalls Tester")
 
-    private var apps: [DeveloperResponse.App]
+    private let apps: [DeveloperResponse.App]
 
 }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Networking/HTTPClient.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Networking/HTTPClient.swift
@@ -193,13 +193,13 @@ private extension HTTPEndpoint {
 
     func url(with domain: URL) -> URL {
         let baseURL = self.isInternal
-            ? domain.appending(path: "internal")
+            ? domain.appendingPathComponent("internal")
             : domain
 
         return baseURL
-            .appending(path: "v1")
-            .appending(path: "developers")
-            .appending(path: self.path)
+            .appendingPathComponent("v1")
+            .appendingPathComponent("developers")
+            .appendingPathComponent(self.path)
     }
 
     private static let baseURL = URL(string: "https://api.revenuecat.com/v1/developers/")!

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/PaywallsPreview.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/PaywallsPreview.swift
@@ -23,7 +23,7 @@ struct PaywallsPreview: App {
         var id: String { paywallIDToShow }
     }
 
-    @State
+    @StateObject
     private var application = ApplicationData()
 
     @State
@@ -46,8 +46,8 @@ struct PaywallsPreview: App {
                     guard let url = userActivity.webpageURL else { return }
                     processURL(url)
                 }
+                .environmentObject(application)
         }
-        .environment(application)
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppList.swift
@@ -10,8 +10,10 @@ import RevenueCat
 
 struct AppList: View {
 
-    @Environment(ApplicationData.self)
-    private var application
+//    @Environment(ApplicationData.self)
+//    private var application
+
+    @EnvironmentObject private var application: ApplicationData
 
     @AppStorage(UserDefaults.introEligibilityStatus) 
     private var introEligibility: IntroEligibilityStatus = .eligible
@@ -49,5 +51,5 @@ struct AppList: View {
 
 #Preview {
     AppList()
-    .environment(ApplicationData())
+    .environmentObject(ApplicationData())
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppList.swift
@@ -10,9 +10,6 @@ import RevenueCat
 
 struct AppList: View {
 
-//    @Environment(ApplicationData.self)
-//    private var application
-
     @EnvironmentObject private var application: ApplicationData
 
     @AppStorage(UserDefaults.introEligibilityStatus) 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CompatibilityContentUnavailableView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CompatibilityContentUnavailableView.swift
@@ -1,0 +1,85 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CompatibilityContentUnavailableView.swift
+//
+//
+//  Created by Cody Kerns on 8/6/24.
+//
+
+import Foundation
+import SwiftUI
+
+#if os(iOS)
+
+/// A SwiftUI view for displaying a message about unavailable content
+@available(iOS 15.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct CompatibilityContentUnavailableView: View {
+    let title: String
+    let systemImage: String
+    let description: Text?
+
+    init(_ title: String, systemImage: String, description: Text? = nil) {
+        self.title = title
+        self.systemImage = systemImage
+        self.description = description
+    }
+
+    var body: some View {
+
+        if #available(iOS 17.0, *) {
+            #if swift(>=5.9)
+            if let description {
+                ContentUnavailableView(
+                    title,
+                    systemImage: systemImage,
+                    description: description
+                )
+            } else {
+                ContentUnavailableView(
+                    title,
+                    systemImage: systemImage
+                )
+            }
+
+            #else
+                // In Xcode 14, any references to ContentUnavailableView would fail to compile since that entity
+                // was included with Xcode 15 and later.
+                // Although Xcode 15 is required for App Store builds, we have some CI processes that run in Xcode 14
+                // so this retains compatibility while not affecting any real world usage.
+                EmptyView()
+            #endif
+        } else {
+            VStack {
+                Image(systemName: systemImage)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 48, height: 48)
+                    .foregroundStyle(.secondary)
+                    .padding()
+
+                Text(title)
+                    .font(.title2)
+                    .bold()
+
+                if let description {
+                    description
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }.frame(maxHeight: .infinity)
+        }
+
+    }
+}
+
+#endif

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginScreen.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginScreen.swift
@@ -103,29 +103,7 @@ private final class LoginViewModel: ObservableObject {
     private(set) var authenticated = false
 
     @Published
-    var formIsComplete: Bool = false {
-        didSet {
-            let now = formIsComplete
-            print("ha: \(now)")
-            print("")
-        }
-    }
-
-    init(username: String = "",
-         password: String = "",
-         code: String = "",
-         codeRequired: Bool = false,
-         operationInProgress: Bool = false,
-         authenticated: Bool = false,
-         authentication: AuthenticationActor = AuthenticationActor()) {
-        self.username = username
-        self.password = password
-        self.code = code
-        self.codeRequired = codeRequired
-        self.operationInProgress = operationInProgress
-        self.authenticated = authenticated
-        self.authentication = authentication
-    }
+    var formIsComplete: Bool = false
 
     @MainActor
     func attemptLogin() async throws {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginScreen.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginScreen.swift
@@ -73,7 +73,7 @@ struct LoginScreen: View {
 }
 
 // MARK: - Private
-
+@MainActor
 private final class LoginViewModel: ObservableObject {
 
     @Published

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginWall.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginWall.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct LoginWall<ContentView: View>: View {
 
-    @Environment(ApplicationData.self) private var application
-    
+    @EnvironmentObject private var application: ApplicationData
+
     @State
     private var error: Error?
 
@@ -52,5 +52,5 @@ struct LoginWall<ContentView: View>: View {
             Text("Developer \(developer.name) is now signed in.")
         }
     }
-    .environment(ApplicationData())
+    .environmentObject(ApplicationData())
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginWall.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginWall.swift
@@ -21,8 +21,10 @@ struct LoginWall<ContentView: View>: View {
         case .unknown:
             ProgressView()
                 .displayError(self.$error)
-                .task { @MainActor in
-                    await reload()
+                .onAppear {
+                    Task {
+                        await reload()
+                    }
                 }
         case let .signedIn(developer):
             content(developer)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginWall.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/Login/LoginWall.swift
@@ -22,6 +22,8 @@ struct LoginWall<ContentView: View>: View {
             ProgressView()
                 .displayError(self.$error)
                 .onAppear {
+                    // note we are using .onAppear and not .task because .task causes an error dialog to
+                    // briefly show when run on iOS 15.
                     Task {
                         await reload()
                     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingButton.swift
@@ -49,7 +49,7 @@ private extension OfferingButton {
 
 private extension OfferingButton {
     
-    @ViewBuilder
+    @MainActor @ViewBuilder
     private func label() -> some View {
         let paywallTitle = rcOffering.paywall?.localizedConfiguration?.title ?? ""
         let decorator = viewModel.hasMultipleOfferingsWithPaywalls && self.selectedItemID == responseOffering.id ? "▶ " : ""
@@ -93,6 +93,7 @@ private extension OfferingButton {
             .lineLimit(1)
     }
 
+    @MainActor
     private func moreActionsMenu() -> some View {
         #if !os(watchOS)
         Menu {
@@ -106,7 +107,7 @@ private extension OfferingButton {
         #endif
     }
 
-    @ViewBuilder
+    @MainActor @ViewBuilder
     private func contextMenuItems() -> some View {
         ForEach(PaywallViewMode.allCases, id: \.self) { mode in
             self.showPaywallMenuButton(for: mode)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -68,8 +68,7 @@ struct OfferingsList: View {
                 Text("No data available.")
             }
         case .error(let error):
-            Text("Error loading paywalls") // JAMES TO DO
-//            ContentUnavailableView("Error loading paywalls", systemImage: "exclamationmark.triangle.fill", description: Text(error.localizedDescription))
+            CompatibilityContentUnavailableView("Error loading paywalls", systemImage: "exclamationmark.triangle.fill", description: Text(error.localizedDescription))
         }
     }
     
@@ -128,8 +127,8 @@ struct OfferingsList: View {
 
     private func noPaywallsListItem() -> some View {
         VStack {
-            Text("No configured paywalls") // JAMES TO DO
-//            ContentUnavailableView("No configured paywalls", systemImage: "exclamationmark.triangle.fill")
+            CompatibilityContentUnavailableView("No configured paywalls",
+                                                         systemImage: "exclamationmark.triangle.fill")
             Text(Self.pullToRefresh)
                 .font(.footnote)
             Text("Use the RevenueCat [web dashboard](https://app.revenuecat.com/) to configure a new paywall for one of this app's offerings.")

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -33,7 +33,7 @@ struct OfferingsList: View {
             .task {
                 await viewModel.updateOfferingsAndPaywalls()
             }
-            .onChange(of: scenePhase) { oldPhase, newPhase in
+            .onChange(of: scenePhase) { newPhase in
                 if newPhase == .active {
                     Task {
                         await viewModel.updateOfferingsAndPaywalls()
@@ -44,13 +44,13 @@ struct OfferingsList: View {
     }
 
     init(app: DeveloperResponse.App, introEligility: Binding<IntroEligibilityStatus>) {
-        self._viewModel = State(initialValue: OfferingsPaywallsViewModel(apps: [app]))
+        self._viewModel = StateObject(wrappedValue: OfferingsPaywallsViewModel(apps: [app]))
         self._introEligility = introEligility
     }
 
     @Environment(\.scenePhase) private var scenePhase
 
-    @State
+    @StateObject
     private var viewModel: OfferingsPaywallsViewModel
 
     @State
@@ -68,7 +68,8 @@ struct OfferingsList: View {
                 Text("No data available.")
             }
         case .error(let error):
-            ContentUnavailableView("Error loading paywalls", systemImage: "exclamationmark.triangle.fill", description: Text(error.localizedDescription))
+            Text("Error loading paywalls") // JAMES TO DO
+//            ContentUnavailableView("Error loading paywalls", systemImage: "exclamationmark.triangle.fill", description: Text(error.localizedDescription))
         }
     }
     
@@ -127,7 +128,8 @@ struct OfferingsList: View {
 
     private func noPaywallsListItem() -> some View {
         VStack {
-            ContentUnavailableView("No configured paywalls", systemImage: "exclamationmark.triangle.fill")
+            Text("No configured paywalls") // JAMES TO DO
+//            ContentUnavailableView("No configured paywalls", systemImage: "exclamationmark.triangle.fill")
             Text(Self.pullToRefresh)
                 .font(.footnote)
             Text("Use the RevenueCat [web dashboard](https://app.revenuecat.com/) to configure a new paywall for one of this app's offerings.")

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/PaywallForID.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/PaywallForID.swift
@@ -10,7 +10,7 @@ import RevenueCat
 
 struct PaywallForID: View {
 
-    @State
+    @StateObject
     private var viewModel: OfferingsPaywallsViewModel
     private let id: String
     private let introEligible: IntroEligibilityStatus
@@ -18,7 +18,7 @@ struct PaywallForID: View {
     init(apps: [DeveloperResponse.App], id: String, introEligible: IntroEligibilityStatus = .unknown) {
         self.id = id
         self.introEligible = introEligible
-        self._viewModel = State(initialValue: OfferingsPaywallsViewModel(apps: apps))
+        self._viewModel = StateObject(wrappedValue: OfferingsPaywallsViewModel(apps: apps))
     }
 
     var body: some View {


### PR DESCRIPTION
Updates the target of Paywalls Tester to iOS 15 so that we can test RevenueCatUI easily.