### PR TITLE
Fix winback tests on iOS 14 & API Tester

### DIFF
--- a/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/ErrorCodesAPI.swift
+++ b/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/ErrorCodesAPI.swift
@@ -53,7 +53,8 @@ func checkPurchasesErrorCodeEnums() {
          .invalidPromotionalOfferError,
          .offlineConnectionError,
          .featureNotAvailableInCustomEntitlementsComputationMode,
-         .signatureVerificationFailed:
+         .signatureVerificationFailed,
+         .featureNotSupportedWithStoreKit1:
         print(errCode!)
     @unknown default:
         fatalError()

--- a/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/StoreProductDiscountAPI.swift
+++ b/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/StoreProductDiscountAPI.swift
@@ -60,7 +60,8 @@ func checkTypeEnum() {
     switch type! {
     case
             .introductory,
-            .promotional:
+            .promotional,
+            .winBack:
         break
 
     @unknown default: fatalError()

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesErrorCodeAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesErrorCodeAPI.m
@@ -57,6 +57,7 @@
         case RCAPIEndpointBlocked:
         case RCInvalidPromotionalOfferError:
         case RCOfflineConnectionError:
+        case RCFeatureNotSupportedWithStoreKit1:
         case RCSignatureVerificationFailed:
             NSLog(@"%ld", (long)errCode);
         case RCFeatureNotAvailableInCustomEntitlementsComputationMode:

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCStoreProductDiscountAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCStoreProductDiscountAPI.m
@@ -48,6 +48,7 @@
     switch (paymentMode) {
         case RCDiscountTypeIntroductory:
         case RCDiscountTypePromotional:
+        case RCDiscountTypeWinBack:
             break;
     }
 }

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/ErrorCodesAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/ErrorCodesAPI.swift
@@ -53,7 +53,8 @@ func checkPurchasesErrorCodeEnums() {
          .invalidPromotionalOfferError,
          .offlineConnectionError,
          .featureNotAvailableInCustomEntitlementsComputationMode,
-         .signatureVerificationFailed:
+         .signatureVerificationFailed,
+         .featureNotSupportedWithStoreKit1:
         print(errCode!)
     @unknown default:
         fatalError()

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
@@ -78,7 +78,8 @@ func checkPurchasesEnums() {
     switch storeMessageType! {
     case .billingIssue,
          .priceIncreaseConsent,
-         .generic:
+         .generic,
+         .winBackOffer:
         print(storeMessageType!)
     @unknown default:
         fatalError()

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/StoreProductDiscountAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/StoreProductDiscountAPI.swift
@@ -58,7 +58,8 @@ func checkTypeEnum() {
     switch type! {
     case
             .introductory,
-            .promotional:
+            .promotional,
+            .winBack:
         break
 
     @unknown default: fatalError()

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesWinBackOfferTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesWinBackOfferTests.swift
@@ -43,6 +43,9 @@ class PurchasesWinBackOfferTests: BasePurchasesTests {
         expect(self.mockWinBackOfferEligibilityCalculator.eligibleWinBackOffersProduct).to(equal(product))
     }
 
+    // async version of fulfillment() is available starting in iOS 15, which was shipped
+    // with Swift 5.5
+    #if swift(>=5.5)
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     func testEligibileWinBackOffersCallbackForwardsSuccess() async throws {
         try AvailabilityChecks.iOS18APIAvailableOrSkipTest()
@@ -113,4 +116,5 @@ class PurchasesWinBackOfferTests: BasePurchasesTests {
 
         await fulfillment(of: [expectation], timeout: 3)
     }
+    #endif
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesWinBackOfferTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesWinBackOfferTests.swift
@@ -28,6 +28,9 @@ class PurchasesWinBackOfferTests: BasePurchasesTests {
         self.setupPurchases()
     }
 
+    // Win-backs are available in Xcode 16.0+, which ships with the 6.0 version
+    // of the Swift compiler
+    #if compiler(>=6.0)
     // MARK: - Success Cases
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     func testEligibileWinBackOffersAsyncForwardsSuccess() async throws {
@@ -43,9 +46,6 @@ class PurchasesWinBackOfferTests: BasePurchasesTests {
         expect(self.mockWinBackOfferEligibilityCalculator.eligibleWinBackOffersProduct).to(equal(product))
     }
 
-    // async version of fulfillment() is available starting in iOS 15, which was shipped
-    // with Swift 5.5
-    #if swift(>=5.5)
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     func testEligibileWinBackOffersCallbackForwardsSuccess() async throws {
         try AvailabilityChecks.iOS18APIAvailableOrSkipTest()


### PR DESCRIPTION
This PR addresses a few issues with some tests that aren't normally covered by the `build-test` workflow. 

Specifically, it addresses two issues:
- The async version of `fulfillment()` wasn't introduced until Xcode 13/Swift 5.5/iOS 15. This PR removes the affected tests from compilation on Swift compiler versions <6.0. This won't affect our test coverage of the win-backs feature since win-backs aren't available on iOS versions below 18.
- Adds a few items from https://github.com/RevenueCat/purchases-ios/pull/4431 to the Obj-C and Swift API testers