### PR TITLE
Add `tenjinAnalyticsInstallationId` setter property

### DIFF
--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -320,6 +320,17 @@ public extension Attribution {
     }
 
     /**
+     * Subscriber attribute associated with the Tenjin analytics installation ID for the user.
+     * Required for the RevenueCat Tenjin integration.
+     *
+     *- Parameter firebaseAppInstanceID: Empty String or `nil` will delete the subscriber attribute.
+     */
+    @objc func setTenjinAnalyticsInstallationID(_ tenjinAnalyticsInstallationID: String?) {
+        self.subscriberAttributesManager.setTenjinAnalyticsInstallationID(tenjinAnalyticsInstallationID,
+                                                                          appUserID: appUserID)
+    }
+
+    /**
      * Subscriber attribute associated with the install media source for the user.
      *
      * #### Related Articles

--- a/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -43,6 +43,7 @@ enum ReservedSubscriberAttribute: String {
     case kochavaDeviceID = "$kochavaDeviceId"
     case mixpanelDistinctID = "$mixpanelDistinctId"
     case firebaseAppInstanceID = "$firebaseAppInstanceId"
+    case tenjinAnalyticsInstallationID = "$tenjinId"
 
     case mediaSource = "$mediaSource"
     case campaign = "$campaign"

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -108,6 +108,10 @@ class SubscriberAttributesManager {
         setReservedAttribute(.firebaseAppInstanceID, value: firebaseAppInstanceID, appUserID: appUserID)
     }
 
+    func setTenjinAnalyticsInstallationID(_ tenjinAnalyticsInstallationID: String?, appUserID: String) {
+        setReservedAttribute(.tenjinAnalyticsInstallationID, value: tenjinAnalyticsInstallationID, appUserID: appUserID)
+    }
+
     func setMediaSource(_ mediaSource: String?, appUserID: String) {
         setReservedAttribute(.mediaSource, value: mediaSource, appUserID: appUserID)
     }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAttributionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAttributionAPI.m
@@ -44,6 +44,8 @@
     [a setMixpanelDistinctID: @""];
     [a setFirebaseAppInstanceID: nil];
     [a setFirebaseAppInstanceID: @""];
+    [a setTenjinAnalyticsInstallationID: nil];
+    [a setTenjinAnalyticsInstallationID: @""];
     [a setMediaSource: nil];
     [a setMediaSource: @""];
     [a setCampaign: nil];

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AttributionAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AttributionAPI.swift
@@ -58,6 +58,9 @@ func checkAttributionAPI() {
     attribution.setFirebaseAppInstanceID("")
     attribution.setFirebaseAppInstanceID(nil)
 
+    attribution.setTenjinAnalyticsInstallationID("")
+    attribution.setTenjinAnalyticsInstallationID(nil)
+
     attribution.setMediaSource("")
     attribution.setMediaSource(nil)
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriberAttributesView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriberAttributesView.swift
@@ -44,6 +44,7 @@ struct SubscriberAttributesView: View {
         case setFBAnonymousID
         case setMixpanelDistinctID
         case setFirebaseAppInstanceID
+        case setTenjinAnalyticsInstallationID
     }
     
     let customerInfo: RevenueCat.CustomerInfo
@@ -155,6 +156,8 @@ struct SubscriberAttributesView: View {
                     Purchases.shared.attribution.setMixpanelDistinctID(self.otherValue)
                 case .setFirebaseAppInstanceID:
                     Purchases.shared.attribution.setFirebaseAppInstanceID(self.otherValue)
+                case .setTenjinAnalyticsInstallationID:
+                    Purchases.shared.attribution.setTenjinAnalyticsInstallationID(self.otherValue)
                 }
             }
         }

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -419,6 +419,10 @@ extension MockPurchases: PurchasesType {
         self.unimplemented()
     }
 
+    func setTenjinAnalyticsInstallationID(_ tenjinAnalyticsInstallationID: String?) {
+        self.unimplemented()
+    }
+
     func collectDeviceIdentifiers() {
         self.unimplemented()
     }

--- a/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
@@ -213,6 +213,18 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
         invokedSetFirebaseAppInstanceIDParametersList.append((firebaseAppInstanceID, appUserID))
     }
 
+    var invokedSetTenjinAnalyticsInstallationID = false
+    var invokedSetTenjinAnalyticsInstallationIDCount = 0
+    var invokedSetTenjinAnalyticsInstallationIDParameters: (tenjinID: String?, appUserID: String?)?
+    var invokedSetTenjinAnalyticsInstallationIDParametersList = [(tenjinID: String?, appUserID: String?)]()
+
+    override func setTenjinAnalyticsInstallationID(_ tenjinAnalyticsInstallationID: String?, appUserID: String) {
+        invokedSetTenjinAnalyticsInstallationID = true
+        invokedSetTenjinAnalyticsInstallationIDCount += 1
+        invokedSetTenjinAnalyticsInstallationIDParameters = (tenjinAnalyticsInstallationID, appUserID)
+        invokedSetTenjinAnalyticsInstallationIDParametersList.append((tenjinAnalyticsInstallationID, appUserID))
+    }
+
     var invokedSetMediaSource = false
     var invokedSetMediaSourceCount = 0
     var invokedSetMediaSourceParameters: (mediaSource: String?, appUserID: String?)?

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -469,6 +469,16 @@ class PurchasesSubscriberAttributesTests: TestCase {
         (nil, purchases.appUserID)
     }
 
+    func testSetAndClearTenjinAnalyticsInstallationID() {
+        setupPurchases()
+        purchases.attribution.setTenjinAnalyticsInstallationID("tenjin")
+        purchases.attribution.setTenjinAnalyticsInstallationID(nil)
+        expect(self.mockSubscriberAttributesManager.invokedSetTenjinAnalyticsInstallationIDParametersList[0]) ==
+        ("tenjin", purchases.appUserID)
+        expect(self.mockSubscriberAttributesManager.invokedSetTenjinAnalyticsInstallationIDParametersList[1]) ==
+        (nil, purchases.appUserID)
+    }
+
     func testSetAndClearMediaSource() {
         setupPurchases()
         purchases.attribution.setMediaSource("media")
@@ -659,6 +669,17 @@ class PurchasesSubscriberAttributesTests: TestCase {
         expect(self.mockSubscriberAttributesManager.invokedSetFirebaseAppInstanceIDParameters?.firebaseAppInstanceID) ==
         "123abc"
         expect(self.mockSubscriberAttributesManager.invokedSetFirebaseAppInstanceIDParameters?.appUserID) ==
+        mockIdentityManager.currentAppUserID
+    }
+
+    func testSetTenjinAnalyticsInstallationIDMakesRightCalls() {
+        setupPurchases()
+
+        Purchases.shared.attribution.setTenjinAnalyticsInstallationID("123abc")
+        expect(self.mockSubscriberAttributesManager.invokedSetTenjinAnalyticsInstallationIDCount) == 1
+        expect(self.mockSubscriberAttributesManager.invokedSetTenjinAnalyticsInstallationIDParameters?.tenjinID) ==
+        "123abc"
+        expect(self.mockSubscriberAttributesManager.invokedSetTenjinAnalyticsInstallationIDParameters?.appUserID) ==
         mockIdentityManager.currentAppUserID
     }
 

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -1353,6 +1353,86 @@ class SubscriberAttributesManagerTests: TestCase {
         checkDeviceIdentifiersAreNotSet()
     }
     // endregion
+    // region FirebaseAppInstanceID
+    func testSetTenjinAnalyticsInstallationID() throws {
+        let tenjinAnalyticsInstallationID = "tenjinAnalyticsInstallationID"
+
+        self.subscriberAttributesManager.setTenjinAnalyticsInstallationID(tenjinAnalyticsInstallationID,
+                                                                          appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$tenjinId"
+        expect(receivedAttribute.value) == tenjinAnalyticsInstallationID
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetSetTenjinAnalyticsInstallationIDSetsEmptyIfNil() throws {
+        let tenjinAnalyticsInstallationID = "tenjinAnalyticsInstallationID"
+
+        self.subscriberAttributesManager.setTenjinAnalyticsInstallationID(tenjinAnalyticsInstallationID,
+                                                                          appUserID: "kratos")
+        self.subscriberAttributesManager.setTenjinAnalyticsInstallationID(nil, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 2
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$tenjinId"
+        expect(receivedAttribute.value) == ""
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetTenjinAnalyticsInstallationIDSkipsIfSameValue() {
+        let tenjinAnalyticsInstallationID = "tenjinAnalyticsInstallationID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(
+            withKey: "$tenjinId",
+            value: tenjinAnalyticsInstallationID
+        )
+        self.subscriberAttributesManager.setTenjinAnalyticsInstallationID(tenjinAnalyticsInstallationID,
+                                                                          appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 0
+    }
+
+    func testSetTenjinAnalyticsInstallationIDOverwritesIfNewValue() throws {
+        let oldSyncTime = Date()
+        let tenjinAnalyticsInstallationID = "tenjinAnalyticsInstallationID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$tenjinId",
+                                                                                    value: "old_id",
+                                                                                    isSynced: true,
+                                                                                    setTime: oldSyncTime)
+
+        self.subscriberAttributesManager.setTenjinAnalyticsInstallationID(tenjinAnalyticsInstallationID,
+                                                                          appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$tenjinId"
+        expect(receivedAttribute.value) == tenjinAnalyticsInstallationID
+        expect(receivedAttribute.isSynced) == false
+        expect(receivedAttribute.setTime) > oldSyncTime
+    }
+
+    func testSetTenjinAnalyticsInstallationIDDoesNotSetDeviceIdentifiers() {
+        let tenjinAnalyticsInstallationID = "tenjinAnalyticsInstallationID"
+        self.subscriberAttributesManager.setTenjinAnalyticsInstallationID(tenjinAnalyticsInstallationID,
+                                                                          appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
+
+        checkDeviceIdentifiersAreNotSet()
+    }
+    // endregion
     // region Media source
     func testSetMediaSource() {
         let mediaSource = "mediaSource"


### PR DESCRIPTION
### Description
This adds a new reserved attribute `$tenjinId` and adds a new `setTenjinAnalyticsInstallationID` API to the SDK to set it.

iOS equivalent of https://github.com/RevenueCat/purchases-android/pull/1897