### PR TITLE
Update StoreKit Version Info in GitHub Issues Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,10 @@
 ---
 name: 🐛 Bug report
 about: Filling a bug report
-title: ""
+title: ''
 labels: bug
-assignees: ""
+assignees: ''
+
 ---
 
 - [ ] I have updated Purchases SDK to the latest version
@@ -19,8 +20,8 @@ A clear and concise description of what the bug is. The more detail you can prov
    1. Platform:
    2. SDK version:
    3. StoreKit version:
-      - [ ] StoreKit 1 (default on versions <5.0.0. Can be enabled in versions >=5.0.0 with `.with(storeKitVersion: .storeKit1)`)
-      - [x] StoreKit 2 (default on versions >=5.0.0)
+      - [x] StoreKit 1
+      - [ ] StoreKit 2 (_enabled with `usesStoreKit2IfAvailable(true)`_)
    4. OS version:
    5. Xcode version:
    6. Device and/or simulator:
@@ -40,8 +41,8 @@ Logs here
 3. Steps to reproduce, with a description of expected vs. actual behavior
 
 _Please fill in_
-
+ 
 4. **Other information** (e.g. stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, etc.)
 
 5. **Additional context**
-   Add any other context about the problem here.
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,8 +20,8 @@ A clear and concise description of what the bug is. The more detail you can prov
    1. Platform:
    2. SDK version:
    3. StoreKit version:
-      - [x] StoreKit 1
-      - [ ] StoreKit 2 (_enabled with `usesStoreKit2IfAvailable(true)`_)
+      - [ ] StoreKit 1 (default on versions <5.0.0. Can be enabled in versions >=5.0.0 with `.with(storeKitVersion: .storeKit1)`)
+      - [x] StoreKit 2 (default on versions >=5.0.0)
    4. OS version:
    5. Xcode version:
    6. Device and/or simulator:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,10 @@
 ---
 name: 🐛 Bug report
 about: Filling a bug report
-title: ""
+title: ''
 labels: bug
-assignees: ""
+assignees: ''
+
 ---
 
 - [ ] I have updated Purchases SDK to the latest version
@@ -31,7 +32,7 @@ A clear and concise description of what the bug is. The more detail you can prov
       - [ ] TestFlight
       - [ ] Production
    8. How widespread is the issue. Percentage of devices affected.
-2. [Debug logs](https://docs.revenuecat.com/docs/debugging) that reproduce the issue. **Complete logs with `Purchases.logLevel = .verbose` will help us debug this issue.**
+2. [Debug logs](https://docs.revenuecat.com/docs/debugging) that reproduce the issue. **Complete logs with `Purchases.logLevel = .verbose` will help us debug this issue.**
 
 ```
 Logs here
@@ -40,8 +41,8 @@ Logs here
 3. Steps to reproduce, with a description of expected vs. actual behavior
 
 _Please fill in_
-
+ 
 4. **Other information** (e.g. stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, etc.)
 
 5. **Additional context**
-   Add any other context about the problem here.
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: 🐛 Bug report
 about: Filling a bug report
-title: ''
+title: ""
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
 - [ ] I have updated Purchases SDK to the latest version
@@ -32,7 +31,7 @@ A clear and concise description of what the bug is. The more detail you can prov
       - [ ] TestFlight
       - [ ] Production
    8. How widespread is the issue. Percentage of devices affected.
-2. [Debug logs](https://docs.revenuecat.com/docs/debugging) that reproduce the issue. **Complete logs with `Purchases.logLevel = .verbose` will help us debug this issue.**
+2. [Debug logs](https://docs.revenuecat.com/docs/debugging) that reproduce the issue. **Complete logs with `Purchases.logLevel = .verbose` will help us debug this issue.**
 
 ```
 Logs here
@@ -41,8 +40,8 @@ Logs here
 3. Steps to reproduce, with a description of expected vs. actual behavior
 
 _Please fill in_
- 
+
 4. **Other information** (e.g. stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, etc.)
 
 5. **Additional context**
-Add any other context about the problem here.
+   Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: 🐛 Bug report
 about: Filling a bug report
-title: ''
+title: ""
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
 - [ ] I have updated Purchases SDK to the latest version
@@ -20,8 +19,8 @@ A clear and concise description of what the bug is. The more detail you can prov
    1. Platform:
    2. SDK version:
    3. StoreKit version:
-      - [x] StoreKit 1
-      - [ ] StoreKit 2 (_enabled with `usesStoreKit2IfAvailable(true)`_)
+      - [ ] StoreKit 1 (default on versions <5.0.0. Can be enabled in versions >=5.0.0 with `.with(storeKitVersion: .storeKit1)`)
+      - [x] StoreKit 2 (default on versions >=5.0.0)
    4. OS version:
    5. Xcode version:
    6. Device and/or simulator:
@@ -41,8 +40,8 @@ Logs here
 3. Steps to reproduce, with a description of expected vs. actual behavior
 
 _Please fill in_
- 
+
 4. **Other information** (e.g. stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, etc.)
 
 5. **Additional context**
-Add any other context about the problem here.
+   Add any other context about the problem here.


### PR DESCRIPTION
### Motivation
Version 5.X of the SDK introduced changes to the default StoreKit version used to process purchases and changes to how developers can override the StoreKit version used by the SDK. This PR updates the GH Issue template to reflect these changes.

### Description
- Marks StoreKit2 as enabled by default, since that's the new default in SDK versions >=5.0.0.
- Updates the comments related to the StoreKit versions to reflect:
     - The default StoreKit versions used on SDK versions <5.X and >=5.X
     - The code used to override the StoreKit version in version >5.X of the SDK.

### Open Questions
This should be merged at some point, but we may want to hold off until the 5.X SDKs have a larger adoption. I'm open to thoughts here!
