### PR TITLE
Make purchase params & winback functions public

### DIFF
--- a/Sources/Misc/Concurrency/Purchases+async.swift
+++ b/Sources/Misc/Concurrency/Purchases+async.swift
@@ -93,8 +93,6 @@ extension Purchases {
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
-    #if ENABLE_PURCHASE_PARAMS
-
     func purchaseAsync(_ params: PurchaseParams) async throws -> PurchaseResultData {
         return try await withUnsafeThrowingContinuation { continuation in
             purchase(params,
@@ -104,8 +102,6 @@ extension Purchases {
             })
         }
     }
-
-    #endif
 
     func syncPurchasesAsync() async throws -> CustomerInfo {
         return try await withUnsafeThrowingContinuation { continuation in

--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -61,9 +61,7 @@ extension CustomerInfoResponse {
         @IgnoreDecodeErrors<PurchaseOwnershipType>
         var ownershipType: PurchaseOwnershipType
         var productPlanIdentifier: String?
-        #if ENABLE_PURCHASE_PARAMS
         var metadata: [String: String]?
-        #endif
 
     }
 

--- a/Sources/Purchasing/Purchases/PurchaseParams.swift
+++ b/Sources/Purchasing/Purchases/PurchaseParams.swift
@@ -102,7 +102,7 @@ import Foundation
          * Availability: iOS 18.0+, macOS 15.0+, tvOS 18.0+, watchOS 11.0+, visionOS 2.0+
          */
         @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-        internal func with(winBackOffer: WinBackOffer) -> Self {
+        public func with(winBackOffer: WinBackOffer) -> Self {
             self.winBackOffer = winBackOffer
             return self
         }

--- a/Sources/Purchasing/Purchases/PurchaseParams.swift
+++ b/Sources/Purchasing/Purchases/PurchaseParams.swift
@@ -29,7 +29,7 @@ import Foundation
  * Purchases.shared.purchase(params)
  * ```
  */
-@objc(RCPurchaseParams) public final class PurchaseParams: NSObject {
+@objc(RCPurchaseParams) public final class PurchaseParams: NSObject, Sendable {
 
     let package: Package?
     let product: StoreProduct?

--- a/Sources/Purchasing/Purchases/PurchaseParams.swift
+++ b/Sources/Purchasing/Purchases/PurchaseParams.swift
@@ -13,7 +13,6 @@
 
 import Foundation
 
-#if ENABLE_PURCHASE_PARAMS
 #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
 /**
@@ -115,5 +114,4 @@ import Foundation
     }
 }
 
-#endif
 #endif

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1006,8 +1006,6 @@ public extension Purchases {
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
-    #if ENABLE_PURCHASE_PARAMS
-
     @objc(params:withCompletion:)
     func purchase(_ params: PurchaseParams, completion: @escaping PurchaseCompletedBlock) {
         purchasesOrchestrator.purchase(params: params, completion: completion)
@@ -1016,8 +1014,6 @@ public extension Purchases {
     func purchase(_ params: PurchaseParams) async throws -> PurchaseResultData {
         return try await purchaseAsync(params)
     }
-
-    #endif
 
     @objc func invalidateCustomerInfoCache() {
         self.customerInfoManager.clearCustomerInfoCache(forAppUserID: appUserID)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1966,7 +1966,7 @@ extension Purchases {
      * - Returns: The win-back offers on the given product that a subscriber is eligible for.
      * - Important: Win-back offers are only supported when the SDK is running with StoreKit 2 enabled.
      */
-    internal func eligibleWinBackOffers(
+    public func eligibleWinBackOffers(
         forProduct product: StoreProduct
     ) async throws -> [WinBackOffer] {
         return try await self.purchasesOrchestrator.eligibleWinBackOffers(forProduct: product)
@@ -1980,7 +1980,7 @@ extension Purchases {
      * offers for the provided product.
      * - Important: Win-back offers are only supported when the SDK is running with StoreKit 2 enabled.
      */
-    internal func eligibleWinBackOffers(
+    public func eligibleWinBackOffers(
         forProduct product: StoreProduct,
         completion: @escaping @Sendable (Result<[WinBackOffer], PublicError>) -> Void
     ) {

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -334,7 +334,6 @@ final class PurchasesOrchestrator {
     }
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-    #if ENABLE_PURCHASE_PARAMS
     func purchase(params: PurchaseParams, completion: @escaping PurchaseCompletedBlock) {
         var product = params.product
         if product == nil {
@@ -352,7 +351,6 @@ final class PurchasesOrchestrator {
                  metadata: params.metadata,
                  completion: completion)
     }
-    #endif
     #endif
 
     func purchase(product: StoreProduct,

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1120,23 +1120,6 @@ public protocol PurchasesSwiftType: AnyObject {
     func recordPurchase(
         _ purchaseResult: StoreKit.Product.PurchaseResult
     ) async throws -> StoreTransaction?
-}
-
-// MARK: -
-
-/// Interface for ``Purchases``'s internal-only methods.
-internal protocol InternalPurchasesType: AnyObject {
-
-    /// Performs an unauthenticated request to the API to verify connectivity.
-    /// - Throws: `PublicError` if request failed.
-    func healthRequest(signatureVerification: Bool) async throws
-
-    func offerings(fetchPolicy: OfferingsManager.FetchPolicy) async throws -> Offerings
-
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func productEntitlementMapping() async throws -> ProductEntitlementMapping
-
-    var responseVerificationMode: Signing.ResponseVerificationMode { get }
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     /**
@@ -1165,5 +1148,22 @@ internal protocol InternalPurchasesType: AnyObject {
         completion: @escaping @Sendable (Result<[WinBackOffer], PublicError>) -> Void
     )
     #endif
+}
+
+// MARK: -
+
+/// Interface for ``Purchases``'s internal-only methods.
+internal protocol InternalPurchasesType: AnyObject {
+
+    /// Performs an unauthenticated request to the API to verify connectivity.
+    /// - Throws: `PublicError` if request failed.
+    func healthRequest(signatureVerification: Bool) async throws
+
+    func offerings(fetchPolicy: OfferingsManager.FetchPolicy) async throws -> Offerings
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func productEntitlementMapping() async throws -> ProductEntitlementMapping
+
+    var responseVerificationMode: Signing.ResponseVerificationMode { get }
 
 }

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -353,8 +353,6 @@ public protocol PurchasesType: AnyObject {
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
-    #if ENABLE_PURCHASE_PARAMS
-
     /**
      * Initiates a purchase.
      *
@@ -398,8 +396,6 @@ public protocol PurchasesType: AnyObject {
      * If the user cancelled the purchase, `userCancelled` will be `true`.
      */
     func purchase(_ params: PurchaseParams) async throws -> PurchaseResultData
-
-    #endif
 
     /**
      * Invalidates the cache for customer information.

--- a/Sources/Purchasing/StoreKitAbstractions/WinBackOffer.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/WinBackOffer.swift
@@ -15,10 +15,10 @@ import Foundation
 
 /// Represents an Apple win-back offer.
 @objc(RCWinBackOffer)
-internal final class WinBackOffer: NSObject, Sendable {
+public final class WinBackOffer: NSObject, Sendable {
 
     /// The ``StoreProductDiscount`` in this offer.
-    @objc internal let discount: StoreProductDiscount
+    @objc public let discount: StoreProductDiscount
 
     init(discount: StoreProductDiscountType) {
         self.discount = StoreProductDiscount.from(discount: discount)

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
@@ -131,11 +131,9 @@ NSString *storeFrontCountryCode;
     RCOfferings * _Nullable __unused offerings = p.cachedOfferings;
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-    #if ENABLE_PURCHASE_PARAMS
     RCPurchaseParams *packageParams = [[[[[RCPurchaseParamsBuilder alloc] initWithPackage:pack] withMetadata: @{@"foo":@"bar"}] withPromotionalOffer:pro] build];
     RCPurchaseParams *productParams = [[[[[RCPurchaseParamsBuilder alloc] initWithProduct:storeProduct] withMetadata: @{@"foo":@"bar"}] withPromotionalOffer:pro] build];
     [p params:packageParams withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
-    #endif
     #endif
 
     [p getProductsWithIdentifiers:@[@""] completion:^(NSArray<RCStoreProduct *> *products) { }];

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
@@ -138,8 +138,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     let discount: StoreProductDiscount! = nil
     let pack: Package! = nil
     let offer: PromotionalOffer! = nil
-    // Commented out until we make fetching/redeeming win-back offers public
-//    let winBackOffer: WinBackOffer! = nil
+    let winBackOffer: WinBackOffer! = nil
 
     purchases.purchase(product: storeProduct) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
     purchases.purchase(package: pack) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
@@ -160,23 +159,26 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
                        promotionalOffer: offer) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-    let packageParams = PurchaseParams.Builder(package: pack)
+    var packageParamsBuilder = PurchaseParams.Builder(package: pack)
         .with(metadata: ["foo":"bar"])
         .with(promotionalOffer: offer)
 
-    // Commented out until we make fetching/redeeming win-back offers public
-//        .with(winBackOffer: winBackOffer)
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+        packageParamsBuilder = packageParamsBuilder.with(winBackOffer: winBackOffer)
+    }
+    let packageParams = packageParamsBuilder.build()
 
-        .build()
-    let productParams = PurchaseParams.Builder(product: storeProduct)
+    var productParamsBuilder = PurchaseParams.Builder(product: storeProduct)
         .with(metadata: ["foo":"bar"])
         .with(promotionalOffer: offer)
 
-    // Commented out until we make fetching/redeeming win-back offers public
-//        .with(winBackOffer: winBackOffer)
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+        productParamsBuilder = packageParamsBuilder.with(winBackOffer: winBackOffer)
+    }
+    let productParams = productParamsBuilder.build()
 
-        .build()
-    purchases.purchase(params) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
+    purchases.purchase(productParams) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
+    purchases.purchase(productParams) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
     #endif
 
     purchases.invalidateCustomerInfoCache()

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
@@ -160,7 +160,6 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
                        promotionalOffer: offer) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-    #if ENABLE_PURCHASE_PARAMS
     let packageParams = PurchaseParams.Builder(package: pack)
         .with(metadata: ["foo":"bar"])
         .with(promotionalOffer: offer)
@@ -178,7 +177,6 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
 
         .build()
     purchases.purchase(params) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
-    #endif
     #endif
 
     purchases.invalidateCustomerInfoCache()

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -160,12 +160,14 @@ extension BaseStoreKitIntegrationTests {
 
         let data: PurchaseResultData
         if let metadata = metadata {
-            var params = PurchaseParams.Builder(product: self.monthlyPackage.storeProduct)
+            let product = await self.monthlyPackage.storeProduct
+            var params = PurchaseParams.Builder(product: product)
                 .with(metadata: metadata)
                 .build()
             data = try await self.purchases.purchase(params)
         } else {
-            data = try await self.purchases.purchase(product: self.monthlyPackage.storeProduct)
+            let product = await self.monthlyPackage.storeProduct
+            data = try await self.purchases.purchase(product: product)
         }
 
         try await self.verifyEntitlementWentThrough(data.customerInfo,

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -158,18 +158,15 @@ extension BaseStoreKitIntegrationTests {
     ) async throws -> PurchaseResultData {
         let logger = TestLogHandler()
 
-        #if ENABLE_PURCHASE_PARAMS
+        let data: PurchaseResultData
         if let metadata = metadata {
             var params = PurchaseParams.Builder(product: self.monthlyPackage.storeProduct)
                 .with(metadata: metadata)
                 .build()
-            let data = try await self.purchases.purchase(params: params)
+            data = try await self.purchases.purchase(params: params)
         } else {
-            let data = try await self.purchases.purchase(product: self.monthlyPackage.storeProduct)
+            data = try await self.purchases.purchase(product: self.monthlyPackage.storeProduct)
         }
-        #else
-        let data = try await self.purchases.purchase(product: self.monthlyPackage.storeProduct)
-        #endif
 
         try await self.verifyEntitlementWentThrough(data.customerInfo,
                                                     file: file,

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -160,13 +160,19 @@ extension BaseStoreKitIntegrationTests {
 
         let data: PurchaseResultData
         if let metadata = metadata {
-            let product = await self.monthlyPackage.storeProduct
-            var params = PurchaseParams.Builder(product: product)
+            let product = try await self.monthlyPackage.storeProduct
+
+            #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+            let params = PurchaseParams.Builder(product: product)
                 .with(metadata: metadata)
                 .build()
             data = try await self.purchases.purchase(params)
+            #else
+            data = try await self.purchases.purchase(product: product)
+            #endif
+
         } else {
-            let product = await self.monthlyPackage.storeProduct
+            let product = try await self.monthlyPackage.storeProduct
             data = try await self.purchases.purchase(product: product)
         }
 

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -163,7 +163,7 @@ extension BaseStoreKitIntegrationTests {
             var params = PurchaseParams.Builder(product: self.monthlyPackage.storeProduct)
                 .with(metadata: metadata)
                 .build()
-            data = try await self.purchases.purchase(params: params)
+            data = try await self.purchases.purchase(params)
         } else {
             data = try await self.purchases.purchase(product: self.monthlyPackage.storeProduct)
         }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -46,7 +46,6 @@ class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
         expect(originalPurchaseDate).toNot(beNil())
     }
 
-    #if ENABLE_PURCHASE_PARAMS
     @available(iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, *)
     func testPurchaseMetadataIsInResponse() async throws {
         // In this scenario, the AppTransaction should be posted with the SK2 transaction JWT
@@ -60,7 +59,6 @@ class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
         let subscription = try XCTUnwrap(customerInfo.subscriber.subscriptions.first?.value)
         expect(subscription.metadata).to(equal(["sample": "data"]))
     }
-    #endif
 
     @available(iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, *)
     func testOriginalApplicationVersionAvailableAfterPurchase() async throws {

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
@@ -333,7 +333,6 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
 
     // MARK: - PurchaseParams
 
-    #if ENABLE_PURCHASE_PARAMS
     func testPurchaseWithPurchaseParamsPostsReceipt() async throws {
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
@@ -407,7 +406,6 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
         let expectedCustomerInfo: CustomerInfo = .emptyInfo
         expect(customerInfo) == expectedCustomerInfo
     }
-    #endif
 
     // MARK: - Paywalls
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -269,7 +269,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
 
     // MARK: - PurchaseParams
 
-    #if ENABLE_PURCHASE_PARAMS
     func testPurchaseWithPurchaseParamsPostsReceipt() async throws {
         self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
@@ -344,7 +343,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         expect(self.mockStoreKit2TransactionListener?.invokedHandle) == true
         expect(self.mockStoreKit2TransactionListener?.invokedHandleCount) == 1
     }
-    #endif
 
     // MARK: - Paywalls
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -31,11 +31,9 @@ protocol PurchasesOrchestratorTests {
 
     // MARK: - PurchaseParams
 
-    #if ENABLE_PURCHASE_PARAMS
     func testPurchaseWithPurchaseParamsPostsReceipt() async throws
 
     func testPurchaseWithPurchaseParamsReturnsCorrectValues() async throws
-    #endif
 
     // MARK: - Paywalls
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Offerings/OfferingDetailView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Offerings/OfferingDetailView.swift
@@ -134,7 +134,6 @@ struct OfferingDetailView: View {
             self.isPurchasing = true
             defer { self.isPurchasing = false }
 
-            #if ENABLE_PURCHASE_PARAMS
             let result: PurchaseResultData
             if let metadata = customerData.metadata {
                 let params = PurchaseParams.Builder(package: package).with(metadata: metadata).build()
@@ -142,9 +141,6 @@ struct OfferingDetailView: View {
             } else {
                 result = try await Purchases.shared.purchase(package: self.package)
             }
-            #else
-            let result = try await Purchases.shared.purchase(package: self.package)
-            #endif
             self.completedPurchase(result)
 
         }
@@ -153,7 +149,6 @@ struct OfferingDetailView: View {
             self.isPurchasing = true
             defer { self.isPurchasing = false }
 
-            #if ENABLE_PURCHASE_PARAMS
             let result: PurchaseResultData
             if let metadata = customerData.metadata {
                 let params = PurchaseParams.Builder(product: self.package.storeProduct).with(metadata: metadata).build()
@@ -161,9 +156,7 @@ struct OfferingDetailView: View {
             } else {
                 result = try await Purchases.shared.purchase(product: self.package.storeProduct)
             }
-            #else
-            let result = try await Purchases.shared.purchase(product: self.package.storeProduct)
-            #endif
+
             self.completedPurchase(result)
         }
 

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -232,7 +232,6 @@ extension MockPurchases: PurchasesType {
         self.unimplemented()
     }
 
-    #if ENABLE_PURCHASE_PARAMS
     func purchase(_ params: PurchaseParams, completion: @escaping PurchaseCompletedBlock) {
         self.unimplemented()
     }
@@ -240,7 +239,6 @@ extension MockPurchases: PurchasesType {
     func purchase(_ params: PurchaseParams) async throws -> PurchaseResultData {
         self.unimplemented()
     }
-    #endif
 
     func restorePurchases(completion: ((CustomerInfo?, PublicError?) -> Void)?) {
         self.unimplemented()

--- a/Tests/UnitTests/Purchasing/PurchaseParamsTests.swift
+++ b/Tests/UnitTests/Purchasing/PurchaseParamsTests.swift
@@ -19,7 +19,6 @@ import XCTest
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 class PurchaseParamsTests: TestCase {
 
-    #if ENABLE_PURCHASE_PARAMS
     // MARK: - PurchaseParams
     func testPurchaseParamsBuilderWithProduct() async throws {
         let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
@@ -94,6 +93,5 @@ class PurchaseParamsTests: TestCase {
             expect(params.winBackOffer).to(equal(winbackOffer))
         }
     }
-    #endif
 
 }


### PR DESCRIPTION
### Description
This is a follow-up PR to https://github.com/RevenueCat/purchases-ios/pull/4485, which does the following:
1. Makes the PurchaseParams functionality publicly available by removing the `ENABLE_PURCHASE_PARAMS` compiler flag checks
   - Note: The PurchaseParams functionality is not available if the `ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION` flag is used
2. Make the functions to fetch & redeem eligible win-back offers public
3. Makes the new transaction metadata functionality public

### Review ordering
This PR is based off of the `purchase-params-api-enhancements` PR to keep the PR size down. [The PR for that branch](https://github.com/RevenueCat/purchases-ios/pull/4485) should be reviewed first.
