### PR TITLE
Improved JSON format for ButtonComponent codables

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */; };
 		2C7F0AD32B8EEB4600381179 /* RateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */; };
 		2C7F0AD62B8EEF7B00381179 /* RateLimiterRests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */; };
+		2C8EC6AF2CCBD34100D6CCF8 /* ButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8EC6AE2CCBD33E00D6CCF8 /* ButtonComponent.swift */; };
 		2CAB87F72CAAB13200247013 /* CornerBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB87F62CAAB13200247013 /* CornerBorder.swift */; };
 		2CB8CF9327BF538F00C34DE3 /* PlatformInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */; };
 		2CC791552CC0452100FBE120 /* PurchaseButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC791522CC0452100FBE120 /* PurchaseButtonComponentViewModel.swift */; };
@@ -1179,6 +1180,7 @@
 		2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesSyncAttributesAndOfferingsIfNeededTests.swift; sourceTree = "<group>"; };
 		2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiter.swift; sourceTree = "<group>"; };
 		2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiterRests.swift; sourceTree = "<group>"; };
+		2C8EC6AE2CCBD33E00D6CCF8 /* ButtonComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponent.swift; sourceTree = "<group>"; };
 		2CAB87F62CAAB13200247013 /* CornerBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerBorder.swift; sourceTree = "<group>"; };
 		2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfo.swift; sourceTree = "<group>"; };
 		2CC7914B2CC0452100FBE120 /* PackageComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentView.swift; sourceTree = "<group>"; };
@@ -2293,6 +2295,14 @@
 				2C2AEB0E2CA64E0E00A50F38 /* Template1Preview.swift */,
 			);
 			path = TemplateComponentsViewPreviews;
+			sourceTree = "<group>";
+		};
+		2C8EC6AD2CCBD33800D6CCF8 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				2C8EC6AE2CCBD33E00D6CCF8 /* ButtonComponent.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		2CC7913E2CC0450900FBE120 /* Recovered References */ = {
@@ -3683,6 +3693,7 @@
 		4FBBD4E22A620516001CBA21 /* Paywalls */ = {
 			isa = PBXGroup;
 			children = (
+				2C8EC6AD2CCBD33800D6CCF8 /* Components */,
 				4FE6FEE62AA940E300780B45 /* Events */,
 				4F6ABC7B2A81673F00250E63 /* PaywallCacheWarmingTests.swift */,
 				4F05876E2A5DE03F00E9A834 /* PaywallDataTests.swift */,
@@ -5911,6 +5922,7 @@
 				5712BE9229241F7900A83F15 /* TimingUtilTests.swift in Sources */,
 				57554CC1282AE1E3009A7E58 /* TestCase.swift in Sources */,
 				57A1772B276A726C0052D3A8 /* SetExtensionsTests.swift in Sources */,
+				2C8EC6AF2CCBD34100D6CCF8 /* ButtonComponent.swift in Sources */,
 				351B515A26D44B6200BD2BD7 /* MockAttributionFetcher.swift in Sources */,
 				5796A38C27D6BA1600653165 /* BackendLoginTests.swift in Sources */,
 				351B51BD26D450E800BD2BD7 /* EntitlementInfosTests.swift in Sources */,

--- a/RevenueCatUI/Templates/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Button/ButtonComponentView.swift
@@ -76,7 +76,7 @@ struct ButtonComponentView: View {
         switch destination {
         case .customerCenter:
             showCustomerCenter = true
-        case .URL(let url, let method),
+        case .url(let url, let method),
                 .privacyPolicy(let url, let method),
                 .terms(let url, let method):
             navigateToUrl(url: url, method: method)

--- a/RevenueCatUI/Templates/Components/Button/ButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/Components/Button/ButtonComponentViewModel.swift
@@ -34,7 +34,7 @@ public class ButtonComponentViewModel {
     /// This way the view layer doesn't need to handle this error scenario.
     internal enum Destination {
         case customerCenter
-        case URL(url: URL, method: PaywallComponent.ButtonComponent.URLMethod)
+        case url(url: URL, method: PaywallComponent.ButtonComponent.URLMethod)
         case privacyPolicy(url: URL, method: PaywallComponent.ButtonComponent.URLMethod)
         case terms(url: URL, method: PaywallComponent.ButtonComponent.URLMethod)
     }
@@ -66,9 +66,9 @@ public class ButtonComponentViewModel {
             switch destination {
             case .customerCenter:
                 self.action = .navigateTo(destination: .customerCenter)
-            case .URL(let urlLid, let method):
+            case .url(let urlLid, let method):
                 self.action = .navigateTo(
-                    destination: .URL(url: try localizedStrings.urlFromLid(urlLid), method: method)
+                    destination: .url(url: try localizedStrings.urlFromLid(urlLid), method: method)
                 )
             case .privacyPolicy(let urlLid, let method):
                 self.action = .navigateTo(

--- a/Sources/Paywalls/Components/PaywallButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallButtonComponent.swift
@@ -45,10 +45,11 @@ public extension PaywallComponent.ButtonComponent {
         case navigateBack
         case navigateTo(destination: Destination)
 
-        // swiftlint:disable:next nesting
+        // swiftline:disable:next nesting
         private enum CodingKeys: String, CodingKey {
             case type
             case destination
+            case url
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -61,7 +62,7 @@ public extension PaywallComponent.ButtonComponent {
                 try container.encode("navigate_back", forKey: .type)
             case .navigateTo(let destination):
                 try container.encode("navigate_to", forKey: .type)
-                try container.encode(destination, forKey: .destination)
+                try destination.encode(to: encoder) // Encode destination directly under action
             }
         }
 
@@ -75,22 +76,19 @@ public extension PaywallComponent.ButtonComponent {
             case "navigate_back":
                 self = .navigateBack
             case "navigate_to":
-                let destination = try container.decode(Destination.self, forKey: .destination)
+                let destination = try Destination(from: decoder) // Decode destination directly under action
                 self = .navigateTo(destination: destination)
             default:
-                throw DecodingError.dataCorruptedError(
-                    forKey: .type,
-                    in: container,
-                    debugDescription: "Invalid action type"
-                )
+                throw DecodingError.dataCorruptedError(forKey: .type,
+                                                       in: container, debugDescription: "Invalid action type")
             }
         }
     }
 
     enum Destination: Codable, Sendable, Hashable, Equatable {
         case customerCenter
-        case terms(urlLid: String, method: URLMethod)
         case privacyPolicy(urlLid: String, method: URLMethod)
+        case terms(urlLid: String, method: URLMethod)
         case url(urlLid: String, method: URLMethod)
 
         // swiftlint:disable:next nesting
@@ -127,23 +125,23 @@ public extension PaywallComponent.ButtonComponent {
             case "terms":
                 let urlPayload = try container.decode(URLPayload.self, forKey: .url)
                 self = .terms(urlLid: urlPayload.urlLid, method: urlPayload.method)
+            case "privacy_policy":
+                let urlPayload = try container.decode(URLPayload.self, forKey: .url)
+                self = .privacyPolicy(urlLid: urlPayload.urlLid, method: urlPayload.method)
             case "url":
                 let urlPayload = try container.decode(URLPayload.self, forKey: .url)
                 self = .url(urlLid: urlPayload.urlLid, method: urlPayload.method)
             default:
-                throw DecodingError.dataCorruptedError(
-                    forKey: .destination,
-                    in: container,
-                    debugDescription: "Invalid destination type"
-                )
+                throw DecodingError.dataCorruptedError(forKey: .destination,
+                                                       in: container, debugDescription: "Invalid destination type")
             }
         }
     }
 
     enum URLMethod: String, Codable, Sendable, Hashable, Equatable {
-        case inAppBrowser
-        case externalBrowser
-        case deepLink
+        case inAppBrowser = "in_app_browser"
+        case externalBrowser = "external_browser"
+        case deepLink = "deep_link"
     }
 
     private struct URLPayload: Codable, Hashable, Sendable {

--- a/Sources/Paywalls/Components/PaywallButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallButtonComponent.swift
@@ -21,28 +21,6 @@ public extension PaywallComponent {
 
     struct ButtonComponent: PaywallComponentBase {
 
-        // swiftlint:disable:next nesting
-        public enum Action: Codable, Sendable, Hashable, Equatable {
-            case restorePurchases
-            case navigateTo(destination: Destination)
-            case navigateBack
-        }
-
-        // swiftlint:disable:next nesting
-        public enum Destination: Codable, Sendable, Hashable, Equatable {
-            case customerCenter
-            case URL(urlLid: String, method: URLMethod)
-            case privacyPolicy(urlLid: String, method: URLMethod)
-            case terms(urlLid: String, method: URLMethod)
-        }
-
-        // swiftlint:disable:next nesting
-        public enum URLMethod: Codable, Sendable, Hashable, Equatable {
-            case inAppBrowser
-            case externalBrowser
-            case deepLink
-        }
-
         let type: ComponentType
         public let action: Action
         public let stack: PaywallComponent.StackComponent
@@ -56,6 +34,121 @@ public extension PaywallComponent {
             self.stack = stack
         }
 
+    }
+
+}
+
+public extension PaywallComponent.ButtonComponent {
+
+    enum Action: Codable, Sendable, Hashable, Equatable {
+        case restorePurchases
+        case navigateBack
+        case navigateTo(destination: Destination)
+
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: String, CodingKey {
+            case type
+            case destination
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            switch self {
+            case .restorePurchases:
+                try container.encode("restore_purchases", forKey: .type)
+            case .navigateBack:
+                try container.encode("navigate_back", forKey: .type)
+            case .navigateTo(let destination):
+                try container.encode("navigate_to", forKey: .type)
+                try container.encode(destination, forKey: .destination)
+            }
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let type = try container.decode(String.self, forKey: .type)
+
+            switch type {
+            case "restore_purchases":
+                self = .restorePurchases
+            case "navigate_back":
+                self = .navigateBack
+            case "navigate_to":
+                let destination = try container.decode(Destination.self, forKey: .destination)
+                self = .navigateTo(destination: destination)
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: .type,
+                    in: container,
+                    debugDescription: "Invalid action type"
+                )
+            }
+        }
+    }
+
+    enum Destination: Codable, Sendable, Hashable, Equatable {
+        case customerCenter
+        case terms(urlLid: String, method: URLMethod)
+        case privacyPolicy(urlLid: String, method: URLMethod)
+        case url(urlLid: String, method: URLMethod)
+
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: String, CodingKey {
+            case destination
+            case url
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            switch self {
+            case .customerCenter:
+                try container.encode("customer_center", forKey: .destination)
+            case .terms(let urlLid, let method):
+                try container.encode("terms", forKey: .destination)
+                try container.encode(URLPayload(urlLid: urlLid, method: method), forKey: .url)
+            case .privacyPolicy(let urlLid, let method):
+                try container.encode("privacy_policy", forKey: .destination)
+                try container.encode(URLPayload(urlLid: urlLid, method: method), forKey: .url)
+            case .url(let urlLid, let method):
+                try container.encode("url", forKey: .destination)
+                try container.encode(URLPayload(urlLid: urlLid, method: method), forKey: .url)
+            }
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let destination = try container.decode(String.self, forKey: .destination)
+
+            switch destination {
+            case "customer_center":
+                self = .customerCenter
+            case "terms":
+                let urlPayload = try container.decode(URLPayload.self, forKey: .url)
+                self = .terms(urlLid: urlPayload.urlLid, method: urlPayload.method)
+            case "url":
+                let urlPayload = try container.decode(URLPayload.self, forKey: .url)
+                self = .url(urlLid: urlPayload.urlLid, method: urlPayload.method)
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: .destination,
+                    in: container,
+                    debugDescription: "Invalid destination type"
+                )
+            }
+        }
+    }
+
+    enum URLMethod: String, Codable, Sendable, Hashable, Equatable {
+        case inAppBrowser
+        case externalBrowser
+        case deepLink
+    }
+
+    private struct URLPayload: Codable, Hashable, Sendable {
+        let urlLid: String
+        let method: URLMethod
     }
 
 }

--- a/Sources/Paywalls/Components/PaywallButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallButtonComponent.swift
@@ -45,7 +45,7 @@ public extension PaywallComponent.ButtonComponent {
         case navigateBack
         case navigateTo(destination: Destination)
 
-        // swiftline:disable:next nesting
+        // swiftlint:disable:next nesting
         private enum CodingKeys: String, CodingKey {
             case type
             case destination

--- a/Sources/Paywalls/Components/PaywallStackComponent.swift
+++ b/Sources/Paywalls/Components/PaywallStackComponent.swift
@@ -40,7 +40,7 @@ public extension PaywallComponent {
         public init(components: [T],
                     dimension: Dimension = .vertical(.center),
                     width: WidthSize? = nil,
-                    spacing: CGFloat? = 0,
+                    spacing: CGFloat? = nil,
                     backgroundColor: ColorInfo? = nil,
                     padding: Padding = .zero,
                     margin: Padding = .zero,

--- a/Tests/UnitTests/Paywalls/Components/ButtonComponent.swift
+++ b/Tests/UnitTests/Paywalls/Components/ButtonComponent.swift
@@ -1,0 +1,185 @@
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+#if PAYWALL_COMPONENTS
+
+class ButtonComponentCodableTests: TestCase {
+
+    let jsonStringDefaultStack = """
+    {
+        "type": "stack",
+        "dimension": {
+            "type": "vertical",
+            "alignment": "center"
+        },
+        "padding": {
+            "top": 0,
+            "bottom": 0,
+            "leading": 0,
+            "trailing": 0
+        },
+        "margin": {
+            "top": 0,
+            "bottom": 0,
+            "leading": 0,
+            "trailing": 0
+        },
+        "components": []
+    }
+    """
+
+    func testRestorePurchasesDecoding() throws {
+        let jsonString = """
+        {
+            "type": "button",
+            "action": {
+                "type": "restore_purchases"
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
+
+        let buttonComponent = PaywallComponent.ButtonComponent(
+            action: .restorePurchases,
+            stack: .init(components: [])
+        )
+
+        XCTAssertEqual(decodedButton, buttonComponent)
+    }
+
+    func testNavigateBackDecoding() throws {
+        let jsonString = """
+        {
+            "type": "button",
+            "action": {
+                "type": "navigate_back"
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
+
+        let buttonComponent = PaywallComponent.ButtonComponent(
+            action: .navigateBack,
+            stack: .init(components: [])
+        )
+
+        XCTAssertEqual(decodedButton, buttonComponent)
+    }
+
+    func testNavigateToCustomerCenterDecoding() throws {
+        let jsonString = """
+        {
+            "type": "button",
+            "action": {
+                "type": "navigate_to",
+                "destination": "customer_center"
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
+
+        let buttonComponent = PaywallComponent.ButtonComponent(
+            action: .navigateTo(destination: .customerCenter),
+            stack: .init(components: [])
+        )
+
+        XCTAssertEqual(decodedButton, buttonComponent)
+    }
+
+    func testNavigateToTermsDecoding() throws {
+        let jsonString = """
+        {
+            "type": "button",
+            "action": {
+                "type": "navigate_to",
+                "destination": "terms",
+                "url": {
+                    "url_lid": "re45",
+                    "method": "in_app_browser"
+                }
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
+
+        let buttonComponent = PaywallComponent.ButtonComponent(
+            action: .navigateTo(
+                destination: .terms(urlLid: "re45",
+                                    method: .inAppBrowser)
+            ),
+            stack: .init(components: [])
+        )
+
+        XCTAssertEqual(decodedButton, buttonComponent)
+    }
+
+    func testNavigateToPrivacyPolicyDecoding() throws {
+        let jsonString = """
+        {
+            "type": "button",
+            "action": {
+                "type": "navigate_to",
+                "destination": "privacy_policy",
+                "url": {
+                    "url_lid": "re45",
+                    "method": "external_browser"
+                }
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
+
+        let buttonComponent = PaywallComponent.ButtonComponent(
+            action: .navigateTo(
+                destination: .privacyPolicy(urlLid: "re45",
+                                            method: .externalBrowser)
+            ),
+            stack: .init(components: [])
+        )
+
+        XCTAssertEqual(decodedButton, buttonComponent)
+    }
+
+    func testNavigateToURLDecoding() throws {
+        let jsonString = """
+        {
+            "type": "button",
+            "action": {
+                "type": "navigate_to",
+                "destination": "url",
+                "url": {
+                    "url_lid": "re45",
+                    "method": "deep_link"
+                }
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
+
+        let buttonComponent = PaywallComponent.ButtonComponent(
+            action: .navigateTo(
+                destination: .url(urlLid: "re45",
+                                  method: .deepLink)
+            ),
+            stack: .init(components: [])
+        )
+
+        XCTAssertEqual(decodedButton, buttonComponent)
+    }
+
+}
+
+#endif


### PR DESCRIPTION
### Motivation

The `ButtonComponent` had great looking enums but I just realized that they wouldn't codable the JSON structure that we want them too.

### Description

Previously...

```json
{
  "type": "button",
  "action": {
    "navigateTo": {
      "destination": {
        "privacyPolicy": {
          "urlLid": "https://example.com/privacy-policy",
          "method": "externalBrowser"
        }
      }
    }
  },
  "stack": {
    "type": "stack",
    "components": []
  }
}
```

Now...

```json
{
  "type": "button",
  "action": {
    "type": "navigate_to",
    "destination": "privacy_policy",
    "url": {
      "urlLid": "https://example.com/terms-of-service",
      "method": "deepLink"
    }
  },
  "stack": {
    "type": "stack",
    "components": []
  }
}
```
