### PR TITLE
adds callout to SPM installation tip for visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ For more detailed information, you can view our complete documentation at [docs.
 
 Please follow the [Quickstart Guide](https://docs.revenuecat.com/docs/) for more information on how to install the SDK.
 
-**Note:** When integrating with SPM, it is recommended to add the SPM mirror repository for faster download/integration times: https://github.com/RevenueCat/purchases-ios-spm
+> [!TIP]
+> When integrating with SPM, it is recommended to add the SPM mirror repository for faster download/integration times: https://github.com/RevenueCat/purchases-ios-spm
 
 Or view our iOS sample apps:
 - [MagicWeather](Examples/MagicWeather)


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
This installation tip is [easy to miss](https://community.revenuecat.com/sdks-51/swift-package-takes-hours-to-download-5318), which costs developers a lot of time.

### Description
Adds a callout format for the SPM installation tip.
