### PR TITLE
Renable latest DocC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1397,6 +1397,6 @@ workflows:
       # - installation-tests-xcode-direct-integration
       # - installation-tests-receipt-parser
       # - api-tests
-      - deploy-purchase-tester:
-          dry_run: true
+      # - deploy-purchase-tester:
+      #     dry_run: true
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1369,34 +1369,34 @@ workflows:
             - "run-from-github-comments"
             - << pipeline.parameters.GHA_Meta >>
     jobs:
-      - backend-integration-tests-SK1
-      - backend-integration-tests-SK2
-      - backend-integration-tests-custom-entitlements
-      - backend-integration-tests-other
-      - build-tv-watch-and-macos
-      - build-visionos
+      # - backend-integration-tests-SK1
+      # - backend-integration-tests-SK2
+      # - backend-integration-tests-custom-entitlements
+      # - backend-integration-tests-other
+      # - build-tv-watch-and-macos
+      # - build-visionos
       - docs-build
-      - run-test-ios-14
-      - run-test-ios-15
-      - run-test-ios-16
-      - run-test-macos
-      - run-test-tvos
-      - run-test-watchos
-      - spm-receipt-parser
-      - spm-release-build
-      - spm-release-build-xcode-14
-      - spm-release-build-xcode-15
-      - spm-revenuecat-ui-ios-15
-      - spm-revenuecat-ui-ios-16
-      - run-revenuecat-ui-ios-17
-      - spm-revenuecat-ui-watchos
-      - installation-tests-cocoapods
-      - installation-tests-swift-package-manager
-      - installation-tests-custom-entitlement-computation-swift-package-manager
-      - installation-tests-carthage
-      - installation-tests-xcode-direct-integration
-      - installation-tests-receipt-parser
-      - api-tests
+      # - run-test-ios-14
+      # - run-test-ios-15
+      # - run-test-ios-16
+      # - run-test-macos
+      # - run-test-tvos
+      # - run-test-watchos
+      # - spm-receipt-parser
+      # - spm-release-build
+      # - spm-release-build-xcode-14
+      # - spm-release-build-xcode-15
+      # - spm-revenuecat-ui-ios-15
+      # - spm-revenuecat-ui-ios-16
+      # - run-revenuecat-ui-ios-17
+      # - spm-revenuecat-ui-watchos
+      # - installation-tests-cocoapods
+      # - installation-tests-swift-package-manager
+      # - installation-tests-custom-entitlement-computation-swift-package-manager
+      # - installation-tests-carthage
+      # - installation-tests-xcode-direct-integration
+      # - installation-tests-receipt-parser
+      # - api-tests
       - deploy-purchase-tester:
           dry_run: true
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -939,6 +939,9 @@ jobs:
           command: bundle exec fastlane build_docs
           environment:
             DOCS_IOS_VERSION: "17.4"
+      - store_artifacts:
+          path: fastlane/output/docs
+          destination: docs_output
 
   docs-deploy:
     executor:

--- a/Package.swift
+++ b/Package.swift
@@ -15,9 +15,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", .upToNextMinor(from: "1.12.0"))
 ]
 if shouldIncludeDocCPlugin {
-    // Versions 1.4.0 and 1.4.1 are failing to compile, so we are pinning it to 1.3.0 for now
-    // https://github.com/RevenueCat/purchases-ios/pull/4216
-    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", .exact("1.3.0")))
+    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
 }
 
 // See https://github.com/RevenueCat/purchases-ios/pull/2989

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -14,9 +14,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", from: "1.11.0")
 ]
 if shouldIncludeDocCPlugin {
-    // Versions 1.4.0 and 1.4.1 are failing to compile, so we are pinning it to 1.3.0 for now
-    // https://github.com/RevenueCat/purchases-ios/pull/4216
-    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", .exact("1.3.0")))
+    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
 }
 
 let package = Package(

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -14,9 +14,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", from: "1.11.0")
 ]
 if shouldIncludeDocCPlugin {
-    // Versions 1.4.0 and 1.4.1 are failing to compile, so we are pinning it to 1.3.0 for now
-    // https://github.com/RevenueCat/purchases-ios/pull/4216
-    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", .exact("1.3.0")))
+    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
 }
 
 let package = Package(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -776,7 +776,8 @@ platform :ios do
 
     hosting_base_path = File.join(docs_repo_name, version_number)
 
-    docs_generation_folder = Dir.mktmpdir
+    docs_generation_folder = "fastlane/output/docs"
+    FileUtils.mkdir_p(docs_generation_folder)
 
     # swift package must be run from the dir that contains the Package.swift
     # output is generated in docs_generation_folder

--- a/fastlane/output/docs/test.txt
+++ b/fastlane/output/docs/test.txt
@@ -1,0 +1,351 @@
+[
+  {
+    "spacing" : 25,
+    "type" : "stack",
+    "components" : [
+      {
+        "padding" : {
+          "top" : 0,
+          "trailing" : 0,
+          "leading" : 0,
+          "bottom" : 0
+        },
+        "type" : "stack",
+        "dimension" : {
+          "alignment" : "bottom",
+          "type" : "zlayer"
+        },
+        "components" : [
+          {
+            "url" : "https:\/\/assets.pawwalls.com\/1075077_1724799222.jpeg",
+            "gradientColors" : [
+              "#FF000000",
+              "#FF000000",
+              "#00000000"
+            ],
+            "_cornerRadius" : 0,
+            "fitMode" : {
+              "crop" : {
+
+              }
+            },
+            "type" : "image"
+          },
+          {
+            "fontWeight" : "black",
+            "padding" : {
+              "bottom" : 10,
+              "leading" : 0,
+              "top" : 0,
+              "trailing" : 0
+            },
+            "textStyle" : "largeTitle",
+            "type" : "text",
+            "text" : {
+              "value" : {
+                "en_US" : "Fitness Coach"
+              }
+            },
+            "fontFamily" : "",
+            "horizontalAlignment" : "center",
+            "color" : {
+              "light" : "#EE4444"
+            }
+          }
+        ],
+        "spacing" : 0
+      },
+      {
+        "dimension" : {
+          "alignment" : "center",
+          "type" : "horizontal"
+        },
+        "components" : [
+          {
+            "type" : "text",
+            "horizontalAlignment" : "center",
+            "fontFamily" : "",
+            "textStyle" : "title2",
+            "text" : {
+              "value" : {
+                "en_US" : "Do a daily workout"
+              }
+            },
+            "fontWeight" : "semibold",
+            "padding" : {
+              "leading" : 0,
+              "top" : 0,
+              "bottom" : 0,
+              "trailing" : 0
+            },
+            "color" : {
+              "light" : "#FFFFFF"
+            }
+          },
+          {
+            "type" : "spacer"
+          },
+          {
+            "_cornerRadius" : 23,
+            "url" : "https:\/\/assets.pawwalls.com\/1075077_1724796818.jpeg",
+            "gradientColors" : [
+
+            ],
+            "type" : "image",
+            "fitMode" : {
+              "fit" : {
+
+              }
+            }
+          },
+          {
+            "type" : "spacer"
+          }
+        ],
+        "padding" : {
+          "trailing" : 40,
+          "top" : 0,
+          "bottom" : 0,
+          "leading" : 40
+        },
+        "type" : "stack"
+      },
+      {
+        "padding" : {
+          "top" : 0,
+          "leading" : 40,
+          "bottom" : 0,
+          "trailing" : 40
+        },
+        "dimension" : {
+          "alignment" : "center",
+          "type" : "horizontal"
+        },
+        "components" : [
+          {
+            "type" : "spacer"
+          },
+          {
+            "_cornerRadius" : 23,
+            "type" : "image",
+            "gradientColors" : [
+
+            ],
+            "url" : "https:\/\/assets.pawwalls.com\/1075077_1724797044.jpg",
+            "fitMode" : {
+              "fit" : {
+
+              }
+            }
+          },
+          {
+            "type" : "spacer"
+          },
+          {
+            "fontFamily" : "",
+            "fontWeight" : "semibold",
+            "text" : {
+              "value" : {
+                "en_US" : "Challenge others and climb the leader ladder"
+              }
+            },
+            "type" : "text",
+            "padding" : {
+              "bottom" : 0,
+              "trailing" : 0,
+              "leading" : 0,
+              "top" : 0
+            },
+            "horizontalAlignment" : "center",
+            "textStyle" : "title2",
+            "color" : {
+              "light" : "#FFFFFF"
+            }
+          }
+        ],
+        "type" : "stack"
+      },
+      {
+        "padding" : {
+          "bottom" : 0,
+          "trailing" : 40,
+          "top" : 0,
+          "leading" : 40
+        },
+        "components" : [
+          {
+            "text" : {
+              "value" : {
+                "en_US" : "Conquer your goals"
+              }
+            },
+            "fontWeight" : "semibold",
+            "textStyle" : "title2",
+            "type" : "text",
+            "color" : {
+              "light" : "#FFFFFF"
+            },
+            "fontFamily" : "",
+            "horizontalAlignment" : "center",
+            "padding" : {
+              "leading" : 0,
+              "bottom" : 0,
+              "top" : 0,
+              "trailing" : 0
+            }
+          },
+          {
+            "type" : "spacer"
+          },
+          {
+            "gradientColors" : [
+
+            ],
+            "fitMode" : {
+              "fit" : {
+
+              }
+            },
+            "_cornerRadius" : 23,
+            "type" : "image",
+            "url" : "https:\/\/assets.pawwalls.com\/1075077_1724797320.jpg"
+          },
+          {
+            "type" : "spacer"
+          }
+        ],
+        "type" : "stack",
+        "dimension" : {
+          "type" : "horizontal",
+          "alignment" : "center"
+        }
+      },
+      {
+        "type" : "link_button",
+        "url" : "https:\/\/pay.rev.cat\/d1db8380eeb98a92\/josh",
+        "textComponent" : {
+          "text" : {
+            "value" : {
+              "en_US" : "Start Today for $9.99\/mo"
+            }
+          },
+          "backgroundColor" : {
+            "light" : "#DD4444"
+          },
+          "textStyle" : "title3",
+          "fontFamily" : "SF Pro",
+          "color" : {
+            "light" : "#FFFFFF"
+          },
+          "fontWeight" : "semibold",
+          "horizontalAlignment" : "center",
+          "padding" : {
+            "leading" : 50,
+            "top" : 10,
+            "trailing" : 50,
+            "bottom" : 10
+          },
+          "type" : "text"
+        }
+      },
+      {
+        "padding" : {
+          "top" : 0,
+          "leading" : 0,
+          "trailing" : 0,
+          "bottom" : 0
+        },
+        "type" : "stack",
+        "components" : [
+          {
+            "type" : "spacer"
+          },
+          {
+            "text" : {
+              "value" : {
+                "en_US" : "Restore purchases"
+              }
+            },
+            "textStyle" : "caption",
+            "fontFamily" : "",
+            "type" : "text",
+            "padding" : {
+              "leading" : 0,
+              "bottom" : 0,
+              "top" : 0,
+              "trailing" : 0
+            },
+            "horizontalAlignment" : "center",
+            "color" : {
+              "light" : "#FFFFFF"
+            },
+            "fontWeight" : "regular"
+          },
+          {
+            "fontWeight" : "regular",
+            "fontFamily" : "",
+            "horizontalAlignment" : "center",
+            "padding" : {
+              "top" : 0,
+              "leading" : 0,
+              "trailing" : 0,
+              "bottom" : 0
+            },
+            "textStyle" : "caption",
+            "text" : {
+              "value" : {
+                "en_US" : "•"
+              }
+            },
+            "color" : {
+              "light" : "#FFFFFF"
+            },
+            "type" : "text"
+          },
+          {
+            "text" : {
+              "value" : {
+                "en_US" : "Terms and conditions"
+              }
+            },
+            "fontWeight" : "regular",
+            "padding" : {
+              "bottom" : 0,
+              "leading" : 0,
+              "trailing" : 0,
+              "top" : 0
+            },
+            "color" : {
+              "light" : "#FFFFFF"
+            },
+            "textStyle" : "caption",
+            "horizontalAlignment" : "center",
+            "fontFamily" : "",
+            "type" : "text"
+          },
+          {
+            "type" : "spacer"
+          }
+        ],
+        "dimension" : {
+          "type" : "horizontal",
+          "alignment" : "center"
+        },
+        "spacing" : 10
+      }
+    ],
+    "backgroundColor" : {
+      "light" : "#000000"
+    },
+    "dimension" : {
+      "type" : "vertical",
+      "alignment" : "center"
+    },
+    "padding" : {
+      "leading" : 0,
+      "bottom" : 0,
+      "top" : 0,
+      "trailing" : 0
+    }
+  }
+]


### PR DESCRIPTION
DocC has [fixed](https://github.com/swiftlang/swift-docc-plugin/releases/tag/1.4.2) [the issue](https://github.com/RevenueCat/purchases-ios/pull/4216), and this PR reverts our package files to use the plugin's latest version, as it was before.

Unsure if we need to check its output somehow, or how best to do that.