### PR TITLE
[Customer Center] Fix `FeedbackSurveyView` not opening

### DIFF
--- a/RevenueCatUI/CustomerCenter/ButtonStyles.swift
+++ b/RevenueCatUI/CustomerCenter/ButtonStyles.swift
@@ -54,12 +54,11 @@ struct ProminentButtonStyle: PrimitiveButtonStyle {
 struct DismissCircleButton: View {
 
     @Environment(\.localization) private var localization
-
-    var action: () -> Void
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         Button {
-            action()
+            self.dismiss()
         } label: {
             Circle()
                 .fill(Color(uiColor: .secondarySystemFill))
@@ -88,9 +87,7 @@ struct ButtonStyles_Previews: PreviewProvider {
             Button("Didn't receive purchase") {}
                 .buttonStyle(ProminentButtonStyle())
 
-            DismissCircleButton {
-
-            }
+            DismissCircleButton()
         }.padding()
             .environment(\.appearance, CustomerCenterConfigTestData.standardAppearance)
             .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -26,9 +26,6 @@ import SwiftUI
 @available(watchOS, unavailable)
 struct ManageSubscriptionsView: View {
 
-    @Environment(\.dismiss)
-    var dismiss
-
     @Environment(\.appearance)
     private var appearance: CustomerCenterConfigData.Appearance
     @Environment(\.localization)
@@ -102,9 +99,7 @@ struct ManageSubscriptionsView: View {
         }
         .toolbar {
             ToolbarItem(placement: .compatibleTopBarTrailing) {
-                DismissCircleButton {
-                    dismiss()
-                }
+                DismissCircleButton()
             }
         }
         .task {

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -30,9 +30,6 @@ struct NoSubscriptionsView: View {
     // TODO: build screen using this configuration
     let configuration: CustomerCenterConfigData
 
-    @Environment(\.dismiss)
-    var dismiss
-
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
     @Environment(\.appearance)
@@ -73,9 +70,7 @@ struct NoSubscriptionsView: View {
         }
         .toolbar {
             ToolbarItem(placement: .compatibleTopBarTrailing) {
-                DismissCircleButton {
-                    dismiss()
-                }
+                DismissCircleButton()
             }
         }
     }

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -30,9 +30,6 @@ struct WrongPlatformView: View {
     @State
     private var store: Store?
 
-    @Environment(\.dismiss)
-    var dismiss
-
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
     @Environment(\.appearance)
@@ -84,9 +81,7 @@ struct WrongPlatformView: View {
         }
         .toolbar {
             ToolbarItem(placement: .compatibleTopBarTrailing) {
-                DismissCircleButton {
-                    dismiss()
-                }
+                DismissCircleButton()
             }
         }
         .task {


### PR DESCRIPTION
For some reason, the dismiss environment variable was causing the view to constantly recreate, which was causing a loop when trying to launch the feedback survey view, and the app would freeze.

I moved the `dismiss` to the `DismissCircleButton` and looks like it has solved it.