### PR TITLE
[Paywalls V2] Enable PAYWALL_COMPONENTS compiler flag when building PaywallTester in Xcode Cloud

### DIFF
--- a/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
+++ b/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
@@ -6,3 +6,6 @@ echo "Replacing API keys on PaywallsTester"
 
 file="$SCRIPT_DIR/../PaywallsTester/Config/ConfigItem.swift"
 sed -i '' 's/static var apiKey: String { "" }/static var apiKey: String { "'"$REVENUECAT_XCODE_CLOUD_RC_APP_API_KEY"'" }/' $file
+
+echo "Enabling PAYWALL_COMPONENTS compiler flag"
+echo "SWIFT_ACTIVE_COMPILATION_CONDITIONS = \$(inherited) PAYWALL_COMPONENTS" > ""$SCRIPT_DIR/../Local.xcconfig"


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
