### PR TITLE
Add `$userAgent` tracking for attribution networks

### DIFF
--- a/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -30,6 +30,7 @@ enum ReservedSubscriberAttribute: String {
     case consentStatus = "$attConsentStatus"
 
     case ip = "$ip"
+    case userAgent = "$userAgent"
 
     case adjustID = "$adjustId"
     case appsFlyerID = "$appsflyerId"

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -140,6 +140,7 @@ class SubscriberAttributesManager {
         setReservedAttribute(.idfa, value: identifierForAdvertisers, appUserID: appUserID)
         setReservedAttribute(.idfv, value: identifierForVendor, appUserID: appUserID)
         setReservedAttribute(.ip, value: "true", appUserID: appUserID)
+        setReservedAttribute(.userAgent, value: "true", appUserID: appUserID)
     }
 
     /// - Parameter syncedAttribute: will be called for every attribute that is updated

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -554,7 +554,7 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetAdjustID() {
         let adjustID = "adjustID"
         self.subscriberAttributesManager.setAdjustID(adjustID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -570,7 +570,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setAdjustID(nil, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 8
+        expect(self.mockDeviceCache.invokedStoreCount) == 10
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -588,7 +588,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setAdjustID(adjustID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 3
+        expect(self.mockDeviceCache.invokedStoreCount) == 4
     }
 
     func testSetAdjustIDOverwritesIfNewValue() {
@@ -602,7 +602,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setAdjustID(adjustID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -616,9 +616,9 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetAdjustIDSetsDeviceIdentifiers() {
         let adjustID = "adjustID"
         self.subscriberAttributesManager.setAdjustID(adjustID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
 
-        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 5
 
         checkDeviceIdentifiersAreSet()
     }
@@ -627,7 +627,7 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetAppsflyerID() {
         let appsflyerID = "appsflyerID"
         self.subscriberAttributesManager.setAppsflyerID(appsflyerID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -643,7 +643,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setAppsflyerID(nil, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 8
+        expect(self.mockDeviceCache.invokedStoreCount) == 10
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -661,7 +661,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setAppsflyerID(appsflyerID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 3
+        expect(self.mockDeviceCache.invokedStoreCount) == 4
     }
 
     func testSetAppsflyerIDOverwritesIfNewValue() {
@@ -675,7 +675,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setAppsflyerID(appsflyerID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -689,9 +689,9 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetAppsflyerIDSetsDeviceIdentifiers() {
         let appsflyerID = "appsflyerID"
         self.subscriberAttributesManager.setAppsflyerID(appsflyerID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
 
-        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 5
 
         checkDeviceIdentifiersAreSet()
     }
@@ -700,7 +700,7 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetFBAnonymousID() {
         let fbAnonID = "fbAnonID"
         self.subscriberAttributesManager.setFBAnonymousID(fbAnonID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -716,7 +716,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setFBAnonymousID(nil, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 8
+        expect(self.mockDeviceCache.invokedStoreCount) == 10
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -734,7 +734,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setFBAnonymousID(fbAnonID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 3
+        expect(self.mockDeviceCache.invokedStoreCount) == 4
     }
 
     func testSetFBAnonymousIDOverwritesIfNewValue() {
@@ -748,7 +748,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setFBAnonymousID(fbAnonID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -762,9 +762,9 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetFBAnonymousIDSetsDeviceIdentifiers() {
         let fbAnonID = "fbAnonID"
         self.subscriberAttributesManager.setFBAnonymousID(fbAnonID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
 
-        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 5
 
         checkDeviceIdentifiersAreSet()
     }
@@ -773,7 +773,7 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetMparticleID() {
         let mparticleID = "mparticleID"
         self.subscriberAttributesManager.setMparticleID(mparticleID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -789,7 +789,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setMparticleID(nil, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 8
+        expect(self.mockDeviceCache.invokedStoreCount) == 10
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -807,7 +807,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setMparticleID(mparticleID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 3
+        expect(self.mockDeviceCache.invokedStoreCount) == 4
     }
 
     func testSetMparticleIDOverwritesIfNewValue() {
@@ -821,7 +821,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setMparticleID(mparticleID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -835,9 +835,9 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetMparticleIDSetsDeviceIdentifiers() {
         let mparticleID = "mparticleID"
         self.subscriberAttributesManager.setMparticleID(mparticleID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
 
-        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 5
 
         checkDeviceIdentifiersAreSet()
     }

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -1825,6 +1825,11 @@ private extension SubscriberAttributesManagerTests {
 
         expect(ipReceived.value) == "true"
         expect(ipReceived.isSynced) == false
+
+        let userAgentReceived = findInvokedAttribute(withName: "$userAgent")
+
+        expect(userAgentReceived.value) == "true"
+        expect(userAgentReceived.isSynced) == false
     }
 
     func checkDeviceIdentifiersAreNotSet() {
@@ -1835,6 +1840,8 @@ private extension SubscriberAttributesManagerTests {
         expect(invokedParams).toNot(containElementSatisfying({ $0.attribute.key == "$idfa" }))
 
         expect(invokedParams).toNot(containElementSatisfying({ $0.attribute.key == "$ip" }))
+
+        expect(invokedParams).toNot(containElementSatisfying({ $0.attribute.key == "$userAgent" }))
     }
 
 }


### PR DESCRIPTION
### Description
This will set up a new property `$userAgent` set to `"true"` when using any attribution network method. When this is set, the backend will know to collect the user agent. 

This is a follow-up for the Kochava PR: #4238 

- [ ] Holding until backend has been deployed
