### PR TITLE
Fix `hasFeature(RetroactiveAttribute)` check in iOS 14

### DIFF
--- a/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -256,7 +256,8 @@ private extension ProductsFetcherSK1 {
 // - It has mutable state, but it's made thread-safe through `queue`.
 extension ProductsFetcherSK1: @unchecked Sendable {}
 
-#if $RetroactiveAttribute
+#if swift(>=5.8)
+#if hasFeature(RetroactiveAttribute)
 // Conformance should be safe since it is only used as dictionary key
 extension SKRequest: @unchecked @retroactive Sendable {}
 extension SKProductsRequest: @unchecked @retroactive Sendable {}

--- a/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -262,3 +262,4 @@ extension ProductsFetcherSK1: @unchecked Sendable {}
 extension SKRequest: @unchecked @retroactive Sendable {}
 extension SKProductsRequest: @unchecked @retroactive Sendable {}
 #endif
+#endif

--- a/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -256,7 +256,7 @@ private extension ProductsFetcherSK1 {
 // - It has mutable state, but it's made thread-safe through `queue`.
 extension ProductsFetcherSK1: @unchecked Sendable {}
 
-#if hasFeature(RetroactiveAttribute)
+#if $RetroactiveAttribute
 // Conformance should be safe since it is only used as dictionary key
 extension SKRequest: @unchecked @retroactive Sendable {}
 extension SKProductsRequest: @unchecked @retroactive Sendable {}


### PR DESCRIPTION
iOS 14 tests are failing with:

```
❌  /Users/distiller/purchases-ios/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift:259:5: unexpected platform condition (expected 'os', 'arch', or 'swift')

#if hasFeature(RetroactiveAttribute)
    ^
```

see https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/22627/workflows/1c541690-3b85-4aa2-ad9e-dc7f15ada779/jobs/262246/steps

I think adding a swift compiler check would fix this, but seeing this issues I realized we should maybe change the check to `#if $RetroactiveAttribute`
https://github.com/swiftlang/swift/issues/69643
https://forums.swift.org/t/hasattribute-only-supports-declaration-attributes/68202
