### PR TITLE
Close feedback survey after picking an option

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
 #if os(iOS)
 
-/// Warning: This is currently in beta and ubject to change.
+/// Warning: This is currently in beta and subject to change.
 ///
 /// A SwiftUI view for displaying a customer support common tasks
 @available(iOS 15.0, *)

--- a/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
@@ -33,19 +33,27 @@ struct FeedbackSurveyView: View {
     @Environment(\.colorScheme)
     private var colorScheme
 
+    @Binding
+    private var isPresented: Bool
+
     init(feedbackSurveyData: FeedbackSurveyData,
-         customerCenterActionHandler: CustomerCenterActionHandler?) {
+         customerCenterActionHandler: CustomerCenterActionHandler?,
+         isPresented: Binding<Bool>) {
         self._viewModel = StateObject(wrappedValue: FeedbackSurveyViewModel(
             feedbackSurveyData: feedbackSurveyData,
             customerCenterActionHandler: customerCenterActionHandler
         ))
+        self._isPresented = isPresented
     }
 
     var body: some View {
         ZStack {
             List {
                 FeedbackSurveyButtonsView(options: self.viewModel.feedbackSurveyData.configuration.options,
-                                          onOptionSelected: self.viewModel.handleAction(for:),
+                                          onOptionSelected: { option in
+                                              await self.viewModel.handleAction(for: option)
+                                              self.isPresented = false
+                                          },
                                           loadingState: self.$viewModel.loadingState)
             }
             .sheet(

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -55,7 +55,8 @@ struct ManageSubscriptionsView: View {
                 .navigationDestination(isPresented: .isNotNil(self.$viewModel.feedbackSurveyData)) {
                     if let feedbackSurveyData = self.viewModel.feedbackSurveyData {
                         FeedbackSurveyView(feedbackSurveyData: feedbackSurveyData,
-                                           customerCenterActionHandler: self.customerCenterActionHandler)
+                                           customerCenterActionHandler: self.customerCenterActionHandler,
+                                           isPresented: .isNotNil(self.$viewModel.feedbackSurveyData))
                     }
                 }
         } else {
@@ -63,7 +64,8 @@ struct ManageSubscriptionsView: View {
                 .background(NavigationLink(
                     destination: self.viewModel.feedbackSurveyData.map { data in
                         FeedbackSurveyView(feedbackSurveyData: data,
-                                           customerCenterActionHandler: self.customerCenterActionHandler)
+                                           customerCenterActionHandler: self.customerCenterActionHandler,
+                                           isPresented: .isNotNil(self.$viewModel.feedbackSurveyData))
                     },
                     isActive: .isNotNil(self.$viewModel.feedbackSurveyData)
                 ) {


### PR DESCRIPTION
Cleans up the flow a bit, so the feedback survey is closed after picking an option and doesn't stay there after cancelling a subscription

This is needed to be able to send the selected feedback survey option to the backend as event.