### PR TITLE
[Paywalls] Send paywall events when the app is backgrounded and after a successful purchase

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -308,6 +308,7 @@
 		4DBF1F362B4D572400D52354 /* LocalReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBF1F352B4D572400D52354 /* LocalReceiptFetcher.swift */; };
 		4DBF1F372B4D572400D52354 /* LocalReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBF1F352B4D572400D52354 /* LocalReceiptFetcher.swift */; };
 		4DC546272AD44BBE005CDB35 /* EncodedAppleReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC546262AD44BBE005CDB35 /* EncodedAppleReceipt.swift */; };
+		4DE3D5742CDB646900838110 /* MockPaywallEventsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFFE6C52AA9465000B2955C /* MockPaywallEventsManager.swift */; };
 		4F0201C42A13C85500091612 /* Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0201C32A13C85500091612 /* Assertions.swift */; };
 		4F05876F2A5DE03F00E9A834 /* PaywallDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F05876E2A5DE03F00E9A834 /* PaywallDataTests.swift */; };
 		4F062D322A85A11600A8A613 /* PaywallData+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F062D312A85A11600A8A613 /* PaywallData+Localization.swift */; };
@@ -5499,6 +5500,7 @@
 				35316DAA2BD14BFD00E4A970 /* MockDiagnosticsSynchronizer.swift in Sources */,
 				2D90F8B426FD208B009B9142 /* MockStoreKit1Wrapper.swift in Sources */,
 				FD9F982D2BE28A7F0091A5BF /* MockNotificationCenter.swift in Sources */,
+				4DE3D5742CDB646900838110 /* MockPaywallEventsManager.swift in Sources */,
 				2D90F8BB26FD20BD009B9142 /* MockIdentityManager.swift in Sources */,
 				A55D083627236F0200D919E0 /* MockSK2BeginRefundRequestHelper.swift in Sources */,
 			);

--- a/Tests/StoreKitUnitTests/BasePurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/BasePurchasesOrchestratorTests.swift
@@ -44,6 +44,14 @@ class BasePurchasesOrchestratorTests: StoreKitConfigTestCase {
     var mockStoreMessagesHelper: MockStoreMessagesHelper!
     var mockWinBackOfferEligibilityCalculator: MockWinBackOfferEligibilityCalculator!
     var mockTransactionFetcher: MockStoreKit2TransactionFetcher!
+    private var paywallEventsManager: PaywallEventsManagerType!
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var mockPaywallEventsManager: MockPaywallEventsManager {
+        get throws {
+            return try XCTUnwrap(self.paywallEventsManager as? MockPaywallEventsManager)
+        }
+    }
 
     var orchestrator: PurchasesOrchestrator!
 
@@ -67,6 +75,11 @@ class BasePurchasesOrchestratorTests: StoreKitConfigTestCase {
         self.deviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo)
         self.backend = MockBackend()
         self.offerings = try XCTUnwrap(self.backend.offerings as? MockOfferingsAPI)
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            self.paywallEventsManager = MockPaywallEventsManager()
+        } else {
+            self.paywallEventsManager = nil
+        }
 
         self.mockOfferingsManager = MockOfferingsManager(deviceCache: self.deviceCache,
                                                          operationDispatcher: self.operationDispatcher,
@@ -175,7 +188,8 @@ class BasePurchasesOrchestratorTests: StoreKitConfigTestCase {
             manageSubscriptionsHelper: self.mockManageSubsHelper,
             beginRefundRequestHelper: self.mockBeginRefundRequestHelper,
             storeMessagesHelper: self.mockStoreMessagesHelper,
-            winBackOfferEligibilityCalculator: self.mockWinBackOfferEligibilityCalculator
+            winBackOfferEligibilityCalculator: self.mockWinBackOfferEligibilityCalculator,
+            paywallEventsManager: self.paywallEventsManager)
         )
         self.storeKit1Wrapper.delegate = self.orchestrator
     }
@@ -212,7 +226,8 @@ class BasePurchasesOrchestratorTests: StoreKitConfigTestCase {
             storeMessagesHelper: self.mockStoreMessagesHelper,
             diagnosticsSynchronizer: diagnosticsSynchronizer,
             diagnosticsTracker: diagnosticsTracker,
-            winBackOfferEligibilityCalculator: self.mockWinBackOfferEligibilityCalculator
+            winBackOfferEligibilityCalculator: self.mockWinBackOfferEligibilityCalculator,
+            paywallEventsManager: self.paywallEventsManager
         )
         self.storeKit1Wrapper.delegate = self.orchestrator
     }

--- a/Tests/StoreKitUnitTests/BasePurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/BasePurchasesOrchestratorTests.swift
@@ -190,7 +190,6 @@ class BasePurchasesOrchestratorTests: StoreKitConfigTestCase {
             storeMessagesHelper: self.mockStoreMessagesHelper,
             winBackOfferEligibilityCalculator: self.mockWinBackOfferEligibilityCalculator,
             paywallEventsManager: self.paywallEventsManager)
-        )
         self.storeKit1Wrapper.delegate = self.orchestrator
     }
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -43,6 +43,9 @@ protocol PurchasesOrchestratorTests {
 
     func testPurchaseFailureRemembersPresentedPaywall() async throws
 
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testPurchaseSyncsPaywallEvents() async throws
+
     // MARK: - AdServices and Attributes
     func testPurchaseDoesNotPostAdServicesTokenIfNotEnabled() async throws
 

--- a/Tests/UnitTests/Mocks/MockNotificationCenter.swift
+++ b/Tests/UnitTests/Mocks/MockNotificationCenter.swift
@@ -60,6 +60,30 @@ class MockNotificationCenter: NotificationCenter {
             }
         }
     }
+
+    func fireApplicationDidEnterBackgroundNotification() {
+        fireNotification(SystemInfo.applicationDidEnterBackgroundNotification)
+    }
+
+    func fireApplicationWillEnterForegroundNotification() {
+        fireNotification(SystemInfo.applicationWillEnterForegroundNotification)
+    }
+
+    private func fireNotification(_ notificationName: NSNotification.Name) {
+        for (observer, selector, name, object) in self.observers {
+            var notification: NSNotification?
+            if let name = name, name == notificationName {
+                notification = NSNotification(name: name, object: object)
+                _ = observer.value?.perform(selector, with: notification)
+            }
+        }
+
+        for (block, name, object) in self.observersWithBlock {
+            if let name = name, name == notificationName {
+                block(Notification(name: name, object: object))
+            }
+        }
+    }
 }
 
 extension MockNotificationCenter: @unchecked Sendable {}

--- a/Tests/UnitTests/Paywalls/Events/PurchasesPaywallEventsTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PurchasesPaywallEventsTests.swift
@@ -29,13 +29,23 @@ class PurchasesPaywallEventsTests: BasePurchasesTests {
     }
 
     func testApplicationWillEnterForegroundSendsEvents() async throws {
-        self.notificationCenter.fireNotifications()
+        self.notificationCenter.fireApplicationWillEnterForegroundNotification()
 
         let manager = try self.mockPaywallEventsManager
 
         try await asyncWait { await manager.invokedFlushEvents == true }
 
         expect(self.mockOperationDispatcher.invokedDispatchAsyncOnWorkerThreadDelayParam) == .long
+    }
+
+    func testApplicationWillEnterBackgroundSendsEvents() async throws {
+        self.notificationCenter.fireApplicationDidEnterBackgroundNotification()
+
+        let manager = try self.mockPaywallEventsManager
+
+        try await asyncWait { await manager.invokedFlushEvents == true }
+
+        expect(self.mockOperationDispatcher.invokedDispatchAsyncOnWorkerThreadDelayParam) == JitterableDelay.none
     }
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -264,7 +264,8 @@ class BasePurchasesTests: TestCase {
             manageSubscriptionsHelper: self.mockManageSubsHelper,
             beginRefundRequestHelper: self.mockBeginRefundRequestHelper,
             storeMessagesHelper: self.mockStoreMessagesHelper,
-            winBackOfferEligibilityCalculator: self.mockWinBackOfferEligibilityCalculator
+            winBackOfferEligibilityCalculator: self.mockWinBackOfferEligibilityCalculator,
+            paywallEventsManager: self.paywallEventsManager
         )
         self.trialOrIntroPriceEligibilityChecker = MockTrialOrIntroPriceEligibilityChecker(
             systemInfo: self.systemInfo,

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -189,7 +189,8 @@ class PurchasesSubscriberAttributesTests: TestCase {
             manageSubscriptionsHelper: self.mockManageSubsHelper,
             beginRefundRequestHelper: self.mockBeginRefundRequestHelper,
             storeMessagesHelper: self.mockStoreMessagesHelper,
-            winBackOfferEligibilityCalculator: self.mockWinBackOfferEligibilityCalculator
+            winBackOfferEligibilityCalculator: self.mockWinBackOfferEligibilityCalculator,
+            paywallEventsManager: nil)
         )
         let trialOrIntroductoryPriceEligibilityChecker = TrialOrIntroPriceEligibilityChecker(
             systemInfo: systemInfo,

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -191,7 +191,6 @@ class PurchasesSubscriberAttributesTests: TestCase {
             storeMessagesHelper: self.mockStoreMessagesHelper,
             winBackOfferEligibilityCalculator: self.mockWinBackOfferEligibilityCalculator,
             paywallEventsManager: nil)
-        )
         let trialOrIntroductoryPriceEligibilityChecker = TrialOrIntroPriceEligibilityChecker(
             systemInfo: systemInfo,
             receiptFetcher: mockReceiptFetcher,


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Right now we are only sending events when the app moves to the foregound. Sending events with backgrounding will help us record impression events that might happen when a user installs an app, opens it, proceeds to uninstall it or never use it again. Additionally, we try to sync events after a successful purchase.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
