### PR TITLE
Fixes macOS snapshots for X-Is-Debug-Build header

### DIFF
--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfig.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfig.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigCachesForSameUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigCallsHTTPMethod.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigCallsHTTPMethodWithRandomDelay.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigFailSendsNil.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigNetworkErrorSendsError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigPassesLocales.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerCenterConfigPassesLocales.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerConfigDoesntCacheForMultipleUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testGetCustomerConfigDoesntCacheForMultipleUserID.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerCenterConfigTests/macOS-testRepeatedRequestsLogDebugMessage.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testCachesCustomerGetsForSameCustomer.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerCallsBackendProperly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoWithFailedVerification.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetCustomerInfoWithVerifiedResponse.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testGetsCustomerInfo.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testHandlesGetCustomerInfoErrors.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testHandlesInvalidJSON.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testSendsNonceWhenEnabled.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:fcbcf165908dd18a9e49f7ff27810176db8e9f63b4352213741664245224f8aa",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/macOS-testUpdatesRequestDateFromResponseHeader.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testEligibilityUnknownIfError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testEligibilityUnknownIfUnknownError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/macOS-testPostsProductIdentifiers.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCachesForSameUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCallsHTTPMethod.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsFailSendsNil.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsNetworkErrorSendsError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testGetOfferingsOneOffering.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/macOS-testRepeatedRequestsLogDebugMessage.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestIsNotAuthenticated.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestIsNotAuthenticated.1.json
@@ -4,6 +4,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestWithFailure.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestWithFailure.1.json
@@ -4,6 +4,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestWithSuccess.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendInternalTests/macOS-testHealthRequestWithSuccess.1.json
@@ -4,6 +4,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCachesForSameUserIDs.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginMakesRightCalls.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginMakesRightCalls.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginMakesRightCalls.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:fcbcf165908dd18a9e49f7ff27810176db8e9f63b4352213741664245224f8aa",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/macOS-testLoginWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:fcbcf165908dd18a9e49f7ff27810176db8e9f63b4352213741664245224f8aa",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/macOS-testGetProductEntitlementMapping.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/macOS-testGetProductEntitlementMapping.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/macOS-testGetProductEntitlementMappingCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendOfflineEntitlementsTests/macOS-testGetProductEntitlementMappingCachesForSameUserID.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/macOS-testPostAdServicesCallsHttpClient.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAdServicesTokenTests/macOS-testPostAdServicesCallsHttpClient.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/macOS-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/macOS-testPostAttributesPutsDataInDataKey.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/macOS-testPostDiagnosticsEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/macOS-testPostDiagnosticsEventsWithMultipleEvents.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/macOS-testPostDiagnosticsEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostDiagnosticsTests/macOS-testPostDiagnosticsEventsWithOneEvent.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningEmptyOffersResponse.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningNetworkError.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/macOS-testOfferForSigningSignatureErrorResponse.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testCachesRequestsForSameReceipt.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesNotPostConsentStatus.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Custom-Entitlements-Computation" : "true",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentCurrency.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentCurrency.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentDiscounts.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentDiscounts.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOffering.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOffering.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOfferings.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentOfferings.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentReceipts.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentReceipts.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentRestore.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testDoesntCacheForDifferentRestore.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testFreeTrialPostsCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:fcbcf165908dd18a9e49f7ff27810176db8e9f63b4352213741664245224f8aa",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:fcbcf165908dd18a9e49f7ff27810176db8e9f63b4352213741664245224f8aa",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testIndividualParamsCanBeNil.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPayAsYouGoPostsCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPayUpFrontPostsCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptCreatesACustomerInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptCreatesACustomerInfoObject.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptForSubscriptionAndServerErrorComputesOfflineUser.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsJWSTokenWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsJWSTokenWithProductDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionAndNoReceiptCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithAppTransactionCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithPresentedOfferingContext.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithPresentedOfferingContext.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithPresentedPaywall.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithPresentedPaywall.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/macOS-testPostsSK2XcodeReceiptWithProductDataCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/macOS-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/macOS-testRequestContainsSignatureHeader.1.json
@@ -5,6 +5,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:fcbcf165908dd18a9e49f7ff27810176db8e9f63b4352213741664245224f8aa",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/macOS-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/macOS-testRequestFailsIfSignatureVerificationFails.1.json
@@ -5,6 +5,7 @@
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
     "X-Headers-Hash" : "X-Is-Sandbox:sha256:fcbcf165908dd18a9e49f7ff27810176db8e9f63b4352213741664245224f8aa",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/macOS-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/macOS-testPostPaywallEventsWithMultipleEvents.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/macOS-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/macOS-testPostPaywallEventsWithOneEvent.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithAdServicesToken.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesPassesCustomerInfoIfStatusCodeIsSuccess.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/macOS-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Is-Debug-Build" : "true",
     "X-Is-Sandbox" : "false",
     "X-Observer-Mode-Enabled" : "false",
     "X-Platform" : "iOS",


### PR DESCRIPTION
As the title says. This PR is mainly intended to fix the `run-test-macos` CI job. 