### PR TITLE
[Paywall] Fix restoreStarted not being called on `presentPaywallIfNeeded` when using `requiredEntitlementIdentifier`

### DIFF
--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -175,6 +175,7 @@ extension View {
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
+            restoreStarted: restoreStarted,
             restoreCompleted: restoreCompleted,
             purchaseFailure: purchaseFailure,
             restoreFailure: restoreFailure,

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -102,6 +102,7 @@ extension View {
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
+            restoreStarted: restoreStarted,
             restoreCompleted: restoreCompleted,
             purchaseFailure: purchaseFailure,
             restoreFailure: restoreFailure
@@ -192,7 +193,7 @@ extension View {
             purchaseStarted: purchaseStarted,
             purchaseCompleted: purchaseCompleted,
             purchaseCancelled: purchaseCancelled,
-            restoreStarted: nil,
+            restoreStarted: restoreStarted,
             restoreCompleted: restoreCompleted,
             purchaseFailure: purchaseFailure,
             restoreFailure: restoreFailure


### PR DESCRIPTION
### Motivation

`restoreStarted` callback was not being fired on `presentPaywallIfNeeded` when using `requiredEntitlementIdentifier`

### Description

We weren't doing anything with the `restoreStarted` argument 🤦‍♂️ Now its getting passed along and gets called 💪 

**BONUS:** Fixed two more that were missing in the footer (thanks @jamesrb1 🙌 )

⚠️ We don't _really_ have a great way to test this right now 😬 All of our existing tests use the call some internal things so we can pass mocked customer info and intro eligibility checkers. So this didn't get caught earlier because its one level above those internal methods that do most of the testing.
