### PR TITLE
Use Failable `String(data:encoding:)` Initializer to Satisfy Swiftlint

### DIFF
--- a/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
+++ b/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
@@ -163,8 +163,10 @@ private let pollInterval: DispatchTimeInterval = .milliseconds(100)
 private extension Encodable {
 
     func asFormattedString(backwardsCompatible: Bool) throws -> String {
-        return String(decoding: try self.asFormattedData(backwardsCompatible: backwardsCompatible),
-                      as: UTF8.self)
+        return String(
+            data: try self.asFormattedData(backwardsCompatible: backwardsCompatible),
+            encoding: .utf8
+        )!
     }
 
     func asFormattedData(backwardsCompatible: Bool) throws -> Data {


### PR DESCRIPTION
### Motivation
Swiftlint is currently failing in main due to a linting issue in `Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift`:


```
Prefer failable `String(data:encoding:)` initializer when converting `Data` to `String``
```


### Description
This PR address the linting issue by using the failable `String(data:encoding:)` initializer.
