### PR TITLE
Enable Paywall Tester to build with Paywalls V2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,13 @@ var additionalCompilerFlags: [PackageDescription.SwiftSetting] = {
         .split(whereSeparator: \.isWhitespace)
         .filter { !$0.isEmpty && !$0.hasPrefix("$") }
         .map { .define(String($0)) }
-        ?? []
+    ?? [.define("PAYWALL_COMPONENTS")]
 }()
+
+var ciCompilerFlags: [PackageDescription.SwiftSetting] = [
+    // REPLACE_HERE
+    .define("PAYWALL_COMPONENTS")
+]
 
 // Only add DocC Plugin when building docs, so that clients of this library won't
 // unnecessarily also get the DocC Plugin
@@ -75,7 +80,7 @@ let package = Package(
                 resources: [
                     .copy("../Sources/PrivacyInfo.xcprivacy")
                 ],
-                swiftSettings: [visionOSSetting] + additionalCompilerFlags),
+                swiftSettings: [visionOSSetting] + ciCompilerFlags + additionalCompilerFlags),
         .target(name: "RevenueCat_CustomEntitlementComputation",
                 path: "CustomEntitlementComputation",
                 exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"],
@@ -85,7 +90,7 @@ let package = Package(
                 swiftSettings: [
                     .define("ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION"),
                     visionOSSetting
-                ] + additionalCompilerFlags),
+                ] + ciCompilerFlags + additionalCompilerFlags),
         // Receipt Parser
         .target(name: "ReceiptParser",
                 path: "LocalReceiptParsing"),

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ var additionalCompilerFlags: [PackageDescription.SwiftSetting] = {
         .split(whereSeparator: \.isWhitespace)
         .filter { !$0.isEmpty && !$0.hasPrefix("$") }
         .map { .define(String($0)) }
-    ?? []
+        ?? []
 }()
 
 var ciCompilerFlags: [PackageDescription.SwiftSetting] = [

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ var additionalCompilerFlags: [PackageDescription.SwiftSetting] = {
         .split(whereSeparator: \.isWhitespace)
         .filter { !$0.isEmpty && !$0.hasPrefix("$") }
         .map { .define(String($0)) }
-    ?? [.define("PAYWALL_COMPONENTS")]
+    ?? []
 }()
 
 var ciCompilerFlags: [PackageDescription.SwiftSetting] = [

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ var additionalCompilerFlags: [PackageDescription.SwiftSetting] = {
 }()
 
 var ciCompilerFlags: [PackageDescription.SwiftSetting] = [
-    // REPLACE_HERE
+    // REPLACE_WITH_DEFINES_HERE
     .define("PAYWALL_COMPONENTS")
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,6 @@ var additionalCompilerFlags: [PackageDescription.SwiftSetting] = {
 
 var ciCompilerFlags: [PackageDescription.SwiftSetting] = [
     // REPLACE_WITH_DEFINES_HERE
-    .define("PAYWALL_COMPONENTS")
 ]
 
 // Only add DocC Plugin when building docs, so that clients of this library won't

--- a/Package.swift
+++ b/Package.swift
@@ -106,7 +106,7 @@ let package = Package(
                     .copy("Resources/background.jpg"),
                     .process("Resources/icons.xcassets")
                 ],
-                swiftSettings: additionalCompilerFlags),
+                swiftSettings: ciCompilerFlags + additionalCompilerFlags),
         .testTarget(name: "RevenueCatUITests",
                     dependencies: [
                         "RevenueCatUI",

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -176,9 +176,10 @@ struct APIKeyDashboardList: View {
                     Text(self.offering.serverDescription)
                     Spacer()
                     #if PAYWALL_COMPONENTS
-                    Image(systemName: "exclamationmark.circle.fill")
-                        .foregroundStyle(Color.red)
-                        .hidden(if: self.offering.paywallComponentsData?.errorInfo?.isEmpty ?? true)
+                    if let errorInfo = self.offering.paywallComponentsData?.errorInfo, !errorInfo.isEmpty {
+                        Image(systemName: "exclamationmark.circle.fill")
+                            .foregroundStyle(Color.red)
+                    }
                     #endif
                 }
             }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -200,7 +200,6 @@ extension APIKeyDashboardList.Template: CustomStringConvertible {
 
     var description: String {
         if let name = self.name {
-            #if DEBUG
             if name == "components" {
                 return "V2"
             } else if let template = PaywallTemplate(rawValue: name) {
@@ -208,9 +207,6 @@ extension APIKeyDashboardList.Template: CustomStringConvertible {
             } else {
                 return "Unrecognized template"
             }
-            #else
-            return name
-            #endif
         } else {
             return "No paywall"
         }

--- a/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
+++ b/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
@@ -7,5 +7,8 @@ echo "Replacing API keys on PaywallsTester"
 file="$SCRIPT_DIR/../PaywallsTester/Config/ConfigItem.swift"
 sed -i '' 's/static var apiKey: String { "" }/static var apiKey: String { "'"$REVENUECAT_XCODE_CLOUD_RC_APP_API_KEY"'" }/' $file
 
-echo "Enabling PAYWALL_COMPONENTS compiler flag"
-echo "SWIFT_ACTIVE_COMPILATION_CONDITIONS = \$(inherited) PAYWALL_COMPONENTS" > "$SCRIPT_DIR/../Local.xcconfig"
+# This allow Local.xcconfig to be found by Xcode
+xcconfig_file="$(cd "$SCRIPT_DIR/../../../../" && pwd)/Local.xcconfig"
+
+echo "Enabling PAYWALL_COMPONENTS compiler flag in $xcconfig_file"
+echo "SWIFT_ACTIVE_COMPILATION_CONDITIONS = \$(inherited) PAYWALL_COMPONENTS\nOTHER_SWIFT_FLAGS = PAYWALL_COMPONENTS" > "$xcconfig_file"

--- a/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
+++ b/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
@@ -10,8 +10,8 @@ sed -i '' 's/static var apiKey: String { "" }/static var apiKey: String { "'"$RE
 # This allow Local.xcconfig to be found by Xcode
 xcconfig_file="$(cd "$SCRIPT_DIR/../../../../" && pwd)/Local.xcconfig"
 
-# echo "Enabling PAYWALL_COMPONENTS compiler flag in $xcconfig_file"
-# echo "SWIFT_ACTIVE_COMPILATION_CONDITIONS = \$(inherited) PAYWALL_COMPONENTS\nOTHER_SWIFT_FLAGS = PAYWALL_COMPONENTS" > "$xcconfig_file"
+echo "Enabling PAYWALL_COMPONENTS compiler flag in $xcconfig_file"
+echo "SWIFT_ACTIVE_COMPILATION_CONDITIONS = \$(inherited) PAYWALL_COMPONENTS" > "$xcconfig_file"
 
 # Update Package.swift with PAYWALL_COMPONENTS define
 package_file="$(cd "$SCRIPT_DIR/../../../../" && pwd)/Package.swift"

--- a/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
+++ b/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
@@ -12,3 +12,8 @@ xcconfig_file="$(cd "$SCRIPT_DIR/../../../../" && pwd)/Local.xcconfig"
 
 echo "Enabling PAYWALL_COMPONENTS compiler flag in $xcconfig_file"
 echo "SWIFT_ACTIVE_COMPILATION_CONDITIONS = \$(inherited) PAYWALL_COMPONENTS\nOTHER_SWIFT_FLAGS = PAYWALL_COMPONENTS" > "$xcconfig_file"
+
+# Update Package.swift with PAYWALL_COMPONENTS define
+package_file="$(cd "$SCRIPT_DIR/../../../../" && pwd)/Package.swift"
+sed -i '' 's/\/\/ REPLACE_WITH_DEFINES_HERE/.define("PAYWALL_COMPONENTS")/' "$package_file"
+

--- a/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
+++ b/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
@@ -10,8 +10,8 @@ sed -i '' 's/static var apiKey: String { "" }/static var apiKey: String { "'"$RE
 # This allow Local.xcconfig to be found by Xcode
 xcconfig_file="$(cd "$SCRIPT_DIR/../../../../" && pwd)/Local.xcconfig"
 
-echo "Enabling PAYWALL_COMPONENTS compiler flag in $xcconfig_file"
-echo "SWIFT_ACTIVE_COMPILATION_CONDITIONS = \$(inherited) PAYWALL_COMPONENTS\nOTHER_SWIFT_FLAGS = PAYWALL_COMPONENTS" > "$xcconfig_file"
+# echo "Enabling PAYWALL_COMPONENTS compiler flag in $xcconfig_file"
+# echo "SWIFT_ACTIVE_COMPILATION_CONDITIONS = \$(inherited) PAYWALL_COMPONENTS\nOTHER_SWIFT_FLAGS = PAYWALL_COMPONENTS" > "$xcconfig_file"
 
 # Update Package.swift with PAYWALL_COMPONENTS define
 package_file="$(cd "$SCRIPT_DIR/../../../../" && pwd)/Package.swift"


### PR DESCRIPTION
## Motivation

Building Paywalls Tester was failing on Xcode Cloud and it also needed to be enabled for Paywalls V2

## Description

Paywalls Tester and the RevenueCat and RevenueCatUI frameworks needed to get the `PAYWALL_COMPONENTS` flag in different ways. Not sure why its works locally (before this change) but not on Xcode Cloud 🤦‍♂️ 

- Paywalls Tester will get the `PAYWALL_COMPONENTS` flag from `Local.xcconfig`
- RevenueCat and RevenueCatUI will get the `PAYWALL_COMPONENTS` flag by replacing a commented out string in `Package.swift` with `.define("PAYWALL_COMPONENTS")` 

It's not great but it works and we can do something different later
