### PR TITLE
[Paywalls] Use store product for `{{ sub_period }}` duration

### DIFF
--- a/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
+++ b/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
@@ -79,8 +79,6 @@ extension Package: VariableDataProvider {
             return nil
         }
 
-        product.productType
-
         switch (period.value, period.unit) {
         case (_, .day):
             return nil

--- a/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
+++ b/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
@@ -74,8 +74,36 @@ extension Package: VariableDataProvider {
         return self.storeProduct.localizedTitle
     }
 
+    func toPackageType(product: StoreProduct) -> PackageType? {
+        guard let period = product.subscriptionPeriod else {
+            return nil
+        }
+
+        product.productType
+
+        switch (period.value, period.unit) {
+        case (_, .day):
+            return nil
+        case (1, .week):
+            return .weekly
+        case (1, .month):
+            return .monthly
+        case (2, .month):
+            return .twoMonth
+        case (3, .month):
+            return .threeMonth
+        case (6, .month):
+            return .sixMonth
+        case (1, .year):
+            return .annual
+        default:
+            return nil
+        }
+    }
+
     func periodNameOrIdentifier(_ locale: Locale) -> String {
-        return Localization.localized(packageType: self.packageType,
+        let packageType = toPackageType(product: self.storeProduct) ?? self.packageType
+        return Localization.localized(packageType: packageType,
                                       locale: locale) ?? self.identifier
     }
 

--- a/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
@@ -172,8 +172,8 @@ class PackageVariablesTests: TestCase {
         expect(TestData.sixMonthPackage.periodNameOrIdentifier(Self.english)) == "6 Month"
         expect(TestData.annualPackage.periodNameOrIdentifier(Self.english)) == "Annual"
         expect(TestData.lifetimePackage.periodNameOrIdentifier(Self.english)) == "Lifetime"
-        expect(TestData.customPackage.periodNameOrIdentifier(Self.english)) == "Custom"
-        expect(TestData.unknownPackage.periodNameOrIdentifier(Self.english)) == "Unknown"
+        expect(TestData.customPackage.periodNameOrIdentifier(Self.english)) == "Annual"
+        expect(TestData.unknownPackage.periodNameOrIdentifier(Self.english)) == "Annual"
     }
 
     func testSpanishPeriodName() {
@@ -183,8 +183,8 @@ class PackageVariablesTests: TestCase {
         expect(TestData.sixMonthPackage.periodNameOrIdentifier(Self.spanish)) == "6 meses"
         expect(TestData.annualPackage.periodNameOrIdentifier(Self.spanish)) == "Anual"
         expect(TestData.lifetimePackage.periodNameOrIdentifier(Self.spanish)) == "Toda la vida"
-        expect(TestData.customPackage.periodNameOrIdentifier(Self.spanish)) == "Custom"
-        expect(TestData.unknownPackage.periodNameOrIdentifier(Self.spanish)) == "Unknown"
+        expect(TestData.customPackage.periodNameOrIdentifier(Self.spanish)) == "Anual"
+        expect(TestData.unknownPackage.periodNameOrIdentifier(Self.spanish)) == "Anual"
     }
 
     func testEnglishPeriodAbbreviation() {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Products.storekit
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Products.storekit
@@ -4,7 +4,36 @@
 
   ],
   "products" : [
-
+    {
+      "displayPrice" : "0.99",
+      "familyShareable" : false,
+      "internalID" : "531C0472",
+      "localizations" : [
+        {
+          "description" : "Lifetime",
+          "displayName" : "Lifetime",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "com.revenuecat.simpleapp.lifetime",
+      "referenceName" : "Lifetime",
+      "type" : "NonConsumable"
+    },
+    {
+      "displayPrice" : "0.99",
+      "familyShareable" : false,
+      "internalID" : "AE159122",
+      "localizations" : [
+        {
+          "description" : "Liftime",
+          "displayName" : "Lifetime Lite",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "com.revenuecat.simpleapp.lifetimelite",
+      "referenceName" : "Lifetime Lite",
+      "type" : "NonConsumable"
+    }
   ],
   "settings" : {
     "_failTransactionsEnabled" : false,


### PR DESCRIPTION
### Motivation

`{{ sub_period }} ` was returning package identifier when using custom package names

### Description

Look at the `StoreProduct` periods to determine the period length first 😁 
