### PR TITLE
Add `kochava` integration

### DIFF
--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -98,6 +98,19 @@ class SystemInfo {
         return Self.forceUniversalAppStore ? "iOS" : self.platformHeaderConstant
     }
 
+    static var deviceVersion: String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+
+        let machineMirror = Mirror(reflecting: systemInfo.machine)
+        let identifier = machineMirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8, value != 0 else { return identifier }
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+
+        return identifier
+    }
+
     var identifierForVendor: String? {
         // Should match available platforms in
         // https://developer.apple.com/documentation/uikit/uidevice?language=swift

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -123,6 +123,7 @@ class HTTPClient {
             "X-Platform": SystemInfo.platformHeader,
             "X-Platform-Version": SystemInfo.systemVersion,
             "X-Platform-Flavor": self.systemInfo.platformFlavor,
+            "X-Platform-Device": SystemInfo.deviceVersion,
             "X-Client-Version": SystemInfo.appVersion,
             "X-Client-Build-Version": SystemInfo.buildVersion,
             "X-Client-Bundle-ID": SystemInfo.bundleIdentifier,

--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -281,6 +281,19 @@ public extension Attribution {
     }
 
     /**
+     * Subscriber attribute associated with the Kochava Device ID for the user.
+     * Recommended for the RevenueCat Kochava integration.
+     *
+     * #### Related Articles
+     * - [Kochava RevenueCat Integration](https://docs.revenuecat.com/docs/kochava)
+     *
+     * - Parameter kochavaDeviceID: Empty String or `nil` will delete the subscriber attribute.
+     */
+    @objc func setKochavaDeviceID(_ kochavaDeviceID: String?) {
+        self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceID, appUserID: appUserID)
+    }
+
+    /**
      * Subscriber attribute associated with the Mixpanel Distinct ID for the user.
      * Optional for the RevenueCat Mixpanel integration.
      *

--- a/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -30,6 +30,7 @@ enum ReservedSubscriberAttribute: String {
     case consentStatus = "$attConsentStatus"
 
     case ip = "$ip"
+    case userAgent = "$userAgent"
 
     case adjustID = "$adjustId"
     case appsFlyerID = "$appsflyerId"

--- a/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -30,7 +30,7 @@ enum ReservedSubscriberAttribute: String {
     case consentStatus = "$attConsentStatus"
 
     case ip = "$ip"
-    case userAgent = "$userAgent"
+    case deviceVersion = "$deviceVersion"
 
     case adjustID = "$adjustId"
     case appsFlyerID = "$appsflyerId"

--- a/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -39,6 +39,7 @@ enum ReservedSubscriberAttribute: String {
     case oneSignalUserID = "$onesignalUserId"
     case airshipChannelID = "$airshipChannelId"
     case cleverTapID = "$clevertapId"
+    case kochavaDeviceID = "$kochavaDeviceId"
     case mixpanelDistinctID = "$mixpanelDistinctId"
     case firebaseAppInstanceID = "$firebaseAppInstanceId"
 

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -140,6 +140,7 @@ class SubscriberAttributesManager {
         setReservedAttribute(.idfa, value: identifierForAdvertisers, appUserID: appUserID)
         setReservedAttribute(.idfv, value: identifierForVendor, appUserID: appUserID)
         setReservedAttribute(.ip, value: "true", appUserID: appUserID)
+        setReservedAttribute(.userAgent, value: "true", appUserID: appUserID)
     }
 
     /// - Parameter syncedAttribute: will be called for every attribute that is updated

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -96,6 +96,10 @@ class SubscriberAttributesManager {
         setReservedAttribute(.cleverTapID, value: cleverTapID, appUserID: appUserID)
     }
 
+    func setKochavaDeviceID(_ kochavaDeviceID: String?, appUserID: String) {
+        setReservedAttribute(.kochavaDeviceID, value: kochavaDeviceID, appUserID: appUserID)
+    }
+
     func setMixpanelDistinctID(_ mixpanelDistinctID: String?, appUserID: String) {
         setReservedAttribute(.mixpanelDistinctID, value: mixpanelDistinctID, appUserID: appUserID)
     }

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -140,7 +140,7 @@ class SubscriberAttributesManager {
         setReservedAttribute(.idfa, value: identifierForAdvertisers, appUserID: appUserID)
         setReservedAttribute(.idfv, value: identifierForVendor, appUserID: appUserID)
         setReservedAttribute(.ip, value: "true", appUserID: appUserID)
-        setReservedAttribute(.userAgent, value: "true", appUserID: appUserID)
+        setReservedAttribute(.deviceVersion, value: "true", appUserID: appUserID)
     }
 
     /// - Parameter syncedAttribute: will be called for every attribute that is updated

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAttributionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAttributionAPI.m
@@ -38,6 +38,8 @@
     [a setOnesignalUserID: @""];
     [a setCleverTapID: nil];
     [a setCleverTapID: @""];
+    [a setKochavaDeviceID:nil];
+    [a setKochavaDeviceID:@""];
     [a setMixpanelDistinctID: nil];
     [a setMixpanelDistinctID: @""];
     [a setFirebaseAppInstanceID: nil];

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AttributionAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AttributionAPI.swift
@@ -49,6 +49,9 @@ func checkAttributionAPI() {
     attribution.setCleverTapID("")
     attribution.setCleverTapID(nil)
 
+    attribution.setKochavaDeviceID("")
+    attribution.setKochavaDeviceID(nil)
+
     attribution.setMixpanelDistinctID("")
     attribution.setMixpanelDistinctID(nil)
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriberAttributesView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriberAttributesView.swift
@@ -38,6 +38,7 @@ struct SubscriberAttributesView: View {
         case setAppsflyerID
         case setAirshipChannelID
         case setCleverTapID
+        case setKochavaDeviceID
         case setMparticleID
         case setOnesignalID
         case setFBAnonymousID
@@ -142,6 +143,8 @@ struct SubscriberAttributesView: View {
                     Purchases.shared.attribution.setAirshipChannelID(self.otherValue)
                 case .setCleverTapID:
                     Purchases.shared.attribution.setCleverTapID(self.otherValue)
+                case .setKochavaDeviceID:
+                    Purchases.shared.attribution.setKochavaDeviceID(self.otherValue)
                 case .setMparticleID:
                     Purchases.shared.attribution.setMparticleID(self.otherValue)
                 case .setOnesignalID:

--- a/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
@@ -177,6 +177,18 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
         invokedSetCleverTapIDParametersList.append((cleverTapID, appUserID))
     }
 
+    var invokedSetKochavaDeviceID = false
+    var invokedSetKochavaDeviceIDCount = 0
+    var invokedSetKochavaDeviceIDParameters: (KochavaDeviceID: String?, appUserID: String?)?
+    var invokedSetKochavaDeviceIDParametersList = [(KochavaDeviceID: String?, appUserID: String?)]()
+
+    override func setKochavaDeviceID(_ kochavaDeviceID: String?, appUserID: String) {
+        invokedSetKochavaDeviceID = true
+        invokedSetKochavaDeviceIDCount += 1
+        invokedSetKochavaDeviceIDParameters = (kochavaDeviceID, appUserID)
+        invokedSetKochavaDeviceIDParametersList.append((kochavaDeviceID, appUserID))
+    }
+
     var invokedSetMixpanelDistinctID = false
     var invokedSetMixpanelDistinctIDCount = 0
     var invokedSetMixpanelDistinctIDParameters: (mixpanelDistinctID: String?, appUserID: String?)?

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -922,6 +922,23 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(headerPresent.value) == true
     }
 
+    func testPassesPlatformDeviceHeader() {
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
+
+        let headerPresent: Atomic<Bool> = false
+
+        stub(condition: hasHeaderNamed("X-Platform-Device", value: SystemInfo.deviceVersion)) { _ in
+            headerPresent.value = true
+            return .emptySuccessResponse()
+        }
+
+        waitUntil { completion in
+            self.client.perform(request) { (_: DataResponse) in completion() }
+        }
+
+        expect(headerPresent.value) == true
+    }
+
     func testPassesPlatformFlavorVersionHeader() {
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -438,6 +438,16 @@ class PurchasesSubscriberAttributesTests: TestCase {
             .to(equal((nil, purchases.appUserID)))
     }
 
+    func testSetAndClearKochavaDeviceID() {
+        setupPurchases()
+        purchases.attribution.setKochavaDeviceID("kochava")
+        purchases.attribution.setKochavaDeviceID(nil)
+        expect(self.mockSubscriberAttributesManager.invokedSetKochavaDeviceIDParametersList[0])
+            .to(equal(("kochava", purchases.appUserID)))
+        expect(self.mockSubscriberAttributesManager.invokedSetKochavaDeviceIDParametersList[1])
+            .to(equal((nil, purchases.appUserID)))
+    }
+
     func testSetAndClearMixpanelDistinctID() {
         setupPurchases()
         purchases.attribution.setMixpanelDistinctID("mixp")

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -554,7 +554,7 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetAdjustID() {
         let adjustID = "adjustID"
         self.subscriberAttributesManager.setAdjustID(adjustID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -570,7 +570,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setAdjustID(nil, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 8
+        expect(self.mockDeviceCache.invokedStoreCount) == 10
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -588,7 +588,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setAdjustID(adjustID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 3
+        expect(self.mockDeviceCache.invokedStoreCount) == 4
     }
 
     func testSetAdjustIDOverwritesIfNewValue() {
@@ -602,7 +602,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setAdjustID(adjustID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -616,9 +616,9 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetAdjustIDSetsDeviceIdentifiers() {
         let adjustID = "adjustID"
         self.subscriberAttributesManager.setAdjustID(adjustID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
 
-        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 5
 
         checkDeviceIdentifiersAreSet()
     }
@@ -627,7 +627,7 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetAppsflyerID() {
         let appsflyerID = "appsflyerID"
         self.subscriberAttributesManager.setAppsflyerID(appsflyerID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -643,7 +643,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setAppsflyerID(nil, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 8
+        expect(self.mockDeviceCache.invokedStoreCount) == 10
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -661,7 +661,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setAppsflyerID(appsflyerID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 3
+        expect(self.mockDeviceCache.invokedStoreCount) == 4
     }
 
     func testSetAppsflyerIDOverwritesIfNewValue() {
@@ -675,7 +675,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setAppsflyerID(appsflyerID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -689,9 +689,9 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetAppsflyerIDSetsDeviceIdentifiers() {
         let appsflyerID = "appsflyerID"
         self.subscriberAttributesManager.setAppsflyerID(appsflyerID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
 
-        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 5
 
         checkDeviceIdentifiersAreSet()
     }
@@ -700,7 +700,7 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetFBAnonymousID() {
         let fbAnonID = "fbAnonID"
         self.subscriberAttributesManager.setFBAnonymousID(fbAnonID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -716,7 +716,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setFBAnonymousID(nil, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 8
+        expect(self.mockDeviceCache.invokedStoreCount) == 10
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -734,7 +734,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setFBAnonymousID(fbAnonID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 3
+        expect(self.mockDeviceCache.invokedStoreCount) == 4
     }
 
     func testSetFBAnonymousIDOverwritesIfNewValue() {
@@ -748,7 +748,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setFBAnonymousID(fbAnonID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -762,9 +762,9 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetFBAnonymousIDSetsDeviceIdentifiers() {
         let fbAnonID = "fbAnonID"
         self.subscriberAttributesManager.setFBAnonymousID(fbAnonID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
 
-        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 5
 
         checkDeviceIdentifiersAreSet()
     }
@@ -773,7 +773,7 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetMparticleID() {
         let mparticleID = "mparticleID"
         self.subscriberAttributesManager.setMparticleID(mparticleID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -789,7 +789,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setMparticleID(nil, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 8
+        expect(self.mockDeviceCache.invokedStoreCount) == 10
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -807,7 +807,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setMparticleID(mparticleID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 3
+        expect(self.mockDeviceCache.invokedStoreCount) == 4
     }
 
     func testSetMparticleIDOverwritesIfNewValue() {
@@ -821,7 +821,7 @@ class SubscriberAttributesManagerTests: TestCase {
 
         self.subscriberAttributesManager.setMparticleID(mparticleID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -835,9 +835,9 @@ class SubscriberAttributesManagerTests: TestCase {
     func testSetMparticleIDSetsDeviceIdentifiers() {
         let mparticleID = "mparticleID"
         self.subscriberAttributesManager.setMparticleID(mparticleID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 5
 
-        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 5
 
         checkDeviceIdentifiersAreSet()
     }

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -1825,6 +1825,11 @@ private extension SubscriberAttributesManagerTests {
 
         expect(ipReceived.value) == "true"
         expect(ipReceived.isSynced) == false
+
+        let userAgentReceived = findInvokedAttribute(withName: "$userAgent")
+
+        expect(userAgentReceived.value) == "true"
+        expect(userAgentReceived.isSynced) == false
     }
 
     func checkDeviceIdentifiersAreNotSet() {
@@ -1835,6 +1840,8 @@ private extension SubscriberAttributesManagerTests {
         expect(invokedParams).toNot(containElementSatisfying({ $0.attribute.key == "$idfa" }))
 
         expect(invokedParams).toNot(containElementSatisfying({ $0.attribute.key == "$ip" }))
+
+        expect(invokedParams).toNot(containElementSatisfying({ $0.attribute.key == "$userAgent" }))
     }
 
 }

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -1134,6 +1134,79 @@ class SubscriberAttributesManagerTests: TestCase {
         checkDeviceIdentifiersAreNotSet()
     }
     // endregion
+    // region kochavaDeviceID
+    func testSetKochavaDeviceID() throws {
+        let kochavaDeviceID = "kochavaDeviceID"
+
+        self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$kochavaDeviceId"
+        expect(receivedAttribute.value) == kochavaDeviceID
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetKochavaDeviceIDSetsEmptyIfNil() throws {
+        let kochavaDeviceID = "kochavaDeviceID"
+
+        self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceID, appUserID: "kratos")
+        self.subscriberAttributesManager.setKochavaDeviceID(nil, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 2
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$kochavaDeviceId"
+        expect(receivedAttribute.value) == ""
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetKochavaDeviceIDSkipsIfSameValue() {
+        let kochavaDeviceID = "kochavaDeviceID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$kochavaDeviceId",
+                                                                                    value: kochavaDeviceID)
+        self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 0
+    }
+
+    func testSetKochavaDeviceIDOverwritesIfNewValue() throws {
+        let oldSyncTime = Date()
+        let kochavaDeviceID = "kochavaDeviceID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$kochavaDeviceId",
+                                                                                    value: "old_id",
+                                                                                    isSynced: true,
+                                                                                    setTime: oldSyncTime)
+
+        self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$kochavaDeviceId"
+        expect(receivedAttribute.value) == kochavaDeviceID
+        expect(receivedAttribute.isSynced) == false
+        expect(receivedAttribute.setTime) > oldSyncTime
+    }
+
+    func testSetKochavaDeviceIDDoesNotSetDeviceIdentifiers() {
+        let kochavaDeviceID = "kochavaDeviceID"
+        self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
+
+        checkDeviceIdentifiersAreNotSet()
+    }
+    // endregion
     // region MixpanelDistinctID
     func testSetMixpanelDistinctID() throws {
         let mixpanelDistinctID = "mixpanelDistinctID"

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -1826,10 +1826,10 @@ private extension SubscriberAttributesManagerTests {
         expect(ipReceived.value) == "true"
         expect(ipReceived.isSynced) == false
 
-        let userAgentReceived = findInvokedAttribute(withName: "$userAgent")
+        let deviceVersionReceived = findInvokedAttribute(withName: "$deviceVersion")
 
-        expect(userAgentReceived.value) == "true"
-        expect(userAgentReceived.isSynced) == false
+        expect(deviceVersionReceived.value) == "true"
+        expect(deviceVersionReceived.isSynced) == false
     }
 
     func checkDeviceIdentifiersAreNotSet() {
@@ -1841,7 +1841,7 @@ private extension SubscriberAttributesManagerTests {
 
         expect(invokedParams).toNot(containElementSatisfying({ $0.attribute.key == "$ip" }))
 
-        expect(invokedParams).toNot(containElementSatisfying({ $0.attribute.key == "$userAgent" }))
+        expect(invokedParams).toNot(containElementSatisfying({ $0.attribute.key == "$deviceVersion" }))
     }
 
 }


### PR DESCRIPTION
### Description
This adds the `kochava` integration.

This brings back the work done in #4238 and picks up the work on #4263 (but renaming it to `$deviceVersion`). Finally, it also adds a new header, `X-Platform-Device` that will contain the model version