### PR TITLE
Adds an `onDismiss` callback to `ErrorDisplay`

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -56,6 +56,12 @@ public struct PaywallView: View {
 
     private var initializationError: NSError?
 
+    @Environment(\.onRequestedDismissal)
+    private var onRequestedDismissal: (() -> Void)?
+
+    @Environment(\.dismiss)
+    private var dismiss
+
     /// Create a view to display the paywall in `Offerings.current`.
     ///
     /// - Parameter fonts: An optional ``PaywallFontProvider``.
@@ -173,7 +179,13 @@ public struct PaywallView: View {
     // swiftlint:disable:next missing_docs
     public var body: some View {
         self.content
-            .displayError(self.$error, dismissOnClose: true)
+            .displayError(self.$error) {
+                guard let onRequestedDismissal = self.onRequestedDismissal else {
+                    self.dismiss()
+                    return
+                }
+                onRequestedDismissal()
+            }
     }
 
     @MainActor

--- a/RevenueCatUI/Views/ErrorDisplay.swift
+++ b/RevenueCatUI/Views/ErrorDisplay.swift
@@ -19,10 +19,7 @@ struct ErrorDisplay: ViewModifier {
 
     @Binding
     var error: NSError?
-    var dismissOnClose: Bool
-
-    @Environment(\.dismiss)
-    private var dismiss
+    var onDismiss: (() -> Void)?
 
     func body(content: Content) -> some View {
         content
@@ -30,9 +27,7 @@ struct ErrorDisplay: ViewModifier {
                 Button {
                     self.error = nil
 
-                    if self.dismissOnClose {
-                        self.dismiss()
-                    }
+                    self.onDismiss?()
                 } label: {
                     Text("OK", bundle: .module)
                 }
@@ -56,8 +51,8 @@ struct ErrorDisplay: ViewModifier {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
-    func displayError(_ error: Binding<NSError?>, dismissOnClose: Bool = false) -> some View {
-        self.modifier(ErrorDisplay(error: error, dismissOnClose: dismissOnClose))
+    func displayError(_ error: Binding<NSError?>, onDismiss: (() -> Void)? = nil) -> some View {
+        self.modifier(ErrorDisplay(error: error, onDismiss: onDismiss))
     }
 
 }


### PR DESCRIPTION
As the title says, and as discussed on Slack. This is needed for https://github.com/RevenueCat/purchases-kmp/issues/217. 