### PR TITLE
Fix `RCPurchaseParams` API tests

### DIFF
--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
@@ -130,13 +130,15 @@ NSString *storeFrontCountryCode;
     [p getOfferingsWithCompletion:^(RCOfferings *info, NSError *error) {}];
     RCOfferings * _Nullable __unused offerings = p.cachedOfferings;
 
+    #if ENABLE_PURCHASE_PARAMS
     RCPurchaseParams *packageParams = [[[[[RCPurchaseParamsBuilder alloc] initWithPackage:pack] withMetadata: @{@"foo":@"bar"}] withPromotionalOffer:pro] build];
     RCPurchaseParams *productParams = [[[[[RCPurchaseParamsBuilder alloc] initWithProduct:storeProduct] withMetadata: @{@"foo":@"bar"}] withPromotionalOffer:pro] build];
+    [p params:packageParams withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
+    #endif
 
     [p getProductsWithIdentifiers:@[@""] completion:^(NSArray<RCStoreProduct *> *products) { }];
     [p purchaseProduct:storeProduct withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
     [p purchasePackage:pack withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
-    [p params:packageParams withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
     [p restorePurchasesWithCompletion:^(RCCustomerInfo *i, NSError *e) {}];
     [p syncPurchasesWithCompletion:^(RCCustomerInfo *i, NSError *e) {}];
     


### PR DESCRIPTION
We were missing a ENABLE_PURCHASE_PARAMS check