### PR TITLE
Fix `compatibleTopBarTrailing` in MacOS and api tests

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/CompatibilityTopBarTrailing.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CompatibilityTopBarTrailing.swift
@@ -19,7 +19,7 @@ import SwiftUI
 internal extension ToolbarItemPlacement {
 
     static var compatibleTopBarTrailing: ToolbarItemPlacement {
-        #if swift(>=5.9)
+        #if swift(>=5.9) && !os(macOS)
             if #available(iOS 14.0, tvOS 14.0, watchOS 10.0, *) {
                 return .topBarTrailing
             } else {

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerCenterConfigDataAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerCenterConfigDataAPI.swift
@@ -16,12 +16,14 @@ func checkCustomerCenterConfigData(_ data: CustomerCenterConfigData) {
     let localization: CustomerCenterConfigData.Localization = data.localization
     let support: CustomerCenterConfigData.Support = data.support
     let lastPublishedAppVersion = data.lastPublishedAppVersion
+    let productId = data.productId
 
     let _: CustomerCenterConfigData = .init(screens: screens,
                                             appearance: appearance,
                                             localization: localization,
                                             support: support,
-                                            lastPublishedAppVersion: lastPublishedAppVersion)
+                                            lastPublishedAppVersion: lastPublishedAppVersion,
+                                            productId: productId)
 }
 
 func checkHelpPath(_ path: CustomerCenterConfigData.HelpPath) {


### PR DESCRIPTION
Build was broken in MacOS, see https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/21833/workflows/1a159a1e-994a-4ed6-bbe2-e7b64203a0ce/jobs/254514

Also API tests