### PR TITLE
[EXTERNAL] `Custom Entitlements Computation`: fix support display on debug screen (#4215) by @NachoSoto

### DIFF
--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -153,6 +153,10 @@ class SystemInfo {
         self.preferredLocalesProvider = preferredLocalesProvider
     }
 
+    var supportsOfflineEntitlements: Bool {
+        !self.observerMode && !self.dangerousSettings.customEntitlementComputation
+    }
+
     /// Asynchronous API if caller can't ensure that it's invoked in the `@MainActor`
     /// - Seealso: `isApplicationBackgrounded`
     func isApplicationBackgrounded(completion: @escaping @Sendable (Bool) -> Void) {

--- a/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
+++ b/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
@@ -35,8 +35,7 @@ class OfflineEntitlementsManager {
         completion: (@MainActor @Sendable (Result<(), Error>) -> Void)?
     ) {
         guard #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
-              !self.systemInfo.observerMode,
-              !self.systemInfo.dangerousSettings.customEntitlementComputation else {
+              self.systemInfo.supportsOfflineEntitlements else {
             Logger.debug(Strings.offlineEntitlements.product_entitlement_mapping_unavailable)
 
             self.dispatchCompletionOnMainThreadIfPossible(completion, result: .failure(.notAvailable))

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1732,7 +1732,7 @@ internal extension Purchases {
     }
 
     var offlineCustomerInfoEnabled: Bool {
-        return self.backend.offlineCustomerInfoEnabled
+        return self.backend.offlineCustomerInfoEnabled && self.systemInfo.supportsOfflineEntitlements
     }
 
     var publicKey: Signing.PublicKey? {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -516,10 +516,25 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(Self.create(purchasesAreCompletedBy: .revenueCat).offlineCustomerInfoEnabled) == true
     }
 
-    private static func create(purchasesAreCompletedBy: PurchasesAreCompletedBy) -> Purchases {
+    func testOfflineCustomerInfoDisabledForCustomEntitlementsComputation() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        expect(
+            Self.create(
+                purchasesAreCompletedBy: .revenueCat,
+                dangerousSettings: .init(customEntitlementComputation: true)
+            ).offlineCustomerInfoEnabled
+        ) == false
+    }
+
+  private static func create(
+      purchasesAreCompletedBy: PurchasesAreCompletedBy,
+      dangerousSettings: DangerousSettings = .init()
+  ) -> Purchases {
         return Purchases.configure(
             with: .init(withAPIKey: "")
                 .with(purchasesAreCompletedBy: purchasesAreCompletedBy, storeKitVersion: .storeKit1)
+                .with(dangerousSettings: dangerousSettings)
         )
     }
 


### PR DESCRIPTION
This shouldn't display "enabled" for custom entitlements computation: ![Screenshot 2024-08-23 at 09 16
17](https://github.com/user-attachments/assets/57e0bb0a-8cf3-4755-a7d9-d1444383b9fa)

Contributed by @NachoSoto in #4215 
