### PR TITLE
Added previews for text component, image component, and paywall for template 1

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1E5F8F782C46BBD90041EECD /* CustomerCenterAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E5F8F772C46BBD90041EECD /* CustomerCenterAction.swift */; };
 		1E99F81F2AC5917F0023E26E /* StoreMessagesHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E99F81D2AC5917F0023E26E /* StoreMessagesHelperTests.swift */; };
 		2C0B98CD2797070B00C5874F /* PromotionalOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */; };
+		2C2AEB0F2CA64E0E00A50F38 /* Template1Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB0E2CA64E0E00A50F38 /* Template1Preview.swift */; };
 		2C4C36132C6FBA8B00AE959B /* CompatibilityTopBarTrailing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4C36122C6FBA8B00AE959B /* CompatibilityTopBarTrailing.swift */; };
 		2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */; };
 		2C7F0AD32B8EEB4600381179 /* RateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */; };
@@ -1146,6 +1147,7 @@
 		1E5F8F772C46BBD90041EECD /* CustomerCenterAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterAction.swift; sourceTree = "<group>"; };
 		1E99F81D2AC5917F0023E26E /* StoreMessagesHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessagesHelperTests.swift; sourceTree = "<group>"; };
 		2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOffer.swift; sourceTree = "<group>"; };
+		2C2AEB0E2CA64E0E00A50F38 /* Template1Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Template1Preview.swift; sourceTree = "<group>"; };
 		2C4C36122C6FBA8B00AE959B /* CompatibilityTopBarTrailing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompatibilityTopBarTrailing.swift; sourceTree = "<group>"; };
 		2C5F71F52C3D6C2600B0FE4B /* header.heic */ = {isa = PBXFileReference; lastKnownFileType = file; path = header.heic; sourceTree = "<group>"; };
 		2C5F71F62C3D6C2600B0FE4B /* background.heic */ = {isa = PBXFileReference; lastKnownFileType = file; path = background.heic; sourceTree = "<group>"; };
@@ -2245,6 +2247,14 @@
 				4F7DBFBC2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift */,
 			);
 			path = StoreKit2;
+			sourceTree = "<group>";
+		};
+		2C2AEB0D2CA64DA900A50F38 /* Previews */ = {
+			isa = PBXGroup;
+			children = (
+				2C2AEB0E2CA64E0E00A50F38 /* Template1Preview.swift */,
+			);
+			path = Previews;
 			sourceTree = "<group>";
 		};
 		2CD72940268A820E00BFC976 /* FoundationExtensions */ = {
@@ -4270,6 +4280,7 @@
 		88AD01352C74196600AA1F2B /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				2C2AEB0D2CA64DA900A50F38 /* Previews */,
 				88B1BAE62C813A3C001B7EE5 /* Image */,
 				88B1BAE22C813A3C001B7EE5 /* LinkButton */,
 				88B1BAE72C813A3C001B7EE5 /* PaywallComponentTypeTransformers.swift */,
@@ -5981,6 +5992,7 @@
 				2D2AFE8F2C6A9D8700D1B0B4 /* CompatibilityContentUnavailableView.swift in Sources */,
 				3537566E2C382C2800A1B8D6 /* RestorePurchasesAlert.swift in Sources */,
 				887A60692C1D037000E1A461 /* IntroEligibilityViewModel.swift in Sources */,
+				2C2AEB0F2CA64E0E00A50F38 /* Template1Preview.swift in Sources */,
 				88EA80ED2C8771A7003E6675 /* TemplateComponentsView+extensions.swift in Sources */,
 				88A543E32C37A4970039C6A5 /* Template7View.swift in Sources */,
 				887A60CB2C1D037000E1A461 /* TemplateBackgroundImageView.swift in Sources */,

--- a/RevenueCatUI/Templates/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Image/ImageComponentView.swift
@@ -64,4 +64,82 @@ struct ImageComponentView: View {
 
 }
 
+#if DEBUG
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct ImageComponentView_Previews: PreviewProvider {
+    static let catUrl = URL(string: "https://assets.pawwalls.com/954459_1701163461.jpg")!
+
+    // Need to wrap in VStack otherwise preview rerenders and images won't show
+    static var previews: some View {
+        // Light - Fit
+        VStack {
+            ImageComponentView(
+                viewModel: try! .init(
+                    localizedStrings: [:],
+                    component: .init(
+                        source: .init(
+                            light: .init(
+                                original: catUrl,
+                                heic: catUrl,
+                                heicLowRes: catUrl
+                            )
+                        ),
+                        fitMode: .fit
+                    )
+                )
+            )
+        }
+        .previewLayout(.fixed(width: 400, height: 400))
+        .previewDisplayName("Light - Fit")
+
+        // Light - Fill
+        VStack {
+            ImageComponentView(
+                viewModel: try! .init(
+                    localizedStrings: [:],
+                    component: .init(
+                        source: .init(
+                            light: .init(
+                                original: catUrl,
+                                heic: catUrl,
+                                heicLowRes: catUrl
+                            )
+                        ),
+                        fitMode: .fill
+                    )
+                )
+            )
+        }
+        .previewLayout(.fixed(width: 400, height: 400))
+        .previewDisplayName("Light - Fill")
+
+        // Light - Gradient
+        VStack {
+            ImageComponentView(
+                viewModel: try! .init(
+                    localizedStrings: [:],
+                    component: .init(
+                        source: .init(
+                            light: .init(
+                                original: catUrl,
+                                heic: catUrl,
+                                heicLowRes: catUrl
+                            )
+                        ),
+                        fitMode: .fill,
+                        gradientColors: [
+                            "#ffffff00", "#ffffff00", "#ffffffff"
+                        ]
+                    )
+                )
+            )
+        }
+        .previewLayout(.fixed(width: 400, height: 400))
+        .previewDisplayName("Light - Fill")
+    }
+}
+
+#endif
+
 #endif

--- a/RevenueCatUI/Templates/Components/Previews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/Components/Previews/Template1Preview.swift
@@ -1,0 +1,124 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TestPaywallPreviews.swift
+//
+//  Created by Josh Holtz on 9/26/24.
+
+import Foundation
+import RevenueCat
+import SwiftUI
+
+#if PAYWALL_COMPONENTS
+
+#if DEBUG
+
+fileprivate struct Template1Preview {
+
+    static let catUrl = URL(string: "https://assets.pawwalls.com/954459_1701163461.jpg")!
+
+    static let catImage = PaywallComponent.ImageComponent(
+        source: .init(
+            light: .init(
+                original: catUrl,
+                heic: catUrl,
+                heicLowRes: catUrl
+            )
+        ),
+        fitMode: .fit,
+        gradientColors: ["#ffffff00", "#ffffff00", "#ffffffff"]
+    )
+
+    static let title = PaywallComponent.TextComponent(
+        textLid: "title",
+        fontFamily: nil,
+        fontWeight: .heavy,
+        color: .init(light: "#000000"),
+        backgroundColor: nil,
+        padding: .zero,
+        margin: .zero,
+        textStyle: .largeTitle,
+        horizontalAlignment: .center
+    )
+
+    static let body = PaywallComponent.TextComponent(
+        textLid: "body",
+        fontFamily: nil,
+        fontWeight: .regular,
+        color: .init(light: "#000000"),
+        backgroundColor: nil,
+        padding: .zero,
+        margin: .zero,
+        textStyle: .body,
+        horizontalAlignment: .center
+    )
+
+    static let contentStack = PaywallComponent.StackComponent(
+        components: [
+            .text(title),
+            .text(body)
+        ],
+        width: .init(type: .fill, value: nil),
+        spacing: 30,
+        backgroundColor: nil,
+        margin: .init(top: 0,
+                      bottom: 0,
+                      leading: 20,
+                      trailing: 20)
+    )
+
+    static let stack = PaywallComponent.StackComponent(
+        components: [
+            .image(catImage),
+            .stack(contentStack),
+        ],
+        width: .init(type: .fill, value: nil),
+        spacing: 20,
+        backgroundColor: nil
+    )
+
+    static let data: PaywallComponentsData = .init(
+        templateName: "components",
+        assetBaseURL: URL(string: "https://assets.pawwalls.com")!,
+        componentsConfig: .init(
+            components: [
+                .stack(stack)
+            ]
+        ),
+        componentsLocalizations: ["en_US": [
+            "title": .string("Ignite your cat's curiosity"),
+            "body": .string("Get access to all of our educational content trusted by thousands of pet parents.")
+        ]],
+        revision: 1,
+        defaultLocaleIdentifier: "en_US"
+    )
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct Template1Preview_Previews: PreviewProvider {
+
+
+    // Need to wrap in VStack otherwise preview rerenders and images won't show
+    static var previews: some View {
+        
+        // Template 1
+        TemplateComponentsView(
+            paywallComponentsData: Template1Preview.data,
+            offering: .init(identifier: "",
+                            serverDescription: "",
+                            availablePackages: [])
+        )
+        .previewLayout(.fixed(width: 400, height: 800))
+        .previewDisplayName("Template 1")
+    }
+}
+
+#endif
+
+#endif

--- a/RevenueCatUI/Templates/Components/TemplateComponentsView.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsView.swift
@@ -48,7 +48,6 @@ public struct TemplateComponentsView: View {
             )
         }
         .frame(maxHeight: .infinity, alignment: .topLeading)
-        .background(.purple)
         .edgesIgnoringSafeArea(.top)
     }
 

--- a/RevenueCatUI/Templates/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Text/TextComponentView.swift
@@ -40,4 +40,56 @@ struct TextComponentView: View {
 
 }
 
+#if DEBUG
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct TextComponentView_Previews: PreviewProvider {
+    static var previews: some View {
+        // Default
+        TextComponentView(
+            viewModel: try! .init(
+                localizedStrings: [
+                    "id_1": .string("Hello, world")
+                ],
+                component: .init(
+                    textLid: "id_1",
+                    color: .init(light: "#000000")
+                )
+            )
+        )
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Default")
+
+        // Customizations
+        TextComponentView(
+            viewModel: try! .init(
+                localizedStrings: [
+                    "id_1": .string("Hello, world")
+                ],
+                component: .init(
+                    textLid: "id_1",
+                    fontFamily: nil,
+                    fontWeight: .heavy,
+                    color: .init(light: "#ff0000"),
+                    backgroundColor: .init(light: "#dedede"),
+                    padding: .init(top: 10, 
+                                   bottom: 10,
+                                   leading: 20,
+                                   trailing: 20),
+                    margin: .init(top: 20,
+                                  bottom: 20,
+                                  leading: 10,
+                                  trailing: 10),
+                    textStyle: .footnote,
+                    horizontalAlignment: .leading
+                )
+            )
+        )
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Customizations")
+    }
+}
+
+#endif
+
 #endif


### PR DESCRIPTION
### Motivation

I was struggling with using Paywalls Tester to hardcode paywalls to see what I was building.

So I side quested into getting some SwiftUI previews up for text, image, and the start of Template 1

### Description

SwiftUI previews in:
- `TextComponent`
- `ImageComponent`
- An instance of `TemplateComponentsView` that is the start of our current Template 1
