### PR TITLE
Default URL to nil in CustomerCenter HelpPaths

### DIFF
--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -187,8 +187,8 @@ public struct CustomerCenterConfigData {
 
         public init(id: String,
                     title: String,
-                    url: URL?,
-                    openMethod: OpenMethod?,
+                    url: URL? = nil,
+                    openMethod: OpenMethod? = nil,
                     type: PathType,
                     detail: PathDetail?) {
             self.id = id


### PR DESCRIPTION
@tonidero I noticed you added this in [#release](https://github.com/RevenueCat/purchases-ios/pull/4391/commits/d9c1e49a67f123263fbb02e5522d41edd9a2fb4f)

Adding as a separate PR before I trigger the release again