### PR TITLE
Remove usage of adServicesToken in syncPurchases

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1045,7 +1045,6 @@ private extension PurchasesOrchestrator {
         }
     }
 
-    // swiftlint:disable:next function_body_length
     func syncPurchasesSK1(receiptRefreshPolicy: ReceiptRefreshPolicy,
                           isRestore: Bool,
                           initiationSource: ProductRequestData.InitiationSource,
@@ -1053,59 +1052,57 @@ private extension PurchasesOrchestrator {
         let currentAppUserID = self.appUserID
         let unsyncedAttributes = self.unsyncedAttributes
 
-        self.attribution.unsyncedAdServicesToken { adServicesToken in
-            // Refresh the receipt and post to backend, this will allow the transactions to be transferred.
-            // https://rev.cat/apple-restoring-purchased-products
-            self.receiptFetcher.receiptData(refreshPolicy: receiptRefreshPolicy) { receiptData, receiptURL in
-                guard let receiptData = receiptData,
-                      !receiptData.isEmpty else {
-                    if self.systemInfo.isSandbox {
-                        Logger.appleWarning(Strings.receipt.no_sandbox_receipt_restore)
-                    }
+        // Refresh the receipt and post to backend, this will allow the transactions to be transferred.
+        // https://rev.cat/apple-restoring-purchased-products
+        self.receiptFetcher.receiptData(refreshPolicy: receiptRefreshPolicy) { receiptData, receiptURL in
+            guard let receiptData = receiptData,
+                  !receiptData.isEmpty else {
+                if self.systemInfo.isSandbox {
+                    Logger.appleWarning(Strings.receipt.no_sandbox_receipt_restore)
+                }
 
+                if let completion = completion {
+                    self.operationDispatcher.dispatchOnMainThread {
+                        completion(.failure(ErrorUtils.missingReceiptFileError(receiptURL)))
+                    }
+                }
+                return
+            }
+
+            self.operationDispatcher.dispatchOnWorkerThread {
+                let hasTransactions = self.transactionsManager.customerHasTransactions(receiptData: receiptData)
+                let cachedCustomerInfo = self.customerInfoManager.cachedCustomerInfo(appUserID: currentAppUserID)
+
+                if !hasTransactions,
+                    let customerInfo = cachedCustomerInfo,
+                    customerInfo.originalPurchaseDate != nil {
                     if let completion = completion {
                         self.operationDispatcher.dispatchOnMainThread {
-                            completion(.failure(ErrorUtils.missingReceiptFileError(receiptURL)))
+                            completion(.success(customerInfo))
                         }
                     }
+
                     return
                 }
 
-                self.operationDispatcher.dispatchOnWorkerThread {
-                    let hasTransactions = self.transactionsManager.customerHasTransactions(receiptData: receiptData)
-                    let cachedCustomerInfo = self.customerInfoManager.cachedCustomerInfo(appUserID: currentAppUserID)
+                self.createProductRequestData(with: receiptData) { productRequestData in
+                    let transactionData: PurchasedTransactionData = .init(
+                        appUserID: currentAppUserID,
+                        presentedOfferingContext: nil,
+                        unsyncedAttributes: unsyncedAttributes,
+                        storefront: productRequestData?.storefront,
+                        source: .init(isRestore: isRestore, initiationSource: initiationSource)
+                    )
 
-                    if !hasTransactions,
-                        let customerInfo = cachedCustomerInfo,
-                        customerInfo.originalPurchaseDate != nil {
-                        if let completion = completion {
-                            self.operationDispatcher.dispatchOnMainThread {
-                                completion(.success(customerInfo))
-                            }
-                        }
-
-                        return
-                    }
-
-                    self.createProductRequestData(with: receiptData) { productRequestData in
-                        let transactionData: PurchasedTransactionData = .init(
-                            appUserID: currentAppUserID,
-                            presentedOfferingContext: nil,
-                            unsyncedAttributes: unsyncedAttributes,
-                            storefront: productRequestData?.storefront,
-                            source: .init(isRestore: isRestore, initiationSource: initiationSource)
-                        )
-
-                        self.backend.post(receipt: .receipt(receiptData),
-                                          productData: productRequestData,
-                                          transactionData: transactionData,
-                                          observerMode: self.observerMode) { result in
-                            self.handleReceiptPost(result: result,
-                                                   transactionData: transactionData,
-                                                   subscriberAttributes: unsyncedAttributes,
-                                                   adServicesToken: adServicesToken,
-                                                   completion: completion)
-                        }
+                    self.backend.post(receipt: .receipt(receiptData),
+                                      productData: productRequestData,
+                                      transactionData: transactionData,
+                                      observerMode: self.observerMode) { result in
+                        self.handleReceiptPost(result: result,
+                                               transactionData: transactionData,
+                                               subscriberAttributes: unsyncedAttributes,
+                                               adServicesToken: nil,
+                                               completion: completion)
                     }
                 }
             }
@@ -1120,72 +1117,70 @@ private extension PurchasesOrchestrator {
         let currentAppUserID = self.appUserID
         let unsyncedAttributes = self.unsyncedAttributes
 
-        self.attribution.unsyncedAdServicesToken { adServicesToken in
-            _ = Task<Void, Never> {
-                let transaction = await self.transactionFetcher.firstVerifiedTransaction
-                let appTransactionJWS = await self.transactionFetcher.appTransactionJWS
+        _ = Task<Void, Never> {
+            let transaction = await self.transactionFetcher.firstVerifiedTransaction
+            let appTransactionJWS = await self.transactionFetcher.appTransactionJWS
 
-                guard let transaction = transaction, let jwsRepresentation = transaction.jwsRepresentation else {
-                    // No transactions are present. If we have the originalPurchaseDate and originalApplicationVersion
-                    // in the cached CustomerInfo, return it. Otherwise, post the AppTransaction.
-                    let cachedCustomerInfo = self.customerInfoManager.cachedCustomerInfo(appUserID: currentAppUserID)
+            guard let transaction = transaction, let jwsRepresentation = transaction.jwsRepresentation else {
+                // No transactions are present. If we have the originalPurchaseDate and originalApplicationVersion
+                // in the cached CustomerInfo, return it. Otherwise, post the AppTransaction.
+                let cachedCustomerInfo = self.customerInfoManager.cachedCustomerInfo(appUserID: currentAppUserID)
 
-                    if let cachedCustomerInfo,
-                       cachedCustomerInfo.originalPurchaseDate != nil,
-                       cachedCustomerInfo.originalApplicationVersion != nil {
-                        self.operationDispatcher.dispatchOnMainActor {
-                            completion?(.success(cachedCustomerInfo))
-                        }
-                        return
-                    }
-
-                    let transactionData: PurchasedTransactionData = .init(
-                        appUserID: currentAppUserID,
-                        presentedOfferingContext: nil,
-                        unsyncedAttributes: unsyncedAttributes,
-                        source: .init(
-                            isRestore: isRestore,
-                            initiationSource: initiationSource
-                        )
-                    )
-
-                    self.backend.post(receipt: .empty,
-                                      productData: nil,
-                                      transactionData: transactionData,
-                                      observerMode: self.observerMode,
-                                      appTransaction: appTransactionJWS) { result in
-
-                        self.handleReceiptPost(result: result,
-                                               transactionData: nil,
-                                               subscriberAttributes: unsyncedAttributes,
-                                               adServicesToken: adServicesToken,
-                                               completion: completion)
+                if let cachedCustomerInfo,
+                   cachedCustomerInfo.originalPurchaseDate != nil,
+                   cachedCustomerInfo.originalApplicationVersion != nil {
+                    self.operationDispatcher.dispatchOnMainActor {
+                        completion?(.success(cachedCustomerInfo))
                     }
                     return
                 }
 
-                let receipt = await self.encodedReceipt(transaction: transaction, jwsRepresentation: jwsRepresentation)
-
-                self.createProductRequestData(with: transaction.productIdentifier) { productRequestData in
-                    let transactionData: PurchasedTransactionData = .init(
-                        appUserID: currentAppUserID,
-                        presentedOfferingContext: nil,
-                        unsyncedAttributes: unsyncedAttributes,
-                        storefront: transaction.storefront,
-                        source: .init(isRestore: isRestore, initiationSource: initiationSource)
+                let transactionData: PurchasedTransactionData = .init(
+                    appUserID: currentAppUserID,
+                    presentedOfferingContext: nil,
+                    unsyncedAttributes: unsyncedAttributes,
+                    source: .init(
+                        isRestore: isRestore,
+                        initiationSource: initiationSource
                     )
+                )
 
-                    self.backend.post(receipt: receipt,
-                                      productData: productRequestData,
-                                      transactionData: transactionData,
-                                      observerMode: self.observerMode,
-                                      appTransaction: appTransactionJWS) { result in
-                        self.handleReceiptPost(result: result,
-                                               transactionData: transactionData,
-                                               subscriberAttributes: unsyncedAttributes,
-                                               adServicesToken: adServicesToken,
-                                               completion: completion)
-                    }
+                self.backend.post(receipt: .empty,
+                                  productData: nil,
+                                  transactionData: transactionData,
+                                  observerMode: self.observerMode,
+                                  appTransaction: appTransactionJWS) { result in
+
+                    self.handleReceiptPost(result: result,
+                                           transactionData: nil,
+                                           subscriberAttributes: unsyncedAttributes,
+                                           adServicesToken: nil,
+                                           completion: completion)
+                }
+                return
+            }
+
+            let receipt = await self.encodedReceipt(transaction: transaction, jwsRepresentation: jwsRepresentation)
+
+            self.createProductRequestData(with: transaction.productIdentifier) { productRequestData in
+                let transactionData: PurchasedTransactionData = .init(
+                    appUserID: currentAppUserID,
+                    presentedOfferingContext: nil,
+                    unsyncedAttributes: unsyncedAttributes,
+                    storefront: transaction.storefront,
+                    source: .init(isRestore: isRestore, initiationSource: initiationSource)
+                )
+
+                self.backend.post(receipt: receipt,
+                                  productData: productRequestData,
+                                  transactionData: transactionData,
+                                  observerMode: self.observerMode,
+                                  appTransaction: appTransactionJWS) { result in
+                    self.handleReceiptPost(result: result,
+                                           transactionData: transactionData,
+                                           subscriberAttributes: unsyncedAttributes,
+                                           adServicesToken: nil,
+                                           completion: completion)
                 }
             }
         }


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
The AdServicesToken wasn't being sent to the the post receipt endpoint when syncing purchases, but was marking it as synced, so better to remove it altogether.

### Description
Removed usage of adServicesToken in syncPurchases.

The diff is a mess even in split mode. The changes are the same in the `syncPurchasesSK1` and `syncPurchasesSK2` methods:

- The following line was removed:

```
self.attribution.unsyncedAdServicesToken { adServicesToken in
```

- The `adServicesToken` parameter was changed to nil:

```
adServicesToken: nil
```