### PR TITLE
[CustomerCenter] Add default info to support emails

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0313FD41268A506400168386 /* DateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313FD40268A506400168386 /* DateProvider.swift */; };
+		1E2F910B2CC8FE5600BDB016 /* ContactSupportUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2F910A2CC8FE5600BDB016 /* ContactSupportUtilities.swift */; };
+		1E2F911B2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */; };
 		1E473B662AC42D34008B07F9 /* StoreMessagesHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E473B652AC42D34008B07F9 /* StoreMessagesHelper.swift */; };
 		1E473B682AC43254008B07F9 /* StoreMessageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E473B672AC43254008B07F9 /* StoreMessageType.swift */; };
 		1E568B512ACC6A8300D3C12F /* StoreMessageTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E568B502ACC6A8300D3C12F /* StoreMessageTypeTests.swift */; };
@@ -1155,6 +1157,8 @@
 
 /* Begin PBXFileReference section */
 		0313FD40268A506400168386 /* DateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateProvider.swift; sourceTree = "<group>"; };
+		1E2F910A2CC8FE5600BDB016 /* ContactSupportUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactSupportUtilities.swift; sourceTree = "<group>"; };
+		1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactSupportUtilitiesTests.swift; sourceTree = "<group>"; };
 		1E473B652AC42D34008B07F9 /* StoreMessagesHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessagesHelper.swift; sourceTree = "<group>"; };
 		1E473B672AC43254008B07F9 /* StoreMessageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessageType.swift; sourceTree = "<group>"; };
 		1E473B692AC46908008B07F9 /* MockStoreMessagesHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreMessagesHelper.swift; sourceTree = "<group>"; };
@@ -3320,6 +3324,7 @@
 				1E5F8F6D2C4515430041EECD /* View+PresentCustomerCenter.swift */,
 				3511088E2C47F6DA0048C4D8 /* CustomerInfo+CurrentEntitlement.swift */,
 				357CEC6F2C5940CE00A80837 /* ColorFromAppearance.swift */,
+				1E2F910A2CC8FE5600BDB016 /* ContactSupportUtilities.swift */,
 			);
 			path = CustomerCenter;
 			sourceTree = "<group>";
@@ -3398,6 +3403,7 @@
 			children = (
 				3544DA692C2C848E00704E9D /* CustomerCenterViewModelTests.swift */,
 				3544DA6A2C2C848E00704E9D /* ManageSubscriptionsViewModelTests.swift */,
+				1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */,
 			);
 			path = CustomerCenter;
 			sourceTree = "<group>";
@@ -6145,6 +6151,7 @@
 				887A60C82C1D037000E1A461 /* ProgressView.swift in Sources */,
 				887A60D02C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift in Sources */,
 				887A60CD2C1D037000E1A461 /* PaywallView.swift in Sources */,
+				1E2F910B2CC8FE5600BDB016 /* ContactSupportUtilities.swift in Sources */,
 				1E5F8F6E2C4515430041EECD /* View+PresentCustomerCenter.swift in Sources */,
 				887A60C12C1D037000E1A461 /* DebugErrorView.swift in Sources */,
 				887A607C2C1D037000E1A461 /* ColorInformation+MultiScheme.swift in Sources */,
@@ -6213,6 +6220,7 @@
 				887A63322C1D177800E1A461 /* CurrentTestCaseTracker.swift in Sources */,
 				887A63332C1D177800E1A461 /* DataExtensions.swift in Sources */,
 				887A63342C1D177800E1A461 /* ImageSnapshot.swift in Sources */,
+				1E2F911B2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift in Sources */,
 				887A63352C1D177800E1A461 /* OSVersionEquivalent.swift in Sources */,
 				887A63362C1D177800E1A461 /* SnapshotTesting+Extensions.swift in Sources */,
 				887A63372C1D177800E1A461 /* TestCase.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/ContactSupportUtilities.swift
+++ b/RevenueCatUI/CustomerCenter/ContactSupportUtilities.swift
@@ -1,0 +1,58 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ContactSupportUtilities.swift
+//
+//  Created by Antonio Rico Diez on 2024-10-23.
+
+import RevenueCat
+#if canImport(UIKit)
+import UIKit
+#endif
+
+extension CustomerCenterConfigData.Support {
+
+    func calculateBody(_ localization: CustomerCenterConfigData.Localization,
+                       dataToInclude: [(String, String)]? = nil) -> String {
+        let infoToInclude: [(String, String)]
+        if let dataToInclude {
+            infoToInclude = dataToInclude
+        } else {
+            infoToInclude = Self.defaultData(localization)
+        }
+        let defaultBody =
+            """
+            \(localization.commonLocalizedString(for: .defaultBody))
+            
+            ---------------------------
+            \(localization.commonLocalizedString(for: .defaultExtraInformation))
+            \(infoToInclude.map { (key, value) in
+                "- \(key): \(value)"
+            }.joined(separator: "\n"))
+            """
+        return defaultBody
+    }
+
+    private static func defaultData(_ localization: CustomerCenterConfigData.Localization) -> [(String, String)] {
+        let unknown = localization.commonLocalizedString(for: .unknown)
+        var iOSVersion = unknown
+        #if canImport(UIKit)
+        iOSVersion = UIDevice.current.systemVersion
+        #endif
+        let userID = Purchases.isConfigured ? Purchases.shared.appUserID : unknown
+        let storeFrontCountryCode = Purchases.isConfigured ? Purchases.shared.storeFrontCountryCode ?? unknown : unknown
+
+        return [
+            ("RCUserID", userID),
+            ("StoreFront Country Code", storeFrontCountryCode),
+            ("App Version", Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? unknown),
+            ("iOS Version", iOSVersion)
+        ]
+    }
+}

--- a/RevenueCatUI/CustomerCenter/ContactSupportUtilities.swift
+++ b/RevenueCatUI/CustomerCenter/ContactSupportUtilities.swift
@@ -29,7 +29,7 @@ extension CustomerCenterConfigData.Support {
         let defaultBody =
             """
             \(localization.commonLocalizedString(for: .defaultBody))
-            
+
             ---------------------------
             \(localization.commonLocalizedString(for: .defaultExtraInformation))
             \(infoToInclude.map { (key, value) in

--- a/RevenueCatUI/CustomerCenter/ContactSupportUtilities.swift
+++ b/RevenueCatUI/CustomerCenter/ContactSupportUtilities.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Antonio Rico Diez on 2024-10-23.
 
+import Foundation
 import RevenueCat
 #if canImport(UIKit)
 import UIKit

--- a/RevenueCatUI/CustomerCenter/ContactSupportUtilities.swift
+++ b/RevenueCatUI/CustomerCenter/ContactSupportUtilities.swift
@@ -42,18 +42,21 @@ extension CustomerCenterConfigData.Support {
 
     private static func defaultData(_ localization: CustomerCenterConfigData.Localization) -> [(String, String)] {
         let unknown = localization.commonLocalizedString(for: .unknown)
-        var iOSVersion = unknown
-        #if canImport(UIKit)
-        iOSVersion = UIDevice.current.systemVersion
+        var osVersion = unknown
+        var deviceModel = unknown
+        #if canImport(UIKit) && !os(watchOS)
+        osVersion = UIDevice.current.systemVersion
+        deviceModel = UIDevice.current.model
         #endif
         let userID = Purchases.isConfigured ? Purchases.shared.appUserID : unknown
         let storeFrontCountryCode = Purchases.isConfigured ? Purchases.shared.storeFrontCountryCode ?? unknown : unknown
 
         return [
-            ("RCUserID", userID),
-            ("StoreFront Country Code", storeFrontCountryCode),
+            ("RC User ID", userID),
             ("App Version", Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? unknown),
-            ("iOS Version", iOSVersion)
+            ("Device", deviceModel),
+            ("OS Version", osVersion),
+            ("StoreFront Country Code", storeFrontCountryCode)
         ]
     }
 }

--- a/RevenueCatUI/CustomerCenter/ContactSupportUtilities.swift
+++ b/RevenueCatUI/CustomerCenter/ContactSupportUtilities.swift
@@ -32,7 +32,6 @@ extension CustomerCenterConfigData.Support {
             \(localization.commonLocalizedString(for: .defaultBody))
 
             ---------------------------
-            \(localization.commonLocalizedString(for: .defaultExtraInformation))
             \(infoToInclude.map { (key, value) in
                 "- \(key): \(value)"
             }.joined(separator: "\n"))

--- a/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
@@ -44,7 +44,7 @@ struct RestorePurchasesAlert: ViewModifier {
     private var supportURL: URL? {
         guard let supportInformation = self.supportInformation else { return nil }
         let subject = self.localization.commonLocalizedString(for: .defaultSubject)
-        let body = self.localization.commonLocalizedString(for: .defaultBody)
+        let body = supportInformation.calculateBody(self.localization)
         return URLUtilities.createMailURLIfPossible(email: supportInformation.email,
                                                     subject: subject,
                                                     body: body)

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -42,7 +42,7 @@ struct WrongPlatformView: View {
     private var supportURL: URL? {
         guard let supportInformation = self.supportInformation else { return nil }
         let subject = self.localization.commonLocalizedString(for: .defaultSubject)
-        let body = self.localization.commonLocalizedString(for: .defaultBody)
+        let body = supportInformation.calculateBody(self.localization)
         return URLUtilities.createMailURLIfPossible(email: supportInformation.email,
                                                     subject: subject,
                                                     body: body)

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -72,7 +72,6 @@ public struct CustomerCenterConfigData {
             case subExpired = "sub_expired"
             case contactSupport = "contact_support"
             case defaultBody = "default_body"
-            case defaultExtraInformation = "default_extra_information"
             case defaultSubject = "default_subject"
             case dismiss = "dismiss"
             case unknown = "unknown"
@@ -142,8 +141,6 @@ public struct CustomerCenterConfigData {
                     return "Contact support"
                 case .defaultBody:
                     return "Please describe your issue or question."
-                case .defaultExtraInformation:
-                    return "Extra information:"
                 case .defaultSubject:
                     return "Support Request"
                 case .dismiss:

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -72,8 +72,10 @@ public struct CustomerCenterConfigData {
             case subExpired = "sub_expired"
             case contactSupport = "contact_support"
             case defaultBody = "default_body"
+            case defaultExtraInformation = "default_extra_information"
             case defaultSubject = "default_subject"
             case dismiss = "dismiss"
+            case unknown = "unknown"
             case updateWarningTitle = "update_warning_title"
             case updateWarningDescription = "update_warning_description"
             case updateWarningUpdate = "update_warning_update"
@@ -140,10 +142,14 @@ public struct CustomerCenterConfigData {
                     return "Contact support"
                 case .defaultBody:
                     return "Please describe your issue or question."
+                case .defaultExtraInformation:
+                    return "Extra information:"
                 case .defaultSubject:
                     return "Support Request"
                 case .dismiss:
                     return "Dismiss"
+                case .unknown:
+                    return "Unknown"
                 case .updateWarningTitle:
                     return "Update available"
                 case .updateWarningDescription:

--- a/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
@@ -25,7 +25,7 @@ class ContactSupportUtilitiesTest: TestCase {
         let body = support.calculateBody(localization)
         let expectedBody = """
         Please describe your issue or question.
-        
+
         ---------------------------
         Extra information:
         - RCUserID: Unknown
@@ -42,7 +42,7 @@ class ContactSupportUtilitiesTest: TestCase {
         let body = support.calculateBody(localization, dataToInclude: givenData)
         let expectedBody = """
         Please describe your issue or question.
-        
+
         ---------------------------
         Extra information:
         - test1: test2

--- a/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
@@ -1,0 +1,55 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerCenterSupportUtilities.swift
+//
+//  Created by Antonio Rico Diez on 2024-10-23.
+
+import Nimble
+import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+class ContactSupportUtilitiesTest: TestCase {
+
+    private let support: CustomerCenterConfigData.Support = .init(email: "support@example.com")
+    private let localization: CustomerCenterConfigData.Localization = .init(locale: "en_US", localizedStrings: [:])
+
+    func testSupportEmailBodyWithDefaultDataIsCorrect() {
+        let body = support.calculateBody(localization)
+        let expectedBody = """
+        Please describe your issue or question.
+        
+        ---------------------------
+        Extra information:
+        - RCUserID: Unknown
+        - StoreFront Country Code: Unknown
+        - App Version: 16.0
+        - iOS Version: 18.0
+        """
+
+        expect(body).to(equal(expectedBody))
+    }
+
+    func testSupportEmailBodyWithGivenDataIsCorrect() {
+        let givenData = [("test1", "test2"), ("test3", "test4")]
+        let body = support.calculateBody(localization, dataToInclude: givenData)
+        let expectedBody = """
+        Please describe your issue or question.
+        
+        ---------------------------
+        Extra information:
+        - test1: test2
+        - test3: test4
+        """
+
+        expect(body).to(equal(expectedBody))
+    }
+
+}

--- a/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
@@ -23,18 +23,20 @@ class ContactSupportUtilitiesTest: TestCase {
 
     func testSupportEmailBodyWithDefaultDataIsCorrect() {
         let body = support.calculateBody(localization)
-        let expectedBody = """
+        let initialBody = """
         Please describe your issue or question.
 
         ---------------------------
         Extra information:
-        - RCUserID: Unknown
-        - StoreFront Country Code: Unknown
-        - App Version: 16.0
-        - iOS Version: 18.0
         """
 
-        expect(body).to(equal(expectedBody))
+        expect(body).to(contain(initialBody))
+        expect(body).to(contain("- RC User ID: Unknown"))
+        expect(body).to(contain("- App Version:"))
+        expect(body).to(contain("- StoreFront Country Code: Unknown"))
+        expect(body).to(contain("- Device:"))
+        expect(body).to(contain("- OS Version:"))
+
     }
 
     func testSupportEmailBodyWithGivenDataIsCorrect() {

--- a/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
@@ -27,7 +27,6 @@ class ContactSupportUtilitiesTest: TestCase {
         Please describe your issue or question.
 
         ---------------------------
-        Extra information:
         """
 
         expect(body).to(contain(initialBody))
@@ -46,7 +45,6 @@ class ContactSupportUtilitiesTest: TestCase {
         Please describe your issue or question.
 
         ---------------------------
-        Extra information:
         - test1: test2
         - test3: test4
         """


### PR DESCRIPTION
### Description
This adds some default information to the support emails when contacting them
![IMG_E9712E046691-1](https://github.com/user-attachments/assets/2a7f60fc-cb7d-46da-bd0c-700e16d50445)
