### PR TITLE
Adds X-Is-Debug-Build header

### DIFF
--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -66,6 +66,14 @@ class SystemInfo {
         return self._isSandbox
     }
 
+    var isDebugBuild: Bool {
+#if DEBUG
+        return true
+#else
+        return false
+#endif
+    }
+
     var storefront: StorefrontType? {
         return self.storefrontProvider.currentStorefront
     }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -132,7 +132,8 @@ class HTTPClient {
             "X-StoreKit-Version": "\(self.systemInfo.storeKitVersion.effectiveVersion)",
             "X-Observer-Mode-Enabled": "\(self.systemInfo.observerMode)",
             RequestHeader.retryCount.rawValue: "0",
-            RequestHeader.sandbox.rawValue: "\(self.systemInfo.isSandbox)"
+            RequestHeader.sandbox.rawValue: "\(self.systemInfo.isSandbox)",
+            "X-Is-Debug-Build": "\(self.systemInfo.isDebugBuild)"
         ]
 
         if let storefront = self.systemInfo.storefront {

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -15,6 +15,7 @@ class MockSystemInfo: SystemInfo {
 
     var stubbedIsApplicationBackgrounded: Bool?
     var stubbedIsSandbox: Bool?
+    var stubbedIsDebugBuild: Bool?
     var stubbedStorefront: StorefrontType?
 
     convenience init(platformInfo: Purchases.PlatformInfo? = nil,
@@ -53,6 +54,10 @@ class MockSystemInfo: SystemInfo {
 
     override var isSandbox: Bool {
         return self.stubbedIsSandbox ?? super.isSandbox
+    }
+
+    override var isDebugBuild: Bool {
+        return self.stubbedIsDebugBuild ?? super.isDebugBuild
     }
 
     override var storefront: StorefrontType? {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfig.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfig.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfigCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfigCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfigCallsHTTPMethod.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfigFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfigFailSendsNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfigPassesLocales.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerCenterConfigPassesLocales.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfig.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfig.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfigCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfigCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfigCallsHTTPMethod.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfigFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfigFailSendsNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfigPassesLocales.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerCenterConfigPassesLocales.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfig.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfig.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfigCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfigCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfigCallsHTTPMethod.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfigFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfigFailSendsNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfigPassesLocales.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerCenterConfigPassesLocales.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfig.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfig.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigCallsHTTPMethod.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigFailSendsNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigPassesLocales.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerCenterConfigPassesLocales.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfig.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfig.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigCallsHTTPMethod.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigFailSendsNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigPassesLocales.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerCenterConfigPassesLocales.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfig.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfig.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfigCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfigCachesForSameUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfigCallsHTTPMethod.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfigFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfigFailSendsNil.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfigPassesLocales.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerCenterConfigPassesLocales.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/iOS18-testRepeatedRequestsLogDebugMessage.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfig.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfig.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigCachesForSameUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigCallsHTTPMethod.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigFailSendsNil.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigPassesLocales.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerCenterConfigPassesLocales.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/watchOS-testRepeatedRequestsLogDebugMessage.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testCachesCustomerGetsForSameCustomer.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerCallsBackendProperly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetsCustomerInfo.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesGetCustomerInfoErrors.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesInvalidJSON.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testUpdatesRequestDateFromResponseHeader.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testCachesCustomerGetsForSameCustomer.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerCallsBackendProperly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetsCustomerInfo.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesGetCustomerInfoErrors.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesInvalidJSON.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testSendsNonceWhenEnabled.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testUpdatesRequestDateFromResponseHeader.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testCachesCustomerGetsForSameCustomer.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerCallsBackendProperly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetsCustomerInfo.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesGetCustomerInfoErrors.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesInvalidJSON.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testUpdatesRequestDateFromResponseHeader.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testCachesCustomerGetsForSameCustomer.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerCallsBackendProperly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetsCustomerInfo.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesGetCustomerInfoErrors.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesInvalidJSON.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testSendsNonceWhenEnabled.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testUpdatesRequestDateFromResponseHeader.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testCachesCustomerGetsForSameCustomer.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerCallsBackendProperly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testGetsCustomerInfo.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesGetCustomerInfoErrors.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testHandlesInvalidJSON.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testSendsNonceWhenEnabled.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testUpdatesRequestDateFromResponseHeader.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testCachesCustomerGetsForSameCustomer.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testGetCustomerCallsBackendProperly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testGetCustomerInfoWithFailedVerification.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testGetsCustomerInfo.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testHandlesGetCustomerInfoErrors.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testHandlesInvalidJSON.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testSendsNonceWhenEnabled.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS18-testUpdatesRequestDateFromResponseHeader.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testCachesCustomerGetsForSameCustomer.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerCallsBackendProperly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerInfoWithFailedVerification.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testGetsCustomerInfo.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testHandlesGetCustomerInfoErrors.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testHandlesInvalidJSON.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testSendsNonceWhenEnabled.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/watchOS-testUpdatesRequestDateFromResponseHeader.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfUnknownError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testPostsProductIdentifiers.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfUnknownError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testPostsProductIdentifiers.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfUnknownError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testPostsProductIdentifiers.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfUnknownError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testPostsProductIdentifiers.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testEligibilityUnknownIfUnknownError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS17-testPostsProductIdentifiers.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS18-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS18-testEligibilityUnknownIfError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS18-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS18-testEligibilityUnknownIfUnknownError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS18-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS18-testPostsProductIdentifiers.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/watchOS-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/watchOS-testEligibilityUnknownIfError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/watchOS-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/watchOS-testEligibilityUnknownIfUnknownError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/watchOS-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/watchOS-testPostsProductIdentifiers.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethod.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsFailSendsNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsNetworkErrorSendsError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsOneOffering.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethod.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsFailSendsNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsNetworkErrorSendsError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsOneOffering.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethod.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsFailSendsNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsNetworkErrorSendsError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsOneOffering.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethod.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsFailSendsNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsNetworkErrorSendsError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsOneOffering.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethod.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsFailSendsNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsNetworkErrorSendsError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testGetOfferingsOneOffering.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetOfferingsCachesForSameUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetOfferingsCallsHTTPMethod.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetOfferingsFailSendsNil.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetOfferingsNetworkErrorSendsError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testGetOfferingsOneOffering.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS18-testRepeatedRequestsLogDebugMessage.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsCachesForSameUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsCallsHTTPMethod.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsFailSendsNil.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsNetworkErrorSendsError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testGetOfferingsOneOffering.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/watchOS-testRepeatedRequestsLogDebugMessage.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestIsNotAuthenticated.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithFailure.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS13-testHealthRequestWithSuccess.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestIsNotAuthenticated.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithFailure.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS14-testHealthRequestWithSuccess.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestIsNotAuthenticated.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithFailure.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS15-testHealthRequestWithSuccess.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestIsNotAuthenticated.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithFailure.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS16-testHealthRequestWithSuccess.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestIsNotAuthenticated.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithFailure.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS17-testHealthRequestWithSuccess.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS18-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS18-testHealthRequestIsNotAuthenticated.1.json
@@ -4,6 +4,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS18-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS18-testHealthRequestWithFailure.1.json
@@ -4,6 +4,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS18-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/iOS18-testHealthRequestWithSuccess.1.json
@@ -4,6 +4,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/watchOS-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/watchOS-testHealthRequestIsNotAuthenticated.1.json
@@ -4,6 +4,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/watchOS-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/watchOS-testHealthRequestWithFailure.1.json
@@ -4,6 +4,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/watchOS-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/watchOS-testHealthRequestWithSuccess.1.json
@@ -4,6 +4,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCachesForSameUserIDs.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginMakesRightCalls.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCachesForSameUserIDs.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginMakesRightCalls.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithFailedVerification.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCachesForSameUserIDs.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginMakesRightCalls.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCachesForSameUserIDs.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginMakesRightCalls.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithFailedVerification.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithVerifiedResponse.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCachesForSameUserIDs.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginMakesRightCalls.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithFailedVerification.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithVerifiedResponse.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginCachesForSameUserIDs.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginMakesRightCalls.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS18-testLoginWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCachesForSameUserIDs.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginMakesRightCalls.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/watchOS-testLoginWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMapping.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS13-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMapping.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS14-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMapping.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS15-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMapping.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS16-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMapping.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS17-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS18-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS18-testGetProductEntitlementMapping.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS18-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/iOS18-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/watchOS-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/watchOS-testGetProductEntitlementMapping.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/watchOS-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/watchOS-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS13-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS13-testPostAdServicesCallsHttpClient.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS14-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS14-testPostAdServicesCallsHttpClient.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS15-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS15-testPostAdServicesCallsHttpClient.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS16-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS16-testPostAdServicesCallsHttpClient.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS17-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS17-testPostAdServicesCallsHttpClient.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS18-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/iOS18-testPostAdServicesCallsHttpClient.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/watchOS-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/watchOS-testPostAdServicesCallsHttpClient.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS13-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS13-testPostAttributesPutsDataInDataKey.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS14-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS14-testPostAttributesPutsDataInDataKey.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS15-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS15-testPostAttributesPutsDataInDataKey.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS16-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS16-testPostAttributesPutsDataInDataKey.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS17-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS17-testPostAttributesPutsDataInDataKey.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS18-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS18-testPostAttributesPutsDataInDataKey.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/watchOS-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/watchOS-testPostAttributesPutsDataInDataKey.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS15-testPostDiagnosticsEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS15-testPostDiagnosticsEventsWithMultipleEvents.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS15-testPostDiagnosticsEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS15-testPostDiagnosticsEventsWithOneEvent.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS16-testPostDiagnosticsEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS16-testPostDiagnosticsEventsWithMultipleEvents.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS16-testPostDiagnosticsEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS16-testPostDiagnosticsEventsWithOneEvent.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS17-testPostDiagnosticsEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS17-testPostDiagnosticsEventsWithMultipleEvents.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS17-testPostDiagnosticsEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS17-testPostDiagnosticsEventsWithOneEvent.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS18-testPostDiagnosticsEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS18-testPostDiagnosticsEventsWithMultipleEvents.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS18-testPostDiagnosticsEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/iOS18-testPostDiagnosticsEventsWithOneEvent.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/watchOS-testPostDiagnosticsEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/watchOS-testPostDiagnosticsEventsWithMultipleEvents.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/watchOS-testPostDiagnosticsEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/watchOS-testPostDiagnosticsEventsWithOneEvent.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningEmptyOffersResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNetworkError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningSignatureErrorResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningEmptyOffersResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNetworkError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningSignatureErrorResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningEmptyOffersResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNetworkError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningSignatureErrorResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningEmptyOffersResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNetworkError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningSignatureErrorResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningEmptyOffersResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNetworkError.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS17-testOfferForSigningSignatureErrorResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS18-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS18-testOfferForSigningCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS18-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS18-testOfferForSigningEmptyOffersResponse.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS18-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS18-testOfferForSigningNetworkError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS18-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS18-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS18-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS18-testOfferForSigningSignatureErrorResponse.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningEmptyOffersResponse.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningNetworkError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/watchOS-testOfferForSigningSignatureErrorResponse.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testCachesRequestsForSameReceipt.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesNotPostConsentStatus.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testFreeTrialPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testIndividualParamsCanBeNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayAsYouGoPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayUpFrontPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testCachesRequestsForSameReceipt.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesNotPostConsentStatus.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testFreeTrialPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testIndividualParamsCanBeNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayAsYouGoPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayUpFrontPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testCachesRequestsForSameReceipt.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesNotPostConsentStatus.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testFreeTrialPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testIndividualParamsCanBeNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayAsYouGoPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayUpFrontPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testCachesRequestsForSameReceipt.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesNotPostConsentStatus.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testFreeTrialPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testIndividualParamsCanBeNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayAsYouGoPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayUpFrontPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithAppTransactionCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testCachesRequestsForSameReceipt.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesNotPostConsentStatus.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentCurrency.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentDiscounts.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOffering.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentOfferings.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentReceipts.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testDoesntCacheForDifferentRestore.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testFreeTrialPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -7,6 +7,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testIndividualParamsCanBeNil.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayAsYouGoPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPayUpFrontPostsCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithAppTransactionCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedOfferingContext.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedOfferingContext.2.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testCachesRequestsForSameReceipt.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesNotPostConsentStatus.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentCurrency.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentCurrency.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentDiscounts.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentDiscounts.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentOffering.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentOffering.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentOfferings.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentOfferings.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentReceipts.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentReceipts.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentRestore.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testDoesntCacheForDifferentRestore.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testFreeTrialPostsCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testGetsEntitlementsWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testIndividualParamsCanBeNil.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPayAsYouGoPostsCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPayUpFrontPostsCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithAppTransactionCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithAppTransactionCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS18-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testCachesRequestsForSameReceipt.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesNotPostConsentStatus.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentCurrency.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentCurrency.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentDiscounts.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentDiscounts.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOffering.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOffering.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOfferings.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentOfferings.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentReceipts.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentReceipts.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentRestore.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testDoesntCacheForDifferentRestore.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testFreeTrialPostsCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsEntitlementsWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testIndividualParamsCanBeNil.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPayAsYouGoPostsCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPayUpFrontPostsCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithAppTransactionCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithAppTransactionCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/watchOS-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestContainsSignatureHeader.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestFailsIfSignatureVerificationFails.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestContainsSignatureHeader.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestFailsIfSignatureVerificationFails.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestContainsSignatureHeader.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestFailsIfSignatureVerificationFails.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestContainsSignatureHeader.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestFailsIfSignatureVerificationFails.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestContainsSignatureHeader.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestFailsIfSignatureVerificationFails.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS18-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS18-testRequestContainsSignatureHeader.1.json
@@ -5,6 +5,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS18-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS18-testRequestFailsIfSignatureVerificationFails.1.json
@@ -5,6 +5,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/watchOS-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/watchOS-testRequestContainsSignatureHeader.1.json
@@ -5,6 +5,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/watchOS-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/watchOS-testRequestFailsIfSignatureVerificationFails.1.json
@@ -5,6 +5,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -295,6 +295,46 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(header.value) == "false"
     }
 
+    func testAlwaysPassesIsDebugBuildHeaderInReleaseMode() {
+        let headerName = "X-Is-Debug-Build"
+        self.systemInfo.stubbedIsDebugBuild = false // "release" mode
+
+        let header: Atomic<String?> = nil
+
+        stub(condition: hasHeaderNamed(headerName)) { request in
+            header.value = request.value(forHTTPHeaderField: headerName)
+            return .emptySuccessResponse()
+        }
+
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
+
+        waitUntil { completion in
+            self.client.perform(request) { (_: EmptyResponse) in completion() }
+        }
+
+        expect(header.value) == "false"
+    }
+
+    func testAlwaysPassesIsDebugBuildHeaderInDebugMode() {
+        let headerName = "X-Is-Debug-Build"
+        self.systemInfo.stubbedIsDebugBuild = true
+
+        let header: Atomic<String?> = nil
+
+        stub(condition: hasHeaderNamed(headerName)) { request in
+            header.value = request.value(forHTTPHeaderField: headerName)
+            return .emptySuccessResponse()
+        }
+
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
+
+        waitUntil { completion in
+            self.client.perform(request) { (_: EmptyResponse) in completion() }
+        }
+
+        expect(header.value) == "true"
+    }
+
     func testRequestWithStorefrontSendsHeader() {
         let headerName = "X-Storefront"
         self.systemInfo.stubbedStorefront = MockStorefront(countryCode: "USA")

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS13-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS13-testPostPaywallEventsWithMultipleEvents.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS13-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS13-testPostPaywallEventsWithOneEvent.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithMultipleEvents.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS17-testPostPaywallEventsWithOneEvent.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS18-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS18-testPostPaywallEventsWithMultipleEvents.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS18-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS18-testPostPaywallEventsWithOneEvent.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/watchOS-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/watchOS-testPostPaywallEventsWithMultipleEvents.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/watchOS-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/watchOS-testPostPaywallEventsWithOneEvent.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithAdServicesToken.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithAdServicesToken.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithAdServicesToken.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithAdServicesToken.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithAdServicesToken.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS17-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostReceiptWithAdServicesToken.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS18-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithAdServicesToken.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/watchOS-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "true",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",


### PR DESCRIPTION
As the title says. Some details:

- `SystemInfo` has a new `isDebugBuild` property.
- `HTTPClient` reads this property and sets the `X-Is-Debug-Build` header accordingly.
- 2 tests were added to `HTTPClientTests`. 
- Backend test snapshots were adjusted.

**Note:** I highly recommend reviewing the first 2 commits separately from the 3rd, as that one is huge because of all the backend snapshots. 

Android implementation: https://github.com/RevenueCat/purchases-android/pull/1873