### PR TITLE
Add option to customize spacing applied to SwiftUI-based paywall footer

### DIFF
--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -18,6 +18,7 @@ struct PaywallViewConfiguration {
     var customerInfo: CustomerInfo?
     var mode: PaywallViewMode
     var fonts: PaywallFontProvider
+    var spacing: CGFloat?
     var displayCloseButton: Bool
     var introEligibility: TrialOrIntroEligibilityChecker?
     var purchaseHandler: PurchaseHandler
@@ -28,6 +29,7 @@ struct PaywallViewConfiguration {
         customerInfo: CustomerInfo? = nil,
         mode: PaywallViewMode = .default,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        spacing: CGFloat? = nil,
         displayCloseButton: Bool = false,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         purchaseHandler: PurchaseHandler,
@@ -37,6 +39,7 @@ struct PaywallViewConfiguration {
         self.customerInfo = customerInfo
         self.mode = mode
         self.fonts = fonts
+        self.spacing = spacing
         self.displayCloseButton = displayCloseButton
         self.introEligibility = introEligibility
         self.purchaseHandler = purchaseHandler

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -81,6 +81,7 @@ extension View {
     public func paywallFooter(
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        spacing: CGFloat? = nil,
         myAppPurchaseLogic: MyAppPurchaseLogic? = nil,
         purchaseStarted: PurchaseOfPackageStartedHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
@@ -97,6 +98,7 @@ extension View {
             customerInfo: nil,
             condensed: condensed,
             fonts: fonts,
+            spacing: spacing,
             introEligibility: nil,
             purchaseHandler: purchaseHandler,
             purchaseStarted: purchaseStarted,
@@ -206,6 +208,7 @@ extension View {
         customerInfo: CustomerInfo?,
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        spacing: CGFloat? = nil,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         purchaseHandler: PurchaseHandler,
         purchaseStarted: PurchaseOfPackageStartedHandler? = nil,
@@ -224,6 +227,7 @@ extension View {
                         customerInfo: customerInfo,
                         mode: condensed ? .condensedFooter : .footer,
                         fonts: fonts,
+                        spacing: spacing,
                         displayCloseButton: false,
                         introEligibility: introEligibility,
                         purchaseHandler: purchaseHandler
@@ -267,7 +271,7 @@ private struct PresentingPaywallFooterModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .safeAreaInset(edge: .bottom) {
+            .safeAreaInset(edge: .bottom, spacing: configuration.spacing) {
                 PaywallView(configuration: self.configuration)
                     .onPurchaseStarted {
                         self.purchaseStarted?($0)


### PR DESCRIPTION
### Checklist
- ~~[ ] If applicable, unit tests~~ (N/A)
- ~~[ ] If applicable, create follow-up issues for `purchases-android` and hybrids~~ (N/A)

### Motivation

This patch makes it possible for API users to customize the amount of spacing that's applied to a `PaywallView` when presented as a footer using the `paywallFooter` SwiftUI modifier. That API uses SwiftUI's `safeAreaInset` modifier internally, which by default adds a system-defined amount of spacing between the view placed within the safe area inset and the host view that the modifier is applied to. With this change, API users are now free to remove or modify that spacing, which is required for certain app designs.

### Description

A new `spacing` parameter was added to RevenueCatUI's `paywallFooter` SwiftUI modifier API, which when forwarded down the call stack can be passed to the SwiftUI `safeAreaInset` API to enable the user to tweak the above mentioned spacing between the paywall footer and its host view.

This is a backward-compatible change, as the added `spacing` parameter is optional with a default value of `nil`, which retains the existing behavior when the new parameter isn't passed by the API user.