### PR TITLE
Fix Paywalls Tester when not being built with Paywalls V2

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -175,9 +175,11 @@ struct APIKeyDashboardList: View {
                 HStack {
                     Text(self.offering.serverDescription)
                     Spacer()
+                    #if PAYWALL_COMPONENTS
                     Image(systemName: "exclamationmark.circle.fill")
                         .foregroundStyle(Color.red)
                         .hidden(if: self.offering.paywallComponentsData?.errorInfo?.isEmpty ?? true)
+                    #endif
                 }
             }
             .buttonStyle(.plain)


### PR DESCRIPTION
### Motivation

Make Paywalls Tester build again

### Description

Add `#if PAYWALL_COMPONENTS` around new logic for displaying if a paywall has an error in it
