### PR TITLE
Add preview test target

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -58,7 +58,18 @@
 		88DFC1932BCF490400273B6D /* OfferingsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC1922BCF490400273B6D /* OfferingsResponse.swift */; };
 		88DFC1942BCF490400273B6D /* PaywallsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC1912BCF490400273B6D /* PaywallsResponse.swift */; };
 		88DFC1972BCF4A5100273B6D /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC1952BCF4A4300273B6D /* MockData.swift */; };
+		FA29FBB22CCAA7A500DA1976 /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = FA29FBB12CCAA7A500DA1976 /* SnapshottingTests */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		FA29FBAC2CCAA79800DA1976 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4F6BED922A26A64200CD9322 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4F6BED992A26A64200CD9322;
+			remoteInfo = PaywallsTester;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		4F6BEDD72A26A68E00CD9322 /* Embed Frameworks */ = {
@@ -138,7 +149,12 @@
 		88DFC1912BCF490400273B6D /* PaywallsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallsResponse.swift; sourceTree = "<group>"; };
 		88DFC1922BCF490400273B6D /* OfferingsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingsResponse.swift; sourceTree = "<group>"; };
 		88DFC1952BCF4A4300273B6D /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
+		FA29FBA82CCAA79800DA1976 /* PaywallsTesterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PaywallsTesterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		FA29FBA92CCAA79800DA1976 /* PaywallsTesterTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = PaywallsTesterTests; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		4F6BED972A26A64200CD9322 /* Frameworks */ = {
@@ -148,6 +164,14 @@
 				4FCA01FB2A3A1CBD00B262C0 /* StoreKit.framework in Frameworks */,
 				4F4EE7D22A5731E800D7EAE1 /* RevenueCat in Frameworks */,
 				4FC80B202A5DE8E300E95DB0 /* RevenueCatUI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FA29FBA52CCAA79800DA1976 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA29FBB22CCAA7A500DA1976 /* SnapshottingTests in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -170,6 +194,7 @@
 				773C13462CB5865400219E42 /* Local.xcconfig */,
 				4F4EE7D02A5731CF00D7EAE1 /* purchases-ios */,
 				4FC046BB2A572E3700A28BCF /* PaywallsTester */,
+				FA29FBA92CCAA79800DA1976 /* PaywallsTesterTests */,
 				4F6BED9B2A26A64200CD9322 /* Products */,
 				4F6BEDCC2A26A68E00CD9322 /* Frameworks */,
 			);
@@ -179,6 +204,7 @@
 			isa = PBXGroup;
 			children = (
 				4F6BED9A2A26A64200CD9322 /* PaywallsTester.app */,
+				FA29FBA82CCAA79800DA1976 /* PaywallsTesterTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -371,6 +397,30 @@
 			productReference = 4F6BED9A2A26A64200CD9322 /* PaywallsTester.app */;
 			productType = "com.apple.product-type.application";
 		};
+		FA29FBA72CCAA79800DA1976 /* PaywallsTesterTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FA29FBAE2CCAA79800DA1976 /* Build configuration list for PBXNativeTarget "PaywallsTesterTests" */;
+			buildPhases = (
+				FA29FBA42CCAA79800DA1976 /* Sources */,
+				FA29FBA52CCAA79800DA1976 /* Frameworks */,
+				FA29FBA62CCAA79800DA1976 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FA29FBAD2CCAA79800DA1976 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				FA29FBA92CCAA79800DA1976 /* PaywallsTesterTests */,
+			);
+			name = PaywallsTesterTests;
+			packageProductDependencies = (
+				FA29FBB12CCAA7A500DA1976 /* SnapshottingTests */,
+			);
+			productName = PaywallsTesterTests;
+			productReference = FA29FBA82CCAA79800DA1976 /* PaywallsTesterTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -378,11 +428,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1430;
+				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					4F6BED992A26A64200CD9322 = {
 						CreatedOnToolsVersion = 14.3;
+					};
+					FA29FBA72CCAA79800DA1976 = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = 4F6BED992A26A64200CD9322;
 					};
 				};
 			};
@@ -402,12 +456,14 @@
 			);
 			mainGroup = 4F6BED912A26A64200CD9322;
 			packageReferences = (
+				FA29FBA12CCAA76E00DA1976 /* XCRemoteSwiftPackageReference "SnapshotPreviews" */,
 			);
 			productRefGroup = 4F6BED9B2A26A64200CD9322 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				4F6BED992A26A64200CD9322 /* PaywallsTester */,
+				FA29FBA72CCAA79800DA1976 /* PaywallsTesterTests */,
 			);
 		};
 /* End PBXProject section */
@@ -420,6 +476,13 @@
 				4F217A102A6DB6FB000B092D /* Assets.xcassets in Resources */,
 				880B2AF22BEC2D62006B9393 /* Preprocessor.sh in Resources */,
 				4F4557E22A6FFE6A00160521 /* Localizable.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FA29FBA62CCAA79800DA1976 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -478,7 +541,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FA29FBA42CCAA79800DA1976 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		FA29FBAD2CCAA79800DA1976 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4F6BED992A26A64200CD9322 /* PaywallsTester */;
+			targetProxy = FA29FBAC2CCAA79800DA1976 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		4F4557E42A6FFE6A00160521 /* Localizable.strings */ = {
@@ -709,6 +787,54 @@
 			};
 			name = Release;
 		};
+		FA29FBAF2CCAA79800DA1976 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.PaywallsTesterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PaywallsTester.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PaywallsTester";
+			};
+			name = Debug;
+		};
+		FA29FBB02CCAA79800DA1976 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.PaywallsTesterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PaywallsTester.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PaywallsTester";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -730,7 +856,27 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		FA29FBAE2CCAA79800DA1976 /* Build configuration list for PBXNativeTarget "PaywallsTesterTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FA29FBAF2CCAA79800DA1976 /* Debug */,
+				FA29FBB02CCAA79800DA1976 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		FA29FBA12CCAA76E00DA1976 /* XCRemoteSwiftPackageReference "SnapshotPreviews" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/EmergeTools/SnapshotPreviews";
+			requirement = {
+				kind = exactVersion;
+				version = 0.10.16;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		4F4EE7D12A5731E800D7EAE1 /* RevenueCat */ = {
@@ -740,6 +886,11 @@
 		4FC80B1F2A5DE8E300E95DB0 /* RevenueCatUI */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = RevenueCatUI;
+		};
+		FA29FBB12CCAA7A500DA1976 /* SnapshottingTests */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FA29FBA12CCAA76E00DA1976 /* XCRemoteSwiftPackageReference "SnapshotPreviews" */;
+			productName = SnapshottingTests;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - Live Config.xcscheme
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - Live Config.xcscheme
@@ -64,6 +64,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA29FBA72CCAA79800DA1976"
+               BuildableName = "PaywallsTesterTests.xctest"
+               BlueprintName = "PaywallsTesterTests"
+               ReferencedContainer = "container:PaywallsTester.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - SK config.xcscheme
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - SK config.xcscheme
@@ -64,6 +64,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA29FBA72CCAA79800DA1976"
+               BuildableName = "PaywallsTesterTests.xctest"
+               BlueprintName = "PaywallsTesterTests"
+               ReferencedContainer = "container:PaywallsTester.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "accessibilitysnapshot",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/EmergeTools/AccessibilitySnapshot.git",
+      "state" : {
+        "revision" : "54046d8fa44b9fa9f0e2229526f6ed89cb5e0ec2",
+        "version" : "1.0.2"
+      }
+    },
+    {
       "identity" : "cwlcatchexception",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlCatchException.git",
@@ -19,12 +28,30 @@
       }
     },
     {
+      "identity" : "flyingfox",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swhitty/FlyingFox.git",
+      "state" : {
+        "revision" : "f7829d4aca8cbfecb410a1cce872b1b045224aa1",
+        "version" : "0.16.0"
+      }
+    },
+    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:Quick/Nimble.git",
       "state" : {
         "revision" : "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
         "version" : "10.0.0"
+      }
+    },
+    {
+      "identity" : "snapshotpreviews",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/EmergeTools/SnapshotPreviews",
+      "state" : {
+        "revision" : "0b0438a52ac22b2eed9a3a9acf2691005d7f9127",
+        "version" : "0.10.16"
       }
     },
     {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/PaywallsTesterTests.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/PaywallsTesterTests.swift
@@ -1,0 +1,13 @@
+//
+//  PaywallsTesterTests.swift
+//  PaywallsTesterTests
+//
+//  Created by Noah Martin on 10/24/24.
+//
+
+import XCTest
+import SnapshottingTests
+
+final class PaywallsTesterTests: SnapshotTest {
+
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Adds a preview snapshot test to locally generate and debug snapshots from previews. This can be used along with EmergeTools snapshot testing whenever you need to debug a snapshot locally.

### Description
Adds the previews snapshot swift package and a new test target that renders all Xcode previews in the app

This also caught a bug with a crashing preview, which I fixed in https://github.com/RevenueCat/purchases-ios/pull/4406