### PR TITLE
Allows enabling PAYWALL_COMPONENTS using a Local.xcconfig file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ Tests/InstallationTests/XcodeDirectInstallation/XcodeDirectInstallation.xcodepro
 # fastlane
 fastlane/.env
 .vscode/settings.json
+
+# Local build settings
+Local.xcconfig

--- a/Local.xcconfig.SAMPLE
+++ b/Local.xcconfig.SAMPLE
@@ -1,0 +1,27 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Local.xcconfig
+//
+//  Created by Jay Shortway on 02/10/2024.
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+// HOW TO USE THIS FILE
+// ====================
+// 1. Make a copy of this file in this directory, removing the .SAMPLE extension.
+// 2. Enable any build settings you wish, below. You can either uncomment example settings
+//    or write new ones. 
+// 3. If there's any new build setting you think others can benefit from, please update the
+//    .SAMPLE file and open a pull request.
+// ====================
+
+// Uncomment to enable the PAYWALL_COMPONENTS flag.
+// SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) PAYWALL_COMPONENTS

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1819,6 +1819,7 @@
 		57FDAABF28493C13009A48F1 /* MockSandboxEnvironmentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSandboxEnvironmentDetector.swift; sourceTree = "<group>"; };
 		57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreTransaction.swift; sourceTree = "<group>"; };
 		7706ED3D2C6E374D0004B9F9 /* ButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyles.swift; sourceTree = "<group>"; };
+		7707A93B2CAD8AA2006E0313 /* Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig; sourceTree = "<group>"; };
 		77372D982C6F8C7B008E59D3 /* AppUpdateWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateWarningView.swift; sourceTree = "<group>"; };
 		77607FD72CAD87D60066C23C /* Global.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Global.xcconfig; sourceTree = "<group>"; };
 		77791ECE2C6B851F00BCEF03 /* SemanticVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersion.swift; sourceTree = "<group>"; };
@@ -3096,6 +3097,7 @@
 		352629F41F7C4B9100C04F2C = {
 			isa = PBXGroup;
 			children = (
+				7707A93B2CAD8AA2006E0313 /* Local.xcconfig */,
 				77607FD72CAD87D60066C23C /* Global.xcconfig */,
 				887A60652C1D037000E1A461 /* RevenueCatUI */,
 				2DC5621724EC63420031F69B /* Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1822,6 +1822,7 @@
 		77372D982C6F8C7B008E59D3 /* AppUpdateWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateWarningView.swift; sourceTree = "<group>"; };
 		77791ECE2C6B851F00BCEF03 /* SemanticVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersion.swift; sourceTree = "<group>"; };
 		777FB4872C661C0600CD4749 /* SemanticVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersionTests.swift; sourceTree = "<group>"; };
+		77BFDB3B2CAD77E70029BE4D /* Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig; sourceTree = "<group>"; };
 		80E80EF026970DC3008F245A /* ReceiptFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
 		84C3F1AC1D7E1E64341D3936 /* Pods_RevenueCat_PurchasesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RevenueCat_PurchasesTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		887A5FB42C1D024300E1A461 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -3095,6 +3096,7 @@
 		352629F41F7C4B9100C04F2C = {
 			isa = PBXGroup;
 			children = (
+				77BFDB3B2CAD77E70029BE4D /* Local.xcconfig */,
 				887A60652C1D037000E1A461 /* RevenueCatUI */,
 				2DC5621724EC63420031F69B /* Sources */,
 				2DDE870027E5238500D8B390 /* Tests */,
@@ -6638,6 +6640,7 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.Purchases;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				RUN_DOCUMENTATION_COMPILER = YES;
@@ -6646,7 +6649,7 @@
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				"SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xros*]" = "$(inherited) VISION_OS";
 				"SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xrsimulator*]" = "$(inherited) VISION_OS";
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6,7";
@@ -6677,6 +6680,7 @@
 					"@loader_path/Frameworks",
 				);
 				MTL_FAST_MATH = YES;
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.Purchases;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -6938,6 +6942,7 @@
 		};
 		35262A101F7C4B9100C04F2C /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 77BFDB3B2CAD77E70029BE4D /* Local.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
@@ -7010,6 +7015,7 @@
 		};
 		35262A111F7C4B9100C04F2C /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 77BFDB3B2CAD77E70029BE4D /* Local.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;


### PR DESCRIPTION
## What
This PR adds a `Local.xcconfig` file that can be used to enable various build settings, such as the `PAYWALL_COMPONENTS` flag or any other future flag. It's added to `.gitignore`, so these settings only affect local builds. 

This allows for a workflow similar to Gradle's `local.properties`. Personally I like this workflow, as it avoids having to find options in Xcode's GUI, which also result in changes in Xcode's project files (which we should be careful not to commit). 

Note that the original workflow of changing compiler flags in Xcode's GUI still works with this PR. It just adds another option.

## How
There's a new `Local.xcconfig.SAMPLE` file, in similar vein as the `fastlane/.env.SAMPLE` file. This file should be copied by the developer, removing the `.SAMPLE` extension. Then, any desired options can be enabled in the `Local.xcconfig` file. `Local.xcconfig` is gitignored, so enable options to your heart's content. 

I added a `Global.xcconfig` Configuration Settings file, which is referenced by the Debug and Release build configurations. Its only purpose is an optional include of `Local.xcconfig`. This allows builds to succeed if `Local.xcconfig` does not exist, such as on CI, or on developer machines who didn't create `Local.xcconfig` (yet). 

I also added a file reference to `Local.xcconfig` to the Xcode project, so it can easily be edited from within Xcode. The only downside is that it is displayed in red in the project navigator if the file doesn't exist (yet). Builds should still succeed regardless of the file existing. Let me know what you think. I can easily revert the commit that added this file reference. 

![image](https://github.com/user-attachments/assets/db6b95b8-f66a-4e7c-a04b-9285000d954b)

