### PR TITLE
Fix setting accent color in Customer Center

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -32,9 +32,6 @@ public struct CustomerCenterView: View {
 
     @Environment(\.colorScheme)
     private var colorScheme
-    private var localization: CustomerCenterConfigData.Localization
-    private var appearance: CustomerCenterConfigData.Appearance
-    private var supportInformation: CustomerCenterConfigData.Support?
 
     /// Create a view to handle common customer support tasks
     /// - Parameters:
@@ -43,16 +40,10 @@ public struct CustomerCenterView: View {
     public init(customerCenterActionHandler: CustomerCenterActionHandler? = nil) {
         self._viewModel = .init(wrappedValue:
                                     CustomerCenterViewModel(customerCenterActionHandler: customerCenterActionHandler))
-        self.localization = .default
-        self.appearance = .default
     }
 
-    fileprivate init(viewModel: CustomerCenterViewModel,
-                     localization: CustomerCenterConfigData.Localization = .default,
-                     appearance: CustomerCenterConfigData.Appearance = .default) {
+    fileprivate init(viewModel: CustomerCenterViewModel) {
         self._viewModel = .init(wrappedValue: viewModel)
-        self.localization = localization
-        self.appearance = appearance
     }
 
     // swiftlint:disable:next missing_docs
@@ -118,7 +109,8 @@ private extension CustomerCenterView {
 
     @ViewBuilder
     func destinationView(configuration: CustomerCenterConfigData) -> some View {
-        let accentColor = Color.from(colorInformation: self.appearance.accentColor, for: self.colorScheme)
+        let accentColor = Color.from(colorInformation: configuration.appearance.accentColor,
+                                     for: self.colorScheme)
 
         CompatibilityNavigationStack {
             destinationContent(configuration: configuration)


### PR DESCRIPTION
#4356 reported that `No Thanks` wasn't getting the correct Accent color.

After digging into it a bit more, I realized that the accent color wasn't being set at all in the Customer Center. I pin pointed it to a regression in the constructor of `CustomerCenterView`, where the appearance was always being set to the defaults