### PR TITLE
Fixes `SubscriptionDetailsView` background color in dark mode

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -205,30 +205,31 @@ struct ManageSubscriptionButton: View {
 struct ManageSubscriptionsView_Previews: PreviewProvider {
 
     static var previews: some View {
-
-        CompatibilityNavigationStack {
-            let viewModelMonthlyRenewing = ManageSubscriptionsViewModel(
-                screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
-                subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing,
-                customerCenterActionHandler: nil,
-                refundRequestStatus: .success)
-            ManageSubscriptionsView(viewModel: viewModelMonthlyRenewing,
-                                    customerCenterActionHandler: nil)
-                .previewDisplayName("Monthly renewing")
+        ForEach(ColorScheme.allCases, id: \.self) { colorScheme in
+            CompatibilityNavigationStack {
+                let viewModelMonthlyRenewing = ManageSubscriptionsViewModel(
+                    screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
+                    subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing,
+                    customerCenterActionHandler: nil,
+                    refundRequestStatus: .success)
+                ManageSubscriptionsView(viewModel: viewModelMonthlyRenewing,
+                                        customerCenterActionHandler: nil)
                 .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
                 .environment(\.appearance, CustomerCenterConfigTestData.customerCenterData.appearance)
-        }
+            }.preferredColorScheme(colorScheme)
+            .previewDisplayName("Monthly renewing - \(colorScheme)")
 
-        CompatibilityNavigationStack {
-            let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
-                screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
-                subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationYearlyExpiring,
-                customerCenterActionHandler: nil)
-            ManageSubscriptionsView(viewModel: viewModelYearlyExpiring,
-                                    customerCenterActionHandler: nil)
-                .previewDisplayName("Yearly expiring")
+            CompatibilityNavigationStack {
+                let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
+                    screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
+                    subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationYearlyExpiring,
+                    customerCenterActionHandler: nil)
+                ManageSubscriptionsView(viewModel: viewModelYearlyExpiring,
+                                        customerCenterActionHandler: nil)
                 .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
                 .environment(\.appearance, CustomerCenterConfigTestData.customerCenterData.appearance)
+            }.preferredColorScheme(colorScheme)
+            .previewDisplayName("Yearly expiring - \(colorScheme)")
         }
     }
 

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
@@ -122,7 +122,6 @@ struct SubscriptionDetailsView: View {
 
         }
         .padding(.vertical, 8.0)
-        .background(Color(UIColor.tertiarySystemBackground))
     }
 
     private func refundStatusMessage(for status: RefundRequestStatus) -> String {

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
@@ -146,13 +146,15 @@ struct SubscriptionDetailsView: View {
 struct SubscriptionDetailsView_Previews: PreviewProvider {
 
     static var previews: some View {
-        SubscriptionDetailsView(
-            subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing,
-            refundRequestStatus: .success
-        )
-        .previewDisplayName("Subscription Details - Monthly")
-        .padding()
-
+        ForEach(ColorScheme.allCases, id: \.self) { colorScheme in
+            SubscriptionDetailsView(
+                subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing,
+                refundRequestStatus: .success
+            )
+            .preferredColorScheme(colorScheme)
+            .previewDisplayName("Subscription Details - Monthly - \(colorScheme)")
+            .padding()
+        }
     }
 
 }


### PR DESCRIPTION
## Bug
The `SubscriptionDetailsView` has 2 different background colors in dark mode.

## Fix
The fix is to remove the entire background color from `SubscriptionDetailsView`. The `Section` in which the `SubscriptionDetailsView` is placed by `ManageSubscriptionsView` already sets the correct background color. 

## Also
Added dark mode previews to `SubscriptionDetailsView` and `ManageSubscriptionsView` to more easily catch these issues.

## Reference image
![image](https://github.com/user-attachments/assets/639517c8-3f2d-496c-9032-904eab49823f)


Closes #4335. 