### PR TITLE
Fixes double callbacks when using `PaywallViewController`

### DIFF
--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -8,7 +8,7 @@
 //      https://opensource.org/licenses/MIT
 //
 //  PaywallViewController.swift
-//  
+//
 //  Created by Nacho Soto on 8/1/23.
 
 // swiftlint:disable file_length
@@ -137,10 +137,12 @@ public class PaywallViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func loadView() {
-        super.loadView()
+    public override func viewDidLoad() {
+        super.viewDidLoad()
 
-        self.hostingController = self.createHostingController()
+        if self.hostingController == nil {
+            self.hostingController = self.createHostingController()
+        }
     }
 
     public override func viewDidDisappear(_ animated: Bool) {
@@ -209,17 +211,20 @@ public class PaywallViewController: UIViewController {
 
     private var hostingController: UIHostingController<PaywallContainerView>? {
         willSet {
-            guard let oldValue = self.hostingController else { return }
+            guard let oldController = self.hostingController else { return }
 
-            oldValue.willMove(toParent: nil)
-            oldValue.view.removeFromSuperview()
-            oldValue.removeFromParent()
+            oldController.willMove(toParent: nil)
+            oldController.view.removeFromSuperview()
+            oldController.removeFromParent()
         }
 
         didSet {
             guard let newController = self.hostingController else { return }
 
             self.addChild(newController)
+
+            self.view.subviews.forEach { $0.removeFromSuperview() }
+
             self.view.addSubview(newController.view)
             newController.didMove(toParent: self)
 


### PR DESCRIPTION
We got a report of duplicated callbacks in Flutter when using the Paywall view in iOS

We pinpointed the issue to the `update(with:` methods, that create a new controller. 

It turned out, the `didSet` function of `hostingController` was calling `loadView` when adding the `subView`, and the `PaywallViewController` ended up having two `PaywallContainerView`. Since each of these views was being set as delegates for the callbacks, Flutter ended up getting two callbacks for the `PaywallView` interactions.

After a lot of attempts, I ended up fixing it by replacing the `loadView` with `viewDidLoad` and ensuring we don't create a new controller there. `viewDidLoad` will be called from the `addSubView` but it won't recreate a new controller since it checks it already has one.

I've tested this both calling `update(with:)` and also calling `presentPaywall` and it looks like it's working.