### PR TITLE
[Paywalls V2] Introduce new `LocalizationProvider` for localized strings and locale

### DIFF
--- a/RevenueCatUI/Templates/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Button/ButtonComponentView.swift
@@ -126,9 +126,12 @@ struct ButtonComponentView_Previews: PreviewProvider {
                             backgroundColor: nil
                         )
                     ),
-                    localizedStrings: [
-                        "buttonText": PaywallComponentsData.LocalizationData.string("Do something")
-                    ],
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [
+                            "buttonText": PaywallComponentsData.LocalizationData.string("Do something")
+                        ]
+                    ),
                     offering: Offering(identifier: "", serverDescription: "", availablePackages: [])
                 ),
                 onDismiss: { }
@@ -144,19 +147,19 @@ fileprivate extension ButtonComponentViewModel {
 
     convenience init(
         component: PaywallComponent.ButtonComponent,
-        localizedStrings: PaywallComponent.LocalizationDictionary,
+        localizationProvider: LocalizationProvider,
         offering: Offering
     ) throws {
         let factory = ViewModelFactory()
         let stackViewModel = try factory.toStackViewModel(
             component: component.stack,
-            localizedStrings: localizedStrings,
+            localizationProvider: localizationProvider,
             offering: offering
         )
 
         try self.init(
             component: component,
-            localizedStrings: localizedStrings,
+            localizationProvider: localizationProvider,
             offering: offering,
             stackViewModel: stackViewModel
         )

--- a/RevenueCatUI/Templates/Components/Button/ButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/Components/Button/ButtonComponentViewModel.swift
@@ -39,19 +39,21 @@ class ButtonComponentViewModel {
     }
 
     let component: PaywallComponent.ButtonComponent
-    let localizedStrings: PaywallComponent.LocalizationDictionary
+    let localizationProvider: LocalizationProvider
     let action: Action
     let stackViewModel: StackComponentViewModel
 
     init(
         component: PaywallComponent.ButtonComponent,
-        localizedStrings: PaywallComponent.LocalizationDictionary,
+        localizationProvider: LocalizationProvider,
         offering: Offering,
         stackViewModel: StackComponentViewModel
     ) throws {
         self.component = component
-        self.localizedStrings = localizedStrings
+        self.localizationProvider = localizationProvider
         self.stackViewModel = stackViewModel
+
+        let localizedStrings = localizationProvider.localizedStrings
 
         // Mapping ButtonComponent.Action to ButtonComponentViewModel.Action to verify that any passed-in urlLids exist
         // in localizedStrings:

--- a/RevenueCatUI/Templates/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Image/ImageComponentView.swift
@@ -71,7 +71,10 @@ struct ImageComponentView_Previews: PreviewProvider {
             ImageComponentView(
                 // swiftlint:disable:next force_try
                 viewModel: try! .init(
-                    localizedStrings: [:],
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [:]
+                    ),
                     component: .init(
                         source: .init(
                             light: .init(
@@ -93,7 +96,10 @@ struct ImageComponentView_Previews: PreviewProvider {
             ImageComponentView(
                 // swiftlint:disable:next force_try
                 viewModel: try! .init(
-                    localizedStrings: [:],
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [:]
+                    ),
                     component: .init(
                         source: .init(
                             light: .init(
@@ -115,7 +121,10 @@ struct ImageComponentView_Previews: PreviewProvider {
             ImageComponentView(
                 // swiftlint:disable:next force_try
                 viewModel: try! .init(
-                    localizedStrings: [:],
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [:]
+                    ),
                     component: .init(
                         source: .init(
                             light: .init(
@@ -140,7 +149,10 @@ struct ImageComponentView_Previews: PreviewProvider {
             ImageComponentView(
                 // swiftlint:disable:next force_try
                 viewModel: try! .init(
-                    localizedStrings: [:],
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [:]
+                    ),
                     component: .init(
                         source: .init(
                             light: .init(

--- a/RevenueCatUI/Templates/Components/Image/ImageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/Components/Image/ImageComponentViewModel.swift
@@ -20,24 +20,24 @@ import SwiftUI
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class ImageComponentViewModel {
 
-    private let localizedStrings: PaywallComponent.LocalizationDictionary
+    private let localizationProvider: LocalizationProvider
     private let component: PaywallComponent.ImageComponent
 
     private let imageInfo: PaywallComponent.ThemeImageUrls
     private let presentedOverrides: PresentedOverrides<LocalizedImagePartial>?
 
-    init(localizedStrings: PaywallComponent.LocalizationDictionary, component: PaywallComponent.ImageComponent) throws {
-        self.localizedStrings = localizedStrings
+    init(localizationProvider: LocalizationProvider, component: PaywallComponent.ImageComponent) throws {
+        self.localizationProvider = localizationProvider
         self.component = component
 
         if let overrideSourceLid = component.overrideSourceLid {
-            self.imageInfo = try localizedStrings.image(key: overrideSourceLid)
+            self.imageInfo = try localizationProvider.localizedStrings.image(key: overrideSourceLid)
         } else {
             self.imageInfo = component.source
         }
 
         self.presentedOverrides = try self.component.overrides?.toPresentedOverrides {
-            try LocalizedImagePartial.create(from: $0, using: localizedStrings)
+            try LocalizedImagePartial.create(from: $0, using: localizationProvider.localizedStrings)
         }
     }
 

--- a/RevenueCatUI/Templates/Components/LinkButton/LinkButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/Components/LinkButton/LinkButtonComponentViewModel.swift
@@ -26,10 +26,10 @@ public class LinkButtonComponentViewModel {
     }
 
     init(component: PaywallComponent.LinkButtonComponent,
-         localizedStrings: PaywallComponent.LocalizationDictionary
+         localizationProvider: LocalizationProvider
     ) throws {
         self.component = component
-        self.textComponentViewModel = try TextComponentViewModel(localizedStrings: localizedStrings,
+        self.textComponentViewModel = try TextComponentViewModel(localizationProvider: localizationProvider,
                                                                  component: component.textComponent)
     }
 

--- a/RevenueCatUI/Templates/Components/Packages/Package/PackageComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Packages/Package/PackageComponentView.swift
@@ -145,10 +145,13 @@ struct PackageComponentView_Previews: PreviewProvider {
                     isSelectedByDefault: false,
                     stack: stack
                 ),
-                localizedStrings: [
-                    "name": .string("Weekly"),
-                    "detail": .string("Get for $39.99/wk")
-                ],
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "name": .string("Weekly"),
+                        "detail": .string("Get for $39.99/wk")
+                    ]
+                ),
                 offering: .init(identifier: "default",
                                 serverDescription: "",
                                 availablePackages: [package])
@@ -167,10 +170,13 @@ struct PackageComponentView_Previews: PreviewProvider {
                     isSelectedByDefault: false,
                     stack: stack
                 ),
-                localizedStrings: [
-                    "name": .string("Weekly"),
-                    "detail": .string("Get for $39.99/wk")
-                ],
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "name": .string("Weekly"),
+                        "detail": .string("Get for $39.99/wk")
+                    ]
+                ),
                 offering: .init(identifier: "default",
                                 serverDescription: "",
                                 availablePackages: [package])
@@ -187,18 +193,17 @@ fileprivate extension PackageComponentViewModel {
 
     convenience init(
         component: PaywallComponent.PackageComponent,
-        localizedStrings: PaywallComponent.LocalizationDictionary,
+        localizationProvider: LocalizationProvider,
         offering: Offering
     ) throws {
         let factory = ViewModelFactory()
         let stackViewModel = try factory.toStackViewModel(
             component: component.stack,
-            localizedStrings: localizedStrings,
+            localizationProvider: localizationProvider,
             offering: offering
         )
 
         self.init(
-            localizedStrings: localizedStrings,
             component: component,
             offering: offering,
             stackViewModel: stackViewModel

--- a/RevenueCatUI/Templates/Components/Packages/Package/PackageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/Components/Packages/Package/PackageComponentViewModel.swift
@@ -24,7 +24,6 @@ class PackageComponentViewModel {
     let stackViewModel: StackComponentViewModel
 
     init(
-        localizedStrings: PaywallComponent.LocalizationDictionary,
         component: PaywallComponent.PackageComponent,
         offering: Offering,
         stackViewModel: StackComponentViewModel

--- a/RevenueCatUI/Templates/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -78,10 +78,13 @@ struct PurchaseButtonComponentView_Previews: PreviewProvider {
                         ))
                     ])
                 ),
-                localizedStrings: [
-                    "id_1": .string("Hello, world"),
-                    "id_2": .string("Hello, world intro offer")
-                ],
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("Hello, world"),
+                        "id_2": .string("Hello, world intro offer")
+                    ]
+                ),
                 offering: Offering(identifier: "",
                                    serverDescription: "",
                                    availablePackages: [])
@@ -115,10 +118,13 @@ struct PurchaseButtonComponentView_Previews: PreviewProvider {
                                                 bottomTrailing: 8))
                     )
                 ),
-                localizedStrings: [
-                    "id_1": .string("Hello, world"),
-                    "id_2": .string("Hello, world intro offer")
-                ],
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("Hello, world"),
+                        "id_2": .string("Hello, world intro offer")
+                    ]
+                ),
                 offering: Offering(identifier: "",
                                    serverDescription: "",
                                    availablePackages: [])
@@ -134,13 +140,13 @@ fileprivate extension PurchaseButtonComponentViewModel {
 
     convenience init(
         component: PaywallComponent.PurchaseButtonComponent,
-        localizedStrings: PaywallComponent.LocalizationDictionary,
+        localizationProvider: LocalizationProvider,
         offering: Offering
     ) throws {
         let factory = ViewModelFactory()
         let stackViewModel = try factory.toStackViewModel(
             component: component.stack,
-            localizedStrings: localizedStrings,
+            localizationProvider: localizationProvider,
             offering: offering
         )
 

--- a/RevenueCatUI/Templates/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Stack/StackComponentView.swift
@@ -188,9 +188,13 @@ struct StackComponentView_Previews: PreviewProvider {
                     ),
                     backgroundColor: .init(light: .hex("#ff0000"))
                 ),
-                localizedStrings: [
-                    "text_1": .string("Hey")
-                ]),
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "text_1": .string("Hey")
+                    ]
+                )
+            ),
             onDismiss: {}
         )
         .previewLayout(.sizeThatFits)
@@ -212,9 +216,13 @@ struct StackComponentView_Previews: PreviewProvider {
                     ),
                     backgroundColor: .init(light: .hex("#ff0000"))
                 ),
-                localizedStrings: [
-                    "text_1": .string("Hey")
-                ]),
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "text_1": .string("Hey")
+                    ]
+                )
+            ),
             onDismiss: {}
         )
         .previewLayout(.sizeThatFits)
@@ -237,9 +245,13 @@ struct StackComponentView_Previews: PreviewProvider {
                         ),
                         backgroundColor: .init(light: .hex("#ff0000"))
                     ),
-                    localizedStrings: [
-                        "text_1": .string("Hey")
-                    ]),
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [
+                            "text_1": .string("Hey")
+                        ]
+                    )
+                ),
                 onDismiss: {}
             )
 
@@ -258,9 +270,13 @@ struct StackComponentView_Previews: PreviewProvider {
                         ),
                         backgroundColor: .init(light: .hex("#0000ff"))
                     ),
-                    localizedStrings: [
-                        "text_1": .string("Hey")
-                    ]),
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [
+                            "text_1": .string("Hey")
+                        ]
+                    )
+                ),
                 onDismiss: {}
             )
 
@@ -279,9 +295,13 @@ struct StackComponentView_Previews: PreviewProvider {
                         ),
                         backgroundColor: .init(light: .hex("#00ff00"))
                     ),
-                    localizedStrings: [
-                        "text_1": .string("Hey")
-                    ]),
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [
+                            "text_1": .string("Hey")
+                        ]
+                    )
+                ),
                 onDismiss: {}
             )
 
@@ -300,9 +320,13 @@ struct StackComponentView_Previews: PreviewProvider {
                         ),
                         backgroundColor: .init(light: .hex("#ff0000"))
                     ),
-                    localizedStrings: [
-                        "text_1": .string("Hey")
-                    ]),
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [
+                            "text_1": .string("Hey")
+                        ]
+                    )
+                ),
                 onDismiss: {}
             )
         }
@@ -317,7 +341,7 @@ fileprivate extension StackComponentViewModel {
 
     convenience init(
         component: PaywallComponent.StackComponent,
-        localizedStrings: PaywallComponent.LocalizationDictionary
+        localizationProvider: LocalizationProvider
     ) throws {
         let validator = PackageValidator()
         let factory = ViewModelFactory()
@@ -328,7 +352,7 @@ fileprivate extension StackComponentViewModel {
                 component: component,
                 packageValidator: validator,
                 offering: offering,
-                localizedStrings: localizedStrings
+                localizationProvider: localizationProvider
             )
         }
 

--- a/RevenueCatUI/Templates/Components/TemplateComponentsView+Extensions.swift
+++ b/RevenueCatUI/Templates/Components/TemplateComponentsView+Extensions.swift
@@ -26,9 +26,11 @@ extension TemplateComponentsView {
             color: PaywallComponent.ColorScheme(light: .hex("#000000"))
         )
 
+        let localizationProvider = LocalizationProvider(locale: Locale.current, localizedStrings: errorDict)
+
         // swiftlint:disable:next force_try
         return try! PaywallComponentViewModel.text(
-            TextComponentViewModel(localizedStrings: errorDict, component: textComponent)
+            TextComponentViewModel(localizationProvider: localizationProvider, component: textComponent)
         )
 
     }

--- a/RevenueCatUI/Templates/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Text/TextComponentView.swift
@@ -240,7 +240,11 @@ struct TextComponentView_Previews: PreviewProvider {
                 localizationProvider: .init(
                     locale: Locale.current,
                     localizedStrings: [
-                        "id_1": .string("{{ product_name }} is {{ price_per_period_full }} ({{ sub_relative_discount }})"),
+                        "id_1": .string(
+                            "{{ product_name }} is " +
+                            "{{ price_per_period_full }} " +
+                            "({{ sub_relative_discount }})"
+                        )
                     ]
                 ),
                 component: .init(

--- a/RevenueCatUI/Templates/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/Components/Text/TextComponentView.swift
@@ -72,9 +72,12 @@ struct TextComponentView_Previews: PreviewProvider {
         TextComponentView(
             // swiftlint:disable:next force_try
             viewModel: try! .init(
-                localizedStrings: [
-                    "id_1": .string("Hello, world")
-                ],
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("Hello, world")
+                    ]
+                ),
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000"))
@@ -92,9 +95,12 @@ struct TextComponentView_Previews: PreviewProvider {
         TextComponentView(
             // swiftlint:disable:next force_try
             viewModel: try! .init(
-                localizedStrings: [
-                    "id_1": .string("Hello, world")
-                ],
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("Hello, world")
+                    ]
+                ),
                 component: .init(
                     text: "id_1",
                     fontName: nil,
@@ -125,9 +131,12 @@ struct TextComponentView_Previews: PreviewProvider {
         TextComponentView(
             // swiftlint:disable:next force_try
             viewModel: try! .init(
-                localizedStrings: [
-                    "id_1": .string("Hello, world")
-                ],
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("Hello, world")
+                    ]
+                ),
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000")),
@@ -164,10 +173,13 @@ struct TextComponentView_Previews: PreviewProvider {
         TextComponentView(
             // swiftlint:disable:next force_try
             viewModel: try! .init(
-                localizedStrings: [
-                    "id_1": .string("THIS TEXT SHOULDN'T SHOW"),
-                    "id_2": .string("Showing medium condition")
-                ],
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("THIS TEXT SHOULDN'T SHOW"),
+                        "id_2": .string("Showing medium condition")
+                    ]
+                ),
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000")),
@@ -193,10 +205,13 @@ struct TextComponentView_Previews: PreviewProvider {
         TextComponentView(
             // swiftlint:disable:next force_try
             viewModel: try! .init(
-                localizedStrings: [
-                    "id_1": .string("Showing compact condition"),
-                    "id_2": .string("SHOULDN'T SHOW MEDIUM")
-                ],
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("Showing compact condition"),
+                        "id_2": .string("SHOULDN'T SHOW MEDIUM")
+                    ]
+                ),
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000")),
@@ -222,9 +237,12 @@ struct TextComponentView_Previews: PreviewProvider {
         TextComponentView(
             // swiftlint:disable:next force_try
             viewModel: try! .init(
-                localizedStrings: [
-                    "id_1": .string("{{ product_name }} is {{ price_per_period_full }} ({{ sub_relative_discount }})")
-                ],
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("{{ product_name }} is {{ price_per_period_full }} ({{ sub_relative_discount }})"),
+                    ]
+                ),
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000"))

--- a/RevenueCatUI/Templates/Components/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/Components/ViewModelFactory.swift
@@ -24,18 +24,18 @@ struct ViewModelFactory {
     func toRootViewModel(
         componentsConfig: PaywallComponentsData.PaywallComponentsConfig,
         offering: Offering,
-        localizedStrings: PaywallComponent.LocalizationDictionary
+        localizationProvider: LocalizationProvider
     ) throws -> RootViewModel {
         let rootStackViewModel = try toStackViewModel(
             component: componentsConfig.stack,
-            localizedStrings: localizedStrings,
+            localizationProvider: localizationProvider,
             offering: offering
         )
 
         let stickyFooterViewModel = try componentsConfig.stickyFooter.flatMap {
             let stackViewModel = try toStackViewModel(
                 component: $0.stack,
-                localizedStrings: localizedStrings,
+                localizationProvider: localizationProvider,
                 offering: offering
             )
 
@@ -56,16 +56,16 @@ struct ViewModelFactory {
         component: PaywallComponent,
         packageValidator: PackageValidator,
         offering: Offering,
-        localizedStrings: PaywallComponent.LocalizationDictionary
+        localizationProvider: LocalizationProvider
     ) throws -> PaywallComponentViewModel {
         switch component {
         case .text(let component):
             return .text(
-                try TextComponentViewModel(localizedStrings: localizedStrings, component: component)
+                try TextComponentViewModel(localizationProvider: localizationProvider, component: component)
             )
         case .image(let component):
             return .image(
-                try ImageComponentViewModel(localizedStrings: localizedStrings, component: component)
+                try ImageComponentViewModel(localizationProvider: localizationProvider, component: component)
             )
         case .spacer(let component):
             return .spacer(
@@ -76,7 +76,7 @@ struct ViewModelFactory {
                 try self.toViewModel(component: component,
                                      packageValidator: packageValidator,
                                      offering: offering,
-                                     localizedStrings: localizedStrings)
+                                     localizationProvider: localizationProvider)
             }
 
             return .stack(
@@ -86,19 +86,19 @@ struct ViewModelFactory {
         case .linkButton(let component):
             return .linkButton(
                 try LinkButtonComponentViewModel(component: component,
-                                                 localizedStrings: localizedStrings)
+                                                 localizationProvider: localizationProvider)
             )
         case .button(let component):
             let stackViewModel = try toStackViewModel(
                 component: component.stack,
-                localizedStrings: localizedStrings,
+                localizationProvider: localizationProvider,
                 offering: offering
             )
 
             return .button(
                 try ButtonComponentViewModel(
                     component: component,
-                    localizedStrings: localizedStrings,
+                    localizationProvider: localizationProvider,
                     offering: offering,
                     stackViewModel: stackViewModel
                 )
@@ -106,12 +106,11 @@ struct ViewModelFactory {
         case .package(let component):
             let stackViewModel = try toStackViewModel(
                 component: component.stack,
-                localizedStrings: localizedStrings,
+                localizationProvider: localizationProvider,
                 offering: offering
             )
 
             let viewModel = PackageComponentViewModel(
-                localizedStrings: localizedStrings,
                 component: component,
                 offering: offering,
                 stackViewModel: stackViewModel
@@ -125,7 +124,7 @@ struct ViewModelFactory {
         case .purchaseButton(let component):
             let stackViewModel = try toStackViewModel(
                 component: component.stack,
-                localizedStrings: localizedStrings,
+                localizationProvider: localizationProvider,
                 offering: offering
             )
 
@@ -135,7 +134,7 @@ struct ViewModelFactory {
         case .stickyFooter(let component):
             let stackViewModel = try toStackViewModel(
                 component: component.stack,
-                localizedStrings: localizedStrings,
+                localizationProvider: localizationProvider,
                 offering: offering
             )
 
@@ -150,7 +149,7 @@ struct ViewModelFactory {
 
     func toStackViewModel(
         component: PaywallComponent.StackComponent,
-        localizedStrings: PaywallComponent.LocalizationDictionary,
+        localizationProvider: LocalizationProvider,
         offering: Offering
     ) throws -> StackComponentViewModel {
         let viewModels = try component.components.map { component in
@@ -158,7 +157,7 @@ struct ViewModelFactory {
                 component: component,
                 packageValidator: packageValidator,
                 offering: offering,
-                localizedStrings: localizedStrings
+                localizationProvider: localizationProvider
             )
         }
 


### PR DESCRIPTION
### Motivation

Needed to pass locale into view models so might as well pair it with the localized strings 🤷‍♂️ 

### Description

This just replaces all `PaywallComponent.LocalizationDictionary` with `LocalizationProvider`

A `LocalizationProvider` contains:
- `PaywallComponent.LocalizationDictionary` 
- `Locale`

It didn't _really_ make sense to just add `Locale` as another parameter into the whole chain so grouped them together in `LocalizationProvider`
