### PR TITLE
Remove access to Localization env variable in ManageSubscriptionsViewModel

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -82,8 +82,7 @@ struct ManageSubscriptionsView: View {
                         Section {
                             SubscriptionDetailsView(
                                 subscriptionInformation: subscriptionInformation,
-                                localization: self.localization,
-                                refundRequestStatusMessage: self.viewModel.refundRequestStatusMessage)
+                                refundRequestStatus: self.viewModel.refundRequestStatus)
                         }
                     }
 
@@ -212,7 +211,7 @@ struct ManageSubscriptionsView_Previews: PreviewProvider {
                 screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
                 subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing,
                 customerCenterActionHandler: nil,
-                refundRequestStatusMessage: "Refund granted successfully!")
+                refundRequestStatus: .success)
             ManageSubscriptionsView(viewModel: viewModelMonthlyRenewing,
                                     customerCenterActionHandler: nil)
                 .previewDisplayName("Monthly renewing")

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
@@ -26,8 +26,9 @@ struct SubscriptionDetailsView: View {
 
     let iconWidth = 22.0
     let subscriptionInformation: SubscriptionInformation
-    let localization: CustomerCenterConfigData.Localization
-    let refundRequestStatusMessage: String?
+    let refundRequestStatus: RefundRequestStatus?
+    @Environment(\.localization) 
+    private var localization: CustomerCenterConfigData.Localization
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -102,7 +103,7 @@ struct SubscriptionDetailsView: View {
                     }
                 }
 
-                if let refundRequestStatusMessage = refundRequestStatusMessage {
+                if let refundRequestStatus = refundRequestStatus {
                     HStack(alignment: .center) {
                         Image(systemName: "arrowshape.turn.up.backward")
                             .accessibilityHidden(true)
@@ -112,7 +113,7 @@ struct SubscriptionDetailsView: View {
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
                                 .textCase(.uppercase)
-                            Text("\(refundRequestStatusMessage)")
+                            Text(refundStatusMessage(for: refundRequestStatus))
                                 .font(.body)
                         }
                     }
@@ -124,6 +125,16 @@ struct SubscriptionDetailsView: View {
         .background(Color(UIColor.tertiarySystemBackground))
     }
 
+    private func refundStatusMessage(for status: RefundRequestStatus) -> String {
+        switch status {
+        case .error:
+            return localization.commonLocalizedString(for: .refundErrorGeneric)
+        case .success:
+            return localization.commonLocalizedString(for: .refundGranted)
+        case .userCancelled:
+            return localization.commonLocalizedString(for: .refundCanceled)
+        }
+    }
 }
 
 #if DEBUG
@@ -137,8 +148,7 @@ struct SubscriptionDetailsView_Previews: PreviewProvider {
     static var previews: some View {
         SubscriptionDetailsView(
             subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing,
-            localization: CustomerCenterConfigTestData.customerCenterData.localization,
-            refundRequestStatusMessage: "Success"
+            refundRequestStatus: .success
         )
         .previewDisplayName("Subscription Details - Monthly")
         .padding()

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
@@ -27,7 +27,7 @@ struct SubscriptionDetailsView: View {
     let iconWidth = 22.0
     let subscriptionInformation: SubscriptionInformation
     let refundRequestStatus: RefundRequestStatus?
-    @Environment(\.localization) 
+    @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
 
     var body: some View {

--- a/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
@@ -45,7 +45,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
 
         expect(viewModel.state) == CustomerCenterViewState.notLoaded
         expect(viewModel.subscriptionInformation).to(beNil())
-        expect(viewModel.refundRequestStatusMessage).to(beNil())
+        expect(viewModel.refundRequestStatus).to(beNil())
         expect(viewModel.screen).toNot(beNil())
         expect(viewModel.showRestoreAlert) == false
         expect(viewModel.isLoaded) == false


### PR DESCRIPTION
There was a warning caused by accessing the `Localization` environment variable from outside a View

```
Accessing Environment<Localization>'s value outside of being installed on a View. This will always read the default value and will not update.
```