### PR TITLE
Add `$kochavaDeviceId` attribution convenience method

### DIFF
--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -287,7 +287,7 @@ public extension Attribution {
      * #### Related Articles
      * - [Kochava RevenueCat Integration](https://docs.revenuecat.com/docs/kochava)
      *
-     *- Parameter kochavaDeviceID: Empty String or `nil` will delete the subscriber attribute.
+     * - Parameter kochavaDeviceID: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc func setKochavaDeviceID(_ kochavaDeviceID: String?) {
         self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceID, appUserID: appUserID)

--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -281,6 +281,19 @@ public extension Attribution {
     }
 
     /**
+     * Subscriber attribute associated with the Kochava Device ID for the user.
+     * Recommended for the RevenueCat Kochava integration.
+     *
+     * #### Related Articles
+     * - [Kochava RevenueCat Integration](https://docs.revenuecat.com/docs/kochava)
+     *
+     *- Parameter kochavaDeviceID: Empty String or `nil` will delete the subscriber attribute.
+     */
+    @objc func setKochavaDeviceID(_ kochavaDeviceID: String?) {
+        self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceID, appUserID: appUserID)
+    }
+
+    /**
      * Subscriber attribute associated with the Mixpanel Distinct ID for the user.
      * Optional for the RevenueCat Mixpanel integration.
      *

--- a/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -39,6 +39,7 @@ enum ReservedSubscriberAttribute: String {
     case oneSignalUserID = "$onesignalUserId"
     case airshipChannelID = "$airshipChannelId"
     case cleverTapID = "$clevertapId"
+    case kochavaDeviceID = "$kochavaDeviceId"
     case mixpanelDistinctID = "$mixpanelDistinctId"
     case firebaseAppInstanceID = "$firebaseAppInstanceId"
 

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -96,6 +96,10 @@ class SubscriberAttributesManager {
         setReservedAttribute(.cleverTapID, value: cleverTapID, appUserID: appUserID)
     }
 
+    func setKochavaDeviceID(_ kochavaDeviceID: String?, appUserID: String) {
+        setReservedAttribute(.kochavaDeviceID, value: kochavaDeviceID, appUserID: appUserID)
+    }
+
     func setMixpanelDistinctID(_ mixpanelDistinctID: String?, appUserID: String) {
         setReservedAttribute(.mixpanelDistinctID, value: mixpanelDistinctID, appUserID: appUserID)
     }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAttributionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAttributionAPI.m
@@ -38,6 +38,8 @@
     [a setOnesignalUserID: @""];
     [a setCleverTapID: nil];
     [a setCleverTapID: @""];
+    [a setKochavaDeviceID:nil];
+    [a setKochavaDeviceID:@""];
     [a setMixpanelDistinctID: nil];
     [a setMixpanelDistinctID: @""];
     [a setFirebaseAppInstanceID: nil];

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AttributionAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AttributionAPI.swift
@@ -49,6 +49,9 @@ func checkAttributionAPI() {
     attribution.setCleverTapID("")
     attribution.setCleverTapID(nil)
 
+    attribution.setKochavaDeviceID("")
+    attribution.setKochavaDeviceID(nil)
+
     attribution.setMixpanelDistinctID("")
     attribution.setMixpanelDistinctID(nil)
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriberAttributesView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriberAttributesView.swift
@@ -38,6 +38,7 @@ struct SubscriberAttributesView: View {
         case setAppsflyerID
         case setAirshipChannelID
         case setCleverTapID
+        case setKochavaDeviceID
         case setMparticleID
         case setOnesignalID
         case setFBAnonymousID
@@ -142,6 +143,8 @@ struct SubscriberAttributesView: View {
                     Purchases.shared.attribution.setAirshipChannelID(self.otherValue)
                 case .setCleverTapID:
                     Purchases.shared.attribution.setCleverTapID(self.otherValue)
+                case .setKochavaDeviceID:
+                    Purchases.shared.attribution.setKochavaDeviceID(self.otherValue)
                 case .setMparticleID:
                     Purchases.shared.attribution.setMparticleID(self.otherValue)
                 case .setOnesignalID:

--- a/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
@@ -177,6 +177,18 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
         invokedSetCleverTapIDParametersList.append((cleverTapID, appUserID))
     }
 
+    var invokedSetKochavaDeviceID = false
+    var invokedSetKochavaDeviceIDCount = 0
+    var invokedSetKochavaDeviceIDParameters: (KochavaDeviceID: String?, appUserID: String?)?
+    var invokedSetKochavaDeviceIDParametersList = [(KochavaDeviceID: String?, appUserID: String?)]()
+
+    override func setKochavaDeviceID(_ kochavaDeviceID: String?, appUserID: String) {
+        invokedSetKochavaDeviceID = true
+        invokedSetKochavaDeviceIDCount += 1
+        invokedSetKochavaDeviceIDParameters = (kochavaDeviceID, appUserID)
+        invokedSetKochavaDeviceIDParametersList.append((kochavaDeviceID, appUserID))
+    }
+
     var invokedSetMixpanelDistinctID = false
     var invokedSetMixpanelDistinctIDCount = 0
     var invokedSetMixpanelDistinctIDParameters: (mixpanelDistinctID: String?, appUserID: String?)?

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -438,6 +438,16 @@ class PurchasesSubscriberAttributesTests: TestCase {
             .to(equal((nil, purchases.appUserID)))
     }
 
+    func testSetAndClearKochavaDeviceID() {
+        setupPurchases()
+        purchases.attribution.setKochavaDeviceID("kochava")
+        purchases.attribution.setKochavaDeviceID(nil)
+        expect(self.mockSubscriberAttributesManager.invokedSetKochavaDeviceIDParametersList[0])
+            .to(equal(("kochava", purchases.appUserID)))
+        expect(self.mockSubscriberAttributesManager.invokedSetKochavaDeviceIDParametersList[1])
+            .to(equal((nil, purchases.appUserID)))
+    }
+
     func testSetAndClearMixpanelDistinctID() {
         setupPurchases()
         purchases.attribution.setMixpanelDistinctID("mixp")

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -1134,6 +1134,79 @@ class SubscriberAttributesManagerTests: TestCase {
         checkDeviceIdentifiersAreNotSet()
     }
     // endregion
+    // region kochavaDeviceID
+    func testSetKochavaDeviceID() throws {
+        let kochavaDeviceID = "kochavaDeviceID"
+
+        self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$kochavaDeviceId"
+        expect(receivedAttribute.value) == kochavaDeviceID
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetKochavaDeviceIDSetsEmptyIfNil() throws {
+        let kochavaDeviceID = "kochavaDeviceID"
+
+        self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceID, appUserID: "kratos")
+        self.subscriberAttributesManager.setKochavaDeviceID(nil, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 2
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$kochavaDeviceId"
+        expect(receivedAttribute.value) == ""
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetKochavaDeviceIDSkipsIfSameValue() {
+        let kochavaDeviceID = "kochavaDeviceID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$kochavaDeviceId",
+                                                                                    value: kochavaDeviceID)
+        self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 0
+    }
+
+    func testSetKochavaDeviceIDOverwritesIfNewValue() throws {
+        let oldSyncTime = Date()
+        let kochavaDeviceID = "kochavaDeviceID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$kochavaDeviceId",
+                                                                                    value: "old_id",
+                                                                                    isSynced: true,
+                                                                                    setTime: oldSyncTime)
+
+        self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$kochavaDeviceId"
+        expect(receivedAttribute.value) == kochavaDeviceID
+        expect(receivedAttribute.isSynced) == false
+        expect(receivedAttribute.setTime) > oldSyncTime
+    }
+
+    func testSetKochavaDeviceIDDoesNotSetDeviceIdentifiers() {
+        let kochavaDeviceID = "kochavaDeviceID"
+        self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
+
+        checkDeviceIdentifiersAreNotSet()
+    }
+    // endregion
     // region MixpanelDistinctID
     func testSetMixpanelDistinctID() throws {
         let mixpanelDistinctID = "mixpanelDistinctID"


### PR DESCRIPTION
### Description
This adds a new API `setKochavaDeviceId` that allows to set the kochava device ID required for the Kochava integration. 

Keeping on hold until backend support is added
