### PR TITLE
Add `appSessionID` to `PaywallEventsManager` 

### DIFF
--- a/Sources/Paywalls/Events/PaywallEventsManager.swift
+++ b/Sources/Paywalls/Events/PaywallEventsManager.swift
@@ -31,6 +31,7 @@ actor PaywallEventsManager: PaywallEventsManagerType {
     private let internalAPI: InternalAPI
     private let userProvider: CurrentUserProvider
     private let store: PaywallEventStoreType
+    private var appSessionID: UUID
 
     private var flushInProgress = false
 
@@ -42,11 +43,17 @@ actor PaywallEventsManager: PaywallEventsManagerType {
         self.internalAPI = internalAPI
         self.userProvider = userProvider
         self.store = store
+        self.appSessionID = UUID()
+    }
+
+    func resetAppSessionID() {
+        self.appSessionID = UUID()
     }
 
     func track(paywallEvent: PaywallEvent) async {
         guard let event: StoredEvent = .init(event: AnyEncodable(paywallEvent),
                                              userID: self.userProvider.currentAppUserID,
+                                             appSessionID: self.appSessionID,
                                              feature: .paywalls) else {
             Logger.error(Strings.paywalls.event_cannot_serialize)
             return

--- a/Sources/Paywalls/Events/PaywallEventsManager.swift
+++ b/Sources/Paywalls/Events/PaywallEventsManager.swift
@@ -23,6 +23,8 @@ protocol PaywallEventsManagerType {
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func flushEvents(count: Int) async throws -> Int
 
+    func resetAppSessionID() async
+
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -820,6 +820,10 @@ public extension Purchases {
             self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
                 self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
             }
+
+            Task {
+                await self.paywallEventsManager?.resetAppSessionID()
+            }
         }
     }
 
@@ -851,6 +855,10 @@ public extension Purchases {
                     }
                 }
                 return
+            }
+
+            Task {
+                await self.paywallEventsManager?.resetAppSessionID()
             }
 
             self.updateAllCaches {


### PR DESCRIPTION
Added an `appSessionID` that can be shared between all events. Since at the moment `session_identifier` in the paywalls represent the paywall session, not the whole app session.

I just added the generation, a reset functionality and a fallback for now