### PR TITLE
Replace withCheckedThrowingContinuation Calls With withUnsafeThrowingContinuation

### DIFF
--- a/Sources/FoundationExtensions/AsyncExtensions.swift
+++ b/Sources/FoundationExtensions/AsyncExtensions.swift
@@ -101,7 +101,10 @@ internal enum Async {
     static func call<Value>(
         method: (@escaping @Sendable (Value) -> Void) -> Void
     ) async -> Value {
-        return await withCheckedContinuation { continuation in
+        // Note: We're using UnsafeContinuation instead of Checked because
+        // of a crash in iOS 18.0 devices when CheckedContinuations are used.
+        // See: https://github.com/RevenueCat/purchases-ios/pull/4286
+        return await withUnsafeContinuation { continuation in
             @Sendable
             func complete(_ value: Value) {
                 continuation.resume(with: .success(value))

--- a/Sources/FoundationExtensions/AsyncExtensions.swift
+++ b/Sources/FoundationExtensions/AsyncExtensions.swift
@@ -80,7 +80,7 @@ internal enum Async {
     static func call<Value, Error: Swift.Error>(
         method: (@escaping @Sendable (Result<Value, Error>) -> Void) -> Void
     ) async throws -> Value {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             @Sendable
             func complete(_ result: Result<Value, Error>) {
                 continuation.resume(with: result)

--- a/Sources/FoundationExtensions/AsyncExtensions.swift
+++ b/Sources/FoundationExtensions/AsyncExtensions.swift
@@ -103,7 +103,7 @@ internal enum Async {
     ) async -> Value {
         // Note: We're using UnsafeContinuation instead of Checked because
         // of a crash in iOS 18.0 devices when CheckedContinuations are used.
-        // See: https://github.com/RevenueCat/purchases-ios/pull/4286
+        // See: https://github.com/RevenueCat/purchases-ios/issues/4177
         return await withUnsafeContinuation { continuation in
             @Sendable
             func complete(_ value: Value) {

--- a/Sources/Misc/Concurrency/Purchases+async.swift
+++ b/Sources/Misc/Concurrency/Purchases+async.swift
@@ -18,7 +18,7 @@ extension Purchases {
 
     // Note: We're using UnsafeContinuation instead of Checked because
     // of a crash in iOS 18.0 devices when CheckedContinuations are used.
-    // See: https://github.com/RevenueCat/purchases-ios/pull/4286
+    // See: https://github.com/RevenueCat/purchases-ios/issues/4177
     
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 

--- a/Sources/Misc/Concurrency/Purchases+async.swift
+++ b/Sources/Misc/Concurrency/Purchases+async.swift
@@ -19,7 +19,7 @@ extension Purchases {
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     func logInAsync(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             logIn(appUserID) { customerInfo, created, error in
                 continuation.resume(with: Result(customerInfo, error)
                                         .map { ($0, created) })
@@ -28,7 +28,7 @@ extension Purchases {
     }
 
     func logOutAsync() async throws -> CustomerInfo {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             logOut { customerInfo, error in
                 continuation.resume(with: Result(customerInfo, error))
             }
@@ -36,7 +36,7 @@ extension Purchases {
     }
 
     func syncAttributesAndOfferingsIfNeededAsync() async throws -> Offerings? {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             syncAttributesAndOfferingsIfNeeded { offerings, error in
                 continuation.resume(with: Result(offerings, error))
             }
@@ -46,7 +46,7 @@ extension Purchases {
     #endif
 
     func offeringsAsync(fetchPolicy: OfferingsManager.FetchPolicy) async throws -> Offerings {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             self.getOfferings(fetchPolicy: fetchPolicy) { offerings, error in
                 continuation.resume(with: Result(offerings, error))
             }
@@ -62,7 +62,7 @@ extension Purchases {
     }
 
     func purchaseAsync(product: StoreProduct) async throws -> PurchaseResultData {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             purchase(product: product) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(with: Result(customerInfo, error)
                                         .map { PurchaseResultData(transaction, $0, userCancelled) })
@@ -71,7 +71,7 @@ extension Purchases {
     }
 
     func purchaseAsync(package: Package) async throws -> PurchaseResultData {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             purchase(package: package) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(with: Result(customerInfo, error)
                                         .map { PurchaseResultData(transaction, $0, userCancelled) })
@@ -80,7 +80,7 @@ extension Purchases {
     }
 
     func restorePurchasesAsync() async throws -> CustomerInfo {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             self.restorePurchases { customerInfo, error in
                 continuation.resume(with: Result(customerInfo, error))
             }
@@ -90,7 +90,7 @@ extension Purchases {
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     func syncPurchasesAsync() async throws -> CustomerInfo {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             syncPurchases { customerInfo, error in
                 continuation.resume(with: Result(customerInfo, error))
             }
@@ -98,7 +98,7 @@ extension Purchases {
     }
 
     func purchaseAsync(product: StoreProduct, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             purchase(product: product,
                      promotionalOffer: promotionalOffer) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(with: Result(customerInfo, error)
@@ -108,7 +108,7 @@ extension Purchases {
     }
 
     func purchaseAsync(package: Package, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             purchase(package: package,
                      promotionalOffer: promotionalOffer) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(with: Result(customerInfo, error)
@@ -118,7 +118,7 @@ extension Purchases {
     }
 
     func customerInfoAsync(fetchPolicy: CacheFetchPolicy) async throws -> CustomerInfo {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             getCustomerInfo(fetchPolicy: fetchPolicy) { customerInfo, error in
                 continuation.resume(with: Result(customerInfo, error))
             }
@@ -145,7 +145,7 @@ extension Purchases {
 
     func promotionalOfferAsync(forProductDiscount discount: StoreProductDiscount,
                                product: StoreProduct) async throws -> PromotionalOffer {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             getPromotionalOffer(forProductDiscount: discount, product: product) { offer, error in
                 continuation.resume(with: Result(offer, error))
              }
@@ -197,7 +197,7 @@ extension Purchases {
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func showManageSubscriptionsAsync() async throws {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             showManageSubscriptions { error in
                 if let error = error {
                     continuation.resume(throwing: error)

--- a/Sources/Misc/Concurrency/Purchases+async.swift
+++ b/Sources/Misc/Concurrency/Purchases+async.swift
@@ -16,6 +16,10 @@ import Foundation
 /// This extension holds the biolerplate logic to convert methods with completion blocks into async / await syntax.
 extension Purchases {
 
+    // Note: We're using UnsafeContinuation instead of Checked because
+    // of a crash in iOS 18.0 devices when CheckedContinuations are used.
+    // See: https://github.com/RevenueCat/purchases-ios/pull/4286
+    
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     func logInAsync(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
@@ -54,7 +58,7 @@ extension Purchases {
     }
 
     func productsAsync(_ productIdentifiers: [String]) async -> [StoreProduct] {
-        return await withCheckedContinuation { continuation in
+        return await withUnsafeContinuation { continuation in
             getProducts(productIdentifiers) { result in
                 continuation.resume(returning: result)
             }
@@ -127,7 +131,7 @@ extension Purchases {
 
     func checkTrialOrIntroductoryDiscountEligibilityAsync(_ product: StoreProduct) async
     -> IntroEligibilityStatus {
-        return await withCheckedContinuation { continuation in
+        return await withUnsafeContinuation { continuation in
             checkTrialOrIntroDiscountEligibility(product: product) { status in
                 continuation.resume(returning: status)
             }
@@ -136,7 +140,7 @@ extension Purchases {
 
     func checkTrialOrIntroductoryDiscountEligibilityAsync(_ productIdentifiers: [String]) async
     -> [String: IntroEligibility] {
-        return await withCheckedContinuation { continuation in
+        return await withUnsafeContinuation { continuation in
             checkTrialOrIntroDiscountEligibility(productIdentifiers: productIdentifiers) { result in
                 continuation.resume(returning: result)
             }

--- a/Sources/Misc/Concurrency/Purchases+async.swift
+++ b/Sources/Misc/Concurrency/Purchases+async.swift
@@ -19,7 +19,7 @@ extension Purchases {
     // Note: We're using UnsafeContinuation instead of Checked because
     // of a crash in iOS 18.0 devices when CheckedContinuations are used.
     // See: https://github.com/RevenueCat/purchases-ios/issues/4177
-    
+
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     func logInAsync(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {

--- a/Sources/Purchasing/ReceiptFetcher.swift
+++ b/Sources/Purchasing/ReceiptFetcher.swift
@@ -76,7 +76,10 @@ class ReceiptFetcher {
     }
 
     func receiptData(refreshPolicy: ReceiptRefreshPolicy) async -> Data? {
-        return await withCheckedContinuation { continuation in
+        // Note: We're using UnsafeContinuation instead of Checked because
+        // of a crash in iOS 18.0 devices when CheckedContinuations are used.
+        // See: https://github.com/RevenueCat/purchases-ios/pull/4286
+        return await withUnsafeContinuation { continuation in
             self.receiptData(refreshPolicy: refreshPolicy) { result, _ in
                 continuation.resume(returning: result)
             }
@@ -155,7 +158,10 @@ private extension ReceiptFetcher {
 
     /// `async` version of `refreshReceipt(_:)`
     func refreshReceipt() async -> (Data, URL?) {
-        await withCheckedContinuation { continuation in
+        // Note: We're using UnsafeContinuation instead of Checked because
+        // of a crash in iOS 18.0 devices when CheckedContinuations are used.
+        // See: https://github.com/RevenueCat/purchases-ios/pull/4286
+        await withUnsafeContinuation { continuation in
             self.refreshReceipt {
                 continuation.resume(returning: ($0, $1))
             }

--- a/Sources/Purchasing/ReceiptFetcher.swift
+++ b/Sources/Purchasing/ReceiptFetcher.swift
@@ -78,7 +78,7 @@ class ReceiptFetcher {
     func receiptData(refreshPolicy: ReceiptRefreshPolicy) async -> Data? {
         // Note: We're using UnsafeContinuation instead of Checked because
         // of a crash in iOS 18.0 devices when CheckedContinuations are used.
-        // See: https://github.com/RevenueCat/purchases-ios/pull/4286
+        // See: https://github.com/RevenueCat/purchases-ios/issues/4177
         return await withUnsafeContinuation { continuation in
             self.receiptData(refreshPolicy: refreshPolicy) { result, _ in
                 continuation.resume(returning: result)
@@ -160,7 +160,7 @@ private extension ReceiptFetcher {
     func refreshReceipt() async -> (Data, URL?) {
         // Note: We're using UnsafeContinuation instead of Checked because
         // of a crash in iOS 18.0 devices when CheckedContinuations are used.
-        // See: https://github.com/RevenueCat/purchases-ios/pull/4286
+        // See: https://github.com/RevenueCat/purchases-ios/issues/4177
         await withUnsafeContinuation { continuation in
             self.refreshReceipt {
                 continuation.resume(returning: ($0, $1))

--- a/Tests/BackendIntegrationTests/Helpers/ExternalPurchasesManager.swift
+++ b/Tests/BackendIntegrationTests/Helpers/ExternalPurchasesManager.swift
@@ -83,7 +83,7 @@ final class ExternalPurchasesManager: NSObject {
 extension ExternalPurchasesManager {
 
     func purchase(sk1Product product: SK1Product) async throws -> SK1PurchaseCompletedResult {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             self.purchase(sk1Product: product) { transaction in
                 if let error = transaction.error {
                     continuation.resume(throwing: error)

--- a/Tests/BackendIntegrationTests/Helpers/SK1ProductFetcher.swift
+++ b/Tests/BackendIntegrationTests/Helpers/SK1ProductFetcher.swift
@@ -31,7 +31,7 @@ final class SK1ProductFetcher: NSObject {
     }
 
     func products(with identifiers: Set<String>) async throws -> Set<SK1Product> {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             self.products(with: identifiers) { result in
                 continuation.resume(with: result)
             }

--- a/Tests/RevenueCatUITests/ImageLoaderTests.swift
+++ b/Tests/RevenueCatUITests/ImageLoaderTests.swift
@@ -238,7 +238,10 @@ private final class MockAsyncURLSession: NSObject, URLSessionType {
         self.completionSet = false
         self.completion = nil
 
-        return try await withCheckedContinuation { continuation in
+        // Note: We're using UnsafeContinuation instead of Checked because
+        // of a crash in iOS 18.0 devices when CheckedContinuations are used.
+        // See: https://github.com/RevenueCat/purchases-ios/pull/4286
+        return try await withUnsafeContinuation { continuation in
             self.completion = { value in
                 continuation.resume(returning: value)
             }

--- a/Tests/RevenueCatUITests/ImageLoaderTests.swift
+++ b/Tests/RevenueCatUITests/ImageLoaderTests.swift
@@ -240,7 +240,7 @@ private final class MockAsyncURLSession: NSObject, URLSessionType {
 
         // Note: We're using UnsafeContinuation instead of Checked because
         // of a crash in iOS 18.0 devices when CheckedContinuations are used.
-        // See: https://github.com/RevenueCat/purchases-ios/pull/4286
+        // See: https://github.com/RevenueCat/purchases-ios/issues/4177
         return try await withUnsafeContinuation { continuation in
             self.completion = { value in
                 continuation.resume(returning: value)

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -226,7 +226,7 @@ private final class AsyncPurchaseHandler {
 
     // Note: We're using UnsafeContinuation instead of Checked because
     // of a crash in iOS 18.0 devices when CheckedContinuations are used.
-    // See: https://github.com/RevenueCat/purchases-ios/pull/4286
+    // See: https://github.com/RevenueCat/purchases-ios/issues/4177
     var continuation: UnsafeContinuation<Void, Never>?
     private(set) var purchaseHandler: PurchaseHandler!
 

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -224,7 +224,10 @@ class PurchaseHandlerTests: TestCase {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private final class AsyncPurchaseHandler {
 
-    var continuation: CheckedContinuation<Void, Never>?
+    // Note: We're using UnsafeContinuation instead of Checked because
+    // of a crash in iOS 18.0 devices when CheckedContinuations are used.
+    // See: https://github.com/RevenueCat/purchases-ios/pull/4286
+    var continuation: UnsafeContinuation<Void, Never>?
     private(set) var purchaseHandler: PurchaseHandler!
 
     init() {
@@ -260,7 +263,7 @@ private final class AsyncPurchaseHandler {
      }
 
     private func createAndWaitForContinuation() async {
-        await withCheckedContinuation { [weak self] continuation in
+        await withUnsafeContinuation { [weak self] continuation in
             self?.continuation = continuation
         }
     }

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
@@ -260,7 +260,7 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
         payment.productIdentifier = ""
 
         let (transaction, customerInfo, error, cancelled) =
-        try await withCheckedThrowingContinuation { continuation in
+        try await withUnsafeThrowingContinuation { continuation in
             self.orchestrator.purchase(
                 sk1Product: product,
                 payment: payment,
@@ -287,7 +287,7 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
         let payment = self.storeKit1Wrapper.payment(with: product)
         self.receiptFetcher.shouldReturnReceipt = false
 
-        let (_, _, error, _) = try await withCheckedThrowingContinuation { continuation in
+        let (_, _, error, _) = try await withUnsafeThrowingContinuation { continuation in
             self.orchestrator.purchase(
                 sk1Product: product,
                 payment: payment,

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/ProductFetcherSK1.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/ProductFetcherSK1.swift
@@ -32,7 +32,7 @@ final class ProductFetcherSK1: NSObject {
     }
 
     func products(with identifiers: Set<String>) async throws -> Set<SK1Product> {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withUnsafeThrowingContinuation { continuation in
             self.products(with: identifiers) { result in
                 continuation.resume(with: result)
             }


### PR DESCRIPTION
### Motivation
iOS 18 introduces a bug in Swift that causes calls to `withCheckedThrowingContinuation` to crash in certain scenarios. This PR provides some promise in addressing this issue, documented in https://github.com/RevenueCat/purchases-ios/issues/4177

### Description
This PR replaces all calls to `withCheckedThrowingContinuation` to `withUnsafeThrowingContinuation`, which we're unable to reproduce the issue with.

### Other Notes
`withUnsafeThrowingContinuation` doesn't provide any checking to ensure that the continuation isn't called multiple times, so this is something we'll need to be aware of going forward. Luckily, all existing usages of `withCheckedThrowingContinuation` were in just a few files and in small functions, so this is easy to check manually for now.