### PR TITLE
Only Treat Deferred StoreKit Messages as Shown When They are Shown

### DIFF
--- a/Sources/Support/StoreMessagesHelper.swift
+++ b/Sources/Support/StoreMessagesHelper.swift
@@ -68,10 +68,9 @@ actor StoreMessagesHelper: StoreMessagesHelperType {
                 }
             }
         }
-        self.deferredMessages.removeAll { message in
-            displayedMessages.contains { displayedMessage in
-                displayedMessage.reason == message.reason
-            }
+
+        for message in displayedMessages {
+            self.deferredMessages.removeAll(where: { $0.hashValue == message.hashValue })
         }
     }
 
@@ -98,6 +97,10 @@ protocol StoreMessage: Sendable {
 
     @available(iOS 16.0, *)
     var reason: Message.Reason { get }
+
+    @available(iOS 16.0, *)
+    // swiftlint:disable:next legacy_hashing
+    var hashValue: Int { get }
 
     @available(iOS 16.0, *)
     @MainActor

--- a/Sources/Support/StoreMessagesHelper.swift
+++ b/Sources/Support/StoreMessagesHelper.swift
@@ -57,16 +57,20 @@ actor StoreMessagesHelper: StoreMessagesHelperType {
     }
 
     func showStoreMessages(types: Set<StoreMessageType>) async {
+        var messagesToKeep: [StoreMessage] = []
         for message in self.deferredMessages {
             if let messageType = message.reason.messageType, types.contains(messageType) {
                 do {
                     try await message.display(in: self.systemInfo.currentWindowScene)
                 } catch {
                     Logger.error(Strings.storeKit.error_displaying_store_message(error))
+                    messagesToKeep.append(message)
                 }
+            } else {
+                messagesToKeep.append(message)
             }
         }
-        self.deferredMessages.removeAll()
+        self.deferredMessages = messagesToKeep
     }
 
     #endif

--- a/Sources/Support/StoreMessagesHelper.swift
+++ b/Sources/Support/StoreMessagesHelper.swift
@@ -57,20 +57,22 @@ actor StoreMessagesHelper: StoreMessagesHelperType {
     }
 
     func showStoreMessages(types: Set<StoreMessageType>) async {
-        var messagesToKeep: [StoreMessage] = []
+        var displayedMessages: [StoreMessage] = []
         for message in self.deferredMessages {
             if let messageType = message.reason.messageType, types.contains(messageType) {
                 do {
                     try await message.display(in: self.systemInfo.currentWindowScene)
+                    displayedMessages.append(message)
                 } catch {
                     Logger.error(Strings.storeKit.error_displaying_store_message(error))
-                    messagesToKeep.append(message)
                 }
-            } else {
-                messagesToKeep.append(message)
             }
         }
-        self.deferredMessages = messagesToKeep
+        self.deferredMessages.removeAll { message in
+            displayedMessages.contains { displayedMessage in
+                displayedMessage.reason == message.reason
+            }
+        }
     }
 
     #endif

--- a/Tests/StoreKitUnitTests/StoreMessagesHelperTests.swift
+++ b/Tests/StoreKitUnitTests/StoreMessagesHelperTests.swift
@@ -147,6 +147,15 @@ private final class MockStoreMessage: StoreMessage {
     var reason: Message.Reason { self._reason.value }
     private let _reason: Box<Message.Reason>
 
+    // swiftlint:disable:next legacy_hashing
+    var hashValue: Int {
+        var hasher = Hasher()
+        hasher.combine(self._reason.value)
+        hasher.combine(self._displayCalled.value)
+        hasher.combine(self._displayCallCount.value)
+        return hasher.finalize()
+    }
+
     init(reason: Message.Reason) {
         self._reason = .init(reason)
     }
@@ -162,7 +171,6 @@ private final class MockStoreMessage: StoreMessage {
         self._displayCalled.value = true
         self._displayCallCount.modify { $0 += 1 }
     }
-
 }
 
 @available(iOS 16.0, *)

--- a/Tests/StoreKitUnitTests/StoreMessagesHelperTests.swift
+++ b/Tests/StoreKitUnitTests/StoreMessagesHelperTests.swift
@@ -102,6 +102,25 @@ class StoreMessagesHelperTests: TestCase {
         expect(message2.displayCallCount) == 1
     }
 
+    func testShowingStoreMessagesDoesntMarkUnshownMessagesAsShown() async throws {
+        self.createHelper(showStoreMessagesAutomatically: false)
+
+        let message1 = MockStoreMessage(reason: .generic)
+        let message2 = MockStoreMessage(reason: .priceIncreaseConsent)
+
+        try await self.waitForDeferredMessages(messages: [message1, message2])
+
+        await self.helper.showStoreMessages(types: Set([StoreMessageType.generic]))
+
+        expect(message1.displayCallCount) == 1
+        expect(message2.displayCallCount) == 0
+
+        await self.helper.showStoreMessages(types: Set(StoreMessageType.allCases))
+
+        expect(message1.displayCallCount) == 1
+        expect(message2.displayCallCount) == 1
+    }
+
 }
 
 @available(iOS 16.0, *)


### PR DESCRIPTION
### Motivation
Currently, when a developer attempts to show deferred StoreKit messages, all pending messages are removed from the list—regardless of their type—even if they haven't been displayed. This leads to a bug where, if a developer intends to display only a specific subset of message types, all messages are incorrectly marked as shown. As a result, subsequent calls to showStoreMessages() fail to display the messages that were initially skipped.

### Description
This PR addresses the issue by retaining any messages that don't match the specified types, allowing them to be displayed in future calls to showStoreMessages().

### Testing
Added a unit test to cover this scenario.