### PR TITLE
created PoC code to handle deeplinks nicely

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		2D4D6AF624F7193700B656BE /* verifyReceiptSample1.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2DDE559A24C8B5E300DCB087 /* verifyReceiptSample1.txt */; };
 		2D4D6AF724F7193700B656BE /* base64encodedreceiptsample1.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2DDE559B24C8B5E300DCB087 /* base64encodedreceiptsample1.txt */; };
 		2D4E926526990AB1000E10B0 /* StoreKit1Wrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4E926426990AB1000E10B0 /* StoreKit1Wrapper.swift */; };
+		2D6AA7B22C99D11A001DD27A /* RevenueCatDeeplinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D6AA7B12C99D11A001DD27A /* RevenueCatDeeplinkHandler.swift */; };
 		2D735F7E26EFF198004E82A7 /* UnitTestsConfiguration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 2D43017726EBFD7100BAB891 /* UnitTestsConfiguration.storekit */; };
 		2D803F6326F144830069D717 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 2D803F6226F144830069D717 /* Nimble */; };
 		2D803F6626F144BF0069D717 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 2D803F6526F144BF0069D717 /* Nimble */; };
@@ -1168,6 +1169,7 @@
 		2D4E926426990AB1000E10B0 /* StoreKit1Wrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit1Wrapper.swift; sourceTree = "<group>"; };
 		2D5BB46A24C8E8ED00E27537 /* PurchasesReceiptParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesReceiptParser.swift; sourceTree = "<group>"; };
 		2D69384426DFF93300FCDBC0 /* StoreProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductTests.swift; sourceTree = "<group>"; };
+		2D6AA7B12C99D11A001DD27A /* RevenueCatDeeplinkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevenueCatDeeplinkHandler.swift; sourceTree = "<group>"; };
 		2D84458826B9CD270033B5A3 /* ReceiptFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcherTests.swift; sourceTree = "<group>"; };
 		2D8D03B42799A2B90044C2ED /* DocCDocumentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = DocCDocumentation.docc; sourceTree = "<group>"; };
 		2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriberAttributeTests.swift; sourceTree = "<group>"; };
@@ -4083,6 +4085,7 @@
 				887A605D2C1D037000E1A461 /* RemoteImage.swift */,
 				887A605E2C1D037000E1A461 /* TemplateBackgroundImageView.swift */,
 				88A543E62C37A4C40039C6A5 /* TierSelectorView.swift */,
+				2D6AA7B12C99D11A001DD27A /* RevenueCatDeeplinkHandler.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -5974,6 +5977,7 @@
 				353756682C382C2800A1B8D6 /* CustomerCenterViewModel.swift in Sources */,
 				887A60BD2C1D037000E1A461 /* TemplateViewType.swift in Sources */,
 				887A606D2C1D037000E1A461 /* Localization.swift in Sources */,
+				2D6AA7B22C99D11A001DD27A /* RevenueCatDeeplinkHandler.swift in Sources */,
 				887A60CA2C1D037000E1A461 /* RemoteImage.swift in Sources */,
 				88B1BAF42C813A3C001B7EE5 /* SpacerComponentViewModel.swift in Sources */,
 				887A607B2C1D037000E1A461 /* Bundle+Extensions.swift in Sources */,

--- a/RevenueCatUI/Views/RevenueCatDeeplinkHandler.swift
+++ b/RevenueCatUI/Views/RevenueCatDeeplinkHandler.swift
@@ -1,0 +1,107 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RevenueCatDeeplinkHandler.swift
+//
+//  Created by Andrés Boedo on 9/17/24.
+
+import Foundation
+import RevenueCat
+import SwiftUI
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
+@available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
+struct RevenueCatDeeplinkHandlerView<Content: View>: View {
+    @State private var isShowingPaywall: Bool = false
+    @State private var offeringID: String?
+
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .onOpenURL { url in
+                if let extractedOfferingID = extractOfferingID(from: url) {
+                    offeringID = extractedOfferingID
+                    isShowingPaywall = true
+                }
+            }
+            .sheet(
+                isPresented: $isShowingPaywall,
+                onDismiss: {
+                    offeringID = nil
+                },
+                content: {
+                    if let offeringID = offeringID {
+                        OfferingLoaderView(offeringID: offeringID)
+                    } else {
+                        Text("Invalid offering ID.")
+                    }
+                })
+    }
+
+    private func extractOfferingID(from url: URL) -> String? {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        return components?.queryItems?.first(where: { $0.name == "offeringID" })?.value
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
+@available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
+extension View {
+    func handleRevenueCatDeeplinks() -> some View {
+        RevenueCatDeeplinkHandlerView {
+            self
+        }
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
+@available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
+struct OfferingLoaderView: View {
+    let offeringID: String
+    @State private var offering: Offering?
+    @State private var isLoading = true
+
+    var body: some View {
+        Group {
+            if let offering = offering {
+                PaywallView(offering: offering)
+            } else if isLoading {
+                ProgressView()
+            } else {
+                Text("Could not load offering.")
+            }
+        }
+        .task {
+            await fetchOffering()
+        }
+    }
+
+    private func fetchOffering() async {
+        do {
+            let offerings = try await Purchases.shared.offerings()
+            if let offering = offerings.offering(identifier: offeringID) {
+                self.offering = offering
+            } else {
+                isLoading = false
+                print("Offering with ID \(offeringID) not found.")
+            }
+        } catch {
+            isLoading = false
+            print("Error fetching offering: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Info.plist
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Info.plist
@@ -2,6 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.revenuecat.PaywallsTester</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>paywallsTester</string>
+			</array>
+		</dict>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Products.storekit
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Products.storekit
@@ -1,4 +1,14 @@
 {
+  "appPolicies" : {
+    "eula" : "",
+    "policies" : [
+      {
+        "locale" : "en_US",
+        "policyText" : "",
+        "policyURL" : ""
+      }
+    ]
+  },
   "identifier" : "882C6E98",
   "nonRenewingSubscriptions" : [
 
@@ -132,7 +142,10 @@
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Monthly",
           "subscriptionGroupID" : "CEEF018E",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
         },
         {
           "adHocOffers" : [
@@ -167,7 +180,10 @@
           "recurringSubscriptionPeriod" : "P1Y",
           "referenceName" : "Yearly",
           "subscriptionGroupID" : "CEEF018E",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
         },
         {
           "adHocOffers" : [
@@ -192,13 +208,16 @@
           "recurringSubscriptionPeriod" : "P1W",
           "referenceName" : "Weekly",
           "subscriptionGroupID" : "CEEF018E",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
         }
       ]
     }
   ],
   "version" : {
-    "major" : 3,
+    "major" : 4,
     "minor" : 0
   }
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
@@ -44,6 +44,7 @@ struct AppContentView: View {
             }
             #endif
         }
+        .handleRevenueCatDeeplinks()
     }
 
     private var background: some View {


### PR DESCRIPTION
Quick-n-dirty PoC to open up paywalls from a deeplink. 

## Usage: 

In a SwiftUIView, just add a modifier: 
```swift
    .handleRevenueCatDeeplinks()
```

And we take it from there! You will have to set up deeplinks for your app, though, obviously. 
Then, once set up, you can deeplinks like: 

```
paywallsTester://paywall?offeringID=Andy_Test_2
paywallsTester://paywall?offeringID=Andy_Test_3
paywallsTester://paywall?offeringID=Andy_Test_4
```

Also added them to paywallsTester for easy testing. 