### PR TITLE
Remove `unneeded_override` disable to fix linter

### DIFF
--- a/Tests/RevenueCatUITests/Helpers/TestCase.swift
+++ b/Tests/RevenueCatUITests/Helpers/TestCase.swift
@@ -32,8 +32,6 @@ class TestCase: XCTestCase {
         XCTestObservationCenter.shared.removeTestObserver(CurrentTestCaseTracker.shared)
     }
 
-    // swiftlint:disable unneeded_override
-
     @MainActor
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -43,8 +41,6 @@ class TestCase: XCTestCase {
     override func tearDown() {
         super.tearDown()
     }
-
-    // swiftlint:enable unneeded_override
 
     // MARK: -
 


### PR DESCRIPTION
There's a new release of Swiftlint 0.56.2 that makes one of our `unneeded_override` disables obsolete

https://github.com/realm/SwiftLint/releases/tag/0.56.2

From the changelog:
> Silence unneeded_override rule on methods and initializers with attributes.


