### PR TITLE
fix: large spacing above title in paywall template 5

### DIFF
--- a/RevenueCatUI/Templates/Template5View.swift
+++ b/RevenueCatUI/Templates/Template5View.swift
@@ -142,8 +142,6 @@ struct Template5View: TemplateViewType {
     private var scrollableContent: some View {
         VStack(spacing: self.defaultVerticalPaddingLength) {
             if self.configuration.mode.isFullScreen {
-                Spacer()
-
                 self.title
                     .frame(maxWidth: .infinity, alignment: .leading)
 


### PR DESCRIPTION
### Motivation
Because it differs very much from the preview in the Paywall editor and it looks strange / undesired design.

### Description
I don't know why this spacer was added as the title already has spacing between the hero and itself.
By removing the spacer the design becomes 1:1 as in the Paywall editor and how I believe it should be.