### PR TITLE
Pin swift-docc-plugin to 1.3.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,8 @@ var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", .upToNextMinor(from: "1.12.0"))
 ]
 if shouldIncludeDocCPlugin {
+    // Versions 1.4.0 and 1.4.1 are failing to compile, so we are pinning it to 1.3.0 for now
+    // https://github.com/RevenueCat/purchases-ios/pull/4216
     dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", .exact("1.3.0")))
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", .upToNextMinor(from: "1.12.0"))
 ]
 if shouldIncludeDocCPlugin {
-    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
+    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", .exact("1.3.0")))
 }
 
 // See https://github.com/RevenueCat/purchases-ios/pull/2989

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -14,7 +14,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", from: "1.11.0")
 ]
 if shouldIncludeDocCPlugin {
-    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
+    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", .exact("1.3.0")))
 }
 
 let package = Package(

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -14,6 +14,8 @@ var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", from: "1.11.0")
 ]
 if shouldIncludeDocCPlugin {
+    // Versions 1.4.0 and 1.4.1 are failing to compile, so we are pinning it to 1.3.0 for now
+    // https://github.com/RevenueCat/purchases-ios/pull/4216
     dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", .exact("1.3.0")))
 }
 

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -14,7 +14,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", from: "1.11.0")
 ]
 if shouldIncludeDocCPlugin {
-    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
+    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", .exact("1.3.0")))
 }
 
 let package = Package(

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -14,6 +14,8 @@ var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", from: "1.11.0")
 ]
 if shouldIncludeDocCPlugin {
+    // Versions 1.4.0 and 1.4.1 are failing to compile, so we are pinning it to 1.3.0 for now
+    // https://github.com/RevenueCat/purchases-ios/pull/4216
     dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", .exact("1.3.0")))
 }
 


### PR DESCRIPTION
Pins swift-docc-plugin for the time being as 1.4.0 and 1.4.1 are failing to compile (https://revenuecat.slack.com/archives/C03HPN9UE80/p1724438146087079).