### PR TITLE
Fix iOS 15, 14 tests using wrong version of `swift-snapshot-testing` and API tests

### DIFF
--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -11,7 +11,7 @@ let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "tr
 
 var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:Quick/Nimble.git", from: "10.0.0"),
-    .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", from: "1.11.0")
+    .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", .upToNextMinor(from: "1.12.0"))
 ]
 if shouldIncludeDocCPlugin {
     // Versions 1.4.0 and 1.4.1 are failing to compile, so we are pinning it to 1.3.0 for now

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -11,7 +11,7 @@ let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "tr
 
 var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:Quick/Nimble.git", from: "10.0.0"),
-    .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", from: "1.11.0")
+    .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", .upToNextMinor(from: "1.12.0"))
 ]
 if shouldIncludeDocCPlugin {
     // Versions 1.4.0 and 1.4.1 are failing to compile, so we are pinning it to 1.3.0 for now

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerCenterConfigDataAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerCenterConfigDataAPI.swift
@@ -27,10 +27,17 @@ func checkCustomerCenterConfigData(_ data: CustomerCenterConfigData) {
 func checkHelpPath(_ path: CustomerCenterConfigData.HelpPath) {
     let id: String = path.id
     let title: String = path.title
+    let url: URL? = path.url
+    let openMethod: CustomerCenterConfigData.HelpPath.OpenMethod? = path.openMethod
     let type: CustomerCenterConfigData.HelpPath.PathType = path.type
     let detail: CustomerCenterConfigData.HelpPath.PathDetail? = path.detail
 
-    let _: CustomerCenterConfigData.HelpPath = .init(id: id, title: title, type: type, detail: detail)
+    let _: CustomerCenterConfigData.HelpPath = .init(id: id,
+                                                     title: title,
+                                                     url: url,
+                                                     openMethod: openMethod,
+                                                     type: type,
+                                                     detail: detail)
 }
 
 func checkHelpPathDetail(_ detail: CustomerCenterConfigData.HelpPath.PathDetail) {


### PR DESCRIPTION
```
❌ /Users/distiller/purchases-ios/Tests/UnitTests/Mocks/MockHTTPClient.swift:98:13: ambiguous use of 'assertSnapshot(matching:as:named:record:timeout:file:testName:line:)'
            assertSnapshot(matching: call,
            ^
```

We were getting that issue only in iOS 14 and iOS 15. @JayShortway noticed the version of `swift-snapshot-testing` might differ because of the how we set the version of the library in the Package.swift files