### PR TITLE
[Diagnostics] Add `backend_error_code` property

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -43,6 +43,7 @@ extension DiagnosticsEvent {
         case responseTimeMillisKey
         case successfulKey
         case responseCodeKey
+        case backendErrorCodeKey
         case eTagHitKey
 
     }

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -27,6 +27,7 @@ protocol DiagnosticsTrackerType {
                                    responseTime: TimeInterval,
                                    wasSuccessful: Bool,
                                    responseCode: Int,
+                                   backendErrorCode: Int?,
                                    resultOrigin: HTTPResponseOrigin?,
                                    verificationResult: VerificationResult) async
 
@@ -70,6 +71,7 @@ final class DiagnosticsTracker: DiagnosticsTrackerType {
                                    responseTime: TimeInterval,
                                    wasSuccessful: Bool,
                                    responseCode: Int,
+                                   backendErrorCode: Int?,
                                    resultOrigin: HTTPResponseOrigin?,
                                    verificationResult: VerificationResult) async {
         await track(
@@ -80,6 +82,7 @@ final class DiagnosticsTracker: DiagnosticsTrackerType {
                     .responseTimeMillisKey: AnyEncodable(responseTime * 1000),
                     .successfulKey: AnyEncodable(wasSuccessful),
                     .responseCodeKey: AnyEncodable(responseCode),
+                    .backendErrorCodeKey: AnyEncodable(backendErrorCode),
                     .eTagHitKey: AnyEncodable(resultOrigin == .cache),
                     .verificationResultKey: AnyEncodable(verificationResult.name)
                 ],

--- a/Sources/Diagnostics/Networking/DiagnosticsEventsRequest.swift
+++ b/Sources/Diagnostics/Networking/DiagnosticsEventsRequest.swift
@@ -84,6 +84,8 @@ private extension DiagnosticsEvent.DiagnosticsPropertyKey {
             return "successful"
         case .responseCodeKey:
             return "response_code"
+        case .backendErrorCodeKey:
+            return "backend_error_code"
         case .eTagHitKey:
             return "etag_hit"
         }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -590,17 +590,21 @@ private extension HTTPClient {
                                                                        responseTime: responseTime,
                                                                        wasSuccessful: true,
                                                                        responseCode: httpStatusCode,
+                                                                       backendErrorCode: nil,
                                                                        resultOrigin: response.origin,
                                                                        verificationResult: verificationResult)
                 case let .failure(error):
                     var responseCode = -1
-                    if case let .errorResponse(_, code, _) = error {
+                    var backendErrorCode: Int?
+                    if case let .errorResponse(errorResponse, code, _) = error {
                         responseCode = code.rawValue
+                        backendErrorCode = errorResponse.code.rawValue
                     }
                     await diagnosticsTracker.trackHttpRequestPerformed(endpointName: requestPathName,
                                                                        responseTime: responseTime,
                                                                        wasSuccessful: false,
                                                                        responseCode: responseCode,
+                                                                       backendErrorCode: backendErrorCode,
                                                                        resultOrigin: nil,
                                                                        verificationResult: .notRequested)
                 }

--- a/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
@@ -113,6 +113,7 @@ class DiagnosticsTrackerTests: TestCase {
                                                      responseTime: 50,
                                                      wasSuccessful: true,
                                                      responseCode: 200,
+                                                     backendErrorCode: 7121,
                                                      resultOrigin: .cache,
                                                      verificationResult: .verified)
         let entries = await self.handler.getEntries()
@@ -123,6 +124,7 @@ class DiagnosticsTrackerTests: TestCase {
                     .responseTimeMillisKey: AnyEncodable(50000),
                     .successfulKey: AnyEncodable(true),
                     .responseCodeKey: AnyEncodable(200),
+                    .backendErrorCodeKey: AnyEncodable(7121),
                     .eTagHitKey: AnyEncodable(true),
                     .verificationResultKey: AnyEncodable("VERIFIED")],
                   timestamp: Self.eventTimestamp1)

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -32,17 +32,24 @@ class MockDiagnosticsTracker: DiagnosticsTrackerType {
 
     private(set) var trackedHttpRequestPerformedParams: [
         // swiftlint:disable:next large_tuple
-        (String, TimeInterval, Bool, Int, HTTPResponseOrigin?, VerificationResult)
+        (String, TimeInterval, Bool, Int, Int?, HTTPResponseOrigin?, VerificationResult)
     ] = []
     // swiftlint:disable:next function_parameter_count
     func trackHttpRequestPerformed(endpointName: String,
                                    responseTime: TimeInterval,
                                    wasSuccessful: Bool,
                                    responseCode: Int,
+                                   backendErrorCode: Int?,
                                    resultOrigin: HTTPResponseOrigin?,
                                    verificationResult: VerificationResult) async {
         self.trackedHttpRequestPerformedParams.append(
-            (endpointName, responseTime, wasSuccessful, responseCode, resultOrigin, verificationResult)
+            (endpointName,
+             responseTime,
+             wasSuccessful,
+             responseCode,
+             backendErrorCode,
+             resultOrigin,
+             verificationResult)
         )
     }
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1634,6 +1634,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             -1, // Any
             true,
             200,
+            nil,
             .backend,
             .notRequested
         )))
@@ -1661,6 +1662,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             -1, // Any
             false,
             401,
+            nil,
             nil,
             .notRequested
         )))
@@ -2253,8 +2255,8 @@ extension HTTPClientTests {
 // swiftlint:disable large_tuple
 
 private func matchTrackParams(
-    _ data: (String, TimeInterval, Bool, Int, HTTPResponseOrigin?, VerificationResult)
-) -> Nimble.Predicate<(String, TimeInterval, Bool, Int, HTTPResponseOrigin?, VerificationResult)> {
+    _ data: (String, TimeInterval, Bool, Int, Int?, HTTPResponseOrigin?, VerificationResult)
+) -> Nimble.Predicate<(String, TimeInterval, Bool, Int, Int?, HTTPResponseOrigin?, VerificationResult)> {
     return .init {
         let other = try $0.evaluate()
         let timeInterval = other?.1 ?? -1
@@ -2263,7 +2265,8 @@ private func matchTrackParams(
                        other?.2 == data.2 &&
                        other?.3 == data.3 &&
                        other?.4 == data.4 &&
-                       other?.5 == data.5)
+                       other?.5 == data.5 &&
+                       other?.6 == data.6)
 
         return .init(bool: matches, message: .fail("Diagnostics tracked params do not match"))
     }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1662,7 +1662,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             -1, // Any
             false,
             401,
-            nil,
+            7225,
             nil,
             .notRequested
         )))


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
This adds the `backend_error_code` property to diagnostics `http_request_performed` events.
