### PR TITLE
[Paywalls V2] Process variables in the text component

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		2C2AEB3F2CA7235300A50F38 /* PaywallPurchaseButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB3E2CA7235300A50F38 /* PaywallPurchaseButtonComponent.swift */; };
 		2C4C36132C6FBA8B00AE959B /* CompatibilityTopBarTrailing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4C36122C6FBA8B00AE959B /* CompatibilityTopBarTrailing.swift */; };
 		2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */; };
+		2C74571F2CE7028E004ACE52 /* ScreenCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C74571E2CE7028A004ACE52 /* ScreenCondition.swift */; };
+		2C7457212CE702BB004ACE52 /* PackageContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7457202CE702BB004ACE52 /* PackageContext.swift */; };
 		2C7F0AD32B8EEB4600381179 /* RateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */; };
 		2C7F0AD62B8EEF7B00381179 /* RateLimiterRests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */; };
 		2C8EC6DB2CCC23B700D6CCF8 /* Template5Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8EC6DA2CCC23B700D6CCF8 /* Template5Preview.swift */; };
@@ -1216,6 +1218,8 @@
 		2C5F71F62C3D6C2600B0FE4B /* background.heic */ = {isa = PBXFileReference; lastKnownFileType = file; path = background.heic; sourceTree = "<group>"; };
 		2C646C282A0EBD0300E5936E /* CI-Snapshots.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = "CI-Snapshots.xctestplan"; path = "Tests/TestPlans/CI-Snapshots.xctestplan"; sourceTree = "<group>"; };
 		2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesSyncAttributesAndOfferingsIfNeededTests.swift; sourceTree = "<group>"; };
+		2C74571E2CE7028A004ACE52 /* ScreenCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCondition.swift; sourceTree = "<group>"; };
+		2C7457202CE702BB004ACE52 /* PackageContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageContext.swift; sourceTree = "<group>"; };
 		2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiter.swift; sourceTree = "<group>"; };
 		2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiterRests.swift; sourceTree = "<group>"; };
 		2C8EC6AE2CCBD33E00D6CCF8 /* ButtonComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentTests.swift; sourceTree = "<group>"; };
@@ -4521,6 +4525,8 @@
 		88AD01352C74196600AA1F2B /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				2C7457202CE702BB004ACE52 /* PackageContext.swift */,
+				2C74571E2CE7028A004ACE52 /* ScreenCondition.swift */,
 				2C91068D2CE2481800189565 /* SizeModifier.swift */,
 				2C08B3342CDD16550024857B /* PaywallComponentViewModel.swift */,
 				2C08B3162CDA443A0024857B /* ViewModelFactory.swift */,
@@ -6255,10 +6261,12 @@
 				77372D992C6F8C7B008E59D3 /* AppUpdateWarningView.swift in Sources */,
 				887A60C52C1D037000E1A461 /* IntroEligibilityStateView.swift in Sources */,
 				88A543E72C37A4C40039C6A5 /* TierSelectorView.swift in Sources */,
+				2C74571F2CE7028E004ACE52 /* ScreenCondition.swift in Sources */,
 				88A543E12C37A4820039C6A5 /* TemplateView+MultiTier.swift in Sources */,
 				887A60B72C1D037000E1A461 /* WatchTemplateView.swift in Sources */,
 				887A60722C1D037000E1A461 /* PaywallViewMode+Extensions.swift in Sources */,
 				887A60C32C1D037000E1A461 /* FooterView.swift in Sources */,
+				2C7457212CE702BB004ACE52 /* PackageContext.swift in Sources */,
 				887A607F2C1D037000E1A461 /* Optional+Extensions.swift in Sources */,
 				2C08B3172CDA44440024857B /* ViewModelFactory.swift in Sources */,
 				356979E02CCFDAA100EE6A9E /* CustomerInfoFixtures.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */; };
 		2C74571F2CE7028E004ACE52 /* ScreenCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C74571E2CE7028A004ACE52 /* ScreenCondition.swift */; };
 		2C7457212CE702BB004ACE52 /* PackageContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7457202CE702BB004ACE52 /* PackageContext.swift */; };
+		2C7457242CE713E5004ACE52 /* PreviewMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7457232CE713E5004ACE52 /* PreviewMock.swift */; };
 		2C7F0AD32B8EEB4600381179 /* RateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */; };
 		2C7F0AD62B8EEF7B00381179 /* RateLimiterRests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */; };
 		2C8EC6DB2CCC23B700D6CCF8 /* Template5Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8EC6DA2CCC23B700D6CCF8 /* Template5Preview.swift */; };
@@ -1220,6 +1221,7 @@
 		2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesSyncAttributesAndOfferingsIfNeededTests.swift; sourceTree = "<group>"; };
 		2C74571E2CE7028A004ACE52 /* ScreenCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCondition.swift; sourceTree = "<group>"; };
 		2C7457202CE702BB004ACE52 /* PackageContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageContext.swift; sourceTree = "<group>"; };
+		2C7457232CE713E5004ACE52 /* PreviewMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewMock.swift; sourceTree = "<group>"; };
 		2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiter.swift; sourceTree = "<group>"; };
 		2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiterRests.swift; sourceTree = "<group>"; };
 		2C8EC6AE2CCBD33E00D6CCF8 /* ButtonComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentTests.swift; sourceTree = "<group>"; };
@@ -2369,6 +2371,14 @@
 				2C8EC6DA2CCC23B700D6CCF8 /* Template5Preview.swift */,
 			);
 			path = TemplateComponentsViewPreviews;
+			sourceTree = "<group>";
+		};
+		2C7457222CE713DA004ACE52 /* PreviewHelpers */ = {
+			isa = PBXGroup;
+			children = (
+				2C7457232CE713E5004ACE52 /* PreviewMock.swift */,
+			);
+			path = PreviewHelpers;
 			sourceTree = "<group>";
 		};
 		2C8EC6AD2CCBD33800D6CCF8 /* Components */ = {
@@ -4538,6 +4548,7 @@
 				88B1BAE32C813A3C001B7EE5 /* TemplateComponentsView.swift */,
 				88EA80EC2C8771A7003E6675 /* TemplateComponentsView+Extensions.swift */,
 				2CAB87F62CAAB13200247013 /* Shape.swift */,
+				2C7457222CE713DA004ACE52 /* PreviewHelpers */,
 				2C2AEB0D2CA64DA900A50F38 /* TemplateComponentsViewPreviews */,
 				7707A94A2CAD936A006E0313 /* Button */,
 				88B1BAE62C813A3C001B7EE5 /* Image */,
@@ -6283,6 +6294,7 @@
 				887A60C92C1D037000E1A461 /* PurchaseButton.swift in Sources */,
 				88B1BAF02C813A3C001B7EE5 /* TextComponentViewModel.swift in Sources */,
 				2D2AFE912C6A9EF500D1B0B4 /* Binding+Extensions.swift in Sources */,
+				2C7457242CE713E5004ACE52 /* PreviewMock.swift in Sources */,
 				7706ED3E2C6E374D0004B9F9 /* ButtonStyles.swift in Sources */,
 				887A60812C1D037000E1A461 /* PaywallData+Default.swift in Sources */,
 				887A606A2C1D037000E1A461 /* TrialOrIntroEligibilityChecker.swift in Sources */,

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -311,7 +311,8 @@ public struct PaywallView: View {
             displayCloseButton: self.displayCloseButton,
             introEligibility: checker,
             purchaseHandler: purchaseHandler,
-            locale: displayedLocale
+            locale: displayedLocale,
+            showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
         )
 
         if let error {

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -230,6 +230,14 @@ public struct PaywallView: View {
         }
     }
 
+    func showZeroDecimalPlacePrices(countries: [String]?) -> Bool {
+        if Purchases.isConfigured, let countries, let currentCountry = Purchases.shared.storeFrontCountryCode {
+            return countries.contains(currentCountry)
+        } else {
+            return false
+        }
+    }
+
     @ViewBuilder
     // swiftlint:disable:next function_body_length
     private func paywallView(
@@ -240,11 +248,16 @@ public struct PaywallView: View {
         purchaseHandler: PurchaseHandler
     ) -> some View {
 
+        let showZeroDecimalPlacePrices = self.showZeroDecimalPlacePrices(
+            countries: offering.paywall?.zeroDecimalPlaceCountries
+        )
+
         #if PAYWALL_COMPONENTS
         if let componentData = offering.paywallComponentsData {
             TemplateComponentsView(
                 paywallComponentsData: componentData,
                 offering: offering,
+                showZeroDecimalPlacePrices: showZeroDecimalPlacePrices,
                 onDismiss: {
                     guard let onRequestedDismissal = self.onRequestedDismissal else {
                         self.dismiss()
@@ -269,7 +282,8 @@ public struct PaywallView: View {
                 displayCloseButton: self.displayCloseButton,
                 introEligibility: checker,
                 purchaseHandler: purchaseHandler,
-                locale: displayedLocale
+                locale: displayedLocale,
+                showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
             )
 
             if let error {
@@ -415,7 +429,8 @@ struct LoadedOfferingPaywallView: View {
         displayCloseButton: Bool,
         introEligibility: TrialOrIntroEligibilityChecker,
         purchaseHandler: PurchaseHandler,
-        locale: Locale
+        locale: Locale,
+        showZeroDecimalPlacePrices: Bool
     ) {
         self.offering = offering
         self.activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers
@@ -429,11 +444,7 @@ struct LoadedOfferingPaywallView: View {
         )
         self._purchaseHandler = .init(initialValue: purchaseHandler)
         self.locale = locale
-        if Purchases.isConfigured, let currentCountry = Purchases.shared.storeFrontCountryCode {
-            self.showZeroDecimalPlacePrices = self.paywall.zeroDecimalPlaceCountries.contains(currentCountry)
-        } else {
-            self.showZeroDecimalPlacePrices = false
-        }
+        self.showZeroDecimalPlacePrices = showZeroDecimalPlacePrices
     }
 
     var body: some View {

--- a/RevenueCatUI/Templates/Components/PackageContext.swift
+++ b/RevenueCatUI/Templates/Components/PackageContext.swift
@@ -1,0 +1,75 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PackageContext.swift
+//
+//  Created by Josh Holtz on 11/14/24.
+
+import RevenueCat
+import SwiftUI
+
+#if PAYWALL_COMPONENTS
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+class PackageContext: ObservableObject {
+
+    struct VariableContext {
+
+        let mostExpensivePricePerMonth: Double?
+        let showZeroDecimalPlacePrices: Bool
+
+        init(packages: [Package], showZeroDecimalPlacePrices: Bool = true) {
+            let mostExpensivePricePerMonth = Self.mostExpensivePricePerMonth(in: packages)
+            self.init(
+                mostExpensivePricePerMonth: mostExpensivePricePerMonth,
+                showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+            )
+        }
+
+        init(mostExpensivePricePerMonth: Double? = nil, showZeroDecimalPlacePrices: Bool = true) {
+            self.mostExpensivePricePerMonth = mostExpensivePricePerMonth
+            self.showZeroDecimalPlacePrices = showZeroDecimalPlacePrices
+        }
+
+        private static func mostExpensivePricePerMonth(in packages: [Package]) -> Double? {
+            return packages
+                .lazy
+                .map(\.storeProduct)
+                .compactMap { product in
+                    product.pricePerMonth.map {
+                        return (
+                            product: product,
+                            pricePerMonth: $0
+                        )
+                    }
+                }
+                .max { productA, productB in
+                    return productA.pricePerMonth.doubleValue < productB.pricePerMonth.doubleValue
+                }
+                .map(\.pricePerMonth.doubleValue)
+        }
+
+    }
+
+    @Published var package: Package?
+    @Published var variableContext: VariableContext
+
+    init(package: Package?, variableContext: VariableContext) {
+        self.package = package
+        self.variableContext = variableContext
+    }
+
+    func update(packageContext: PackageContext) {
+        self.package = package
+        self.variableContext = variableContext
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Templates/Components/PackageValidator.swift
+++ b/RevenueCatUI/Templates/Components/PackageValidator.swift
@@ -31,6 +31,10 @@ class PackageValidator {
         !packageInfos.isEmpty
     }
 
+    var packages: [Package] {
+        packageInfos.map(\.package)
+    }
+
     var defaultSelectedPackage: Package? {
         let defaultSelectedPackage = packageInfos.first(where: { pkg in
             return pkg.isSelectedByDefault

--- a/RevenueCatUI/Templates/Components/Packages/Package/PackageComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Packages/Package/PackageComponentView.swift
@@ -45,13 +45,21 @@ struct PackageComponentView: View {
                 self.packageContext.update(packageContext: .init(
                     package: package,
                     variableContext: self.packageContext.variableContext
-                ))
+                ))  
             } label: {
                 StackComponentView(
                     viewModel: self.viewModel.stackViewModel,
                     onDismiss: self.onDismiss
                 )
                 .environment(\.componentViewState, componentViewState)
+                // Overrides the existing PackageContext
+                .environmentObject(PackageContext(
+                    // This is needed so text component children use this
+                    // package and not selected package for processing variables
+                    package: package,
+                    // However, reusing the same package variable context from parent
+                    variableContext: packageContext.variableContext)
+                )
             }
         } else {
             EmptyView()

--- a/RevenueCatUI/Templates/Components/Packages/Package/PackageComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Packages/Package/PackageComponentView.swift
@@ -21,13 +21,14 @@ import SwiftUI
 struct PackageComponentView: View {
 
     @EnvironmentObject
-    private var paywallState: PaywallState
+    private var packageContext: PackageContext
 
     let viewModel: PackageComponentViewModel
     let onDismiss: () -> Void
 
     private var componentViewState: ComponentViewState {
-        guard let selectedPackage = paywallState.selectedPackage,
+        // Gets selected package context from parent heirarchy
+        guard let selectedPackage = packageContext.package,
                 let package = viewModel.package else {
             return .default
         }
@@ -38,7 +39,13 @@ struct PackageComponentView: View {
     var body: some View {
         if let package = self.viewModel.package {
             Button {
-                self.paywallState.select(package: package)
+                // Updating package with same variable context
+                // This will be needed when different sets of packages
+                // in different tiers
+                self.packageContext.update(packageContext: .init(
+                    package: package,
+                    variableContext: self.packageContext.variableContext
+                ))
             } label: {
                 StackComponentView(
                     viewModel: self.viewModel.stackViewModel,
@@ -65,8 +72,14 @@ struct PackageComponentView_Previews: PreviewProvider {
                      offeringIdentifier: "default")
     }
 
-    static let paywallState = PaywallState(selectedPackage: nil)
-    static let paywallStateSelected = PaywallState(selectedPackage: package)
+    static let packageContext = PackageContext(
+        package: nil,
+        variableContext: .init()
+    )
+    static let packageContextSelected = PackageContext(
+        package: Self.package,
+        variableContext: .init()
+    )
 
     static var stack: PaywallComponent.StackComponent {
         return .init(
@@ -133,7 +146,7 @@ struct PackageComponentView_Previews: PreviewProvider {
                                 availablePackages: [package])
             ), onDismiss: {}
         )
-        .environmentObject(paywallState)
+        .environmentObject(packageContext)
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Package")
 
@@ -155,7 +168,7 @@ struct PackageComponentView_Previews: PreviewProvider {
                                 availablePackages: [package])
             ), onDismiss: {}
         )
-        .environmentObject(paywallStateSelected)
+        .environmentObject(packageContextSelected)
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Package - Selected")
     }

--- a/RevenueCatUI/Templates/Components/Packages/Package/PackageComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Packages/Package/PackageComponentView.swift
@@ -45,7 +45,7 @@ struct PackageComponentView: View {
                 self.packageContext.update(packageContext: .init(
                     package: package,
                     variableContext: self.packageContext.variableContext
-                ))  
+                ))
             } label: {
                 StackComponentView(
                     viewModel: self.viewModel.stackViewModel,

--- a/RevenueCatUI/Templates/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -21,7 +21,7 @@ import SwiftUI
 struct PurchaseButtonComponentView: View {
 
     @EnvironmentObject
-    private var paywallState: PaywallState
+    private var packageContext: PackageContext
 
     @EnvironmentObject
     private var purchaseHandler: PurchaseHandler
@@ -37,7 +37,7 @@ struct PurchaseButtonComponentView: View {
             guard !self.purchaseHandler.actionInProgress else { return }
 
             // WIP: Need to log warning if currently subscribed
-            guard let selectedPackage = self.paywallState.selectedPackage
+            guard let selectedPackage = self.packageContext.package
 //                    , selectedPackage.currentlySubscribed
             else {
                 Logger.warning(Strings.product_already_subscribed)

--- a/RevenueCatUI/Templates/Components/PreviewHelpers/PreviewMock.swift
+++ b/RevenueCatUI/Templates/Components/PreviewHelpers/PreviewMock.swift
@@ -1,0 +1,114 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockProduct.swift
+//
+//  Created by Josh Holtz on 11/14/24.
+
+#if PAYWALL_COMPONENTS
+
+#if DEBUG
+
+import RevenueCat
+import StoreKit
+
+// swiftlint:disable identifier_name
+
+enum PreviewMock {
+
+    static var weeklyPackage: Package = .init(
+        identifier: "weekly",
+        packageType: .monthly,
+        storeProduct: .init(sk1Product: Product(
+            price: 3.99,
+            unit: .week,
+            localizedTitle: "Weekly"
+        )),
+        offeringIdentifier: "default"
+    )
+
+    static var monthlyPackage: Package = .init(
+        identifier: "monthly",
+        packageType: .monthly,
+        storeProduct: .init(sk1Product: Product(
+            price: 9.99,
+            unit: .month,
+            localizedTitle: "Monthly"
+        )),
+        offeringIdentifier: "default"
+    )
+
+    static var annualPackage: Package = .init(
+        identifier: "annual",
+        packageType: .annual,
+        storeProduct: .init(sk1Product: Product(
+            price: 99.99,
+            unit: .year,
+            localizedTitle: "Annual"
+        )),
+        offeringIdentifier: "default"
+    )
+
+}
+
+extension PreviewMock {
+
+    class Product: SK1Product, @unchecked Sendable {
+
+        class MockSubPeriod: SKProductSubscriptionPeriod, @unchecked Sendable {
+
+            let _unit: SKProduct.PeriodUnit
+
+            init(unit: SKProduct.PeriodUnit) {
+                self._unit = unit
+            }
+
+            override var numberOfUnits: Int {
+                return 1
+            }
+
+            override var unit: SKProduct.PeriodUnit {
+                return self._unit
+            }
+
+        }
+
+        let _price: NSDecimalNumber
+        let _unit: SKProduct.PeriodUnit
+        let _localizedTitle: String
+
+        init(price: NSDecimalNumber, unit: SKProduct.PeriodUnit, localizedTitle: String) {
+            self._price = price
+            self._unit = unit
+            self._localizedTitle = localizedTitle
+        }
+
+        override var price: NSDecimalNumber {
+            return self._price
+        }
+
+        override var subscriptionPeriod: SKProductSubscriptionPeriod? {
+            return MockSubPeriod(unit: self._unit)
+        }
+
+        override var localizedTitle: String {
+            return self._localizedTitle
+        }
+
+        override var priceLocale: Locale {
+            return Locale(identifier: "en-US")
+        }
+
+    }
+
+}
+
+#endif
+
+#endif

--- a/RevenueCatUI/Templates/Components/PreviewHelpers/PreviewMock.swift
+++ b/RevenueCatUI/Templates/Components/PreviewHelpers/PreviewMock.swift
@@ -61,6 +61,7 @@ extension PreviewMock {
 
     class Product: SK1Product, @unchecked Sendable {
 
+        // swiftlint:disable:next nesting
         class MockSubPeriod: SKProductSubscriptionPeriod, @unchecked Sendable {
 
             let _unit: SKProduct.PeriodUnit

--- a/RevenueCatUI/Templates/Components/ScreenCondition.swift
+++ b/RevenueCatUI/Templates/Components/ScreenCondition.swift
@@ -1,0 +1,52 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ScreenCondition.swift
+//
+//  Created by Josh Holtz on 11/14/24.
+
+import SwiftUI
+
+#if PAYWALL_COMPONENTS
+
+enum ScreenCondition {
+
+    case compact, medium, expanded
+
+    static func from(_ sizeClass: UserInterfaceSizeClass?) -> Self {
+        guard let sizeClass else {
+            return .compact
+        }
+
+        switch sizeClass {
+        case .compact:
+            return .compact
+        case .regular:
+            return .medium
+        @unknown default:
+            return .compact
+        }
+    }
+
+}
+
+struct ScreenConditionKey: EnvironmentKey {
+    static let defaultValue = ScreenCondition.compact
+}
+
+extension EnvironmentValues {
+
+    var screenCondition: ScreenCondition {
+        get { self[ScreenConditionKey.self] }
+        set { self[ScreenConditionKey.self] = newValue }
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Templates/Components/TemplateComponentsView.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsView.swift
@@ -30,7 +30,12 @@ struct TemplateComponentsView: View {
     private let componentViewModel: PaywallComponentViewModel
     private let onDismiss: () -> Void
 
-    public init(paywallComponentsData: PaywallComponentsData, offering: Offering, onDismiss: @escaping () -> Void) {
+    public init(
+        paywallComponentsData: PaywallComponentsData,
+        offering: Offering,
+        showZeroDecimalPlacePrices: Bool,
+        onDismiss: @escaping () -> Void
+    ) {
         self.paywallComponentsData = paywallComponentsData
         self.onDismiss = onDismiss
 
@@ -68,7 +73,7 @@ struct TemplateComponentsView: View {
                 package: factory.packageValidator.defaultSelectedPackage,
                 variableContext: .init(
                     packages: factory.packageValidator.packages,
-                    showZeroDecimalPlacePrices: true // TODO: Get from paywall info
+                    showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
                 )
             ))
         } catch {

--- a/RevenueCatUI/Templates/Components/TemplateComponentsView.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsView.swift
@@ -11,99 +11,9 @@ import SwiftUI
 
 #if PAYWALL_COMPONENTS
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-class PackageContext: ObservableObject {
-
-    struct VariableContext {
-
-        let mostExpensivePricePerMonth: Double?
-        let showZeroDecimalPlacePrices: Bool
-
-        init(packages: [Package], showZeroDecimalPlacePrices: Bool = true) {
-            let mostExpensivePricePerMonth = Self.mostExpensivePricePerMonth(in: packages)
-            self.init(
-                mostExpensivePricePerMonth: mostExpensivePricePerMonth,
-                showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
-            )
-        }
-
-        init(mostExpensivePricePerMonth: Double? = nil, showZeroDecimalPlacePrices: Bool = true) {
-            self.mostExpensivePricePerMonth = mostExpensivePricePerMonth
-            self.showZeroDecimalPlacePrices = showZeroDecimalPlacePrices
-        }
-
-        private static func mostExpensivePricePerMonth(in packages: [Package]) -> Double? {
-            return packages
-                .lazy
-                .map(\.storeProduct)
-                .compactMap { product in
-                    product.pricePerMonth.map {
-                        return (
-                            product: product,
-                            pricePerMonth: $0
-                        )
-                    }
-                }
-                .max { productA, productB in
-                    return productA.pricePerMonth.doubleValue < productB.pricePerMonth.doubleValue
-                }
-                .map(\.pricePerMonth.doubleValue)
-        }
-
-    }
-
-    @Published var package: Package?
-    @Published var variableContext: VariableContext
-
-    init(package: Package?, variableContext: VariableContext) {
-        self.package = package
-        self.variableContext = variableContext
-    }
-
-    func update(packageContext: PackageContext) {
-        self.package = package
-        self.variableContext = variableContext
-    }
-
-}
-
 enum PackageGroupValidationError: Error {
 
     case noAvailablePackages(String)
-
-}
-
-enum ScreenCondition {
-
-    case compact, medium, expanded
-
-    static func from(_ sizeClass: UserInterfaceSizeClass?) -> Self {
-        guard let sizeClass else {
-            return .compact
-        }
-
-        switch sizeClass {
-        case .compact:
-            return .compact
-        case .regular:
-            return .medium
-        @unknown default:
-            return .compact
-        }
-    }
-
-}
-
-struct ScreenConditionKey: EnvironmentKey {
-    static let defaultValue = ScreenCondition.compact
-}
-
-extension EnvironmentValues {
-
-    var screenCondition: ScreenCondition {
-        get { self[ScreenConditionKey.self] }
-        set { self[ScreenConditionKey.self] = newValue }
-    }
 
 }
 

--- a/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -177,6 +177,7 @@ struct Template1Preview_Previews: PreviewProvider {
             offering: .init(identifier: "default",
                             serverDescription: "",
                             availablePackages: [package]),
+            showZeroDecimalPlacePrices: true,
             onDismiss: { }
         )
         .previewLayout(.fixed(width: 400, height: 800))

--- a/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template5Preview.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template5Preview.swift
@@ -267,6 +267,7 @@ struct Template5Preview_Previews: PreviewProvider {
                                         storeProduct: .init(sk1Product: .init()),
                                         offeringIdentifier: "default")
                                ]),
+            showZeroDecimalPlacePrices: true,
             onDismiss: { }
         )
         .previewLayout(.fixed(width: 400, height: 800))

--- a/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template5Preview.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template5Preview.swift
@@ -91,17 +91,22 @@ private enum Template5Preview {
                     text: nameTextLid,
                     fontWeight: .bold,
                     color: .init(light: .hex("#000000")),
+                    size: .init(width: .fill, height: .fit),
                     padding: .zero,
-                    margin: .zero
+                    margin: .zero,
+                    horizontalAlignment: .leading
                 )),
                 .text(.init(
                     text: detailTextLid,
                     color: .init(light: .hex("#000000")),
+                    size: .init(width: .fill, height: .fit),
                     padding: .zero,
-                    margin: .zero
+                    margin: .zero,
+                    horizontalAlignment: .leading
                 ))
             ],
             dimension: .vertical(.leading, .start),
+            size: .init(width: .fill, height: .fit),
             spacing: 0,
             backgroundColor: nil,
             padding: PaywallComponent.Padding(top: 10,
@@ -124,13 +129,13 @@ private enum Template5Preview {
 
     static let packagesStack = PaywallComponent.StackComponent(
         components: [
-            .package(makePackage(packageID: "weekly",
+            .package(makePackage(packageID: PreviewMock.weeklyPackage.identifier,
                                  nameTextLid: "weekly_name",
                                  detailTextLid: "weekly_detail")),
             .package(makePackage(packageID: "non_existant_package",
                                  nameTextLid: "non_existant_name",
                                  detailTextLid: "non_existant_detail")),
-            .package(makePackage(packageID: "monthly",
+            .package(makePackage(packageID: PreviewMock.monthlyPackage.identifier,
                                  nameTextLid: "monthly_name",
                                  detailTextLid: "monthly_detail",
                                  isSelectedByDefault: true)),
@@ -221,14 +226,14 @@ private enum Template5Preview {
         componentsLocalizations: ["en_US": [
             "title": .string("Ignite your cat's curiosity"),
             "body": .string("Get access to all of our educational content trusted by thousands of pet parents."),
-            "cta": .string("Get Started"),
+            "cta": .string("Continue for {{ price_per_period }}"),
             "cta_intro": .string("Claim Free Trial"),
 
             // Packages
-            "weekly_name": .string("Weekly"),
-            "weekly_detail": .string("Get for $39.99/week"),
-            "monthly_name": .string("Monthly"),
-            "monthly_detail": .string("Get for $139.99/month"),
+            "weekly_name": .string("{{ sub_period }} {{ sub_relative_discount }}"),
+            "weekly_detail": .string("Get for {{ total_price_and_per_month }}"),
+            "monthly_name": .string("{{ sub_period }} {{ sub_relative_discount }}"),
+            "monthly_detail": .string("Get for {{ total_price_and_per_month }}"),
             "non_existant_name": .string("THIS SHOULDN'T SHOW"),
             "non_existant_detail": .string("THIS SHOULDN'T SHOW"),
 
@@ -242,13 +247,6 @@ private enum Template5Preview {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct Template5Preview_Previews: PreviewProvider {
 
-    static var package: Package {
-        return .init(identifier: "weekly",
-                     packageType: .weekly,
-                     storeProduct: .init(sk1Product: .init()),
-                     offeringIdentifier: "default")
-    }
-
     // Need to wrap in VStack otherwise preview rerenders and images won't show
     static var previews: some View {
 
@@ -258,14 +256,8 @@ struct Template5Preview_Previews: PreviewProvider {
             offering: Offering(identifier: "default",
                                serverDescription: "",
                                availablePackages: [
-                                Package(identifier: "weekly",
-                                        packageType: .weekly,
-                                        storeProduct: .init(sk1Product: .init()),
-                                        offeringIdentifier: "default"),
-                                Package(identifier: "monthly",
-                                        packageType: .monthly,
-                                        storeProduct: .init(sk1Product: .init()),
-                                        offeringIdentifier: "default")
+                                PreviewMock.monthlyPackage,
+                                PreviewMock.weeklyPackage
                                ]),
             showZeroDecimalPlacePrices: true,
             onDismiss: { }

--- a/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template5Preview.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsViewPreviews/Template5Preview.swift
@@ -19,9 +19,13 @@ import SwiftUI
 
 #if DEBUG
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private enum Template5Preview {
 
-    static let paywallState = PaywallState(selectedPackage: nil)
+    static let paywallState = PackageContext(
+        package: nil,
+        variableContext: .init()
+    )
 
     static let catUrl = URL(string: "https://assets.pawwalls.com/954459_1701163461.jpg")!
 

--- a/RevenueCatUI/Templates/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Text/TextComponentView.swift
@@ -64,6 +64,8 @@ struct TextComponentView: View {
 
 #if DEBUG
 
+// swiftlint:disable identifier_name
+
 import StoreKit
 
 class MockProduct: SK1Product, @unchecked Sendable {
@@ -295,7 +297,7 @@ struct TextComponentView_Previews: PreviewProvider {
             // swiftlint:disable:next force_try
             viewModel: try! .init(
                 localizedStrings: [
-                    "id_1": .string("{{ product_name }} is {{ price_per_period_full }} ({{ sub_relative_discount }})"),
+                    "id_1": .string("{{ product_name }} is {{ price_per_period_full }} ({{ sub_relative_discount }})")
                 ],
                 component: .init(
                     text: "id_1",

--- a/RevenueCatUI/Templates/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Text/TextComponentView.swift
@@ -64,82 +64,8 @@ struct TextComponentView: View {
 
 #if DEBUG
 
-// swiftlint:disable identifier_name
-
-import StoreKit
-
-class MockProduct: SK1Product, @unchecked Sendable {
-
-    class MockSubPeriod: SKProductSubscriptionPeriod, @unchecked Sendable {
-
-        let _unit: SKProduct.PeriodUnit
-
-        init(unit: SKProduct.PeriodUnit) {
-            self._unit = unit
-        }
-
-        override var numberOfUnits: Int {
-            return 1
-        }
-
-        override var unit: SKProduct.PeriodUnit {
-            return self._unit
-        }
-
-    }
-
-    let _price: NSDecimalNumber
-    let _unit: SKProduct.PeriodUnit
-    let _localizedTitle: String
-
-    init(price: NSDecimalNumber, unit: SKProduct.PeriodUnit, localizedTitle: String) {
-        self._price = price
-        self._unit = unit
-        self._localizedTitle = localizedTitle
-    }
-
-    override var price: NSDecimalNumber {
-        return self._price
-    }
-
-    override var subscriptionPeriod: SKProductSubscriptionPeriod? {
-        return MockSubPeriod(unit: self._unit)
-    }
-
-    override var localizedTitle: String {
-        return self._localizedTitle
-    }
-
-    override var priceLocale: Locale {
-        return Locale(identifier: "en-US")
-    }
-
-}
-
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct TextComponentView_Previews: PreviewProvider {
-
-    static var monthlyPackage: Package = .init(
-        identifier: "monthly",
-        packageType: .monthly,
-        storeProduct: .init(sk1Product: MockProduct(
-            price: 9.99,
-            unit: .month,
-            localizedTitle: "Monthly"
-        )),
-        offeringIdentifier: "default"
-    )
-
-    static var annualPackage: Package = .init(
-        identifier: "annual",
-        packageType: .annual,
-        storeProduct: .init(sk1Product: MockProduct(
-            price: 99.99,
-            unit: .year,
-            localizedTitle: "Annual"
-        )),
-        offeringIdentifier: "default"
-    )
 
     static var previews: some View {
         // Default
@@ -306,8 +232,8 @@ struct TextComponentView_Previews: PreviewProvider {
             )
         )
         .environmentObject(PackageContext(
-            package: self.annualPackage,
-            variableContext: .init(packages: [self.monthlyPackage, self.annualPackage]))
+            package: PreviewMock.annualPackage,
+            variableContext: .init(packages: [PreviewMock.monthlyPackage, PreviewMock.annualPackage]))
         )
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Process variable")

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -45,7 +45,8 @@ struct LoadingPaywallView: View {
             displayCloseButton: self.displayCloseButton,
             introEligibility: Self.introEligibility,
             purchaseHandler: Self.purchaseHandler,
-            locale: Locale.current
+            locale: Locale.current,
+            showZeroDecimalPlacePrices: true
         )
         .allowsHitTesting(false)
         .redacted(reason: .placeholder)


### PR DESCRIPTION
## Motivation

Process the same [Paywalls V1 variables](https://www.revenuecat.com/docs/tools/paywalls/creating-paywalls#variables) but in the Paywalls V2 text component

## Description

- Renamed `PaywallState` to `PackageContext`
  - Stored on the paywall to store the "selected package"
  - Renamed because this is now used by the `TextComponentView` to get the any type of package context
      - Could be because text is INSIDE `Package` component
      - Could be because text is OUTSIDE `Package` component (like a CTA) and needs to get the selected package

### Demo

It works 👇 

<img width="1745" alt="Screenshot 2024-11-14 at 11 40 12 PM" src="https://github.com/user-attachments/assets/ee14f8ef-49df-470f-b6c3-902a22557ddc">

