### PR TITLE
Fixes for paywalls v2 renderer after testing some real life paywalls

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		1E99F81F2AC5917F0023E26E /* StoreMessagesHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E99F81D2AC5917F0023E26E /* StoreMessagesHelperTests.swift */; };
 		1ED4CA9F2CC25A5F0021AB8F /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED4CA9E2CC25A5F0021AB8F /* SafariView.swift */; };
 		2C08B2E92CD40DBF0024857B /* ButtonComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */; };
+		2C08B3072CD55D660024857B /* FlexHStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C08B3062CD55D590024857B /* FlexHStack.swift */; };
 		2C0B98CD2797070B00C5874F /* PromotionalOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */; };
 		2C2AEB0F2CA64E0E00A50F38 /* Template1Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB0E2CA64E0E00A50F38 /* Template1Preview.swift */; };
 		2C2AEB3B2CA7209F00A50F38 /* PaywallPackageComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB3A2CA7209F00A50F38 /* PaywallPackageComponent.swift */; };
@@ -1178,6 +1179,7 @@
 		1E99F81D2AC5917F0023E26E /* StoreMessagesHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessagesHelperTests.swift; sourceTree = "<group>"; };
 		1ED4CA9E2CC25A5F0021AB8F /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentTests.swift; sourceTree = "<group>"; };
+		2C08B3062CD55D590024857B /* FlexHStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexHStack.swift; sourceTree = "<group>"; };
 		2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOffer.swift; sourceTree = "<group>"; };
 		2C2AEB0E2CA64E0E00A50F38 /* Template1Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Template1Preview.swift; sourceTree = "<group>"; };
 		2C2AEB3A2CA7209F00A50F38 /* PaywallPackageComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallPackageComponent.swift; sourceTree = "<group>"; };
@@ -4495,6 +4497,7 @@
 		88B1BAEA2C813A3C001B7EE5 /* Stack */ = {
 			isa = PBXGroup;
 			children = (
+				2C08B3062CD55D590024857B /* FlexHStack.swift */,
 				88B1BAE82C813A3C001B7EE5 /* StackComponentView.swift */,
 				88B1BAE92C813A3C001B7EE5 /* StackComponentViewModel.swift */,
 			);
@@ -6213,6 +6216,7 @@
 				887A60C12C1D037000E1A461 /* DebugErrorView.swift in Sources */,
 				887A607C2C1D037000E1A461 /* ColorInformation+MultiScheme.swift in Sources */,
 				88B1BAFE2C813A3C001B7EE5 /* ImageComponentViewModel.swift in Sources */,
+				2C08B3072CD55D660024857B /* FlexHStack.swift in Sources */,
 				35C200B12C39254100B9778B /* FeedbackSurveyView.swift in Sources */,
 				35F249CC2C493DCC0058993A /* CustomerCenterPurchasesType.swift in Sources */,
 				887A60672C1D037000E1A461 /* PaywallError.swift in Sources */,

--- a/RevenueCatUI/Templates/Components/PaywallComponentTypeTransformers.swift
+++ b/RevenueCatUI/Templates/Components/PaywallComponentTypeTransformers.swift
@@ -60,7 +60,7 @@ extension PaywallComponent.FontWeight {
 
     var fontWeight: Font.Weight {
         switch self {
-        case .ultraLight:
+        case .extraLight:
             return .ultraLight
         case .thin:
             return .thin
@@ -74,7 +74,7 @@ extension PaywallComponent.FontWeight {
             return .semibold
         case .bold:
             return .bold
-        case .heavy:
+        case .extraBold:
             return .heavy
         case .black:
             return .black

--- a/RevenueCatUI/Templates/Components/PaywallComponentTypeTransformers.swift
+++ b/RevenueCatUI/Templates/Components/PaywallComponentTypeTransformers.swift
@@ -127,6 +127,17 @@ extension PaywallComponent.TwoDimensionAlignment {
 
 extension PaywallComponent.HorizontalAlignment {
 
+    var stackAlignment: SwiftUI.HorizontalAlignment {
+        switch self {
+        case .leading:
+            return .leading
+        case .center:
+            return .center
+        case .trailing:
+            return .trailing
+        }
+    }
+
     var textAlignment: TextAlignment {
         switch self {
         case .leading:
@@ -138,7 +149,7 @@ extension PaywallComponent.HorizontalAlignment {
         }
     }
 
-    var stackAlignment: SwiftUI.Alignment {
+    var frameAlignment: SwiftUI.Alignment {
         switch self {
         case .leading:
             return .leading

--- a/RevenueCatUI/Templates/Components/Stack/FlexHStack.swift
+++ b/RevenueCatUI/Templates/Components/Stack/FlexHStack.swift
@@ -1,0 +1,96 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  FlexHStack.swift
+//
+//  Created by Josh Holtz on 11/1/24.
+
+import SwiftUI
+
+#if PAYWALL_COMPONENTS
+
+enum JustifyContent {
+    case start, center, end, spaceBetween, spaceAround, spaceEvenly
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct FlexHStack: View {
+    let alignment: VerticalAlignment
+    let justifyContent: JustifyContent
+    let spacing: CGFloat?
+    let componentViewModels: [PaywallComponentViewModel]
+
+    let onDismiss: () -> Void
+
+    init(
+        alignment: VerticalAlignment,
+        spacing: CGFloat?,
+        justifyContent: JustifyContent,
+        componentViewModels: [PaywallComponentViewModel],
+        onDismiss: @escaping () -> Void
+    ) {
+        self.alignment = alignment
+        self.spacing = spacing
+        self.justifyContent = justifyContent
+        self.componentViewModels = componentViewModels
+        self.onDismiss = onDismiss
+    }
+
+    var body: some View {
+        HStack(alignment: self.alignment, spacing: self.spacing) {
+            switch justifyContent {
+            case .start:
+                ForEach(0..<componentViewModels.count, id: \.self) { index in
+                    ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
+                }
+                Spacer()
+
+            case .center:
+                Spacer()
+                ForEach(0..<componentViewModels.count, id: \.self) { index in
+                    ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
+                }
+                Spacer()
+
+            case .end:
+                Spacer()
+                ForEach(0..<componentViewModels.count, id: \.self) { index in
+                    ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
+                }
+
+            case .spaceBetween:
+                ForEach(0..<componentViewModels.count, id: \.self) { index in
+                    ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
+                    if index < self.componentViewModels.count - 1 {
+                        Spacer()
+                    }
+                }
+
+            case .spaceAround:
+                Spacer()
+                ForEach(0..<componentViewModels.count, id: \.self) { index in
+                    ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
+                    if index < self.componentViewModels.count - 1 {
+                        Spacer()
+                    }
+                }
+                Spacer()
+
+            case .spaceEvenly:
+                ForEach(0..<componentViewModels.count, id: \.self) { index in
+                    Spacer()
+                    ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
+                }
+                Spacer()
+            }
+        }
+    }
+}
+
+#endif

--- a/RevenueCatUI/Templates/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Stack/StackComponentView.swift
@@ -36,7 +36,6 @@ struct StackComponentView: View {
             switch viewModel.dimension {
             case .vertical(let horizontalAlignment):
                 Group {
-                    // TODO: Need to add alignment back into the vstack
                     // This is NOT a final implementation of this
                     // There are some horizontal sizing issues with using LazyVStack
                     // There are so performance issues with VStack with lots of children

--- a/RevenueCatUI/Templates/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Stack/StackComponentView.swift
@@ -35,14 +35,54 @@ struct StackComponentView: View {
         Group {
             switch viewModel.dimension {
             case .vertical(let horizontalAlignment):
-                // LazyVStack needed for performance when loading
-                LazyVStack(spacing: viewModel.spacing) {
-                    ComponentsView(componentViewModels: self.viewModel.viewModels, onDismiss: self.onDismiss)
-                    .frame(maxWidth: .infinity, alignment: horizontalAlignment.stackAlignment)
+                Group {
+                    // TODO: Need to add alignment back into the vstack
+                    // This is NOT a final implementation of this
+                    // There are some horizontal sizing issues with using LazyVStack
+                    // There are so performance issues with VStack with lots of children
+                    if viewModel.shouldUseVStack {
+                        // VStack when not many things
+                        VStack(
+                            alignment: horizontalAlignment.stackAlignment,
+                            spacing: viewModel.spacing
+                        ) {
+                            ComponentsView(
+                                componentViewModels: self.viewModel.viewModels,
+                                onDismiss: self.onDismiss
+                            )
+                        }
+                    } else {
+                        // LazyVStack needed for performance when loading
+                        LazyVStack(
+                            alignment: horizontalAlignment.stackAlignment,
+                            spacing: viewModel.spacing
+                        ) {
+                            ComponentsView(
+                                componentViewModels: self.viewModel.viewModels,
+                                onDismiss: self.onDismiss
+                            )
+                        }
+                    }
                 }
-            case .horizontal(let verticalAlignment):
-                HStack(alignment: verticalAlignment.stackAlignment, spacing: viewModel.spacing) {
-                    ComponentsView(componentViewModels: self.viewModel.viewModels, onDismiss: self.onDismiss)
+                .applyIf(viewModel.shouldUseFlex) {
+                    $0.frame(
+                        maxWidth: .infinity,
+                        alignment: horizontalAlignment.frameAlignment
+                    )
+                }
+            case .horizontal(let verticalAlignment, let distribution):
+                if viewModel.shouldUseFlex {
+                    FlexHStack(
+                        alignment: verticalAlignment.stackAlignment,
+                        spacing: viewModel.spacing,
+                        justifyContent: distribution.justifyContent,
+                        componentViewModels: self.viewModel.viewModels,
+                        onDismiss: self.onDismiss
+                    )
+                } else {
+                    HStack(alignment: verticalAlignment.stackAlignment, spacing: viewModel.spacing) {
+                        ComponentsView(componentViewModels: self.viewModel.viewModels, onDismiss: self.onDismiss)
+                    }
                 }
             case .zlayer(let alignment):
                 ZStack(alignment: alignment.stackAlignment) {
@@ -61,6 +101,27 @@ struct StackComponentView: View {
             view.compositingGroup().shadow(shadow: shadow)
         }
         .padding(viewModel.margin)
+    }
+
+}
+
+extension PaywallComponent.FlexDistribution {
+
+    var justifyContent: JustifyContent {
+        switch self {
+        case .start:
+            return .start
+        case .center:
+            return .center
+        case .end:
+            return .end
+        case .spaceBetween:
+            return .spaceBetween
+        case .spaceAround:
+            return .spaceAround
+        case .spaceEvenly:
+            return .spaceEvenly
+        }
     }
 
 }

--- a/RevenueCatUI/Templates/Components/Stack/StackComponentViewModel.swift
+++ b/RevenueCatUI/Templates/Components/Stack/StackComponentViewModel.swift
@@ -47,6 +47,33 @@ class StackComponentViewModel {
         self.viewModels = viewModels
     }
 
+    var shouldUseVStack: Bool {
+        switch self.dimension {
+        case .vertical:
+            if viewModels.count < 3 {
+                return true
+            }
+            return false
+        case .horizontal, .zlayer:
+            return false
+        }
+    }
+
+    var shouldUseFlex: Bool {
+        guard let widthType = self.component.width?.type else {
+            return false
+        }
+
+        switch widthType {
+        case .fit:
+            return false
+        case .fill:
+            return true
+        case .fixed:
+            return true
+        }
+    }
+
     var dimension: PaywallComponent.Dimension {
         component.dimension
     }

--- a/RevenueCatUI/Templates/Components/TemplateComponentsView.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsView.swift
@@ -83,7 +83,7 @@ struct TemplateComponentsView: View {
         self.onDismiss = onDismiss
 
         // Step 0: Decide which ComponentsConfig to use (base is default)
-        let componentsConfig = paywallComponentsData.componentsConfigs.base
+        let componentsConfig = paywallComponentsData.componentsConfig.base
 
         // Step 1: Get localization
         let localization = Self.chooseLocalization(for: paywallComponentsData)
@@ -113,10 +113,11 @@ struct TemplateComponentsView: View {
                 )
             )
 
-            guard packageValidator.isValid else {
-                Logger.error(Strings.paywall_could_not_find_any_packages)
-                throw PackageGroupValidationError.noAvailablePackages("No available packages found")
-            }
+            // WIP: Maybe re-enable this later or add some warnings
+//            guard packageValidator.isValid else {
+//                Logger.error(Strings.paywall_could_not_find_any_packages)
+//                throw PackageGroupValidationError.noAvailablePackages("No available packages found")
+//            }
 
             self.componentViewModel = componentViewModel
             self._paywallState = .init(wrappedValue: PaywallState(

--- a/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -137,7 +137,7 @@ private enum Template1Preview {
     static let data: PaywallComponentsData = .init(
         templateName: "components",
         assetBaseURL: URL(string: "https://assets.pawwalls.com")!,
-        componentsConfigs: .init(
+        componentsConfig: .init(
             base: .init(
                 stack: .init(
                     components: [

--- a/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -38,7 +38,7 @@ private enum Template1Preview {
     static let title = PaywallComponent.TextComponent(
         text: "title",
         fontFamily: nil,
-        fontWeight: .heavy,
+        fontWeight: .black,
         color: .init(light: "#000000"),
         backgroundColor: nil,
         padding: .zero,

--- a/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template5Preview.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template5Preview.swift
@@ -207,7 +207,7 @@ private enum Template5Preview {
     static let data: PaywallComponentsData = .init(
         templateName: "components",
         assetBaseURL: URL(string: "https://assets.pawwalls.com")!,
-        componentsConfigs: .init(
+        componentsConfig: .init(
             base: .init(
                 stack: .init(
                     components: [

--- a/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template5Preview.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template5Preview.swift
@@ -41,7 +41,7 @@ private enum Template5Preview {
     static let title = PaywallComponent.TextComponent(
         text: "title",
         fontFamily: nil,
-        fontWeight: .heavy,
+        fontWeight: .black,
         color: .init(light: "#000000"),
         backgroundColor: nil,
         padding: .zero,

--- a/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template5Preview.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template5Preview.swift
@@ -171,7 +171,7 @@ private enum Template5Preview {
         components: [
             .purchaseButton(purchaseButton)
         ],
-        dimension: .horizontal(.center),
+        dimension: .horizontal(.center, .start),
         width: .init(type: .fill, value: nil),
         spacing: 0,
         backgroundColor: nil

--- a/RevenueCatUI/Templates/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Text/TextComponentView.swift
@@ -88,7 +88,7 @@ struct TextComponentView_Previews: PreviewProvider {
                 component: .init(
                     text: "id_1",
                     fontFamily: nil,
-                    fontWeight: .heavy,
+                    fontWeight: .black,
                     color: .init(light: "#ff0000"),
                     backgroundColor: .init(light: "#dedede"),
                     padding: .init(top: 10,

--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -18,17 +18,17 @@ import Foundation
 
 public struct PaywallComponentsData: Codable, Equatable, Sendable {
 
-    public struct ComponentsConfigs: Codable, Equatable, Sendable {
+    public struct ComponentsConfig: Codable, Equatable, Sendable {
 
-        public var base: ComponentsConfig
+        public var base: PaywallComponentsConfig
 
-        public init(base: ComponentsConfig) {
+        public init(base: PaywallComponentsConfig) {
             self.base = base
         }
 
     }
 
-    public struct ComponentsConfig: Codable, Equatable, Sendable {
+    public struct PaywallComponentsConfig: Codable, Equatable, Sendable {
 
         public var stack: PaywallComponent.StackComponent
         public let stickyFooter: PaywallComponent.StickyFooterComponent?
@@ -83,7 +83,7 @@ public struct PaywallComponentsData: Codable, Equatable, Sendable {
         set { self._revision = newValue }
     }
 
-    public var componentsConfigs: ComponentsConfigs
+    public var componentsConfig: ComponentsConfig
     public var componentsLocalizations: [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary]
     public var defaultLocale: String
 
@@ -92,7 +92,7 @@ public struct PaywallComponentsData: Codable, Equatable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case templateName
-        case componentsConfigs
+        case componentsConfig
         case componentsLocalizations
         case defaultLocale
         case assetBaseURL = "assetBaseUrl"
@@ -101,13 +101,13 @@ public struct PaywallComponentsData: Codable, Equatable, Sendable {
 
     public init(templateName: String,
                 assetBaseURL: URL,
-                componentsConfigs: ComponentsConfigs,
+                componentsConfig: ComponentsConfig,
                 componentsLocalizations: [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary],
                 revision: Int,
                 defaultLocaleIdentifier: String) {
         self.templateName = templateName
         self.assetBaseURL = assetBaseURL
-        self.componentsConfigs = componentsConfigs
+        self.componentsConfig = componentsConfig
         self.componentsLocalizations = componentsLocalizations
         self._revision = revision
         self.defaultLocale = defaultLocaleIdentifier

--- a/Sources/Paywalls/Components/Common/Dimension.swift
+++ b/Sources/Paywalls/Components/Common/Dimension.swift
@@ -21,7 +21,7 @@ public extension PaywallComponent {
     enum Dimension: Codable, Sendable, Hashable {
 
         case vertical(HorizontalAlignment)
-        case horizontal(VerticalAlignment)
+        case horizontal(VerticalAlignment, FlexDistribution)
         case zlayer(TwoDimensionAlignment)
 
         public func encode(to encoder: any Encoder) throws {
@@ -31,9 +31,10 @@ public extension PaywallComponent {
             case .vertical(let alignment):
                 try container.encode(DimensionType.vertical.rawValue, forKey: .type)
                 try container.encode(alignment, forKey: .alignment)
-            case .horizontal(let alignment):
+            case .horizontal(let alignment, let distribution):
                 try container.encode(DimensionType.horizontal.rawValue, forKey: .type)
                 try container.encode(alignment, forKey: .alignment)
+                try container.encode(distribution, forKey: .distribution)
             case .zlayer(let alignment):
                 try container.encode(DimensionType.zlayer.rawValue, forKey: .type)
                 try container.encode(alignment.rawValue, forKey: .alignment)
@@ -50,7 +51,8 @@ public extension PaywallComponent {
                 self = .vertical(alignment)
             case .horizontal:
                 let alignment = try container.decode(VerticalAlignment.self, forKey: .alignment)
-                self = .horizontal(alignment)
+                let distribution = try container.decode(FlexDistribution.self, forKey: .distribution)
+                self = .horizontal(alignment, distribution)
             case .zlayer:
                 let alignment = try container.decode(TwoDimensionAlignment.self, forKey: .alignment)
                 self = .zlayer(alignment)
@@ -58,7 +60,7 @@ public extension PaywallComponent {
         }
 
         public static func horizontal() -> Dimension {
-            return .horizontal(.center)
+            return .horizontal(.center, .start)
         }
 
         public static func vertical() -> Dimension {
@@ -70,6 +72,7 @@ public extension PaywallComponent {
 
             case type
             case alignment
+            case distribution
 
         }
 

--- a/Sources/Paywalls/Components/Common/Dimension.swift
+++ b/Sources/Paywalls/Components/Common/Dimension.swift
@@ -18,7 +18,7 @@ import Foundation
 
 public extension PaywallComponent {
 
-    enum Dimension: Codable, Sendable, Hashable {
+    @frozen enum Dimension: Codable, Sendable, Hashable {
 
         case vertical(HorizontalAlignment)
         case horizontal(VerticalAlignment, FlexDistribution)

--- a/Sources/Paywalls/Components/Common/Dimension.swift
+++ b/Sources/Paywalls/Components/Common/Dimension.swift
@@ -18,7 +18,7 @@ import Foundation
 
 public extension PaywallComponent {
 
-    @frozen enum Dimension: Codable, Sendable, Hashable {
+    enum Dimension: Codable, Sendable, Hashable {
 
         case vertical(HorizontalAlignment)
         case horizontal(VerticalAlignment, FlexDistribution)

--- a/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
@@ -32,8 +32,8 @@ public enum PaywallComponent: PaywallComponentBase {
         case linkButton = "link_button"
         case button
         case package
-        case purchaseButton
-        case stickyFooter
+        case purchaseButton = "purchase_button"
+        case stickyFooter = "sticky_footer"
 
     }
 

--- a/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
@@ -125,6 +125,17 @@ public extension PaywallComponent {
 
     }
 
+    enum FlexDistribution: String, Codable, Sendable, Hashable, Equatable {
+
+        case start
+        case center
+        case end
+        case spaceBetween = "space_between"
+        case spaceAround = "space_around"
+        case spaceEvenly = "space_evenly"
+
+    }
+
     enum HorizontalAlignment: String, Codable, Sendable, Hashable, Equatable {
 
         case leading

--- a/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
@@ -109,7 +109,7 @@ public extension PaywallComponent {
 
     }
 
-    enum WidthSizeType: String, Codable, Sendable, Hashable, Equatable {
+    @frozen enum WidthSizeType: String, Codable, Sendable, Hashable, Equatable {
         case fit, fill, fixed
     }
 
@@ -125,7 +125,7 @@ public extension PaywallComponent {
 
     }
 
-    enum FlexDistribution: String, Codable, Sendable, Hashable, Equatable {
+    @frozen enum FlexDistribution: String, Codable, Sendable, Hashable, Equatable {
 
         case start
         case center
@@ -136,7 +136,7 @@ public extension PaywallComponent {
 
     }
 
-    enum HorizontalAlignment: String, Codable, Sendable, Hashable, Equatable {
+    @frozen enum HorizontalAlignment: String, Codable, Sendable, Hashable, Equatable {
 
         case leading
         case center
@@ -144,7 +144,7 @@ public extension PaywallComponent {
 
     }
 
-    enum VerticalAlignment: String, Codable, Sendable, Hashable, Equatable {
+    @frozen enum VerticalAlignment: String, Codable, Sendable, Hashable, Equatable {
 
         case top
         case center
@@ -152,7 +152,7 @@ public extension PaywallComponent {
 
     }
 
-    enum TwoDimensionAlignment: String, Decodable, Sendable, Hashable, Equatable {
+    @frozen enum TwoDimensionAlignment: String, Decodable, Sendable, Hashable, Equatable {
 
         case center
         case leading
@@ -166,7 +166,7 @@ public extension PaywallComponent {
 
     }
 
-    enum FontWeight: String, Codable, Sendable, Hashable, Equatable {
+    @frozen enum FontWeight: String, Codable, Sendable, Hashable, Equatable {
 
         case ultraLight = "ultra_light"
         case thin
@@ -180,7 +180,7 @@ public extension PaywallComponent {
 
     }
 
-    enum TextStyle: String, Codable, Sendable, Hashable, Equatable {
+    @frozen  enum TextStyle: String, Codable, Sendable, Hashable, Equatable {
 
         case largeTitle = "large_title"
         case title
@@ -200,7 +200,7 @@ public extension PaywallComponent {
 
     }
 
-    enum FitMode: String, Codable, Sendable, Hashable, Equatable {
+    @frozen enum FitMode: String, Codable, Sendable, Hashable, Equatable {
 
         case fit
         case fill

--- a/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
@@ -168,19 +168,19 @@ public extension PaywallComponent {
 
     @frozen enum FontWeight: String, Codable, Sendable, Hashable, Equatable {
 
-        case ultraLight = "ultra_light"
+        case extraLight = "extra_light"
         case thin
         case light
         case regular
         case medium
         case semibold
         case bold
-        case heavy
+        case extraBold = "extra_bold"
         case black
 
     }
 
-    @frozen  enum TextStyle: String, Codable, Sendable, Hashable, Equatable {
+    @frozen enum TextStyle: String, Codable, Sendable, Hashable, Equatable {
 
         case largeTitle = "large_title"
         case title

--- a/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
@@ -109,7 +109,7 @@ public extension PaywallComponent {
 
     }
 
-    @frozen enum WidthSizeType: String, Codable, Sendable, Hashable, Equatable {
+    enum WidthSizeType: String, Codable, Sendable, Hashable, Equatable {
         case fit, fill, fixed
     }
 
@@ -125,7 +125,7 @@ public extension PaywallComponent {
 
     }
 
-    @frozen enum FlexDistribution: String, Codable, Sendable, Hashable, Equatable {
+    enum FlexDistribution: String, Codable, Sendable, Hashable, Equatable {
 
         case start
         case center
@@ -136,7 +136,7 @@ public extension PaywallComponent {
 
     }
 
-    @frozen enum HorizontalAlignment: String, Codable, Sendable, Hashable, Equatable {
+    enum HorizontalAlignment: String, Codable, Sendable, Hashable, Equatable {
 
         case leading
         case center
@@ -144,7 +144,7 @@ public extension PaywallComponent {
 
     }
 
-    @frozen enum VerticalAlignment: String, Codable, Sendable, Hashable, Equatable {
+    enum VerticalAlignment: String, Codable, Sendable, Hashable, Equatable {
 
         case top
         case center
@@ -152,7 +152,7 @@ public extension PaywallComponent {
 
     }
 
-    @frozen enum TwoDimensionAlignment: String, Decodable, Sendable, Hashable, Equatable {
+    enum TwoDimensionAlignment: String, Decodable, Sendable, Hashable, Equatable {
 
         case center
         case leading
@@ -166,7 +166,7 @@ public extension PaywallComponent {
 
     }
 
-    @frozen enum FontWeight: String, Codable, Sendable, Hashable, Equatable {
+    enum FontWeight: String, Codable, Sendable, Hashable, Equatable {
 
         case extraLight = "extra_light"
         case thin
@@ -180,7 +180,7 @@ public extension PaywallComponent {
 
     }
 
-    @frozen enum TextStyle: String, Codable, Sendable, Hashable, Equatable {
+    enum TextStyle: String, Codable, Sendable, Hashable, Equatable {
 
         case largeTitle = "large_title"
         case title
@@ -200,7 +200,7 @@ public extension PaywallComponent {
 
     }
 
-    @frozen enum FitMode: String, Codable, Sendable, Hashable, Equatable {
+    enum FitMode: String, Codable, Sendable, Hashable, Equatable {
 
         case fit
         case fill

--- a/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
@@ -148,16 +148,16 @@ public extension PaywallComponent {
         case trailing
         case top
         case bottom
-        case topLeading
-        case topTrailing
-        case bottomLeading
-        case bottomTrailing
+        case topLeading = "top_leading"
+        case topTrailing = "top_trailing"
+        case bottomLeading = "bottom_leading"
+        case bottomTrailing = "bottom_trailing"
 
     }
 
     enum FontWeight: String, Codable, Sendable, Hashable, Equatable {
 
-        case ultraLight
+        case ultraLight = "ultra_light"
         case thin
         case light
         case regular

--- a/Sources/Paywalls/Components/PaywallPackageComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPackageComponent.swift
@@ -35,6 +35,18 @@ public extension PaywallComponent {
             self.isSelectedByDefault = isSelectedByDefault
             self.stack = stack
         }
+
+    }
+
+}
+
+extension PaywallComponent.PackageComponent {
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case packageID = "packageId"
+        case isSelectedByDefault = "isDefaultSelected"
+        case stack
     }
 
 }

--- a/Sources/Paywalls/Components/PaywallPackageComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPackageComponent.swift
@@ -45,7 +45,7 @@ extension PaywallComponent.PackageComponent {
     enum CodingKeys: String, CodingKey {
         case type
         case packageID = "packageId"
-        case isSelectedByDefault = "isDefaultSelected"
+        case isSelectedByDefault
         case stack
     }
 

--- a/Sources/Paywalls/Components/PaywallTextComponent.swift
+++ b/Sources/Paywalls/Components/PaywallTextComponent.swift
@@ -97,7 +97,7 @@ extension PaywallComponent.TextComponent {
 
     enum CodingKeys: String, CodingKey {
         case type
-        case text = "text_lid"
+        case text = "textLid"
         case fontFamily
         case fontWeight
         case color
@@ -116,7 +116,7 @@ extension PaywallComponent.PartialTextComponent {
 
     enum CodingKeys: String, CodingKey {
         case visible
-        case text = "text_lid"
+        case text = "textLid"
         case fontFamily
         case fontWeight
         case color

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/SamplePaywalls.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/SamplePaywalls.swift
@@ -650,7 +650,7 @@ private extension SamplePaywallLoader {
     ) -> PaywallComponentsData {
         PaywallComponentsData(templateName: "Component Sample",
                               assetBaseURL: URL(string:"https://assets.pawwalls.com/")!,
-                              componentsConfigs: .init(
+                              componentsConfig: .init(
                                 base: .init(
                                     stack: .init(components: components),
                                     stickyFooter: stickyFooter

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/SamplePaywalls.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/SamplePaywalls.swift
@@ -928,7 +928,7 @@ private extension SamplePaywallLoader {
 
     static func simpleFeatureStack(text: PaywallComponent) -> PaywallComponent {
         .stack(.init(components: [checkmarkImage, text],
-                     dimension: .horizontal(.center),
+                     dimension: .horizontal(.center, .start),
                      spacing: nil,
                      backgroundColor: nil,
                      padding: PaywallComponent.Padding(top: 0, bottom: 0, leading: 40, trailing: 40)))
@@ -1109,7 +1109,7 @@ private extension SamplePaywallLoader {
 
     static var featureImageStack1: PaywallComponent = {
         .stack(.init(components: [treadmillText, spacer, treadmill, spacer],
-                     dimension: .horizontal(.center),
+                     dimension: .horizontal(.center, .start),
                      spacing: nil,
                      backgroundColor: nil,
                      padding: PaywallComponent.Padding(top: 0, bottom: 0, leading: 40, trailing: 40)))
@@ -1117,7 +1117,7 @@ private extension SamplePaywallLoader {
 
     static var featureImageStack2: PaywallComponent = {
         .stack(.init(components: [spacer, cycle, spacer, cycleText],
-                     dimension: .horizontal(.center),
+                     dimension: .horizontal(.center, .start),
                      spacing: nil,
                      backgroundColor: nil,
                      padding: PaywallComponent.Padding(top: 0, bottom: 0, leading: 40, trailing: 40)))
@@ -1125,7 +1125,7 @@ private extension SamplePaywallLoader {
 
     static var featureImageStack3: PaywallComponent = {
         .stack(.init(components: [weightsText, spacer, weights, spacer],
-                     dimension: .horizontal(.center),
+                     dimension: .horizontal(.center, .start),
                      spacing: nil,
                      backgroundColor: nil,
                      padding: PaywallComponent.Padding(top: 0, bottom: 0, leading: 40, trailing: 40)))

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -208,7 +208,9 @@ extension APIKeyDashboardList.Template: CustomStringConvertible {
     var description: String {
         if let name = self.name {
             #if DEBUG
-            if let template = PaywallTemplate(rawValue: name) {
+            if name == "components" {
+                return "V2"
+            } else if let template = PaywallTemplate(rawValue: name) {
                 return template.name
             } else {
                 return "Unrecognized template"

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -140,26 +140,10 @@ struct APIKeyDashboardList: View {
             }
         }
         .sheet(item: self.$presentedPaywall) { paywall in
-            #if PAYWALL_COMPONENTS
-            if let componentData = paywall.offering.paywallComponentsData {
-                // TODO: Get locale
-                TemplateComponentsView(
-                    paywallComponentsData: componentData,
-                    offering: paywall.offering,
-                    onDismiss: { self.presentedPaywall = nil }
-                )
-            } else {
-                PaywallPresenter(offering: paywall.offering, mode: paywall.mode, introEligility: .eligible)
-                    .onRestoreCompleted { _ in
-                        self.presentedPaywall = nil
-                    }
-            }
-            #else
             PaywallPresenter(offering: paywall.offering, mode: paywall.mode, introEligility: .eligible)
                 .onRestoreCompleted { _ in
                     self.presentedPaywall = nil
                 }
-            #endif
         }
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -109,7 +109,7 @@ struct SamplePaywallsList: View {
             Section("Components") {
                 Button {
                     let data = SamplePaywallLoader.template1Components
-                    data.componentsConfigs.base.stack.components.printAsJSON()
+                    data.componentsConfig.base.stack.components.printAsJSON()
                     data.componentsLocalizations.printAsJSON()
                     self.display = .componentPaywall(data)
                 } label: {
@@ -117,7 +117,7 @@ struct SamplePaywallsList: View {
                 }
                 Button {
                     let data = SamplePaywallLoader.fitnessComponents
-                    data.componentsConfigs.base.stack.components.printAsJSON()
+                    data.componentsConfig.base.stack.components.printAsJSON()
                     data.componentsLocalizations.printAsJSON()
                     self.display = .componentPaywall(data)
                 } label: {
@@ -125,7 +125,7 @@ struct SamplePaywallsList: View {
                 }
                 Button {
                     let data = SamplePaywallLoader.simpleSampleComponents
-                    data.componentsConfigs.base.stack.components.printAsJSON()
+                    data.componentsConfig.base.stack.components.printAsJSON()
                     data.componentsLocalizations.printAsJSON()
                     self.display = .componentPaywall(data)
                 } label: {
@@ -133,7 +133,7 @@ struct SamplePaywallsList: View {
                 }
                 Button {
                     let data = SamplePaywallLoader.longWithStickyFooter
-                    data.componentsConfigs.base.stack.components.printAsJSON()
+                    data.componentsConfig.base.stack.components.printAsJSON()
                     data.componentsLocalizations.printAsJSON()
                     self.display = .componentPaywall(data)
                 } label: {


### PR DESCRIPTION
## Motivation

Fixes for paywall tester for Paywalls V2

## Description

- Added `@frozen` to all the enums to get rid of Swift 6 warnings
- New `FlexHStack` to support horizontal `distribution`
- Fixed a width bug with `LazyVStack`
  - `LazyVStack` is used to make rendering a bit snappier feeling but it has issues with width sometimes
  - It was behaving as `maxWidth: .infinity` so added some naive logic to only use `LazyVStack` if more than 3 children. Ideally this should look recursively down  
- Temporarily removed the error in the paywall if there are no packages (because it makes initial testing of paywall designs hard)
  - Could maybe only show a warning when in debug
- Fixed a bunch of `Codable` things that were failing when testing real life paywalls

### Demo

| Blinkist | HabitKit |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 Pro - 2024-11-01 at 15 56 46](https://github.com/user-attachments/assets/808c3b42-dbb2-443f-b7f3-e3309a6e5a87) | ![Simulator Screenshot - iPhone 16 Pro - 2024-11-01 at 17 46 22](https://github.com/user-attachments/assets/e88a33ac-ccae-4938-b381-8e56211a0797) | 
