### PR TITLE
[Customer Center] Add padding to `No thanks` in promotional offer screen

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -62,10 +62,13 @@ struct PromotionalOfferView: View {
 
                     PromoOfferButtonView(viewModel: self.viewModel, appearance: self.appearance)
 
-                    let dismissButtonTitle = self.localization.commonLocalizedString(for: .noThanks)
-                    Button(dismissButtonTitle) {
+                    Button {
                         dismiss()
+                    } label: {
+                        Text(self.localization.commonLocalizedString(for: .noThanks))
                     }
+                    .padding()
+                    .frame(maxWidth: .infinity)
                 } else {
                     EmptyView()
                         .onAppear {


### PR DESCRIPTION

| Before | After |
|--------|--------|
| ![simulator_screenshot_1D4B17FD-B4FE-4F00-BC80-B9A2428EA757](https://github.com/user-attachments/assets/420291bc-45cf-4d91-9dc7-82fdca13c733) | ![simulator_screenshot_4B84F02B-2296-47A9-B5B1-2649A0778289](https://github.com/user-attachments/assets/5cd2c5e3-dc7b-476d-9d6b-49e89b010600) | 



