### PR TITLE
Add support for `product_mapping` in promotional offers

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -47,7 +47,7 @@ enum CustomerCenterConfigTestData {
                                     eligible: true,
                                     title: "title",
                                     subtitle: "subtitle",
-                                    productMapping: ["monthly" : "offer_id"]
+                                    productMapping: ["monthly": "offer_id"]
                                 ))
                             ),
                             .init(

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -46,7 +46,8 @@ enum CustomerCenterConfigTestData {
                                     iosOfferId: "offer_id",
                                     eligible: true,
                                     title: "title",
-                                    subtitle: "subtitle"
+                                    subtitle: "subtitle",
+                                    productMapping: ["monthly" : "offer_id"]
                                 ))
                             ),
                             .init(

--- a/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
+++ b/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
@@ -50,7 +50,7 @@ class LoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
             }
 
             let exactMatch = if !promoOfferDetails.productMapping.isEmpty {
-                // Try to find match using product mapping first
+                // Try to find match using product mapping if configured and ignore iosOfferId
                 subscribedProduct.discounts.first { discount in
                     guard let offerIdentifier = discount.offerIdentifier else { return false }
                     return promoOfferDetails.productMapping[productIdentifier] == offerIdentifier
@@ -78,8 +78,17 @@ class LoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
             }
 
             guard let discount = discount else {
-                let message =
-                Strings.could_not_offer_for_active_subscriptions(promoOfferDetails.iosOfferId, productIdentifier)
+                let message = if !promoOfferDetails.productMapping.isEmpty {
+                    Strings.could_not_offer_for_active_subscriptions(
+                        promoOfferDetails.productMapping[productIdentifier] ?? "nil",
+                        productIdentifier
+                    )
+                } else {
+                    Strings.could_not_offer_for_active_subscriptions(
+                        promoOfferDetails.iosOfferId,
+                        productIdentifier
+                    )
+                }
                 Logger.debug(message)
                 return .failure(CustomerCenterError.couldNotFindSubscriptionInformation)
             }

--- a/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
+++ b/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
@@ -42,67 +42,102 @@ class LoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
     ) async -> Result<PromotionalOfferData, Error> {
         do {
             let customerInfo = try await self.purchasesProvider.customerInfo()
-
-            guard let productIdentifier = customerInfo.earliestExpiringAppStoreEntitlement()?.productIdentifier,
-                  let subscribedProduct = await self.purchasesProvider.products([productIdentifier]).first else {
-                Logger.warning(Strings.could_not_offer_for_any_active_subscriptions)
-                return .failure(CustomerCenterError.couldNotFindSubscriptionInformation)
-            }
-
-            let exactMatch = if !promoOfferDetails.productMapping.isEmpty {
-                // Try to find match using product mapping if configured and ignore iosOfferId
-                subscribedProduct.discounts.first { discount in
-                    guard let offerIdentifier = discount.offerIdentifier else { return false }
-                    return promoOfferDetails.productMapping[productIdentifier] == offerIdentifier
-                }
-            } else {
-                // Fall back to iosOfferId if no mapping (in case of using legacy iosOfferId)
-                subscribedProduct.discounts.first { discount in
-                    discount.offerIdentifier == promoOfferDetails.iosOfferId
-                }
-            }
-
-            let discount: StoreProductDiscount?
-            if let exactMatch = exactMatch {
-                discount = exactMatch
-            } else if promoOfferDetails.productMapping.isEmpty {
-                // Only try suffix matching if we're using iosOfferId (no mapping)
-                discount = subscribedProduct.discounts.first { discount in
-                    guard let offerIdentifier = discount.offerIdentifier else {
-                        return false
-                    }
-                    return offerIdentifier.hasSuffix("_\(promoOfferDetails.iosOfferId)")
-                }
-            } else {
-                discount = nil
-            }
-
-            guard let discount = discount else {
-                let message = if !promoOfferDetails.productMapping.isEmpty {
-                    Strings.could_not_offer_for_active_subscriptions(
-                        promoOfferDetails.productMapping[productIdentifier] ?? "nil",
-                        productIdentifier
-                    )
-                } else {
-                    Strings.could_not_offer_for_active_subscriptions(
-                        promoOfferDetails.iosOfferId,
-                        productIdentifier
-                    )
-                }
-                Logger.debug(message)
-                return .failure(CustomerCenterError.couldNotFindSubscriptionInformation)
-            }
-
-            let promotionalOffer = try await self.purchasesProvider.promotionalOffer(forProductDiscount: discount,
-                                                                                     product: subscribedProduct)
-            let promotionalOfferData = PromotionalOfferData(promotionalOffer: promotionalOffer,
-                                                            product: subscribedProduct,
-                                                            promoOfferDetails: promoOfferDetails)
-            return .success(promotionalOfferData)
+            
+            let (productIdentifier, subscribedProduct) = try await getActiveSubscription(customerInfo)
+            let discount = try findDiscount(for: subscribedProduct, 
+                                          productIdentifier: productIdentifier,
+                                          promoOfferDetails: promoOfferDetails)
+            
+            let promotionalOffer = try await self.purchasesProvider.promotionalOffer(
+                forProductDiscount: discount,
+                product: subscribedProduct
+            )
+            return .success(PromotionalOfferData(
+                promotionalOffer: promotionalOffer,
+                product: subscribedProduct,
+                promoOfferDetails: promoOfferDetails
+            ))
         } catch {
             Logger.warning(Strings.error_fetching_promotional_offer(error))
             return .failure(CustomerCenterError.couldNotFindOfferForActiveProducts)
         }
+    }
+
+    private func getActiveSubscription(_ customerInfo: CustomerInfo) async throws -> (String, StoreProduct) {
+        guard let productIdentifier = customerInfo.earliestExpiringAppStoreEntitlement()?.productIdentifier,
+              let subscribedProduct = await self.purchasesProvider.products([productIdentifier]).first else {
+            Logger.warning(Strings.could_not_offer_for_any_active_subscriptions)
+            throw CustomerCenterError.couldNotFindSubscriptionInformation
+        }
+        return (productIdentifier, subscribedProduct)
+    }
+
+    private func findDiscount(
+        for product: StoreProduct,
+        productIdentifier: String,
+        promoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer
+    ) throws -> StoreProductDiscount {
+        let discount = if !promoOfferDetails.productMapping.isEmpty {
+            findMappedDiscount(for: product, 
+                              productIdentifier: productIdentifier,
+                              promoOfferDetails: promoOfferDetails)
+        } else {
+            findLegacyDiscount(for: product, promoOfferDetails: promoOfferDetails)
+        }
+        
+        guard let discount = discount else {
+            logDiscountError(productIdentifier: productIdentifier, promoOfferDetails: promoOfferDetails)
+            throw CustomerCenterError.couldNotFindSubscriptionInformation
+        }
+        
+        return discount
+    }
+
+    private func findMappedDiscount(
+        for product: StoreProduct,
+        productIdentifier: String,
+        promoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer
+    ) -> StoreProductDiscount? {
+        product.discounts.first { discount in
+            guard let offerIdentifier = discount.offerIdentifier else { return false }
+            return promoOfferDetails.productMapping[productIdentifier] == offerIdentifier
+        }
+    }
+
+    private func findLegacyDiscount(
+        for product: StoreProduct,
+        promoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer
+    ) -> StoreProductDiscount? {
+        // Try exact match first
+        if let exactMatch = product.discounts.first(where: { 
+            $0.offerIdentifier == promoOfferDetails.iosOfferId 
+        }) {
+            return exactMatch
+        }
+        
+        // Fall back to suffix matching
+        return product.discounts.first { discount in
+            guard let offerIdentifier = discount.offerIdentifier else { return false }
+            return offerIdentifier.hasSuffix("_\(promoOfferDetails.iosOfferId)")
+        }
+    }
+
+    private func logDiscountError(
+        productIdentifier: String,
+        promoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer
+    ) {
+        let message = if !promoOfferDetails.productMapping.isEmpty {
+            Strings.could_not_offer_for_active_subscriptions(
+                promoOfferDetails.productMapping[productIdentifier] ?? "nil",
+                productIdentifier
+            )
+        } else {
+            Strings.could_not_offer_for_active_subscriptions(
+                promoOfferDetails.iosOfferId,
+                productIdentifier
+            )
+        }
+        Logger.debug(message)
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
+++ b/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
@@ -43,9 +43,9 @@ class LoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
         do {
             let customerInfo = try await self.purchasesProvider.customerInfo()
 
-            let (productIdentifier, subscribedProduct) = try await getActiveSubscription(customerInfo)
+            let subscribedProduct = try await getActiveSubscription(customerInfo)
             let discount = try findDiscount(for: subscribedProduct,
-                                            productIdentifier: productIdentifier,
+                                            productIdentifier: subscribedProduct.productIdentifier,
                                             promoOfferDetails: promoOfferDetails)
 
             let promotionalOffer = try await self.purchasesProvider.promotionalOffer(
@@ -63,13 +63,13 @@ class LoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
         }
     }
 
-    private func getActiveSubscription(_ customerInfo: CustomerInfo) async throws -> (String, StoreProduct) {
+    private func getActiveSubscription(_ customerInfo: CustomerInfo) async throws -> StoreProduct {
         guard let productIdentifier = customerInfo.earliestExpiringAppStoreEntitlement()?.productIdentifier,
               let subscribedProduct = await self.purchasesProvider.products([productIdentifier]).first else {
             Logger.warning(Strings.could_not_offer_for_any_active_subscriptions)
             throw CustomerCenterError.couldNotFindSubscriptionInformation
         }
-        return (productIdentifier, subscribedProduct)
+        return subscribedProduct
     }
 
     private func findDiscount(

--- a/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
+++ b/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
@@ -106,10 +106,7 @@ private extension LoadPromotionalOfferUseCase {
         productIdentifier: String,
         promoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer
     ) -> StoreProductDiscount? {
-        product.discounts.first { discount in
-            guard let offerIdentifier = discount.offerIdentifier else { return false }
-            return promoOfferDetails.productMapping[productIdentifier] == offerIdentifier
-        }
+        product.discounts.first { $0.offerIdentifier == promoOfferDetails.productMapping[productIdentifier] }
     }
 
     private func findLegacyDiscount(
@@ -124,10 +121,7 @@ private extension LoadPromotionalOfferUseCase {
         }
 
         // Fall back to suffix matching
-        return product.discounts.first { discount in
-            guard let offerIdentifier = discount.offerIdentifier else { return false }
-            return offerIdentifier.hasSuffix("_\(promoOfferDetails.iosOfferId)")
-        }
+        return product.discounts.first { $0.offerIdentifier?.hasSuffix("_\(promoOfferDetails.iosOfferId)") == true }
     }
 
     private func logDiscountError(

--- a/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
+++ b/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
@@ -42,12 +42,12 @@ class LoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
     ) async -> Result<PromotionalOfferData, Error> {
         do {
             let customerInfo = try await self.purchasesProvider.customerInfo()
-            
+
             let (productIdentifier, subscribedProduct) = try await getActiveSubscription(customerInfo)
-            let discount = try findDiscount(for: subscribedProduct, 
-                                          productIdentifier: productIdentifier,
-                                          promoOfferDetails: promoOfferDetails)
-            
+            let discount = try findDiscount(for: subscribedProduct,
+                                            productIdentifier: productIdentifier,
+                                            promoOfferDetails: promoOfferDetails)
+
             let promotionalOffer = try await self.purchasesProvider.promotionalOffer(
                 forProductDiscount: discount,
                 product: subscribedProduct
@@ -78,18 +78,18 @@ class LoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
         promoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer
     ) throws -> StoreProductDiscount {
         let discount = if !promoOfferDetails.productMapping.isEmpty {
-            findMappedDiscount(for: product, 
-                              productIdentifier: productIdentifier,
-                              promoOfferDetails: promoOfferDetails)
+            findMappedDiscount(for: product,
+                               productIdentifier: productIdentifier,
+                               promoOfferDetails: promoOfferDetails)
         } else {
             findLegacyDiscount(for: product, promoOfferDetails: promoOfferDetails)
         }
-        
+
         guard let discount = discount else {
             logDiscountError(productIdentifier: productIdentifier, promoOfferDetails: promoOfferDetails)
             throw CustomerCenterError.couldNotFindSubscriptionInformation
         }
-        
+
         return discount
     }
 
@@ -109,12 +109,12 @@ class LoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
         promoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer
     ) -> StoreProductDiscount? {
         // Try exact match first
-        if let exactMatch = product.discounts.first(where: { 
-            $0.offerIdentifier == promoOfferDetails.iosOfferId 
+        if let exactMatch = product.discounts.first(where: {
+            $0.offerIdentifier == promoOfferDetails.iosOfferId
         }) {
             return exactMatch
         }
-        
+
         // Fall back to suffix matching
         return product.discounts.first { discount in
             guard let offerIdentifier = discount.offerIdentifier else { return false }

--- a/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
+++ b/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
@@ -63,6 +63,14 @@ class LoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
         }
     }
 
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private extension LoadPromotionalOfferUseCase {
+
     private func getActiveSubscription(_ customerInfo: CustomerInfo) async throws -> StoreProduct {
         guard let productIdentifier = customerInfo.earliestExpiringAppStoreEntitlement()?.productIdentifier,
               let subscribedProduct = await self.purchasesProvider.products([productIdentifier]).first else {

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -279,12 +279,18 @@ public struct CustomerCenterConfigData {
             public let eligible: Bool
             public let title: String
             public let subtitle: String
+            public let productMapping: [String: String]
 
-            public init(iosOfferId: String, eligible: Bool, title: String, subtitle: String) {
+            public init(iosOfferId: String,
+                        eligible: Bool,
+                        title: String,
+                        subtitle: String,
+                        productMapping: [String: String]) {
                 self.iosOfferId = iosOfferId
                 self.eligible = eligible
                 self.title = title
                 self.subtitle = subtitle
+                self.productMapping = productMapping
             }
 
         }
@@ -511,6 +517,7 @@ extension CustomerCenterConfigData.HelpPath.PromotionalOffer {
         self.eligible = response.eligible
         self.title = response.title
         self.subtitle = response.subtitle
+        self.productMapping = response.productMapping
     }
 
 }

--- a/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
+++ b/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
@@ -74,6 +74,7 @@ struct CustomerCenterConfigResponse {
             let eligible: Bool
             let title: String
             let subtitle: String
+            let productMapping: [String: String]
 
         }
 

--- a/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
@@ -432,7 +432,11 @@ class ManageSubscriptionsViewModelTests: TestCase {
         let promoOfferDetails = CustomerCenterConfigData.HelpPath.PromotionalOffer(iosOfferId: offerIdentifier,
                                                                                    eligible: false,
                                                                                    title: "Wait",
-                                                                                   subtitle: "Here's an offer for you")
+                                                                                   subtitle: "Here's an offer for you",
+                                                                                   productMapping: [
+                                                                                    "product_id": "offer_id"
+                                                                                   ]
+        )
         let loadPromotionalOfferUseCase = MockLoadPromotionalOfferUseCase()
         loadPromotionalOfferUseCase.mockedProduct = product
         loadPromotionalOfferUseCase.mockedPromoOfferDetails = promoOfferDetails
@@ -527,7 +531,10 @@ class ManageSubscriptionsViewModelTests: TestCase {
         CustomerCenterConfigData.HelpPath.PromotionalOffer(iosOfferId: offerIdentifierInJSON,
                                                            eligible: true,
                                                            title: "Wait",
-                                                           subtitle: "Here's an offer for you")
+                                                           subtitle: "Here's an offer for you",
+                                                           productMapping: [
+                                                            "product_id": "offer_id"
+                                                           ])
         let loadPromotionalOfferUseCase = MockLoadPromotionalOfferUseCase()
         loadPromotionalOfferUseCase.mockedProduct = product
         loadPromotionalOfferUseCase.mockedPromoOfferDetails = promoOfferDetails

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationFixtures.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationFixtures.swift
@@ -54,7 +54,8 @@ enum SubscriptionInformationFixtures {
                     iosOfferId: "offer_id",
                     eligible: false,
                     title: "title",
-                    subtitle: "subtitle"
+                    subtitle: "subtitle",
+                    productMapping: ["product_id": "offer_id"]
                 ))
             )
         ]
@@ -76,7 +77,8 @@ enum SubscriptionInformationFixtures {
                         iosOfferId: offerID,
                         eligible: true,
                         title: "title",
-                        subtitle: "subtitle"
+                        subtitle: "subtitle",
+                        productMapping: ["product_id": "offer_id"]
                     ))
                 )
             ]

--- a/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
+++ b/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
@@ -61,7 +61,10 @@ class CustomerCenterConfigDataTests: TestCase {
                                 promotionalOffer: .init(iosOfferId: "offer_id",
                                                         eligible: true,
                                                         title: "Wait!",
-                                                        subtitle: "Before you go"),
+                                                        subtitle: "Before you go",
+                                                        productMapping: [
+                                                            "product_id": "offer_id"
+                                                        ]),
                                 feedbackSurvey: nil
                             ),
                             .init(
@@ -78,7 +81,10 @@ class CustomerCenterConfigDataTests: TestCase {
                                                               promotionalOffer: .init(iosOfferId: "offer_id_1",
                                                                                       eligible: true,
                                                                                       title: "Wait!",
-                                                                                      subtitle: "Before you go"))
+                                                                                      subtitle: "Before you go",
+                                                                                      productMapping: [
+                                                                                          "product_id": "offer_id"
+                                                                                      ]))
                                                       ])
                             ),
                             .init(
@@ -90,7 +96,10 @@ class CustomerCenterConfigDataTests: TestCase {
                                 promotionalOffer: .init(iosOfferId: "offer_id",
                                                         eligible: true,
                                                         title: "Wait!",
-                                                        subtitle: "Before you go"),
+                                                        subtitle: "Before you go",
+                                                        productMapping: [
+                                                            "product_id": "offer_id"
+                                                        ]),
                                 feedbackSurvey: nil
                             )
                         ]

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerCenterConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerCenterConfigTests.swift
@@ -299,7 +299,10 @@ private extension BackendGetCustomerCenterConfigTests {
                                 "ios_offer_id": "rc-refund-offer",
                                 "eligible": true,
                                 "title": "Wait!",
-                                "subtitle": "Here's an offer for you"
+                                "subtitle": "Here's an offer for you",
+                                "product_mapping": [
+                                    "product_id": "offer_id"
+                                ]
                             ] as [String: Any],
                             "title": "Request a refund",
                             "type": "REFUND_REQUEST"
@@ -318,7 +321,10 @@ private extension BackendGetCustomerCenterConfigTests {
                                             "ios_offer_id": "rc-cancel-offer",
                                             "eligible": false,
                                             "title": "Wait!",
-                                            "subtitle": "Here's an offer for you"
+                                            "subtitle": "Here's an offer for you",
+                                            "product_mapping": [
+                                                "product_id": "offer_id"
+                                            ]
                                         ] as [String: Any],
                                         "title": "Too expensive"
                                     ] as [String: Any],
@@ -328,7 +334,10 @@ private extension BackendGetCustomerCenterConfigTests {
                                             "ios_offer_id": "rc-cancel-offer",
                                             "eligible": false,
                                             "title": "Wait!",
-                                            "subtitle": "Here's an offer for you"
+                                            "subtitle": "Here's an offer for you",
+                                            "product_mapping": [
+                                                "product_id": "offer_id"
+                                            ]
                                         ] as [String: Any],
                                         "title": "Don't use the app"
                                     ] as [String: Any],


### PR DESCRIPTION
There's a new `product_mapping` field in the `promotional_offer` JSON object. This map is more specific on which offer to load. This mapping will be configurable with the new UI, but we should still support the old `ios_offer_id` in case the developer has not configured a mapping yet.