### PR TITLE
[CustomerCenter] Hide unknown paths

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -161,7 +161,7 @@ struct ManageSubscriptionsButtonsView: View {
 #if targetEnvironment(macCatalyst)
             return path.type == .refundRequest
 #else
-            return true
+            return path.type != .unknown
 #endif
         }
         ForEach(filteredPaths, id: \.id) { path in


### PR DESCRIPTION
### Description
We were displaying paths with unknown type and just ignoring the button when tapped. This is not a problem right now but might be in the future.

We might also want to move this processing to the view model or something but wanted to fix the issue separately for now.