### PR TITLE
[Customer Center] Clean up colors in WrongPlatformView and NoSubscriptionsView

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -74,10 +74,6 @@ struct ManageSubscriptionsView: View {
     @ViewBuilder
     var content: some View {
         ZStack {
-            if let background = Color.from(colorInformation: appearance.backgroundColor, for: colorScheme) {
-                background.edgesIgnoringSafeArea(.all)
-            }
-
             if self.viewModel.isLoaded {
                 List {
 

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -47,34 +47,29 @@ struct NoSubscriptionsView: View {
     }
 
     var body: some View {
-        let background = Color.from(colorInformation: appearance.backgroundColor, for: colorScheme)
-        let textColor = Color.from(colorInformation: appearance.textColor, for: colorScheme)
-
         let fallbackDescription = "We can try checking your Apple account for any previous purchases"
 
-        ZStack {
-            if background != nil {
-                background.edgesIgnoringSafeArea(.all)
-            }
-            VStack {
+        List {
+            Section {
                 CompatibilityContentUnavailableView(
                     self.configuration.screens[.noActive]?.title ?? "No subscriptions found",
                     systemImage: "exclamationmark.triangle.fill",
                     description:
                         Text(self.configuration.screens[.noActive]?.subtitle ?? fallbackDescription)
-
                 )
+            }
 
-                Spacer()
-
+            Section {
                 Button(localization.commonLocalizedString(for: .restorePurchases)) {
                     showRestoreAlert = true
                 }
                 .restorePurchasesAlert(isPresented: $showRestoreAlert)
-                .buttonStyle(ProminentButtonStyle())
+            } header: {
+                let subtitle = localization.commonLocalizedString(for: .tryCheckRestore)
+                Text(subtitle)
+                    .textCase(nil)
             }
-            .padding(.horizontal)
-            .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
+
         }
         .toolbar {
             ToolbarItem(placement: .compatibleTopBarTrailing) {

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -39,6 +39,19 @@ struct WrongPlatformView: View {
     private var appearance: CustomerCenterConfigData.Appearance
     @Environment(\.colorScheme)
     private var colorScheme
+    @Environment(\.supportInformation)
+    private var supportInformation: CustomerCenterConfigData.Support?
+    @Environment(\.openURL)
+    private var openURL
+
+    private var supportURL: URL? {
+        guard let supportInformation = self.supportInformation else { return nil }
+        let subject = self.localization.commonLocalizedString(for: .defaultSubject)
+        let body = self.localization.commonLocalizedString(for: .defaultBody)
+        return URLUtilities.createMailURLIfPossible(email: supportInformation.email,
+                                                    subject: subject,
+                                                    body: body)
+    }
 
     init() {
     }
@@ -48,13 +61,8 @@ struct WrongPlatformView: View {
     }
 
     var body: some View {
-        ZStack {
-            if let background = Color.from(colorInformation: appearance.backgroundColor, for: colorScheme) {
-                background.edgesIgnoringSafeArea(.all)
-            }
-            let textColor = Color.from(colorInformation: appearance.textColor, for: colorScheme)
-
-            VStack {
+        List {
+            Section {
                 let platformInstructions = self.humanReadableInstructions(for: store)
 
                 CompatibilityContentUnavailableView(
@@ -63,8 +71,16 @@ struct WrongPlatformView: View {
                     description: Text(platformInstructions.1)
                 )
             }
-            .padding(.horizontal)
-            .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
+            if let url = supportURL {
+                Section {
+                    AsyncButton {
+                        openURL(url)
+                    } label: {
+                        Text(localization.commonLocalizedString(for: .contactSupport))
+                    }
+                }
+            }
+
         }
         .toolbar {
             ToolbarItem(placement: .compatibleTopBarTrailing) {


### PR DESCRIPTION
Changed the `WrongPlatformView` and `NoSubscriptionsView` to use lists, so they don't use the prominent buttons and look more native

| WrongPlatformView | NoSubscriptionsView |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-08-21 at 14 59 48](https://github.com/user-attachments/assets/4c083f3f-88a5-4a50-81c3-5079143f2287) | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-21 at 14 51 17](https://github.com/user-attachments/assets/286d549e-4982-4398-b540-793adceca680)
 | 