### PR TITLE
Update allowSharingAppStoreAccount deprecation message

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1548,7 +1548,7 @@ public extension Purchases {
     /**
      * Deprecated
      */
-    @available(*, deprecated, message: "Configure behavior through the RevenueCat dashboard instead. If have configured the "Legacy" restore behavior in the [RevenueCat Dashboard](app.revenuecat.com) and are currently setting this to `true`, keep this setting active.")
+    @available(*, deprecated, message: "Configure behavior through the RevenueCat dashboard instead. If you have configured the \"Legacy\" restore behavior in the [RevenueCat Dashboard](app.revenuecat.com) and are currently setting this to `true`, keep this setting active.")
     @objc var allowSharingAppStoreAccount: Bool {
         get { purchasesOrchestrator.allowSharingAppStoreAccount }
         set { purchasesOrchestrator.allowSharingAppStoreAccount = newValue }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1548,7 +1548,7 @@ public extension Purchases {
     /**
      * Deprecated
      */
-    @available(*, deprecated, message: "Configure behavior through the RevenueCat dashboard instead. If you are using the legacy restore behavior and are currently setting this to true, continue doing so.")
+    @available(*, deprecated, message: "Configure behavior through the RevenueCat dashboard instead. If have configured the "Legacy" restore behavior in the [RevenueCat Dashboard](app.revenuecat.com) and are currently setting this to `true`, keep this setting active.")
     @objc var allowSharingAppStoreAccount: Bool {
         get { purchasesOrchestrator.allowSharingAppStoreAccount }
         set { purchasesOrchestrator.allowSharingAppStoreAccount = newValue }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1550,7 +1550,7 @@ public extension Purchases {
      */
     @available(*, deprecated, message: """
     Configure behavior through the RevenueCat dashboard instead. If you have configured the \"Legacy\" restore 
-    behavior in the [RevenueCat Dashboard](app.revenuecat.com) and are currently setting this to `true`, keep 
+    behavior in the [RevenueCat Dashboard](app.revenuecat.com) and are currently setting this to `true`, keep
     this setting active.
     """
     )

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1548,7 +1548,12 @@ public extension Purchases {
     /**
      * Deprecated
      */
-    @available(*, deprecated, message: "Configure behavior through the RevenueCat dashboard instead. If you have configured the \"Legacy\" restore behavior in the [RevenueCat Dashboard](app.revenuecat.com) and are currently setting this to `true`, keep this setting active.")
+    @available(*, deprecated, message: """
+    Configure behavior through the RevenueCat dashboard instead. If you have configured the \"Legacy\" restore 
+    behavior in the [RevenueCat Dashboard](app.revenuecat.com) and are currently setting this to `true`, keep 
+    this setting active.
+    """
+    )
     @objc var allowSharingAppStoreAccount: Bool {
         get { purchasesOrchestrator.allowSharingAppStoreAccount }
         set { purchasesOrchestrator.allowSharingAppStoreAccount = newValue }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1548,7 +1548,7 @@ public extension Purchases {
     /**
      * Deprecated
      */
-    @available(*, deprecated, message: "Configure behavior through the RevenueCat dashboard instead")
+    @available(*, deprecated, message: "Configure behavior through the RevenueCat dashboard instead. If you are using the legacy restore behavior and are currently setting this to true, continue doing so.")
     @objc var allowSharingAppStoreAccount: Bool {
         get { purchasesOrchestrator.allowSharingAppStoreAccount }
         set { purchasesOrchestrator.allowSharingAppStoreAccount = newValue }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1549,7 +1549,7 @@ public extension Purchases {
      * Deprecated
      */
     @available(*, deprecated, message: """
-    Configure behavior through the RevenueCat dashboard instead. If you have configured the \"Legacy\" restore 
+    Configure behavior through the RevenueCat dashboard instead. If you have configured the \"Legacy\" restore
     behavior in the [RevenueCat Dashboard](app.revenuecat.com) and are currently setting this to `true`, keep
     this setting active.
     """


### PR DESCRIPTION
### Description
Updates the deprecation message of `allowSharingAppStoreAccount` to tell people who are already using the field to continue using it and not remove it. 
