### PR TITLE
[EXTERNAL] Polished the Polish paywall translation

### DIFF
--- a/RevenueCatUI/Resources/pl.lproj/Localizable.strings
+++ b/RevenueCatUI/Resources/pl.lproj/Localizable.strings
@@ -3,7 +3,7 @@
 "Privacy" = "Prywatność";
 "Privacy policy" = "Polityka prywatności";
 "Purchases restored successfully!" = "Pomyślnie przywrócono zakupy!";
-"Restore" = "Przywrócić";
+"Restore" = "Przywróć";
 "Restore purchases" = "Przywróć zakupy";
 "Terms" = "Warunki";
 "Terms and conditions" = "Regulamin";
@@ -15,7 +15,7 @@
 "Weekly" = "Co tydzień";
 "Lifetime" = "Dożywotni";
 "%d%% off" = "%d%% zniżki";
-"Continue" = "Kontynuować";
+"Continue" = "Kontynuuj";
 "Default_offer_details_with_intro_offer" = "Rozpocznij okres próbny {{ sub_offer_duration }}, a następnie {{ total_price_and_per_month }}.";
 "free_trial_period" = "%@ za darmo";
 "pay_as_you_go_period" = "%@ przez %@";


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids
https://github.com/RevenueCat/purchases-android/pull/1919

### Motivation
The Polish translation for Restore and Continue actions does not sound great for native speakers:
- "Przywrócić" means "To restore", not "Restore" which should be on a CTA
- "Kontynuować" means "To continue", not "Continue" which should be on a CTA

### Description
After this changes, the paywall in Polish 🇵🇱 will feel better. Thanks for all the good work!
