### PR TITLE
Add default values to enums in Customer Center config response

### DIFF
--- a/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
+++ b/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
@@ -129,14 +129,42 @@ extension CustomerCenterConfigResponse: Codable, Equatable {}
 extension CustomerCenterConfigResponse.CustomerCenter: Codable, Equatable {}
 extension CustomerCenterConfigResponse.Localization: Codable, Equatable {}
 extension CustomerCenterConfigResponse.HelpPath: Codable, Equatable {}
-extension CustomerCenterConfigResponse.HelpPath.PathType: Codable, Equatable {}
+extension CustomerCenterConfigResponse.HelpPath.PathType: Equatable {}
 extension CustomerCenterConfigResponse.HelpPath.PromotionalOffer: Codable, Equatable {}
 extension CustomerCenterConfigResponse.HelpPath.FeedbackSurvey: Codable, Equatable {}
 extension CustomerCenterConfigResponse.HelpPath.FeedbackSurvey.Option: Codable, Equatable {}
 extension CustomerCenterConfigResponse.Appearance: Codable, Equatable {}
 extension CustomerCenterConfigResponse.Appearance.AppearanceCustomColors: Codable, Equatable {}
 extension CustomerCenterConfigResponse.Screen: Codable, Equatable {}
-extension CustomerCenterConfigResponse.Screen.ScreenType: Codable, Equatable {}
+extension CustomerCenterConfigResponse.Screen.ScreenType: Equatable {}
 extension CustomerCenterConfigResponse.Support: Codable, Equatable {}
+
+protocol CodableEnumWithUnknownCase: Codable {
+
+    static var unknownCase: Self { get }
+
+}
+
+extension CodableEnumWithUnknownCase where Self: RawRepresentable, Self.RawValue == String {
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        self = Self(rawValue: value) ?? Self.unknownCase
+    }
+
+}
+
+extension CustomerCenterConfigResponse.Screen.ScreenType: CodableEnumWithUnknownCase {
+
+    static var unknownCase: Self { .unknown }
+
+}
+
+extension CustomerCenterConfigResponse.HelpPath.PathType: CodableEnumWithUnknownCase {
+
+    static var unknownCase: Self { .unknown }
+
+}
 
 extension CustomerCenterConfigResponse: HTTPResponseBody {}

--- a/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
+++ b/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
@@ -141,4 +141,69 @@ class CustomerCenterConfigDataTests: TestCase {
         expect(configData.productId) == 123
     }
 
+    func testUnknownValuesHandling() throws {
+        let jsonString = """
+        {
+            "customerCenter": {
+                "appearance": {
+                    "light": {
+                        "accentColor": "#000000",
+                        "textColor": "#000000",
+                        "backgroundColor": "#000000",
+                        "buttonTextColor": "#000000",
+                        "buttonBackgroundColor": "#000000"
+                    },
+                    "dark": {
+                        "accentColor": "#FFFFFF",
+                        "textColor": "#FFFFFF",
+                        "backgroundColor": "#FFFFFF",
+                        "buttonTextColor": "#FFFFFF",
+                        "buttonBackgroundColor": "#FFFFFF"
+                    }
+                },
+                "screens": {
+                    "UNKNOWN_SCREEN": {
+                        "title": "Unknown Screen",
+                        "type": "UNKNOWN_SCREEN_TYPE",
+                        "subtitle": "This is an unknown screen type",
+                        "paths": [
+                            {
+                                "id": "unknown_path",
+                                "title": "Unknown Path",
+                                "type": "UNKNOWN_PATH_TYPE"
+                            }
+                        ]
+                    }
+                },
+                "localization": {
+                    "locale": "en_US",
+                    "localizedStrings": {}
+                },
+                "support": {
+                    "email": "support@example.com"
+                }
+            },
+            "lastPublishedAppVersion": "1.0.0",
+            "itunesTrackId": 123
+        }
+        """
+
+        let jsonData = jsonString.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let response = try decoder.decode(CustomerCenterConfigResponse.self, from: jsonData)
+
+        let configData = CustomerCenterConfigData(from: response)
+
+        expect(configData.screens.count) == 1
+        let unknownScreen = configData.screens.first?.value
+        expect(unknownScreen?.type) == .unknown
+        expect(unknownScreen?.title) == "Unknown Screen"
+        expect(unknownScreen?.subtitle) == "This is an unknown screen type"
+
+        expect(unknownScreen?.paths.count) == 1
+        let unknownPath = unknownScreen?.paths.first
+        expect(unknownPath?.type) == .unknown
+        expect(unknownPath?.id) == "unknown_path"
+        expect(unknownPath?.title) == "Unknown Path"
+    }
 }


### PR DESCRIPTION
We added a new case in the backend for path types, and current code in the SDK fails to decode unknown values.

We need to handle unknown values and also make sure these new values are not sent down by the backend for versions that break with unknown values.