### PR TITLE
Adds `.index-build` to `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ fastlane/.env
 
 # Local build settings
 Local.xcconfig
+
+# Gets created when Cursor is used with the sswg Swift extension
+/.index-build/


### PR DESCRIPTION
As discussed in the weekly, this adds the `.index-build` folder to `.gitignore`. 
  
From some exploratory testing, I have concluded that it is caused by the combination of Cursor and the sswg Swift extension. Some observations from opening the project in various editors: 

| Editor | `.index-build` created |
|---------------|-----------------|
| Xcode 16 | ❌ |
| VS Code without Swift extension | ❌ |
| VS Code with Swift extension | ❌ |
| Cursor without Swift extension |  ❌ |
| Cursor with Swift extension | ✅ |