### PR TITLE
[CustomerCenter] Move sheet and restore alert creation to `ManageSubscriptionsView`

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -105,6 +105,18 @@ struct ManageSubscriptionsView: View {
         .task {
             await loadInformationIfNeeded()
         }
+        .restorePurchasesAlert(isPresented: self.$viewModel.showRestoreAlert)
+        .sheet(item: self.$viewModel.promotionalOfferData,
+               onDismiss: {
+            Task {
+                await self.viewModel.handleSheetDismiss()
+            }
+        },
+               content: { promotionalOfferData in
+            PromotionalOfferView(promotionalOffer: promotionalOfferData.promotionalOffer,
+                                 product: promotionalOfferData.product,
+                                 promoOfferDetails: promotionalOfferData.promoOfferDetails)
+        })
         .navigationTitle(self.viewModel.screen.title)
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -178,18 +190,6 @@ struct ManageSubscriptionButton: View {
             }
         })
         .disabled(self.viewModel.loadingPath != nil)
-        .restorePurchasesAlert(isPresented: self.$viewModel.showRestoreAlert)
-        .sheet(item: self.$viewModel.promotionalOfferData,
-               onDismiss: {
-            Task {
-                await self.viewModel.handleSheetDismiss()
-            }
-        },
-               content: { promotionalOfferData in
-            PromotionalOfferView(promotionalOffer: promotionalOfferData.promotionalOffer,
-                                 product: promotionalOfferData.product,
-                                 promoOfferDetails: promotionalOfferData.promoOfferDetails)
-        })
     }
 
 }


### PR DESCRIPTION
The sheet was being created multiple times and we realized it was due to it being created from the buttons instead of from the view `ManageSubscriptionsView` itself

We moved the creation of the sheet and the restore alert to the `ManageSubscriptionsView` to fix it