### PR TITLE
Fixes broken references in project.pbxproj.

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -19,30 +19,12 @@
 		2C2AEB3B2CA7209F00A50F38 /* PaywallPackageComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB3A2CA7209F00A50F38 /* PaywallPackageComponent.swift */; };
 		2C2AEB3D2CA720B700A50F38 /* PaywallPackageGroupComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB3C2CA720B700A50F38 /* PaywallPackageGroupComponent.swift */; };
 		2C2AEB3F2CA7235300A50F38 /* PaywallPurchaseButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB3E2CA7235300A50F38 /* PaywallPurchaseButtonComponent.swift */; };
-		2C2AEB442CA72D9F00A50F38 /* PackageGroupComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB432CA72D9F00A50F38 /* PackageGroupComponentViewModel.swift */; };
-		2C2AEB462CA7302400A50F38 /* PackageComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB452CA7302400A50F38 /* PackageComponentViewModel.swift */; };
-		2C2AEB482CA7304900A50F38 /* PurchaseButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB472CA7304900A50F38 /* PurchaseButtonComponentViewModel.swift */; };
-		2C2AEB4A2CA7338A00A50F38 /* PackageGroupComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB492CA7338A00A50F38 /* PackageGroupComponentView.swift */; };
-		2C2AEB4C2CA7339200A50F38 /* PackageComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB4B2CA7339200A50F38 /* PackageComponentView.swift */; };
-		2C2AEB4E2CA7339E00A50F38 /* PurchaseButtonComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB4D2CA7339E00A50F38 /* PurchaseButtonComponentView.swift */; };
 		2C4C36132C6FBA8B00AE959B /* CompatibilityTopBarTrailing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4C36122C6FBA8B00AE959B /* CompatibilityTopBarTrailing.swift */; };
 		2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */; };
 		2C7F0AD32B8EEB4600381179 /* RateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */; };
 		2C7F0AD62B8EEF7B00381179 /* RateLimiterRests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */; };
 		2CAB87F72CAAB13200247013 /* CornerBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB87F62CAAB13200247013 /* CornerBorder.swift */; };
 		2CB8CF9327BF538F00C34DE3 /* PlatformInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */; };
-		2CC790CA2CC00C5900FBE120 /* PackageComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC790B12CC00C5900FBE120 /* PackageComponentView.swift */; };
-		2CC790CC2CC00C5900FBE120 /* PurchaseButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC790B82CC00C5900FBE120 /* PurchaseButtonComponentViewModel.swift */; };
-		2CC790CF2CC00C5900FBE120 /* PackageComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC790B22CC00C5900FBE120 /* PackageComponentViewModel.swift */; };
-		2CC790D02CC00C5900FBE120 /* PackageGroupComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC790B52CC00C5900FBE120 /* PackageGroupComponentViewModel.swift */; };
-		2CC790D32CC00C5900FBE120 /* PackageGroupComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC790B42CC00C5900FBE120 /* PackageGroupComponentView.swift */; };
-		2CC790D82CC00C5900FBE120 /* PurchaseButtonComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC790B72CC00C5900FBE120 /* PurchaseButtonComponentView.swift */; };
-		2CC791282CC01F1200FBE120 /* PurchaseButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC791252CC01F1200FBE120 /* PurchaseButtonComponentViewModel.swift */; };
-		2CC791292CC01F1200FBE120 /* PackageComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC7911F2CC01F1200FBE120 /* PackageComponentViewModel.swift */; };
-		2CC7912A2CC01F1200FBE120 /* PurchaseButtonComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC791242CC01F1200FBE120 /* PurchaseButtonComponentView.swift */; };
-		2CC7912B2CC01F1200FBE120 /* PackageGroupComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC791212CC01F1200FBE120 /* PackageGroupComponentView.swift */; };
-		2CC7912C2CC01F1200FBE120 /* PackageComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC7911E2CC01F1200FBE120 /* PackageComponentView.swift */; };
-		2CC7912D2CC01F1200FBE120 /* PackageGroupComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC791222CC01F1200FBE120 /* PackageGroupComponentViewModel.swift */; };
 		2CC791552CC0452100FBE120 /* PurchaseButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC791522CC0452100FBE120 /* PurchaseButtonComponentViewModel.swift */; };
 		2CC791562CC0452100FBE120 /* PackageComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC7914B2CC0452100FBE120 /* PackageComponentView.swift */; };
 		2CC791572CC0452100FBE120 /* PackageGroupComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC7914F2CC0452100FBE120 /* PackageGroupComponentViewModel.swift */; };
@@ -1184,12 +1166,6 @@
 		2C2AEB3A2CA7209F00A50F38 /* PaywallPackageComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallPackageComponent.swift; sourceTree = "<group>"; };
 		2C2AEB3C2CA720B700A50F38 /* PaywallPackageGroupComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallPackageGroupComponent.swift; sourceTree = "<group>"; };
 		2C2AEB3E2CA7235300A50F38 /* PaywallPurchaseButtonComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallPurchaseButtonComponent.swift; sourceTree = "<group>"; };
-		2C2AEB432CA72D9F00A50F38 /* PackageGroupComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageGroupComponentViewModel.swift; sourceTree = "<group>"; };
-		2C2AEB452CA7302400A50F38 /* PackageComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentViewModel.swift; sourceTree = "<group>"; };
-		2C2AEB472CA7304900A50F38 /* PurchaseButtonComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseButtonComponentViewModel.swift; sourceTree = "<group>"; };
-		2C2AEB492CA7338A00A50F38 /* PackageGroupComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageGroupComponentView.swift; sourceTree = "<group>"; };
-		2C2AEB4B2CA7339200A50F38 /* PackageComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentView.swift; sourceTree = "<group>"; };
-		2C2AEB4D2CA7339E00A50F38 /* PurchaseButtonComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseButtonComponentView.swift; sourceTree = "<group>"; };
 		2C4C36122C6FBA8B00AE959B /* CompatibilityTopBarTrailing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompatibilityTopBarTrailing.swift; sourceTree = "<group>"; };
 		2C5F71F52C3D6C2600B0FE4B /* header.heic */ = {isa = PBXFileReference; lastKnownFileType = file; path = header.heic; sourceTree = "<group>"; };
 		2C5F71F62C3D6C2600B0FE4B /* background.heic */ = {isa = PBXFileReference; lastKnownFileType = file; path = background.heic; sourceTree = "<group>"; };
@@ -1197,29 +1173,8 @@
 		2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesSyncAttributesAndOfferingsIfNeededTests.swift; sourceTree = "<group>"; };
 		2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiter.swift; sourceTree = "<group>"; };
 		2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiterRests.swift; sourceTree = "<group>"; };
-		2CAB87EC2CA78ED800247013 /* StackableComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackableComponent.swift; sourceTree = "<group>"; };
-		2CAB87EE2CA78EF600247013 /* Dimension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dimension.swift; sourceTree = "<group>"; };
-		2CAB87F32CAAAF9300247013 /* Border.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Border.swift; sourceTree = "<group>"; };
 		2CAB87F62CAAB13200247013 /* CornerBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerBorder.swift; sourceTree = "<group>"; };
 		2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfo.swift; sourceTree = "<group>"; };
-		2CC790B12CC00C5900FBE120 /* PackageComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentView.swift; sourceTree = "<group>"; };
-		2CC790B22CC00C5900FBE120 /* PackageComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentViewModel.swift; sourceTree = "<group>"; };
-		2CC790B42CC00C5900FBE120 /* PackageGroupComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageGroupComponentView.swift; sourceTree = "<group>"; };
-		2CC790B52CC00C5900FBE120 /* PackageGroupComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageGroupComponentViewModel.swift; sourceTree = "<group>"; };
-		2CC790B72CC00C5900FBE120 /* PurchaseButtonComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseButtonComponentView.swift; sourceTree = "<group>"; };
-		2CC790B82CC00C5900FBE120 /* PurchaseButtonComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseButtonComponentViewModel.swift; sourceTree = "<group>"; };
-		2CC7911E2CC01F1200FBE120 /* PackageComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentView.swift; sourceTree = "<group>"; };
-		2CC7911F2CC01F1200FBE120 /* PackageComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentViewModel.swift; sourceTree = "<group>"; };
-		2CC791212CC01F1200FBE120 /* PackageGroupComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageGroupComponentView.swift; sourceTree = "<group>"; };
-		2CC791222CC01F1200FBE120 /* PackageGroupComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageGroupComponentViewModel.swift; sourceTree = "<group>"; };
-		2CC791242CC01F1200FBE120 /* PurchaseButtonComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseButtonComponentView.swift; sourceTree = "<group>"; };
-		2CC791252CC01F1200FBE120 /* PurchaseButtonComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseButtonComponentViewModel.swift; sourceTree = "<group>"; };
-		2CC7912E2CC0212900FBE120 /* Border.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Border.swift; sourceTree = "<group>"; };
-		2CC7912F2CC0212900FBE120 /* Dimension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dimension.swift; sourceTree = "<group>"; };
-		2CC791302CC0212900FBE120 /* PaywallComponentBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentBase.swift; sourceTree = "<group>"; };
-		2CC791312CC0212900FBE120 /* PaywallComponentLocalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentLocalization.swift; sourceTree = "<group>"; };
-		2CC791322CC0212900FBE120 /* PaywallComponentPropertyTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentPropertyTypes.swift; sourceTree = "<group>"; };
-		2CC791332CC0212900FBE120 /* StackableComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackableComponent.swift; sourceTree = "<group>"; };
 		2CC7914B2CC0452100FBE120 /* PackageComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentView.swift; sourceTree = "<group>"; };
 		2CC7914C2CC0452100FBE120 /* PackageComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentViewModel.swift; sourceTree = "<group>"; };
 		2CC7914E2CC0452100FBE120 /* PackageGroupComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageGroupComponentView.swift; sourceTree = "<group>"; };
@@ -2337,33 +2292,6 @@
 		2CC7913E2CC0450900FBE120 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
-				2CC7912E2CC0212900FBE120 /* Border.swift */,
-				2CC791302CC0212900FBE120 /* PaywallComponentBase.swift */,
-				2CC7912F2CC0212900FBE120 /* Dimension.swift */,
-				2CC791312CC0212900FBE120 /* PaywallComponentLocalization.swift */,
-				2CC791332CC0212900FBE120 /* StackableComponent.swift */,
-				2CC791322CC0212900FBE120 /* PaywallComponentPropertyTypes.swift */,
-				2CAB87F32CAAAF9300247013 /* Border.swift */,
-				2CAB87EC2CA78ED800247013 /* StackableComponent.swift */,
-				2CAB87EE2CA78EF600247013 /* Dimension.swift */,
-				2C2AEB4D2CA7339E00A50F38 /* PurchaseButtonComponentView.swift */,
-				2CC791252CC01F1200FBE120 /* PurchaseButtonComponentViewModel.swift */,
-				2CC7911F2CC01F1200FBE120 /* PackageComponentViewModel.swift */,
-				2CC791242CC01F1200FBE120 /* PurchaseButtonComponentView.swift */,
-				2CC791212CC01F1200FBE120 /* PackageGroupComponentView.swift */,
-				2CC7911E2CC01F1200FBE120 /* PackageComponentView.swift */,
-				2CC791222CC01F1200FBE120 /* PackageGroupComponentViewModel.swift */,
-				2C2AEB452CA7302400A50F38 /* PackageComponentViewModel.swift */,
-				2C2AEB4B2CA7339200A50F38 /* PackageComponentView.swift */,
-				2C2AEB492CA7338A00A50F38 /* PackageGroupComponentView.swift */,
-				2CC790B12CC00C5900FBE120 /* PackageComponentView.swift */,
-				2CC790B82CC00C5900FBE120 /* PurchaseButtonComponentViewModel.swift */,
-				2CC790B22CC00C5900FBE120 /* PackageComponentViewModel.swift */,
-				2CC790B52CC00C5900FBE120 /* PackageGroupComponentViewModel.swift */,
-				2CC790B42CC00C5900FBE120 /* PackageGroupComponentView.swift */,
-				2CC790B72CC00C5900FBE120 /* PurchaseButtonComponentView.swift */,
-				2C2AEB472CA7304900A50F38 /* PurchaseButtonComponentViewModel.swift */,
-				2C2AEB432CA72D9F00A50F38 /* PackageGroupComponentViewModel.swift */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -6135,16 +6063,8 @@
 				88B1BB132C81479F001B7EE5 /* PaywallComponentTypeTransformers.swift in Sources */,
 				88B1BB042C813A3C001B7EE5 /* StackComponentViewModel.swift in Sources */,
 				1E5F8F782C46BBD90041EECD /* CustomerCenterAction.swift in Sources */,
-				2C2AEB4E2CA7339E00A50F38 /* PurchaseButtonComponentView.swift in Sources */,
 				887A60CC2C1D037000E1A461 /* PaywallFontProvider.swift in Sources */,
 				887A60B82C1D037000E1A461 /* Template1View.swift in Sources */,
-				2CC791282CC01F1200FBE120 /* PurchaseButtonComponentViewModel.swift in Sources */,
-				2CC791292CC01F1200FBE120 /* PackageComponentViewModel.swift in Sources */,
-				2CC7912A2CC01F1200FBE120 /* PurchaseButtonComponentView.swift in Sources */,
-				2CC7912B2CC01F1200FBE120 /* PackageGroupComponentView.swift in Sources */,
-				2CC7912C2CC01F1200FBE120 /* PackageComponentView.swift in Sources */,
-				2CC7912D2CC01F1200FBE120 /* PackageGroupComponentViewModel.swift in Sources */,
-				2C2AEB462CA7302400A50F38 /* PackageComponentViewModel.swift in Sources */,
 				887A60C62C1D037000E1A461 /* LoadingPaywallView.swift in Sources */,
 				88B1BAF22C813A3C001B7EE5 /* SpacerComponentView.swift in Sources */,
 				77791ECF2C6B852000BCEF03 /* SemanticVersion.swift in Sources */,
@@ -6156,7 +6076,6 @@
 				88A543E12C37A4820039C6A5 /* TemplateView+MultiTier.swift in Sources */,
 				887A60B72C1D037000E1A461 /* WatchTemplateView.swift in Sources */,
 				887A60722C1D037000E1A461 /* PaywallViewMode+Extensions.swift in Sources */,
-				2C2AEB4C2CA7339200A50F38 /* PackageComponentView.swift in Sources */,
 				887A60C32C1D037000E1A461 /* FooterView.swift in Sources */,
 				887A607F2C1D037000E1A461 /* Optional+Extensions.swift in Sources */,
 				3511088F2C47F6DA0048C4D8 /* CustomerInfo+CurrentEntitlement.swift in Sources */,
@@ -6227,30 +6146,21 @@
 				887A607C2C1D037000E1A461 /* ColorInformation+MultiScheme.swift in Sources */,
 				88B1BAFE2C813A3C001B7EE5 /* ImageComponentViewModel.swift in Sources */,
 				35C200B12C39254100B9778B /* FeedbackSurveyView.swift in Sources */,
-				2C2AEB4A2CA7338A00A50F38 /* PackageGroupComponentView.swift in Sources */,
 				35F249CC2C493DCC0058993A /* CustomerCenterPurchasesType.swift in Sources */,
 				887A60672C1D037000E1A461 /* PaywallError.swift in Sources */,
 				88A543E52C37A4AF0039C6A5 /* ConsistentTierContentView.swift in Sources */,
 				3525D8A42C4AB3D600C21D99 /* CustomerCenterEnvironment.swift in Sources */,
-				2CC790CA2CC00C5900FBE120 /* PackageComponentView.swift in Sources */,
-				2CC790CC2CC00C5900FBE120 /* PurchaseButtonComponentViewModel.swift in Sources */,
-				2CC790CF2CC00C5900FBE120 /* PackageComponentViewModel.swift in Sources */,
-				2CC790D02CC00C5900FBE120 /* PackageGroupComponentViewModel.swift in Sources */,
-				2CC790D32CC00C5900FBE120 /* PackageGroupComponentView.swift in Sources */,
-				2CC790D82CC00C5900FBE120 /* PurchaseButtonComponentView.swift in Sources */,
 				35C496062C482ACC0023E924 /* PromotionalOfferData.swift in Sources */,
 				887A606E2C1D037000E1A461 /* LocalizedAlertError.swift in Sources */,
 				887A60802C1D037000E1A461 /* Package+VariableDataProvider.swift in Sources */,
 				887A60CE2C1D037000E1A461 /* View+PresentPaywall.swift in Sources */,
 				357CEC702C5940CE00A80837 /* ColorFromAppearance.swift in Sources */,
 				887A60832C1D037000E1A461 /* VersionDetector.swift in Sources */,
-				2C2AEB482CA7304900A50F38 /* PurchaseButtonComponentViewModel.swift in Sources */,
 				88B1BAFC2C813A3C001B7EE5 /* ImageComponentView.swift in Sources */,
 				887A60872C1D037000E1A461 /* ViewExtensions.swift in Sources */,
 				88B1BB022C813A3C001B7EE5 /* StackComponentView.swift in Sources */,
 				353756712C382C2800A1B8D6 /* ManageSubscriptionsPurchaseType.swift in Sources */,
 				35C200AF2C39252D00B9778B /* FeedbackSurveyData.swift in Sources */,
-				2C2AEB442CA72D9F00A50F38 /* PackageGroupComponentViewModel.swift in Sources */,
 				353FDC0D2CA41CB20055F328 /* SubscriptionPeriod+Extensions.swift in Sources */,
 				3551E39D2C4A6A1400D27C25 /* TintedProgressView.swift in Sources */,
 				88B1BAF82C813A3C001B7EE5 /* LinkButtonComponentViewModel.swift in Sources */,


### PR DESCRIPTION
This PR intends to fix errors like: 
```
error: Multiple commands produce '/Users/distiller/Library/Developer/Xcode/DerivedData/RevenueCat-etwwovrsjatlsobqeniqyhgbqoaq/Build/Intermediates.noindex/RevenueCat.build/Release-iphonesimulator/RevenueCatUI.build/Objects-normal/arm64/PurchaseButtonComponentView.stringsdata'
```

It removes these broken references in `project.pbxproj`:
![image](https://github.com/user-attachments/assets/9bb822b0-bd97-4316-98e3-811f5d06b0c2)
