### PR TITLE
Post error test results to Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1237,7 +1237,6 @@ jobs:
       - run:
           name: Run Danger
           command: bundle exec danger --verbose
-      - slack-notify
   tag-release-branch:
     docker:
       - image: cimg/ruby:3.1.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1387,25 +1387,25 @@ workflows:
     jobs:
       - lint:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - run-test-ios-17:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - run-test-ios-18:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - pod-lib-lint:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - run-revenuecat-ui-ios-17:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - run-revenuecat-ui-ios-18:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - emerge_purchases_ui_snapshot_tests:
           context:
-            - slack-secrets
+            - slack-secrets-ios
 
   create-tag:
     when:
@@ -1517,94 +1517,94 @@ workflows:
     jobs:
       - backend-integration-tests-SK1:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - backend-integration-tests-SK2:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - backend-integration-tests-custom-entitlements:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - backend-integration-tests-other:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - build-tv-watch-and-macos:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - build-visionos:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - docs-build:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - run-test-ios-14:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - run-test-ios-15:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - run-test-ios-16:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - run-test-macos:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - run-test-tvos:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - run-test-watchos:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - spm-receipt-parser:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - spm-release-build:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - spm-release-build-xcode-14:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - spm-release-build-xcode-15:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - spm-revenuecat-ui-ios-15:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - spm-revenuecat-ui-ios-16:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - run-revenuecat-ui-ios-17:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - run-revenuecat-ui-ios-18:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - spm-revenuecat-ui-watchos:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - installation-tests-cocoapods:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - installation-tests-swift-package-manager:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - installation-tests-custom-entitlement-computation-swift-package-manager:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - installation-tests-carthage:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - installation-tests-xcode-direct-integration:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - installation-tests-receipt-parser:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - api-tests:
           context:
-            - slack-secrets
+            - slack-secrets-ios
       - deploy-purchase-tester:
           context:
-            - slack-secrets
+            - slack-secrets-ios
           dry_run: true
       - emerge_purchases_ui_snapshot_tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 orbs:
   macos: circleci/macos@2.5.1
-  slack: circleci/slack@4.10.1
+  slack: circleci/slack@5.0.0
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 
@@ -92,6 +92,12 @@ aliases:
         only: main
 
 commands:
+  slack-notify:
+    steps:
+      - slack/notify:
+          channel: 'feed-circleci-ios-failures'
+          event: fail
+          template: basic_fail_1
   set-maximum-duration:
     parameters:
       seconds:
@@ -411,6 +417,7 @@ jobs:
           name: SPM Release Build
           command: swift build -c release --target RevenueCat
           no_output_timeout: 30m
+      - slack-notify
 
   spm-release-build-xcode-16:
     executor:
@@ -423,6 +430,7 @@ jobs:
           name: SPM Release Build
           command: swift build -c release --target RevenueCat
           no_output_timeout: 30m
+      - slack-notify
 
   spm-release-build-xcode-15:
     executor:
@@ -435,6 +443,7 @@ jobs:
           name: SPM Release Build
           command: swift build -c release --target RevenueCat
           no_output_timeout: 30m
+      - slack-notify
 
   spm-xcode-14-1:
     executor:
@@ -451,6 +460,7 @@ jobs:
           name: SPM RevenueCatUI Release Build
           command: swift build -c release --target RevenueCatUI
           no_output_timeout: 30m
+      - slack-notify
 
   pod-lib-lint:
     executor:
@@ -461,6 +471,7 @@ jobs:
       - run:
           name: Check pods and deployment targets
           command: bundle exec fastlane check_pods
+      - slack-notify
 
   spm-release-build:
     executor:
@@ -475,6 +486,7 @@ jobs:
           name: SPM RevenueCatUI Release Build
           command: swift build -c release --target RevenueCatUI
           no_output_timeout: 30m
+      - slack-notify
 
   api-tests:
     executor:
@@ -485,6 +497,7 @@ jobs:
       - run:
           name: API Tests
           command: bundle exec fastlane run_api_tests
+      - slack-notify
 
   spm-receipt-parser:
     executor:
@@ -495,6 +508,7 @@ jobs:
           name: SPM Receipt Parser
           command: swift build -c release --target ReceiptParser
           no_output_timeout: 30m
+      - slack-notify
 
   spm-revenuecat-ui-ios-15:
     executor:
@@ -524,6 +538,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
+      - slack-notify
 
   spm-revenuecat-ui-ios-16:
     executor:
@@ -557,6 +572,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
+      - slack-notify
 
   run-revenuecat-ui-ios-17:
     executor:
@@ -590,6 +606,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
+      - slack-notify
 
   run-revenuecat-ui-ios-18:
     executor:
@@ -623,6 +640,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
+      - slack-notify
 
   spm-revenuecat-ui-watchos:
     executor:
@@ -647,7 +665,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-
+      - slack-notify
   run-test-macos:
     executor:
       name: macos-executor
@@ -670,6 +688,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify
 
   run-test-ios-18:
     executor:
@@ -698,7 +717,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-
+      - slack-notify
   run-test-ios-17:
     executor:
       name: macos-executor
@@ -726,6 +745,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify
 
   run-test-ios-16:
     executor:
@@ -758,7 +778,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-
+      - slack-notify
   run-test-ios-15:
     executor:
       name: macos-executor
@@ -790,6 +810,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify
 
   run-test-tvos:
     executor:
@@ -809,7 +830,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-
+      - slack-notify
   run-test-watchos:
     executor:
       name: macos-executor
@@ -836,6 +857,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify
 
   run-test-ios-14:
     executor:
@@ -872,7 +894,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-
+      - slack-notify
   run-test-ios-13:
     executor:
       name: macos-executor
@@ -907,6 +929,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify
 
   build-tv-watch-and-macos:
     executor:
@@ -918,6 +941,7 @@ jobs:
           name: Build tvOS, watchOS and macOS
           command: bundle exec fastlane build_tv_watch_mac
           no_output_timeout: 30m
+      - slack-notify
 
   build-visionos:
     executor:
@@ -929,13 +953,14 @@ jobs:
           name: Build visionOS
           command: bundle exec fastlane build_visionos
           no_output_timeout: 30m
-
+      - slack-notify
   backend-integration-tests-SK1:
     executor:
       name: macos-executor
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-SK1"
+      - slack-notify
 
   backend-integration-tests-SK2:
     executor:
@@ -943,13 +968,14 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-SK2"
-
+      - slack-notify
   backend-integration-tests-other:
     executor:
       name: macos-executor
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-Other"
+      - slack-notify
 
   backend-integration-tests-offline:
     executor:
@@ -957,6 +983,7 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-Offline"
+      - slack-notify
 
   backend-integration-tests-custom-entitlements:
     executor:
@@ -964,7 +991,7 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-CustomEntitlements"
-
+      - slack-notify
   release-checks:
     executor:
       name: macos-executor
@@ -999,6 +1026,7 @@ jobs:
       - store_artifacts:
           path: RevenueCatUI.xcframework.zip
           destination: RevenueCatUI.xcframework.zip
+      - slack-notify
 
   docs-build:
     executor:
@@ -1015,7 +1043,7 @@ jobs:
           command: bundle exec fastlane build_docs
           environment:
             DOCS_IOS_VERSION: "17.4"
-
+      - slack-notify
   docs-deploy:
     executor:
       name: macos-executor
@@ -1031,6 +1059,7 @@ jobs:
           command: bundle exec fastlane build_and_publish_docs
           environment:
             DOCS_IOS_VERSION: "17.4"
+      - slack-notify
 
   make-release:
     executor:
@@ -1044,7 +1073,7 @@ jobs:
           name: Deploy new version
           command: bundle exec fastlane release
           no_output_timeout: 30m
-
+      - slack-notify
   push-revenuecat-pod:
     executor:
       name: macos-executor
@@ -1056,6 +1085,7 @@ jobs:
           name: Deploy new version
           command: bundle exec fastlane push_revenuecat_pod
           no_output_timeout: 30m
+      - slack-notify
 
   push-revenuecatui-pod:
     executor:
@@ -1068,7 +1098,7 @@ jobs:
           name: Deploy new version
           command: bundle exec fastlane push_revenuecatui_pod
           no_output_timeout: 30m
-
+      - slack-notify
   prepare-next-version:
     executor:
       name: macos-executor
@@ -1080,6 +1110,7 @@ jobs:
       - run:
           name: Prepare next version
           command: bundle exec fastlane prepare_next_version
+      - slack-notify
 
   installation-tests-cocoapods:
     executor:
@@ -1096,7 +1127,7 @@ jobs:
             bundle exec pod install
       - scan-and-archive:
           directory: Tests/InstallationTests/CocoapodsInstallation
-
+      - slack-notify
   installation-tests-swift-package-manager:
     executor:
       name: macos-executor
@@ -1109,6 +1140,7 @@ jobs:
           directory: Tests/InstallationTests/SPMInstallation/
       - scan-and-archive-all-platforms:
           directory: Tests/InstallationTests/SPMInstallation/
+      - slack-notify
 
   installation-tests-custom-entitlement-computation-swift-package-manager:
     executor:
@@ -1122,7 +1154,7 @@ jobs:
           directory: Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/
       - scan:
           directory: Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/
-
+      - slack-notify
   installation-tests-receipt-parser:
     executor:
       name: macos-executor
@@ -1135,6 +1167,7 @@ jobs:
           directory: Tests/InstallationTests/ReceiptParserInstallation/
       - scan-and-archive-all-platforms:
           directory: Tests/InstallationTests/ReceiptParserInstallation/
+      - slack-notify
 
   installation-tests-carthage:
     executor:
@@ -1157,6 +1190,7 @@ jobs:
 
       - install-dependencies-scan-and-archive:
           directory: Tests/InstallationTests/CarthageInstallation/
+      - slack-notify
 
   installation-tests-xcode-direct-integration:
     executor:
@@ -1168,6 +1202,7 @@ jobs:
 
       - install-dependencies-scan-and-archive:
           directory: Tests/InstallationTests/XcodeDirectInstallation/
+      - slack-notify
 
   lint:
     executor:
@@ -1188,6 +1223,7 @@ jobs:
           path: fastlane/test_output
       - store_artifacts:
           path: fastlane/test_output
+      - slack-notify
 
   danger:
     docker:
@@ -1200,7 +1236,7 @@ jobs:
       - run:
           name: Run Danger
           command: bundle exec danger --verbose
-
+      - slack-notify
   tag-release-branch:
     docker:
       - image: cimg/ruby:3.1.2
@@ -1214,7 +1250,7 @@ jobs:
       - run:
           name: Tag branch
           command: bundle exec fastlane tag_current_branch
-
+      - slack-notify
   release-train:
     executor:
       name: macos-executor
@@ -1226,7 +1262,7 @@ jobs:
       - run:
           name: Create automatic PR
           command: bundle exec fastlane automatic_bump github_rate_limit:10
-
+      - slack-notify
   integration-tests-all:
     executor:
       name: macos-executor
@@ -1250,6 +1286,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify
 
   loadshedder-integration-tests-v3:
     executor:
@@ -1266,6 +1303,7 @@ jobs:
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: v3LoadShedderIntegration
+      - slack-notify
 
   deploy-purchase-tester:
     executor:
@@ -1283,6 +1321,7 @@ jobs:
       - run:
           name: Submit Purchase Tester
           command: bundle exec fastlane deploy_purchase_tester dry_run:<< parameters.dry_run >>
+      - slack-notify
 
   emerge_purchases_ui_snapshot_tests:
     executor:
@@ -1296,6 +1335,7 @@ jobs:
       - run:
           name: Build Paywalls Tester
           command: bundle exec fastlane build_paywalls_tester_for_emerge
+      - slack-notify
 
   deploy-to-spm:
     docker:
@@ -1313,6 +1353,7 @@ jobs:
             git remote set-url origin https://github.com/RevenueCat/purchases-ios-spm.git
             git push origin
             git push --tags
+      - slack-notify
 
 workflows:
   version: 2
@@ -1344,13 +1385,27 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      - lint
-      - run-test-ios-17
-      - run-test-ios-18
-      - pod-lib-lint
-      - run-revenuecat-ui-ios-17
-      - run-revenuecat-ui-ios-18
-      - emerge_purchases_ui_snapshot_tests
+      - lint:
+          context:
+            - slack-secrets
+      - run-test-ios-17:
+          context:
+            - slack-secrets
+      - run-test-ios-18:
+          context:
+            - slack-secrets
+      - pod-lib-lint:
+          context:
+            - slack-secrets
+      - run-revenuecat-ui-ios-17:
+          context:
+            - slack-secrets
+      - run-revenuecat-ui-ios-18:
+          context:
+            - slack-secrets
+      - emerge_purchases_ui_snapshot_tests:
+          context:
+            - slack-secrets
 
   create-tag:
     when:
@@ -1460,36 +1515,96 @@ workflows:
             - "run-from-github-comments"
             - << pipeline.parameters.GHA_Meta >>
     jobs:
-      - backend-integration-tests-SK1
-      - backend-integration-tests-SK2
-      - backend-integration-tests-custom-entitlements
-      - backend-integration-tests-other
-      - build-tv-watch-and-macos
-      - build-visionos
-      - docs-build
-      - run-test-ios-14
-      - run-test-ios-15
-      - run-test-ios-16
-      - run-test-macos
-      - run-test-tvos
-      - run-test-watchos
-      - spm-receipt-parser
-      - spm-release-build
-      - spm-release-build-xcode-14
-      - spm-release-build-xcode-15
-      - spm-revenuecat-ui-ios-15
-      - spm-revenuecat-ui-ios-16
-      - run-revenuecat-ui-ios-17
-      - run-revenuecat-ui-ios-18
-      - spm-revenuecat-ui-watchos
-      - installation-tests-cocoapods
-      - installation-tests-swift-package-manager
-      - installation-tests-custom-entitlement-computation-swift-package-manager
-      - installation-tests-carthage
-      - installation-tests-xcode-direct-integration
-      - installation-tests-receipt-parser
-      - api-tests
+      - backend-integration-tests-SK1:
+          context:
+            - slack-secrets
+      - backend-integration-tests-SK2:
+          context:
+            - slack-secrets
+      - backend-integration-tests-custom-entitlements:
+          context:
+            - slack-secrets
+      - backend-integration-tests-other:
+          context:
+            - slack-secrets
+      - build-tv-watch-and-macos:
+          context:
+            - slack-secrets
+      - build-visionos:
+          context:
+            - slack-secrets
+      - docs-build:
+          context:
+            - slack-secrets
+      - run-test-ios-14:
+          context:
+            - slack-secrets
+      - run-test-ios-15:
+          context:
+            - slack-secrets
+      - run-test-ios-16:
+          context:
+            - slack-secrets
+      - run-test-macos:
+          context:
+            - slack-secrets
+      - run-test-tvos:
+          context:
+            - slack-secrets
+      - run-test-watchos:
+          context:
+            - slack-secrets
+      - spm-receipt-parser:
+          context:
+            - slack-secrets
+      - spm-release-build:
+          context:
+            - slack-secrets
+      - spm-release-build-xcode-14:
+          context:
+            - slack-secrets
+      - spm-release-build-xcode-15:
+          context:
+            - slack-secrets
+      - spm-revenuecat-ui-ios-15:
+          context:
+            - slack-secrets
+      - spm-revenuecat-ui-ios-16:
+          context:
+            - slack-secrets
+      - run-revenuecat-ui-ios-17:
+          context:
+            - slack-secrets
+      - run-revenuecat-ui-ios-18:
+          context:
+            - slack-secrets
+      - spm-revenuecat-ui-watchos:
+          context:
+            - slack-secrets
+      - installation-tests-cocoapods:
+          context:
+            - slack-secrets
+      - installation-tests-swift-package-manager:
+          context:
+            - slack-secrets
+      - installation-tests-custom-entitlement-computation-swift-package-manager:
+          context:
+            - slack-secrets
+      - installation-tests-carthage:
+          context:
+            - slack-secrets
+      - installation-tests-xcode-direct-integration:
+          context:
+            - slack-secrets
+      - installation-tests-receipt-parser:
+          context:
+            - slack-secrets
+      - api-tests:
+          context:
+            - slack-secrets
       - deploy-purchase-tester:
+          context:
+            - slack-secrets
           dry_run: true
       - emerge_purchases_ui_snapshot_tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ commands:
   slack-notify:
     steps:
       - slack/notify:
+          branch_pattern: main
           channel: 'feed-circleci-ios-failures'
           event: fail
           template: basic_fail_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ commands:
   slack-notify:
     steps:
       - slack/notify:
-          branch_pattern: main
+          branch_pattern: post-test-results-slack
           channel: 'feed-circleci-ios-failures'
           event: fail
           template: basic_fail_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,6 @@ jobs:
           name: SPM Release Build
           command: swift build -c release --target RevenueCat
           no_output_timeout: 30m
-      - slack-notify
 
   spm-release-build-xcode-16:
     executor:
@@ -431,7 +430,6 @@ jobs:
           name: SPM Release Build
           command: swift build -c release --target RevenueCat
           no_output_timeout: 30m
-      - slack-notify
 
   spm-release-build-xcode-15:
     executor:
@@ -444,7 +442,6 @@ jobs:
           name: SPM Release Build
           command: swift build -c release --target RevenueCat
           no_output_timeout: 30m
-      - slack-notify
 
   spm-xcode-14-1:
     executor:
@@ -461,7 +458,6 @@ jobs:
           name: SPM RevenueCatUI Release Build
           command: swift build -c release --target RevenueCatUI
           no_output_timeout: 30m
-      - slack-notify
 
   pod-lib-lint:
     executor:
@@ -487,7 +483,6 @@ jobs:
           name: SPM RevenueCatUI Release Build
           command: swift build -c release --target RevenueCatUI
           no_output_timeout: 30m
-      - slack-notify
 
   api-tests:
     executor:
@@ -498,7 +493,6 @@ jobs:
       - run:
           name: API Tests
           command: bundle exec fastlane run_api_tests
-      - slack-notify
 
   spm-receipt-parser:
     executor:
@@ -509,7 +503,6 @@ jobs:
           name: SPM Receipt Parser
           command: swift build -c release --target ReceiptParser
           no_output_timeout: 30m
-      - slack-notify
 
   spm-revenuecat-ui-ios-15:
     executor:
@@ -539,7 +532,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify
 
   spm-revenuecat-ui-ios-16:
     executor:
@@ -573,7 +565,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify
 
   run-revenuecat-ui-ios-17:
     executor:
@@ -666,7 +657,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify
+
   run-test-macos:
     executor:
       name: macos-executor
@@ -689,7 +680,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify
 
   run-test-ios-18:
     executor:
@@ -719,6 +709,7 @@ jobs:
           path: fastlane/test_output/xctest
           destination: scan-test-output
       - slack-notify
+
   run-test-ios-17:
     executor:
       name: macos-executor
@@ -779,7 +770,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify
+
   run-test-ios-15:
     executor:
       name: macos-executor
@@ -811,7 +802,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify
 
   run-test-tvos:
     executor:
@@ -831,7 +821,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify
+
   run-test-watchos:
     executor:
       name: macos-executor
@@ -858,7 +848,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify
 
   run-test-ios-14:
     executor:
@@ -895,7 +884,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify
+
   run-test-ios-13:
     executor:
       name: macos-executor
@@ -930,7 +919,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify
 
   build-tv-watch-and-macos:
     executor:
@@ -942,7 +930,6 @@ jobs:
           name: Build tvOS, watchOS and macOS
           command: bundle exec fastlane build_tv_watch_mac
           no_output_timeout: 30m
-      - slack-notify
 
   build-visionos:
     executor:
@@ -954,14 +941,13 @@ jobs:
           name: Build visionOS
           command: bundle exec fastlane build_visionos
           no_output_timeout: 30m
-      - slack-notify
+
   backend-integration-tests-SK1:
     executor:
       name: macos-executor
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-SK1"
-      - slack-notify
 
   backend-integration-tests-SK2:
     executor:
@@ -969,14 +955,12 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-SK2"
-      - slack-notify
   backend-integration-tests-other:
     executor:
       name: macos-executor
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-Other"
-      - slack-notify
 
   backend-integration-tests-offline:
     executor:
@@ -984,7 +968,6 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-Offline"
-      - slack-notify
 
   backend-integration-tests-custom-entitlements:
     executor:
@@ -992,7 +975,6 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-CustomEntitlements"
-      - slack-notify
   release-checks:
     executor:
       name: macos-executor
@@ -1027,7 +1009,6 @@ jobs:
       - store_artifacts:
           path: RevenueCatUI.xcframework.zip
           destination: RevenueCatUI.xcframework.zip
-      - slack-notify
 
   docs-build:
     executor:
@@ -1044,7 +1025,7 @@ jobs:
           command: bundle exec fastlane build_docs
           environment:
             DOCS_IOS_VERSION: "17.4"
-      - slack-notify
+
   docs-deploy:
     executor:
       name: macos-executor
@@ -1060,7 +1041,6 @@ jobs:
           command: bundle exec fastlane build_and_publish_docs
           environment:
             DOCS_IOS_VERSION: "17.4"
-      - slack-notify
 
   make-release:
     executor:
@@ -1074,7 +1054,7 @@ jobs:
           name: Deploy new version
           command: bundle exec fastlane release
           no_output_timeout: 30m
-      - slack-notify
+
   push-revenuecat-pod:
     executor:
       name: macos-executor
@@ -1086,7 +1066,6 @@ jobs:
           name: Deploy new version
           command: bundle exec fastlane push_revenuecat_pod
           no_output_timeout: 30m
-      - slack-notify
 
   push-revenuecatui-pod:
     executor:
@@ -1099,7 +1078,7 @@ jobs:
           name: Deploy new version
           command: bundle exec fastlane push_revenuecatui_pod
           no_output_timeout: 30m
-      - slack-notify
+
   prepare-next-version:
     executor:
       name: macos-executor
@@ -1128,7 +1107,7 @@ jobs:
             bundle exec pod install
       - scan-and-archive:
           directory: Tests/InstallationTests/CocoapodsInstallation
-      - slack-notify
+
   installation-tests-swift-package-manager:
     executor:
       name: macos-executor
@@ -1141,7 +1120,6 @@ jobs:
           directory: Tests/InstallationTests/SPMInstallation/
       - scan-and-archive-all-platforms:
           directory: Tests/InstallationTests/SPMInstallation/
-      - slack-notify
 
   installation-tests-custom-entitlement-computation-swift-package-manager:
     executor:
@@ -1155,7 +1133,7 @@ jobs:
           directory: Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/
       - scan:
           directory: Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/
-      - slack-notify
+
   installation-tests-receipt-parser:
     executor:
       name: macos-executor
@@ -1168,7 +1146,6 @@ jobs:
           directory: Tests/InstallationTests/ReceiptParserInstallation/
       - scan-and-archive-all-platforms:
           directory: Tests/InstallationTests/ReceiptParserInstallation/
-      - slack-notify
 
   installation-tests-carthage:
     executor:
@@ -1191,7 +1168,6 @@ jobs:
 
       - install-dependencies-scan-and-archive:
           directory: Tests/InstallationTests/CarthageInstallation/
-      - slack-notify
 
   installation-tests-xcode-direct-integration:
     executor:
@@ -1203,7 +1179,6 @@ jobs:
 
       - install-dependencies-scan-and-archive:
           directory: Tests/InstallationTests/XcodeDirectInstallation/
-      - slack-notify
 
   lint:
     executor:
@@ -1237,6 +1212,7 @@ jobs:
       - run:
           name: Run Danger
           command: bundle exec danger --verbose
+
   tag-release-branch:
     docker:
       - image: cimg/ruby:3.1.2
@@ -1250,7 +1226,7 @@ jobs:
       - run:
           name: Tag branch
           command: bundle exec fastlane tag_current_branch
-      - slack-notify
+
   release-train:
     executor:
       name: macos-executor
@@ -1262,7 +1238,7 @@ jobs:
       - run:
           name: Create automatic PR
           command: bundle exec fastlane automatic_bump github_rate_limit:10
-      - slack-notify
+
   integration-tests-all:
     executor:
       name: macos-executor
@@ -1286,7 +1262,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify
 
   loadshedder-integration-tests-v3:
     executor:
@@ -1303,7 +1278,6 @@ jobs:
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: v3LoadShedderIntegration
-      - slack-notify
 
   deploy-purchase-tester:
     executor:
@@ -1321,7 +1295,6 @@ jobs:
       - run:
           name: Submit Purchase Tester
           command: bundle exec fastlane deploy_purchase_tester dry_run:<< parameters.dry_run >>
-      - slack-notify
 
   emerge_purchases_ui_snapshot_tests:
     executor:
@@ -1353,7 +1326,6 @@ jobs:
             git remote set-url origin https://github.com/RevenueCat/purchases-ios-spm.git
             git push origin
             git push --tags
-      - slack-notify
 
 workflows:
   version: 2
@@ -1515,96 +1487,36 @@ workflows:
             - "run-from-github-comments"
             - << pipeline.parameters.GHA_Meta >>
     jobs:
-      - backend-integration-tests-SK1:
-          context:
-            - slack-secrets-ios
-      - backend-integration-tests-SK2:
-          context:
-            - slack-secrets-ios
-      - backend-integration-tests-custom-entitlements:
-          context:
-            - slack-secrets-ios
-      - backend-integration-tests-other:
-          context:
-            - slack-secrets-ios
-      - build-tv-watch-and-macos:
-          context:
-            - slack-secrets-ios
-      - build-visionos:
-          context:
-            - slack-secrets-ios
-      - docs-build:
-          context:
-            - slack-secrets-ios
-      - run-test-ios-14:
-          context:
-            - slack-secrets-ios
-      - run-test-ios-15:
-          context:
-            - slack-secrets-ios
-      - run-test-ios-16:
-          context:
-            - slack-secrets-ios
-      - run-test-macos:
-          context:
-            - slack-secrets-ios
-      - run-test-tvos:
-          context:
-            - slack-secrets-ios
-      - run-test-watchos:
-          context:
-            - slack-secrets-ios
-      - spm-receipt-parser:
-          context:
-            - slack-secrets-ios
-      - spm-release-build:
-          context:
-            - slack-secrets-ios
-      - spm-release-build-xcode-14:
-          context:
-            - slack-secrets-ios
-      - spm-release-build-xcode-15:
-          context:
-            - slack-secrets-ios
-      - spm-revenuecat-ui-ios-15:
-          context:
-            - slack-secrets-ios
-      - spm-revenuecat-ui-ios-16:
-          context:
-            - slack-secrets-ios
-      - run-revenuecat-ui-ios-17:
-          context:
-            - slack-secrets-ios
-      - run-revenuecat-ui-ios-18:
-          context:
-            - slack-secrets-ios
-      - spm-revenuecat-ui-watchos:
-          context:
-            - slack-secrets-ios
-      - installation-tests-cocoapods:
-          context:
-            - slack-secrets-ios
-      - installation-tests-swift-package-manager:
-          context:
-            - slack-secrets-ios
-      - installation-tests-custom-entitlement-computation-swift-package-manager:
-          context:
-            - slack-secrets-ios
-      - installation-tests-carthage:
-          context:
-            - slack-secrets-ios
-      - installation-tests-xcode-direct-integration:
-          context:
-            - slack-secrets-ios
-      - installation-tests-receipt-parser:
-          context:
-            - slack-secrets-ios
-      - api-tests:
-          context:
-            - slack-secrets-ios
+      - backend-integration-tests-SK1
+      - backend-integration-tests-SK2
+      - backend-integration-tests-custom-entitlements
+      - backend-integration-tests-other
+      - build-tv-watch-and-macos
+      - build-visionos
+      - docs-build
+      - run-test-ios-14
+      - run-test-ios-15
+      - run-test-ios-16
+      - run-test-macos
+      - run-test-tvos
+      - run-test-watchos
+      - spm-receipt-parser
+      - spm-release-build
+      - spm-release-build-xcode-14
+      - spm-release-build-xcode-15
+      - spm-revenuecat-ui-ios-15
+      - spm-revenuecat-ui-ios-16
+      - run-revenuecat-ui-ios-17
+      - run-revenuecat-ui-ios-18
+      - spm-revenuecat-ui-watchos
+      - installation-tests-cocoapods
+      - installation-tests-swift-package-manager
+      - installation-tests-custom-entitlement-computation-swift-package-manager
+      - installation-tests-carthage
+      - installation-tests-xcode-direct-integration
+      - installation-tests-receipt-parser
+      - api-tests
       - deploy-purchase-tester:
-          context:
-            - slack-secrets-ios
           dry_run: true
       - emerge_purchases_ui_snapshot_tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ commands:
   slack-notify:
     steps:
       - slack/notify:
-          branch_pattern: post-test-results-slack
+          branch_pattern: main
           channel: 'feed-circleci-ios-failures'
           event: fail
           template: basic_fail_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ aliases:
         only: main
 
 commands:
-  slack-notify:
+  slack-notify-on-fail:
     steps:
       - slack/notify:
           branch_pattern: main
@@ -468,7 +468,7 @@ jobs:
       - run:
           name: Check pods and deployment targets
           command: bundle exec fastlane check_pods
-      - slack-notify
+      - slack-notify-on-fail
 
   spm-release-build:
     executor:
@@ -598,7 +598,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify
+      - slack-notify-on-fail
 
   run-revenuecat-ui-ios-18:
     executor:
@@ -632,7 +632,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify
+      - slack-notify-on-fail
 
   spm-revenuecat-ui-watchos:
     executor:
@@ -708,7 +708,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify
+      - slack-notify-on-fail
 
   run-test-ios-17:
     executor:
@@ -737,7 +737,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify
+      - slack-notify-on-fail
 
   run-test-ios-16:
     executor:
@@ -1090,7 +1090,7 @@ jobs:
       - run:
           name: Prepare next version
           command: bundle exec fastlane prepare_next_version
-      - slack-notify
+      - slack-notify-on-fail
 
   installation-tests-cocoapods:
     executor:
@@ -1199,7 +1199,7 @@ jobs:
           path: fastlane/test_output
       - store_artifacts:
           path: fastlane/test_output
-      - slack-notify
+      - slack-notify-on-fail
 
   danger:
     docker:
@@ -1308,7 +1308,7 @@ jobs:
       - run:
           name: Build Paywalls Tester
           command: bundle exec fastlane build_paywalls_tester_for_emerge
-      - slack-notify
+      - slack-notify-on-fail
 
   deploy-to-spm:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ commands:
       - slack/notify:
           branch_pattern: main
           channel: 'feed-circleci-ios-failures'
+          event: fail
           template: basic_fail_1
   set-maximum-duration:
     parameters:
@@ -406,12 +407,6 @@ commands:
           destination: scan-test-output
 
 jobs:
-  slack-notify:
-    executor:
-      name: macos-executor
-    steps:
-      - slack-notify
-
   spm-release-build-xcode-14:
     executor:
       name: macos-executor
@@ -473,6 +468,7 @@ jobs:
       - run:
           name: Check pods and deployment targets
           command: bundle exec fastlane check_pods
+      - slack-notify
 
   spm-release-build:
     executor:
@@ -602,6 +598,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
+      - slack-notify
 
   run-revenuecat-ui-ios-18:
     executor:
@@ -635,6 +632,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
+      - slack-notify
 
   spm-revenuecat-ui-watchos:
     executor:
@@ -710,6 +708,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify
 
   run-test-ios-17:
     executor:
@@ -738,6 +737,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify
 
   run-test-ios-16:
     executor:
@@ -1090,6 +1090,7 @@ jobs:
       - run:
           name: Prepare next version
           command: bundle exec fastlane prepare_next_version
+      - slack-notify
 
   installation-tests-cocoapods:
     executor:
@@ -1198,6 +1199,7 @@ jobs:
           path: fastlane/test_output
       - store_artifacts:
           path: fastlane/test_output
+      - slack-notify
 
   danger:
     docker:
@@ -1306,6 +1308,7 @@ jobs:
       - run:
           name: Build Paywalls Tester
           command: bundle exec fastlane build_paywalls_tester_for_emerge
+      - slack-notify
 
   deploy-to-spm:
     docker:
@@ -1354,24 +1357,27 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      - lint
-      - run-test-ios-17
-      - run-test-ios-18
-      - pod-lib-lint
-      - run-revenuecat-ui-ios-17
-      - run-revenuecat-ui-ios-18
-      - emerge_purchases_ui_snapshot_tests
-      - slack-notify:
+      - lint:
           context:
             - slack-secrets-ios
-          requires:
-            - lint: failed
-            - run-test-ios-17: failed
-            - run-test-ios-18: failed
-            - pod-lib-lint: failed
-            - run-revenuecat-ui-ios-17: failed
-            - run-revenuecat-ui-ios-18: failed
-            - emerge_purchases_ui_snapshot_tests: failed
+      - run-test-ios-17:
+          context:
+            - slack-secrets-ios
+      - run-test-ios-18:
+          context:
+            - slack-secrets-ios
+      - pod-lib-lint:
+          context:
+            - slack-secrets-ios
+      - run-revenuecat-ui-ios-17:
+          context:
+            - slack-secrets-ios
+      - run-revenuecat-ui-ios-18:
+          context:
+            - slack-secrets-ios
+      - emerge_purchases_ui_snapshot_tests:
+          context:
+            - slack-secrets-ios
 
   create-tag:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,6 @@ commands:
       - slack/notify:
           branch_pattern: main
           channel: 'feed-circleci-ios-failures'
-          event: fail
           template: basic_fail_1
   set-maximum-duration:
     parameters:
@@ -407,6 +406,12 @@ commands:
           destination: scan-test-output
 
 jobs:
+  slack-notify:
+    executor:
+      name: macos-executor
+    steps:
+      - slack-notify
+
   spm-release-build-xcode-14:
     executor:
       name: macos-executor
@@ -468,7 +473,6 @@ jobs:
       - run:
           name: Check pods and deployment targets
           command: bundle exec fastlane check_pods
-      - slack-notify
 
   spm-release-build:
     executor:
@@ -598,7 +602,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify
 
   run-revenuecat-ui-ios-18:
     executor:
@@ -632,7 +635,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify
 
   spm-revenuecat-ui-watchos:
     executor:
@@ -708,7 +710,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify
 
   run-test-ios-17:
     executor:
@@ -737,7 +738,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify
 
   run-test-ios-16:
     executor:
@@ -1090,7 +1090,6 @@ jobs:
       - run:
           name: Prepare next version
           command: bundle exec fastlane prepare_next_version
-      - slack-notify
 
   installation-tests-cocoapods:
     executor:
@@ -1199,7 +1198,6 @@ jobs:
           path: fastlane/test_output
       - store_artifacts:
           path: fastlane/test_output
-      - slack-notify
 
   danger:
     docker:
@@ -1308,7 +1306,6 @@ jobs:
       - run:
           name: Build Paywalls Tester
           command: bundle exec fastlane build_paywalls_tester_for_emerge
-      - slack-notify
 
   deploy-to-spm:
     docker:
@@ -1357,27 +1354,24 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      - lint:
+      - lint
+      - run-test-ios-17
+      - run-test-ios-18
+      - pod-lib-lint
+      - run-revenuecat-ui-ios-17
+      - run-revenuecat-ui-ios-18
+      - emerge_purchases_ui_snapshot_tests
+      - slack-notify:
           context:
             - slack-secrets-ios
-      - run-test-ios-17:
-          context:
-            - slack-secrets-ios
-      - run-test-ios-18:
-          context:
-            - slack-secrets-ios
-      - pod-lib-lint:
-          context:
-            - slack-secrets-ios
-      - run-revenuecat-ui-ios-17:
-          context:
-            - slack-secrets-ios
-      - run-revenuecat-ui-ios-18:
-          context:
-            - slack-secrets-ios
-      - emerge_purchases_ui_snapshot_tests:
-          context:
-            - slack-secrets-ios
+          requires:
+            - lint: failed
+            - run-test-ios-17: failed
+            - run-test-ios-18: failed
+            - pod-lib-lint: failed
+            - run-revenuecat-ui-ios-17: failed
+            - run-revenuecat-ui-ios-18: failed
+            - emerge_purchases_ui_snapshot_tests: failed
 
   create-tag:
     when:

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -115,7 +115,7 @@ final class PurchasesOrchestrator {
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    var storeKit2ObserverModePurchaseDetector: StoreKit2ObserverModePurchaseDetectorType? {
+    var storeKit2ObserverModePurchaseDetector:StoreKit2ObserverModePurchaseDetectorType? {
         return self._storeKit2ObserverModePurchaseDetector as? StoreKit2ObserverModePurchaseDetectorType
     }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -115,7 +115,7 @@ final class PurchasesOrchestrator {
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    var storeKit2ObserverModePurchaseDetector:StoreKit2ObserverModePurchaseDetectorType? {
+    var storeKit2ObserverModePurchaseDetector: StoreKit2ObserverModePurchaseDetectorType? {
         return self._storeKit2ObserverModePurchaseDetector as? StoreKit2ObserverModePurchaseDetectorType
     }
 


### PR DESCRIPTION
### Description
This adds a slack notification to all CircleCI jobs that error out. Currently posts to the #feed-circleci-ios-failures