### PR TITLE
Paywalls: Update Finnish "restore" localization

### DIFF
--- a/RevenueCatUI/Resources/fi.lproj/Localizable.strings
+++ b/RevenueCatUI/Resources/fi.lproj/Localizable.strings
@@ -2,9 +2,9 @@
 "All subscriptions" = "Kaikki tilaukset";
 "Privacy" = "Yksityisyys";
 "Privacy policy" = "Tietosuojakäytäntö";
-"Purchases restored successfully!" = "Ostokset palautettu onnistuneesti!";
-"Restore" = "Palauttaa";
-"Restore purchases" = "Palauttaa ostot";
+"Purchases restored successfully!" = "Ostot palautettu onnistuneesti!";
+"Restore" = "Palauta";
+"Restore purchases" = "Palauta ostot";
 "Terms" = "Ehdot";
 "Terms and conditions" = "Käyttöehdot";
 "Annual" = "Vuosittainen";


### PR DESCRIPTION
## Motivation
Better translations provided by a customer. Internal ticket 48413.

## Description
"Restore" > Palauta 
"Restore Purchases" > Palauta ostot
"Purchases restored successfully!" Ostot palautettu onnistuneesti 