### PR TITLE
Increase iOS 15 CI timeout from 10 to 15 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -692,7 +692,8 @@ jobs:
 
     steps:
       - checkout
-      - set-maximum-duration
+      - set-maximum-duration:
+          seconds: 900
       - install-dependencies:
           install_swiftlint: false
       - update-spm-installation-commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -693,7 +693,7 @@ jobs:
     steps:
       - checkout
       - set-maximum-duration:
-          seconds: 900
+          seconds: 1800
       - install-dependencies:
           install_swiftlint: false
       - update-spm-installation-commit


### PR DESCRIPTION
### Motivation

The iOS 15 CI job has been reaching its 10 minute max too often

### Description

Attempting an increase from 10 minutes to 15 minutes
