### PR TITLE
Set a maximum duration for iOS 15 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,18 +94,18 @@ aliases:
 commands:
   set-maximum-duration:
     parameters:
-      time:
+      seconds:
         type: integer
         default: 600
     steps:
       - run:
-          name: Set maximum job duration to << parameters.time >> minutes
+          name: Set maximum job duration to << parameters.seconds >> seconds
           background: true
           command: |
-            sleep << parameters.time >>
+            sleep << parameters.seconds >>
             curl --request POST \
             --url https://circleci.com/api/v2/project/gh/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/job/$CIRCLE_BUILD_NUM/cancel \
-          --header "Circle-Token: $CIRCLECI_API_TOKEN"
+            --header "Circle-Token: $CIRCLECI_API_TOKEN"
   install-runtime:
     parameters:
       runtime-name:
@@ -633,7 +633,7 @@ jobs:
     steps:
       - checkout
       - set-maximum-duration:
-          time: 60
+          seconds: 60
       - install-dependencies:
           install_swiftlint: false
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,6 +632,8 @@ jobs:
 
     steps:
       - checkout
+      - set-maximum-duration:
+          time: 1
       - install-dependencies:
           install_swiftlint: false
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,13 +96,13 @@ commands:
     parameters:
       time:
         type: integer
-        default: 10
+        default: 600
     steps:
       - run:
           name: Set maximum job duration to << parameters.time >> minutes
           background: true
           command: |
-            sleep << parameters.time >>m
+            sleep << parameters.time >>
             curl --request POST \
             --url https://circleci.com/api/v2/project/gh/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/job/$CIRCLE_BUILD_NUM/cancel \
           --header "Circle-Token: $CIRCLECI_API_TOKEN"
@@ -633,7 +633,7 @@ jobs:
     steps:
       - checkout
       - set-maximum-duration:
-          time: 1
+          time: 60
       - install-dependencies:
           install_swiftlint: false
       - run:
@@ -694,8 +694,7 @@ jobs:
 
     steps:
       - checkout
-      - set-maximum-duration:
-          time: 10
+      - set-maximum-duration
       - install-dependencies:
           install_swiftlint: false
       - update-spm-installation-commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,8 +632,6 @@ jobs:
 
     steps:
       - checkout
-      - set-maximum-duration:
-          seconds: 60
       - install-dependencies:
           install_swiftlint: false
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,20 @@ aliases:
         only: main
 
 commands:
+  set-maximum-duration:
+    parameters:
+      time:
+        type: integer
+        default: 10
+    steps:
+      - run:
+          name: Set maximum job duration to << parameters.time >> minutes
+          background: true
+          command: |
+            sleep << parameters.time >>m
+            curl --request POST \
+            --url https://circleci.com/api/v2/project/gh/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/job/$CIRCLE_BUILD_NUM/cancel \
+          --header "Circle-Token: $CIRCLECI_API_TOKEN"
   install-runtime:
     parameters:
       runtime-name:
@@ -678,6 +692,8 @@ jobs:
 
     steps:
       - checkout
+      - set-maximum-duration:
+          time: 10
       - install-dependencies:
           install_swiftlint: false
       - update-spm-installation-commit


### PR DESCRIPTION
We are not sure why but iOS 15 tests get sometimes stuck re-running forever (see https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/21864/workflows/7af8697c-aad3-4e1f-92ae-f55186a72f27/jobs/254961). It looks like rerunning fixes it.

Until we find out what's up, we are going to set a max time for this job. CircleCI recommends setting a sleep and calling an API to cancel the job when that finishes https://support.circleci.com/hc/en-us/articles/14114124583195-How-to-set-a-custom-maximum-job-duration

