### PR TITLE
Fix version number in plist files

### DIFF
--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.2.2</string>
+	<string>5.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>

--- a/Tests/BackendIntegrationTestApp/Info.plist
+++ b/Tests/BackendIntegrationTestApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.2.2</string>
+	<string>5.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Tests/BackendIntegrationTests/Info.plist
+++ b/Tests/BackendIntegrationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.2.2</string>
+	<string>5.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Tests/UnitTests/Info.plist
+++ b/Tests/UnitTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.2.2</string>
+	<string>5.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Tests/UnitTestsHostApp/Info.plist
+++ b/Tests/UnitTestsHostApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.2.2</string>
+	<string>5.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
I am unsure why (paths look correct) but the plist files had the wrong version number. My theory is that the previous release was manual and someone might have forgotten to update these.