### PR TITLE
Add lifetime support to the Customer Center

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -225,7 +225,7 @@
 		353756522C382BC700A1B8D6 /* PreferredLocalesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353756512C382BC700A1B8D6 /* PreferredLocalesProvider.swift */; };
 		353756652C382C2800A1B8D6 /* CustomerCenterConfigTestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353756532C382C2800A1B8D6 /* CustomerCenterConfigTestData.swift */; };
 		353756662C382C2800A1B8D6 /* CustomerCenterError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353756542C382C2800A1B8D6 /* CustomerCenterError.swift */; };
-		353756672C382C2800A1B8D6 /* SubscriptionInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353756552C382C2800A1B8D6 /* SubscriptionInformation.swift */; };
+		353756672C382C2800A1B8D6 /* PurchaseInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353756552C382C2800A1B8D6 /* PurchaseInformation.swift */; };
 		353756682C382C2800A1B8D6 /* CustomerCenterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353756572C382C2800A1B8D6 /* CustomerCenterViewModel.swift */; };
 		353756692C382C2800A1B8D6 /* CustomerCenterViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353756582C382C2800A1B8D6 /* CustomerCenterViewState.swift */; };
 		3537566A2C382C2800A1B8D6 /* ManageSubscriptionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353756592C382C2800A1B8D6 /* ManageSubscriptionsViewModel.swift */; };
@@ -1473,7 +1473,7 @@
 		353756512C382BC700A1B8D6 /* PreferredLocalesProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferredLocalesProvider.swift; sourceTree = "<group>"; };
 		353756532C382C2800A1B8D6 /* CustomerCenterConfigTestData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerCenterConfigTestData.swift; sourceTree = "<group>"; };
 		353756542C382C2800A1B8D6 /* CustomerCenterError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerCenterError.swift; sourceTree = "<group>"; };
-		353756552C382C2800A1B8D6 /* SubscriptionInformation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionInformation.swift; sourceTree = "<group>"; };
+		353756552C382C2800A1B8D6 /* PurchaseInformation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseInformation.swift; sourceTree = "<group>"; };
 		353756572C382C2800A1B8D6 /* CustomerCenterViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerCenterViewModel.swift; sourceTree = "<group>"; };
 		353756582C382C2800A1B8D6 /* CustomerCenterViewState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerCenterViewState.swift; sourceTree = "<group>"; };
 		353756592C382C2800A1B8D6 /* ManageSubscriptionsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsViewModel.swift; sourceTree = "<group>"; };
@@ -3420,7 +3420,7 @@
 				353756532C382C2800A1B8D6 /* CustomerCenterConfigTestData.swift */,
 				353756542C382C2800A1B8D6 /* CustomerCenterError.swift */,
 				35C200AE2C39252D00B9778B /* FeedbackSurveyData.swift */,
-				353756552C382C2800A1B8D6 /* SubscriptionInformation.swift */,
+				353756552C382C2800A1B8D6 /* PurchaseInformation.swift */,
 				1E5F8F772C46BBD90041EECD /* CustomerCenterAction.swift */,
 				35C496052C482ACC0023E924 /* PromotionalOfferData.swift */,
 				35F249C92C493D970058993A /* LoadPromotionalOfferUseCase.swift */,
@@ -6378,7 +6378,7 @@
 				7783607B2CCA88E4000785B8 /* StickyFooterComponentView.swift in Sources */,
 				887A608B2C1D037000E1A461 /* PurchaseHandler+TestData.swift in Sources */,
 				35F249CE2C493E3D0058993A /* CustomerCenterPurchases.swift in Sources */,
-				353756672C382C2800A1B8D6 /* SubscriptionInformation.swift in Sources */,
+				353756672C382C2800A1B8D6 /* PurchaseInformation.swift in Sources */,
 				887A60682C1D037000E1A461 /* TemplateError.swift in Sources */,
 				887A60792C1D037000E1A461 /* UserInterfaceIdiom.swift in Sources */,
 				C3AD12BC2C6EA69D00A4F86F /* SubscriptionDetailsView.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -128,7 +128,7 @@ enum CustomerCenterConfigTestData {
         buttonBackgroundColor: .init(light: "#287aff", dark: "#287aff")
     )
 
-    static let subscriptionInformationMonthlyRenewing: SubscriptionInformation = .init(
+    static let subscriptionInformationMonthlyRenewing: PurchaseInformation = .init(
         title: "Basic",
         durationTitle: "Monthly",
         explanation: .earliestRenewal,
@@ -141,7 +141,7 @@ enum CustomerCenterConfigTestData {
         store: .appStore
     )
 
-    static let subscriptionInformationYearlyExpiring: SubscriptionInformation = .init(
+    static let subscriptionInformationYearlyExpiring: PurchaseInformation = .init(
         title: "Basic",
         durationTitle: "Yearly",
         explanation: .earliestRenewal,

--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -94,7 +94,7 @@ struct PurchaseInformation {
         if let dateString = expirationDate.map({ dateFormatter.string(from: $0) }) {
             let date = PurchaseInformation.ExpirationOrRenewal.Date.date(dateString)
             self.expirationOrRenewal = PurchaseInformation.ExpirationOrRenewal(label: .expires,
-                                                                                   date: date)
+                                                                               date: date)
         } else {
             self.expirationOrRenewal = nil
         }

--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -92,8 +92,8 @@ struct PurchaseInformation {
         self.durationTitle = product.subscriptionPeriod?.durationTitle
         self.price = .paid(product.localizedPriceString)
         if let dateString = expirationDate.map({ dateFormatter.string(from: $0) }) {
-            let date = SubscriptionInformation.ExpirationOrRenewal.Date.date(dateString)
-            self.expirationOrRenewal = SubscriptionInformation.ExpirationOrRenewal(label: .expires,
+            let date = PurchaseInformation.ExpirationOrRenewal.Date.date(dateString)
+            self.expirationOrRenewal = PurchaseInformation.ExpirationOrRenewal(label: .expires,
                                                                                    date: date)
         } else {
             self.expirationOrRenewal = nil
@@ -141,7 +141,7 @@ struct PurchaseInformation {
 
 fileprivate extension EntitlementInfo {
 
-    func priceBestEffort(product: StoreProduct?) -> SubscriptionInformation.PriceDetails {
+    func priceBestEffort(product: StoreProduct?) -> PurchaseInformation.PriceDetails {
         if let product {
             return .paid(product.localizedPriceString)
         }
@@ -165,19 +165,19 @@ fileprivate extension EntitlementInfo {
         return nil
     }
 
-    func expirationOrRenewal(dateFormatter: DateFormatter) -> SubscriptionInformation.ExpirationOrRenewal? {
+    func expirationOrRenewal(dateFormatter: DateFormatter) -> PurchaseInformation.ExpirationOrRenewal? {
         guard let date = expirationDateBestEffort(dateFormatter: dateFormatter) else {
             return nil
         }
-        let label: SubscriptionInformation.ExpirationOrRenewal.Label =
+        let label: PurchaseInformation.ExpirationOrRenewal.Label =
         self.isActive ? (
             self.willRenew ? .nextBillingDate : .expires
         ) : .expired
-        return SubscriptionInformation.ExpirationOrRenewal(label: label, date: date)
+        return PurchaseInformation.ExpirationOrRenewal(label: label, date: date)
 
     }
 
-    var explanation: SubscriptionInformation.Explanation {
+    var explanation: PurchaseInformation.Explanation {
         switch self.store {
         case .appStore, .macAppStore:
             if self.expirationDate != nil {
@@ -204,7 +204,7 @@ fileprivate extension EntitlementInfo {
 
     private func expirationDateBestEffort(
         dateFormatter: DateFormatter
-    ) -> SubscriptionInformation.ExpirationOrRenewal.Date? {
+    ) -> PurchaseInformation.ExpirationOrRenewal.Date? {
         if self.expirationDate == nil {
             return .never
         }

--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -17,7 +17,7 @@ import Foundation
 import RevenueCat
 
 // swiftlint:disable nesting
-struct SubscriptionInformation {
+struct PurchaseInformation {
 
     let title: String?
     let durationTitle: String?

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -106,8 +106,6 @@ import RevenueCat
 
     func loadHasSubscriptions() async {
         do {
-            // swiftlint:disable:next todo
-            // TODO: support non-consumables
             let customerInfo = try await self.customerInfoFetcher()
             let hasSubscriptions = customerInfo.activeSubscriptions.count > 0
             let hasNonSubscriptions = customerInfo.nonSubscriptions.count > 0

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -104,7 +104,7 @@ import RevenueCat
 
     #endif
 
-    func loadHasSubscriptions() async {
+    func loadHasActivePurchases() async {
         do {
             let customerInfo = try await self.customerInfoFetcher()
             self.hasActiveProducts = customerInfo.activeSubscriptions.count > 0 ||

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
@@ -52,7 +52,7 @@ class ManageSubscriptionsViewModel: ObservableObject {
     }
 
     @Published
-    private(set) var subscriptionInformation: SubscriptionInformation?
+    private(set) var purchaseInformation: PurchaseInformation?
     @Published
     private(set) var refundRequestStatus: RefundRequestStatus?
 
@@ -73,11 +73,11 @@ class ManageSubscriptionsViewModel: ObservableObject {
     }
 
     init(screen: CustomerCenterConfigData.Screen,
-         subscriptionInformation: SubscriptionInformation,
+         purchaseInformation: PurchaseInformation,
          customerCenterActionHandler: CustomerCenterActionHandler?,
          refundRequestStatus: RefundRequestStatus? = nil) {
         self.screen = screen
-        self.subscriptionInformation = subscriptionInformation
+        self.purchaseInformation = purchaseInformation
         self.purchasesProvider = ManageSubscriptionPurchases()
         self.refundRequestStatus = refundRequestStatus
         self.customerCenterActionHandler = customerCenterActionHandler
@@ -87,14 +87,14 @@ class ManageSubscriptionsViewModel: ObservableObject {
 
     func loadScreen() async {
         do {
-            try await loadSubscriptionInformation()
+            try await loadPurchaseInformation()
             self.state = .success
         } catch {
             self.state = .error(error)
         }
     }
 
-    private func loadSubscriptionInformation() async throws {
+    private func loadPurchaseInformation() async throws {
         let customerInfo = try await purchasesProvider.customerInfo()
 
         guard let currentEntitlement = customerInfo.earliestExpiringAppStoreEntitlement(),
@@ -104,9 +104,9 @@ class ManageSubscriptionsViewModel: ObservableObject {
             throw CustomerCenterError.couldNotFindSubscriptionInformation
         }
 
-        let subscriptionInformation = SubscriptionInformation(entitlement: currentEntitlement,
+        let purchaseInformation = PurchaseInformation(entitlement: currentEntitlement,
                                                               subscribedProduct: product)
-        self.subscriptionInformation = subscriptionInformation
+        self.purchaseInformation = purchaseInformation
     }
 
 #if os(iOS) || targetEnvironment(macCatalyst)
@@ -199,8 +199,8 @@ private extension ManageSubscriptionsViewModel {
             self.showRestoreAlert = true
         case .refundRequest:
             do {
-                guard let subscriptionInformation = self.subscriptionInformation else { return }
-                let productId = subscriptionInformation.productIdentifier
+                guard let purchaseInformation = self.purchaseInformation else { return }
+                let productId = purchaseInformation.productIdentifier
                 self.customerCenterActionHandler?(.refundRequestStarted(productId))
                 let status = try await self.purchasesProvider.beginRefundRequest(forProduct: productId)
                 self.refundRequestStatus = status

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
@@ -105,7 +105,7 @@ class ManageSubscriptionsViewModel: ObservableObject {
         }
 
         let purchaseInformation = PurchaseInformation(entitlement: currentEntitlement,
-                                                              subscribedProduct: product)
+                                                      subscribedProduct: product)
         self.purchaseInformation = purchaseInformation
     }
 
@@ -218,7 +218,7 @@ private extension ManageSubscriptionsViewModel {
             }
         case .customUrl:
             guard let url = path.url,
-                let openMethod = path.openMethod else {
+                  let openMethod = path.openMethod else {
                 Logger.warning("Found a custom URL path without a URL or open method. Ignoring tap.")
                 return
             }

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
@@ -97,49 +97,16 @@ class ManageSubscriptionsViewModel: ObservableObject {
     private func loadSubscriptionInformation() async throws {
         let customerInfo = try await purchasesProvider.customerInfo()
 
-        // Find earliest expiring subscription
-        guard let earliestProductId =
-                customerInfo.activeSubscriptions.compactMap({ productId -> (String, Date)? in
-                    guard let expirationDate = customerInfo.expirationDate(forProductIdentifier: productId) else {
-                        return nil
-                    }
-                    return (productId, expirationDate)
-                })
-            .sorted(by: { $0.1 < $1.1 })
-            .first?
-            .0
+        guard let currentEntitlement = customerInfo.earliestExpiringAppStoreEntitlement(),
+              let product = await purchasesProvider.products([currentEntitlement.productIdentifier]).first
         else {
-            // If no subscriptions found, check for lifetime purchases
-            if let firstNonSub = customerInfo.nonSubscriptions.first,
-               let entitlement = customerInfo.entitlements.active.values.first,
-               let product = await purchasesProvider.products([firstNonSub.productIdentifier]).first {
-                let subscriptionInformation = SubscriptionInformation(entitlement: entitlement,
-                                                                      subscribedProduct: product)
-                self.subscriptionInformation = subscriptionInformation
-                return
-            }
             Logger.warning(Strings.could_not_find_subscription_information)
             throw CustomerCenterError.couldNotFindSubscriptionInformation
         }
 
-        guard let product = await purchasesProvider.products([earliestProductId]).first else {
-            Logger.warning(Strings.could_not_find_subscription_information)
-            throw CustomerCenterError.couldNotFindSubscriptionInformation
-        }
-
-        // If we find a matching entitlement, use it. Otherwise, just use the product
-        if let entitlement = customerInfo.entitlements.active.values.first(where: {
-            $0.productIdentifier == earliestProductId
-        }) {
-            let subscriptionInformation = SubscriptionInformation(entitlement: entitlement,
-                                                                  subscribedProduct: product)
-            self.subscriptionInformation = subscriptionInformation
-        } else {
-            let expirationDate = customerInfo.expirationDate(forProductIdentifier: product.productIdentifier)
-            let subscriptionInformation = SubscriptionInformation(product: product,
-                                                                  expirationDate: expirationDate)
-            self.subscriptionInformation = subscriptionInformation
-        }
+        let subscriptionInformation = SubscriptionInformation(entitlement: currentEntitlement,
+                                                              subscribedProduct: product)
+        self.subscriptionInformation = subscriptionInformation
     }
 
 #if os(iOS) || targetEnvironment(macCatalyst)

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
@@ -100,7 +100,9 @@ class ManageSubscriptionsViewModel: ObservableObject {
         // Find earliest expiring subscription
         guard let earliestProductId =
                 customerInfo.activeSubscriptions.compactMap({ productId -> (String, Date)? in
-                    guard let expirationDate = customerInfo.expirationDate(forProductIdentifier: productId) else { return nil }
+                    guard let expirationDate = customerInfo.expirationDate(forProductIdentifier: productId) else {
+                        return nil
+                    }
                     return (productId, expirationDate)
                 })
             .sorted(by: { $0.1 < $1.1 })

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -76,7 +76,7 @@ private extension CustomerCenterView {
 
     func loadInformationIfNeeded() async {
         if !viewModel.isLoaded {
-            await viewModel.loadHasSubscriptions()
+            await viewModel.loadHasActivePurchases()
             await viewModel.loadCustomerCenterConfig()
         }
     }

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -83,8 +83,8 @@ private extension CustomerCenterView {
 
     @ViewBuilder
     func destinationContent(configuration: CustomerCenterConfigData) -> some View {
-        if viewModel.hasSubscriptions {
-            if viewModel.subscriptionsAreFromApple,
+        if viewModel.hasActiveProducts {
+            if viewModel.hasAppleEntitlement,
                let screen = configuration.screens[.management] {
                 if let productId = configuration.productId, !ignoreAppUpdateWarning && !viewModel.appIsLatestVersion {
                     AppUpdateWarningView(
@@ -129,7 +129,7 @@ private extension CustomerCenterView {
 struct CustomerCenterView_Previews: PreviewProvider {
 
    static var previews: some View {
-       let viewModel = CustomerCenterViewModel(hasSubscriptions: false, areSubscriptionsFromApple: false)
+       let viewModel = CustomerCenterViewModel(hasActiveProducts: false, hasAppleEntitlement: false)
        CustomerCenterView(viewModel: viewModel)
    }
 

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -80,10 +80,10 @@ struct ManageSubscriptionsView: View {
             if self.viewModel.isLoaded {
                 List {
 
-                    if let subscriptionInformation = self.viewModel.subscriptionInformation {
+                    if let purchaseInformation = self.viewModel.purchaseInformation {
                         Section {
                             SubscriptionDetailsView(
-                                subscriptionInformation: subscriptionInformation,
+                                purchaseInformation: purchaseInformation,
                                 refundRequestStatus: self.viewModel.refundRequestStatus)
                         }
                     }
@@ -221,7 +221,7 @@ struct ManageSubscriptionsView_Previews: PreviewProvider {
             CompatibilityNavigationStack {
                 let viewModelMonthlyRenewing = ManageSubscriptionsViewModel(
                     screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
-                    subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing,
+                    purchaseInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing,
                     customerCenterActionHandler: nil,
                     refundRequestStatus: .success)
                 ManageSubscriptionsView(viewModel: viewModelMonthlyRenewing,
@@ -234,7 +234,7 @@ struct ManageSubscriptionsView_Previews: PreviewProvider {
             CompatibilityNavigationStack {
                 let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
                     screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
-                    subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationYearlyExpiring,
+                    purchaseInformation: CustomerCenterConfigTestData.subscriptionInformationYearlyExpiring,
                     customerCenterActionHandler: nil)
                 ManageSubscriptionsView(viewModel: viewModelYearlyExpiring,
                                         customerCenterActionHandler: nil)

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
@@ -24,21 +24,21 @@ import SwiftUI
 @available(watchOS, unavailable)
 struct SubscriptionDetailsView: View {
 
-    let subscriptionInformation: SubscriptionInformation
+    let purchaseInformation: PurchaseInformation
     let refundRequestStatus: RefundRequestStatus?
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            SubscriptionDetailsHeader(subscriptionInformation: subscriptionInformation, localization: localization)
+            SubscriptionDetailsHeader(purchaseInformation: purchaseInformation, localization: localization)
                 .padding(.bottom, 10)
 
             Divider()
                 .padding(.bottom)
 
             VStack(alignment: .leading, spacing: 16.0) {
-                if let durationTitle = subscriptionInformation.durationTitle {
+                if let durationTitle = purchaseInformation.durationTitle {
                     IconLabelView(
                         iconName: "coloncurrencysign.arrow.circlepath",
                         label: localization.commonLocalizedString(for: .billingCycle),
@@ -47,7 +47,7 @@ struct SubscriptionDetailsView: View {
                 }
 
                 let priceValue: String? = {
-                    switch subscriptionInformation.price {
+                    switch purchaseInformation.price {
                     case .free:
                         return localization.commonLocalizedString(for: .free)
                     case .paid(let localizedPrice):
@@ -65,7 +65,7 @@ struct SubscriptionDetailsView: View {
                     )
                 }
 
-                if let expirationOrRenewal = subscriptionInformation.expirationOrRenewal {
+                if let expirationOrRenewal = purchaseInformation.expirationOrRenewal {
                     switch expirationOrRenewal.date {
                     case .never:
                         IconLabelView(
@@ -108,7 +108,7 @@ struct SubscriptionDetailsView: View {
         }
     }
 
-    private func label(for expirationOrRenewal: SubscriptionInformation.ExpirationOrRenewal) -> String {
+    private func label(for expirationOrRenewal: PurchaseInformation.ExpirationOrRenewal) -> String {
         switch expirationOrRenewal.label {
         case .nextBillingDate:
             return localization.commonLocalizedString(for: .nextBillingDate)
@@ -125,17 +125,17 @@ struct SubscriptionDetailsView: View {
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 struct SubscriptionDetailsHeader: View {
-    let subscriptionInformation: SubscriptionInformation
+    let purchaseInformation: PurchaseInformation
     let localization: CustomerCenterConfigData.Localization
 
     var body: some View {
         VStack(alignment: .leading) {
-            if let title = subscriptionInformation.title {
+            if let title = purchaseInformation.title {
                 Text(title)
                     .font(.headline)
             }
 
-            let explanation = getSubscriptionExplanation(from: subscriptionInformation, localization: localization)
+            let explanation = getSubscriptionExplanation(from: purchaseInformation, localization: localization)
 
             Text(explanation)
                 .font(.subheadline)
@@ -144,9 +144,9 @@ struct SubscriptionDetailsHeader: View {
         }
     }
 
-    private func getSubscriptionExplanation(from subscriptionInformation: SubscriptionInformation,
+    private func getSubscriptionExplanation(from purchaseInformation: PurchaseInformation,
                                             localization: CustomerCenterConfigData.Localization) -> String {
-        switch subscriptionInformation.explanation {
+        switch purchaseInformation.explanation {
         case .promotional:
             return localization.commonLocalizedString(for: .youHavePromo)
         case .earliestRenewal:
@@ -208,7 +208,7 @@ struct SubscriptionDetailsView_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(ColorScheme.allCases, id: \.self) { colorScheme in
             SubscriptionDetailsView(
-                subscriptionInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing,
+                purchaseInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing,
                 refundRequestStatus: .success
             )
             .preferredColorScheme(colorScheme)

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -67,7 +67,7 @@ struct WrongPlatformView: View {
         List {
             if let subscriptionInformation = self.subscriptionInformation {
                 Section {
-                    SubscriptionDetailsView(subscriptionInformation: subscriptionInformation,
+                    SubscriptionDetailsView(purchaseInformation: subscriptionInformation,
                                             refundRequestStatus: nil)
                 }
             }

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -30,7 +30,7 @@ struct WrongPlatformView: View {
     @State
     private var managementURL: URL?
     @State
-    private var subscriptionInformation: SubscriptionInformation?
+    private var subscriptionInformation: PurchaseInformation?
 
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
@@ -57,7 +57,7 @@ struct WrongPlatformView: View {
 
     fileprivate init(store: Store,
                      managementURL: URL?,
-                     subscriptionInformation: SubscriptionInformation) {
+                     subscriptionInformation: PurchaseInformation) {
         self._store = State(initialValue: store)
         self._managementURL = State(initialValue: managementURL)
         self._subscriptionInformation = State(initialValue: subscriptionInformation)
@@ -104,7 +104,7 @@ struct WrongPlatformView: View {
                    let entitlement = customerInfo.entitlements.active.first?.value {
                     self.store = entitlement.store
                     self.managementURL = customerInfo.managementURL
-                    self.subscriptionInformation = SubscriptionInformation(entitlement: entitlement)
+                    self.subscriptionInformation = PurchaseInformation(entitlement: entitlement)
                 }
             }
         }
@@ -187,15 +187,15 @@ struct WrongPlatformView_Previews: PreviewProvider {
                 WrongPlatformView(
                     store: data.store,
                     managementURL: data.managementURL,
-                    subscriptionInformation: getSubscriptionInformation(for: data.customerInfo)
+                    subscriptionInformation: getPurchaseInformation(for: data.customerInfo)
                 )
                 .previewDisplayName(data.displayName)
             }
         }
     }
 
-    private static func getSubscriptionInformation(for customerInfo: CustomerInfo) -> SubscriptionInformation {
-        return SubscriptionInformation(entitlement: customerInfo.entitlements.active.first!.value)
+    private static func getPurchaseInformation(for customerInfo: CustomerInfo) -> PurchaseInformation {
+        return PurchaseInformation(entitlement: customerInfo.entitlements.active.first!.value)
     }
 
 }

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -69,52 +69,52 @@ class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.isLoaded) == true
     }
 
-    func testLoadHasActivePurchasesApple() async {
+    func testLoadHasSubscriptionsApple() async {
         let viewModel = CustomerCenterViewModel(customerCenterActionHandler: nil,
                                                 customerInfoFetcher: {
             return await CustomerCenterViewModelTests.customerInfoWithAppleSubscriptions
         })
 
-        await viewModel.loadHasActivePurchases()
+        await viewModel.loadHasSubscriptions()
 
         expect(viewModel.hasActiveProducts) == true
         expect(viewModel.hasAppleEntitlement) == true
         expect(viewModel.state) == .success
     }
 
-    func testLoadHasActivePurchasesGoogle() async {
+    func testLoadHasSubscriptionsGoogle() async {
         let viewModel = CustomerCenterViewModel(customerCenterActionHandler: nil,
                                                 customerInfoFetcher: {
             return await CustomerCenterViewModelTests.customerInfoWithGoogleSubscriptions
         })
 
-        await viewModel.loadHasActivePurchases()
+        await viewModel.loadHasSubscriptions()
 
         expect(viewModel.hasActiveProducts) == true
         expect(viewModel.hasAppleEntitlement) == false
         expect(viewModel.state) == .success
     }
 
-    func testLoadHasActivePurchasesNonActive() async {
+    func testLoadHasSubscriptionsNonActive() async {
         let viewModel = CustomerCenterViewModel(customerCenterActionHandler: nil,
                                                 customerInfoFetcher: {
             return await CustomerCenterViewModelTests.customerInfoWithoutSubscriptions
         })
 
-        await viewModel.loadHasActivePurchases()
+        await viewModel.loadHasSubscriptions()
 
         expect(viewModel.hasActiveProducts) == false
         expect(viewModel.hasAppleEntitlement) == false
         expect(viewModel.state) == .success
     }
 
-    func testLoadHasActivePurchasesError() async {
+    func testLoadHasSubscriptionsFailure() async {
         let viewModel = CustomerCenterViewModel(customerCenterActionHandler: nil,
                                                 customerInfoFetcher: {
             throw TestError(message: "An error occurred")
         })
 
-        await viewModel.loadHasActivePurchases()
+        await viewModel.loadHasSubscriptions()
 
         expect(viewModel.hasActiveProducts) == false
         expect(viewModel.hasAppleEntitlement) == false

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -40,8 +40,8 @@ class CustomerCenterViewModelTests: TestCase {
         let viewModel = CustomerCenterViewModel(customerCenterActionHandler: nil)
 
         expect(viewModel.state) == .notLoaded
-        expect(viewModel.hasSubscriptions) == false
-        expect(viewModel.subscriptionsAreFromApple) == false
+        expect(viewModel.hasActiveProducts) == false
+        expect(viewModel.hasAppleEntitlement) == false
         expect(viewModel.isLoaded) == false
     }
 
@@ -77,8 +77,8 @@ class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadHasSubscriptions()
 
-        expect(viewModel.hasSubscriptions) == true
-        expect(viewModel.subscriptionsAreFromApple) == true
+        expect(viewModel.hasActiveProducts) == true
+        expect(viewModel.hasAppleEntitlement) == true
         expect(viewModel.state) == .success
     }
 
@@ -90,8 +90,8 @@ class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadHasSubscriptions()
 
-        expect(viewModel.hasSubscriptions) == true
-        expect(viewModel.subscriptionsAreFromApple) == false
+        expect(viewModel.hasActiveProducts) == true
+        expect(viewModel.hasAppleEntitlement) == false
         expect(viewModel.state) == .success
     }
 
@@ -103,8 +103,8 @@ class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadHasSubscriptions()
 
-        expect(viewModel.hasSubscriptions) == false
-        expect(viewModel.subscriptionsAreFromApple) == false
+        expect(viewModel.hasActiveProducts) == false
+        expect(viewModel.hasAppleEntitlement) == false
         expect(viewModel.state) == .success
     }
 
@@ -116,8 +116,8 @@ class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadHasSubscriptions()
 
-        expect(viewModel.hasSubscriptions) == false
-        expect(viewModel.subscriptionsAreFromApple) == false
+        expect(viewModel.hasActiveProducts) == false
+        expect(viewModel.hasAppleEntitlement) == false
         switch viewModel.state {
         case .error(let stateError):
             expect(stateError as? TestError) == error

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -69,52 +69,52 @@ class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.isLoaded) == true
     }
 
-    func testLoadHasSubscriptionsApple() async {
+    func testLoadHasActivePurchasesApple() async {
         let viewModel = CustomerCenterViewModel(customerCenterActionHandler: nil,
                                                 customerInfoFetcher: {
             return await CustomerCenterViewModelTests.customerInfoWithAppleSubscriptions
         })
 
-        await viewModel.loadHasSubscriptions()
+        await viewModel.loadHasActivePurchases()
 
         expect(viewModel.hasActiveProducts) == true
         expect(viewModel.hasAppleEntitlement) == true
         expect(viewModel.state) == .success
     }
 
-    func testLoadHasSubscriptionsGoogle() async {
+    func testLoadHasActivePurchasesGoogle() async {
         let viewModel = CustomerCenterViewModel(customerCenterActionHandler: nil,
                                                 customerInfoFetcher: {
             return await CustomerCenterViewModelTests.customerInfoWithGoogleSubscriptions
         })
 
-        await viewModel.loadHasSubscriptions()
+        await viewModel.loadHasActivePurchases()
 
         expect(viewModel.hasActiveProducts) == true
         expect(viewModel.hasAppleEntitlement) == false
         expect(viewModel.state) == .success
     }
 
-    func testLoadHasSubscriptionsNonActive() async {
+    func testLoadHasActivePurchasesNonActive() async {
         let viewModel = CustomerCenterViewModel(customerCenterActionHandler: nil,
                                                 customerInfoFetcher: {
             return await CustomerCenterViewModelTests.customerInfoWithoutSubscriptions
         })
 
-        await viewModel.loadHasSubscriptions()
+        await viewModel.loadHasActivePurchases()
 
         expect(viewModel.hasActiveProducts) == false
         expect(viewModel.hasAppleEntitlement) == false
         expect(viewModel.state) == .success
     }
 
-    func testLoadHasSubscriptionsFailure() async {
+    func testLoadHasActivePurchasesError() async {
         let viewModel = CustomerCenterViewModel(customerCenterActionHandler: nil,
                                                 customerInfoFetcher: {
             throw TestError(message: "An error occurred")
         })
 
-        await viewModel.loadHasSubscriptions()
+        await viewModel.loadHasActivePurchases()
 
         expect(viewModel.hasActiveProducts) == false
         expect(viewModel.hasAppleEntitlement) == false

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -75,7 +75,7 @@ class CustomerCenterViewModelTests: TestCase {
             return await CustomerCenterViewModelTests.customerInfoWithAppleSubscriptions
         })
 
-        await viewModel.loadHasSubscriptions()
+        await viewModel.loadHasActivePurchases()
 
         expect(viewModel.hasActiveProducts) == true
         expect(viewModel.hasAppleEntitlement) == true
@@ -88,7 +88,7 @@ class CustomerCenterViewModelTests: TestCase {
             return await CustomerCenterViewModelTests.customerInfoWithGoogleSubscriptions
         })
 
-        await viewModel.loadHasSubscriptions()
+        await viewModel.loadHasActivePurchases()
 
         expect(viewModel.hasActiveProducts) == true
         expect(viewModel.hasAppleEntitlement) == false
@@ -101,7 +101,7 @@ class CustomerCenterViewModelTests: TestCase {
             return await CustomerCenterViewModelTests.customerInfoWithoutSubscriptions
         })
 
-        await viewModel.loadHasSubscriptions()
+        await viewModel.loadHasActivePurchases()
 
         expect(viewModel.hasActiveProducts) == false
         expect(viewModel.hasAppleEntitlement) == false
@@ -114,7 +114,7 @@ class CustomerCenterViewModelTests: TestCase {
             throw TestError(message: "An error occurred")
         })
 
-        await viewModel.loadHasSubscriptions()
+        await viewModel.loadHasActivePurchases()
 
         expect(viewModel.hasActiveProducts) == false
         expect(viewModel.hasAppleEntitlement) == false

--- a/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
@@ -202,7 +202,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
         }
     }
 
-    func testShouldShowEarliestExpiration_whenUserHasLifetimeAndSubscriptionsOneEntitlement() async throws {
+    func testShouldShowLifetime_whenUserHasLifetimeAndSubscriptionsOneEntitlement() async throws {
         let productIdLifetime = "com.revenuecat.simpleapp.lifetime"
         let productIdMonthly = "com.revenuecat.simpleapp.monthly"
         let productIdYearly = "com.revenuecat.simpleapp.yearly"
@@ -282,7 +282,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
         expect(purchaseInformation.expirationOrRenewal?.date) == .never
     }
 
-    func testShouldShowLifetim_whenUserHasLifetimeOneEntitlement() async throws {
+    func testShouldShowLifetime_whenUserHasLifetimeOneEntitlement() async throws {
         let productIdLifetime = "com.revenuecat.simpleapp.lifetime"
         let purchaseDateLifetime = "2024-11-21T16:04:20Z"
 

--- a/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
@@ -82,9 +82,9 @@ class ManageSubscriptionsViewModelTests: TestCase {
         let purchaseDate = "2022-04-12T00:03:28Z"
         let expirationDate = "2062-04-12T00:03:35Z"
         let products = [PurchaseInformationFixtures.product(id: productId,
-                                                                title: "title",
-                                                                duration: .month,
-                                                                price: 2.99)]
+                                                            title: "title",
+                                                            duration: .month,
+                                                            price: 2.99)]
         let customerInfo = CustomerInfoFixtures.customerInfo(
             subscriptions: [
                 CustomerInfoFixtures.Subscription(
@@ -148,26 +148,26 @@ class ManageSubscriptionsViewModelTests: TestCase {
             duration: "1 month",
             price: Decimal(2.99)
         )
-        
+
         // Test both possible subscription array orders
         let subscriptionOrders = [
             [yearlyProduct, monthlyProduct],
             [monthlyProduct, yearlyProduct]
         ]
-        
+
         for subscriptions in subscriptionOrders {
             let purchaseDate = "2022-04-12T00:03:28Z"
             let products = [
-                PurchaseInformationFixtures.product(id: yearlyProduct.id, 
-                                                  title: yearlyProduct.title, 
-                                                  duration: .year, 
-                                                  price: yearlyProduct.price),
-                PurchaseInformationFixtures.product(id: monthlyProduct.id, 
-                                                  title: monthlyProduct.title, 
-                                                  duration: .month, 
-                                                  price: monthlyProduct.price)
+                PurchaseInformationFixtures.product(id: yearlyProduct.id,
+                                                    title: yearlyProduct.title,
+                                                    duration: .year,
+                                                    price: yearlyProduct.price),
+                PurchaseInformationFixtures.product(id: monthlyProduct.id,
+                                                    title: monthlyProduct.title,
+                                                    duration: .month,
+                                                    price: monthlyProduct.price)
             ]
-            
+
             let customerInfo = CustomerInfoFixtures.customerInfo(
                 subscriptions: subscriptions.map { product in
                     CustomerInfoFixtures.Subscription(
@@ -188,12 +188,12 @@ class ManageSubscriptionsViewModelTests: TestCase {
             )
 
             let viewModel = ManageSubscriptionsViewModel(screen: ManageSubscriptionsViewModelTests.screen,
-                                                       customerCenterActionHandler: nil,
-                                                       purchasesProvider: MockManageSubscriptionsPurchases(
-                                                          customerInfo: customerInfo,
-                                                          products: products
-                                                       ),
-                                                       loadPromotionalOfferUseCase: MockLoadPromotionalOfferUseCase())
+                                                         customerCenterActionHandler: nil,
+                                                         purchasesProvider: MockManageSubscriptionsPurchases(
+                                                            customerInfo: customerInfo,
+                                                            products: products
+                                                         ),
+                                                         loadPromotionalOfferUseCase: MockLoadPromotionalOfferUseCase())
 
             // Act
             await viewModel.loadScreen()
@@ -228,72 +228,80 @@ class ManageSubscriptionsViewModelTests: TestCase {
 
         let products = [
             PurchaseInformationFixtures.product(id: productIdLifetime,
-                                                    title: "lifetime",
-                                                    duration: nil,
-                                                    price: 29.99),
+                                                title: "lifetime",
+                                                duration: nil,
+                                                price: 29.99),
             PurchaseInformationFixtures.product(id: productIdMonthly,
-                                                    title: "monthly",
-                                                    duration: .month,
-                                                    price: 2.99),
+                                                title: "monthly",
+                                                duration: .month,
+                                                price: 2.99),
             PurchaseInformationFixtures.product(id: productIdYearly,
-                                                    title: "yearly",
-                                                    duration: .year,
-                                                    price: 29.99)
+                                                title: "yearly",
+                                                duration: .year,
+                                                price: 29.99)
         ]
 
-        let customerInfo = CustomerInfoFixtures.customerInfo(
-            subscriptions: [
-                CustomerInfoFixtures.Subscription(
-                    id: productIdMonthly,
-                    store: "app_store",
-                    purchaseDate: purchaseDateMonthly,
-                    expirationDate: expirationDateMonthly
-                ),
-                CustomerInfoFixtures.Subscription(
-                    id: productIdYearly,
-                    store: "app_store",
-                    purchaseDate: purchaseDateYearly,
-                    expirationDate: expirationDateYearly
-                )
-            ].shuffled(),
-            entitlements: [
-                CustomerInfoFixtures.Entitlement(
-                    entitlementId: "pro",
-                    productId: productIdLifetime,
-                    purchaseDate: purchaseDateLifetime,
-                    expirationDate: nil
-                )
+        // Test both possible subscription array orders
+        let subscriptionOrders = [
+            [
+                (id: productIdMonthly, date: purchaseDateMonthly, exp: expirationDateMonthly),
+                (id: productIdYearly, date: purchaseDateYearly, exp: expirationDateYearly)
             ],
-            nonSubscriptions: [
-                CustomerInfoFixtures.NonSubscriptionTransaction(
-                    productId: productIdLifetime,
-                    id: "2fdd18f128",
-                    store: "app_store",
-                    purchaseDate: purchaseDateLifetime
-                )
+            [
+                (id: productIdYearly, date: purchaseDateYearly, exp: expirationDateYearly),
+                (id: productIdMonthly, date: purchaseDateMonthly, exp: expirationDateMonthly)
             ]
-        )
+        ]
 
-        let viewModel = ManageSubscriptionsViewModel(screen: ManageSubscriptionsViewModelTests.screen,
-                                                     customerCenterActionHandler: nil,
-                                                     purchasesProvider: MockManageSubscriptionsPurchases(
-                                                        customerInfo: customerInfo,
-                                                        products: products
-                                                     ),
-                                                     loadPromotionalOfferUseCase: MockLoadPromotionalOfferUseCase())
+        for subscriptions in subscriptionOrders {
+            let customerInfo = CustomerInfoFixtures.customerInfo(
+                subscriptions: subscriptions.map { subscription in
+                    CustomerInfoFixtures.Subscription(
+                        id: subscription.id,
+                        store: "app_store",
+                        purchaseDate: subscription.date,
+                        expirationDate: subscription.exp
+                    )
+                },
+                entitlements: [
+                    CustomerInfoFixtures.Entitlement(
+                        entitlementId: "pro",
+                        productId: productIdLifetime,
+                        purchaseDate: purchaseDateLifetime,
+                        expirationDate: nil
+                    )
+                ],
+                nonSubscriptions: [
+                    CustomerInfoFixtures.NonSubscriptionTransaction(
+                        productId: productIdLifetime,
+                        id: "2fdd18f128",
+                        store: "app_store",
+                        purchaseDate: purchaseDateLifetime
+                    )
+                ]
+            )
 
-        await viewModel.loadScreen()
+            let viewModel = ManageSubscriptionsViewModel(screen: ManageSubscriptionsViewModelTests.screen,
+                                                         customerCenterActionHandler: nil,
+                                                         purchasesProvider: MockManageSubscriptionsPurchases(
+                                                            customerInfo: customerInfo,
+                                                            products: products
+                                                         ),
+                                                         loadPromotionalOfferUseCase: MockLoadPromotionalOfferUseCase())
 
-        expect(viewModel.screen).toNot(beNil())
-        expect(viewModel.state) == .success
+            await viewModel.loadScreen()
 
-        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
-        expect(purchaseInformation.title) == "lifetime"
-        expect(purchaseInformation.durationTitle).to(beNil())
-        expect(purchaseInformation.price) == .paid("$29.99")
-        expect(purchaseInformation.productIdentifier) == productIdLifetime
+            expect(viewModel.screen).toNot(beNil())
+            expect(viewModel.state) == .success
 
-        expect(purchaseInformation.expirationOrRenewal?.date) == .never
+            let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+            expect(purchaseInformation.title) == "lifetime"
+            expect(purchaseInformation.durationTitle).to(beNil())
+            expect(purchaseInformation.price) == .paid("$29.99")
+            expect(purchaseInformation.productIdentifier) == productIdLifetime
+
+            expect(purchaseInformation.expirationOrRenewal?.date) == .never
+        }
     }
 
     func testShouldShowLifetime_whenUserHasLifetimeOneEntitlement() async throws {
@@ -302,9 +310,9 @@ class ManageSubscriptionsViewModelTests: TestCase {
 
         let products = [
             PurchaseInformationFixtures.product(id: productIdLifetime,
-                                                    title: "lifetime",
-                                                    duration: nil,
-                                                    price: 29.99)
+                                                title: "lifetime",
+                                                duration: nil,
+                                                price: 29.99)
         ]
 
         let customerInfo = CustomerInfoFixtures.customerInfo(
@@ -351,142 +359,172 @@ class ManageSubscriptionsViewModelTests: TestCase {
 
     func testShouldShowEarliestExpiration_whenUserHasTwoActiveSubscriptionsTwoEntitlements() async throws {
         // Arrange
-        let productIdOne = "com.revenuecat.product1"
-        let productIdTwo = "com.revenuecat.product2"
-        let purchaseDate = "2022-04-12T00:03:28Z"
-        let expirationDateFirst = "2062-04-12T00:03:35Z"
-        let expirationDateSecond = "2062-05-12T00:03:35Z"
-        let products = [
-            PurchaseInformationFixtures.product(id: productIdOne, title: "yearly", duration: .year, price: 29.99),
-            PurchaseInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
-        ]
-        let customerInfo = CustomerInfoFixtures.customerInfo(
-            subscriptions: [
-                CustomerInfoFixtures.Subscription(
-                    id: productIdOne,
-                    store: "app_store",
-                    purchaseDate: purchaseDate,
-                    expirationDate: expirationDateFirst
-                ),
-                CustomerInfoFixtures.Subscription(
-                    id: productIdTwo,
-                    store: "app_store",
-                    purchaseDate: purchaseDate,
-                    expirationDate: expirationDateSecond
-                )
-            ].shuffled(),
-            entitlements: [
-                CustomerInfoFixtures.Entitlement(
-                    entitlementId: "premium",
-                    productId: productIdOne,
-                    purchaseDate: purchaseDate,
-                    expirationDate: expirationDateFirst
-                ),
-                CustomerInfoFixtures.Entitlement(
-                    entitlementId: "plus",
-                    productId: productIdTwo,
-                    purchaseDate: purchaseDate,
-                    expirationDate: expirationDateSecond
-                )
-            ].shuffled()
+        let yearlyProduct = (
+            id: "com.revenuecat.product1",
+            exp: "2062-04-12T00:03:35Z", // Earlier expiration
+            title: "yearly",
+            duration: "1 year",
+            price: Decimal(29.99)
+        )
+        let monthlyProduct = (
+            id: "com.revenuecat.product2",
+            exp: "2062-05-12T00:03:35Z", // Later expiration
+            title: "monthly",
+            duration: "1 month",
+            price: Decimal(2.99)
         )
 
-        let viewModel = ManageSubscriptionsViewModel(screen: ManageSubscriptionsViewModelTests.screen,
-                                                     customerCenterActionHandler: nil,
-                                                     purchasesProvider: MockManageSubscriptionsPurchases(
-                                                        customerInfo: customerInfo,
-                                                        products: products
-                                                     ),
-                                                     loadPromotionalOfferUseCase: MockLoadPromotionalOfferUseCase())
+        // Test both possible subscription and entitlement array orders
+        let subscriptionOrders = [
+            [yearlyProduct, monthlyProduct],
+            [monthlyProduct, yearlyProduct]
+        ]
 
-        // Act
-        await viewModel.loadScreen()
+        for subscriptions in subscriptionOrders {
+            let purchaseDate = "2022-04-12T00:03:28Z"
+            let products = [
+                PurchaseInformationFixtures.product(id: yearlyProduct.id,
+                                                    title: yearlyProduct.title,
+                                                    duration: .year,
+                                                    price: yearlyProduct.price),
+                PurchaseInformationFixtures.product(id: monthlyProduct.id,
+                                                    title: monthlyProduct.title,
+                                                    duration: .month,
+                                                    price: monthlyProduct.price)
+            ]
 
-        // Assert
-        expect(viewModel.screen).toNot(beNil())
-        expect(viewModel.state) == .success
+            let customerInfo = CustomerInfoFixtures.customerInfo(
+                subscriptions: subscriptions.map { product in
+                    CustomerInfoFixtures.Subscription(
+                        id: product.id,
+                        store: "app_store",
+                        purchaseDate: purchaseDate,
+                        expirationDate: product.exp
+                    )
+                },
+                entitlements: subscriptions.map { product in
+                    CustomerInfoFixtures.Entitlement(
+                        entitlementId: product.id == yearlyProduct.id ? "premium" : "plus",
+                        productId: product.id,
+                        purchaseDate: purchaseDate,
+                        expirationDate: product.exp
+                    )
+                }
+            )
 
-        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
-        expect(purchaseInformation.title) == "yearly"
-        expect(purchaseInformation.durationTitle) == "1 year"
-        expect(purchaseInformation.price) == .paid("$29.99")
+            let viewModel = ManageSubscriptionsViewModel(screen: ManageSubscriptionsViewModelTests.screen,
+                                                         customerCenterActionHandler: nil,
+                                                         purchasesProvider: MockManageSubscriptionsPurchases(
+                                                            customerInfo: customerInfo,
+                                                            products: products
+                                                         ),
+                                                         loadPromotionalOfferUseCase: MockLoadPromotionalOfferUseCase())
 
-        let expirationOrRenewal = try XCTUnwrap(purchaseInformation.expirationOrRenewal)
-        expect(expirationOrRenewal.label) == .nextBillingDate
-        expect(expirationOrRenewal.date) == .date(reformat(ISO8601Date: expirationDateFirst))
+            // Act
+            await viewModel.loadScreen()
 
-        expect(purchaseInformation.productIdentifier) == productIdOne
+            // Assert
+            expect(viewModel.screen).toNot(beNil())
+            expect(viewModel.state) == .success
+
+            let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+            // Should always show yearly subscription since it expires first
+            expect(purchaseInformation.title) == yearlyProduct.title
+            expect(purchaseInformation.durationTitle) == yearlyProduct.duration
+            expect(purchaseInformation.price) == .paid("$\(String(format: "%.2f", NSDecimalNumber(decimal: yearlyProduct.price).doubleValue))")
+
+            let expirationOrRenewal = try XCTUnwrap(purchaseInformation.expirationOrRenewal)
+            expect(expirationOrRenewal.label) == .nextBillingDate
+            expect(expirationOrRenewal.date) == .date(reformat(ISO8601Date: yearlyProduct.exp))
+
+            expect(purchaseInformation.productIdentifier) == yearlyProduct.id
+        }
     }
 
     func testShouldShowAppleSubscription_whenUserHasBothGoogleAndAppleSubscriptions() async throws {
         // Arrange
-        let productIdOne = "com.revenuecat.product1"
-        let productIdTwo = "com.revenuecat.product2"
-        let purchaseDate = "2022-04-12T00:03:28Z"
-        let expirationDateFirst = "2062-04-12T00:03:35Z"
-        let expirationDateSecond = "2062-05-12T00:03:35Z"
-        let products = [
-            PurchaseInformationFixtures.product(id: productIdOne, title: "yearly", duration: .year, price: 29.99),
-            PurchaseInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
-        ]
-        let customerInfo = CustomerInfoFixtures.customerInfo(
-            subscriptions: [
-                CustomerInfoFixtures.Subscription(
-                    id: productIdOne,
-                    store: "play_store",
-                    purchaseDate: purchaseDate,
-                    expirationDate: expirationDateFirst
-                ),
-                CustomerInfoFixtures.Subscription(
-                    id: productIdTwo,
-                    store: "app_store",
-                    purchaseDate: purchaseDate,
-                    expirationDate: expirationDateSecond
-                )
-            ].shuffled(),
-            entitlements: [
-                CustomerInfoFixtures.Entitlement(
-                    entitlementId: "premium",
-                    productId: productIdOne,
-                    purchaseDate: purchaseDate,
-                    expirationDate: expirationDateFirst
-                ),
-                CustomerInfoFixtures.Entitlement(
-                    entitlementId: "plus",
-                    productId: productIdTwo,
-                    purchaseDate: purchaseDate,
-                    expirationDate: expirationDateSecond
-                )
-            ].shuffled()
+        let googleProduct = (
+            id: "com.revenuecat.product1",
+            store: "play_store",
+            exp: "2062-04-12T00:03:35Z",
+            title: "yearly",
+            duration: "1 year",
+            price: Decimal(29.99)
+        )
+        let appleProduct = (
+            id: "com.revenuecat.product2",
+            store: "app_store",
+            exp: "2062-05-12T00:03:35Z",
+            title: "monthly",
+            duration: "1 month",
+            price: Decimal(2.99)
         )
 
-        let viewModel = ManageSubscriptionsViewModel(screen: ManageSubscriptionsViewModelTests.screen,
-                                                     customerCenterActionHandler: nil,
-                                                     purchasesProvider: MockManageSubscriptionsPurchases(
-                                                        customerInfo: customerInfo,
-                                                        products: products
-                                                     ),
-                                                     loadPromotionalOfferUseCase: MockLoadPromotionalOfferUseCase())
+        // Test both possible subscription and entitlement array orders
+        let subscriptionOrders = [
+            [googleProduct, appleProduct],
+            [appleProduct, googleProduct]
+        ]
 
-        // Act
-        await viewModel.loadScreen()
+        for subscriptions in subscriptionOrders {
+            let purchaseDate = "2022-04-12T00:03:28Z"
+            let products = [
+                PurchaseInformationFixtures.product(id: googleProduct.id,
+                                                    title: googleProduct.title,
+                                                    duration: .year,
+                                                    price: googleProduct.price),
+                PurchaseInformationFixtures.product(id: appleProduct.id,
+                                                    title: appleProduct.title,
+                                                    duration: .month,
+                                                    price: appleProduct.price)
+            ]
 
-        // Assert
-        expect(viewModel.screen).toNot(beNil())
-        expect(viewModel.state) == .success
+            let customerInfo = CustomerInfoFixtures.customerInfo(
+                subscriptions: subscriptions.map { product in
+                    CustomerInfoFixtures.Subscription(
+                        id: product.id,
+                        store: product.store,
+                        purchaseDate: purchaseDate,
+                        expirationDate: product.exp
+                    )
+                },
+                entitlements: subscriptions.map { product in
+                    CustomerInfoFixtures.Entitlement(
+                        entitlementId: product.id == googleProduct.id ? "premium" : "plus",
+                        productId: product.id,
+                        purchaseDate: purchaseDate,
+                        expirationDate: product.exp
+                    )
+                }
+            )
 
-        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
-        // We expect to see the monthly one, because the yearly one is a Google subscription.
-        expect(purchaseInformation.title) == "monthly"
-        expect(purchaseInformation.durationTitle) == "1 month"
+            let viewModel = ManageSubscriptionsViewModel(screen: ManageSubscriptionsViewModelTests.screen,
+                                                         customerCenterActionHandler: nil,
+                                                         purchasesProvider: MockManageSubscriptionsPurchases(
+                                                            customerInfo: customerInfo,
+                                                            products: products
+                                                         ),
+                                                         loadPromotionalOfferUseCase: MockLoadPromotionalOfferUseCase())
 
-        expect(purchaseInformation.price) == .paid("$2.99")
+            // Act
+            await viewModel.loadScreen()
 
-        let expirationOrRenewal = try XCTUnwrap(purchaseInformation.expirationOrRenewal)
-        expect(expirationOrRenewal.label) == .nextBillingDate
-        expect(expirationOrRenewal.date) == .date(reformat(ISO8601Date: expirationDateSecond))
+            // Assert
+            expect(viewModel.screen).toNot(beNil())
+            expect(viewModel.state) == .success
 
-        expect(purchaseInformation.productIdentifier) == productIdTwo
+            let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+            // We expect to see the monthly one, because the yearly one is a Google subscription
+            expect(purchaseInformation.title) == appleProduct.title
+            expect(purchaseInformation.durationTitle) == appleProduct.duration
+            expect(purchaseInformation.price) == .paid("$\(String(format: "%.2f", NSDecimalNumber(decimal: appleProduct.price).doubleValue))")
+
+            let expirationOrRenewal = try XCTUnwrap(purchaseInformation.expirationOrRenewal)
+            expect(expirationOrRenewal.label) == .nextBillingDate
+            expect(expirationOrRenewal.date) == .date(reformat(ISO8601Date: appleProduct.exp))
+
+            expect(purchaseInformation.productIdentifier) == appleProduct.id
+        }
     }
 
     func testLoadScreenNoActiveSubscription() async {
@@ -549,92 +587,115 @@ class ManageSubscriptionsViewModelTests: TestCase {
         let expirationDateFirst = "2062-04-12T00:03:35Z"
         let expirationDateSecond = "2062-05-12T00:03:35Z"
         let offerIdentifier = "offer_id"
-        let product = PurchaseInformationFixtures.product(id: productIdOne,
-                                                              title: "yearly",
-                                                              duration: .year,
-                                                              price: 29.99,
-                                                              offerIdentifier: offerIdentifier)
-        let products = [
-            product,
-            PurchaseInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
+
+        // Test both possible subscription array orders
+        let subscriptionOrders = [
+            [(id: productIdOne, exp: expirationDateFirst),
+             (id: productIdTwo, exp: expirationDateSecond)],
+            [(id: productIdTwo, exp: expirationDateSecond),
+             (id: productIdOne, exp: expirationDateFirst)]
         ]
-        let customerInfo = CustomerInfoFixtures.customerInfo(
-            subscriptions: [
-                CustomerInfoFixtures.Subscription(
-                    id: productIdOne,
-                    store: "app_store",
-                    purchaseDate: purchaseDate,
-                    expirationDate: expirationDateFirst
-                ),
-                CustomerInfoFixtures.Subscription(
+
+        for subscriptions in subscriptionOrders {
+            let product = PurchaseInformationFixtures.product(
+                id: productIdOne,
+                title: "yearly",
+                duration: .year,
+                price: Decimal(29.99),
+                offerIdentifier: offerIdentifier
+            )
+            let products = [
+                product,
+                PurchaseInformationFixtures.product(
                     id: productIdTwo,
-                    store: "app_store",
-                    purchaseDate: purchaseDate,
-                    expirationDate: expirationDateSecond
-                )
-            ].shuffled(),
-            entitlements: [
-                CustomerInfoFixtures.Entitlement(
-                    entitlementId: "premium",
-                    productId: productIdOne,
-                    purchaseDate: purchaseDate,
-                    expirationDate: expirationDateFirst
+                    title: "monthly",
+                    duration: .month,
+                    price: Decimal(2.99)
                 )
             ]
-        )
-        let promoOfferDetails = CustomerCenterConfigData.HelpPath.PromotionalOffer(iosOfferId: offerIdentifier,
-                                                                                   eligible: false,
-                                                                                   title: "Wait",
-                                                                                   subtitle: "Here's an offer for you",
-                                                                                   productMapping: [
-                                                                                    "product_id": "offer_id"
-                                                                                   ]
-        )
-        let loadPromotionalOfferUseCase = MockLoadPromotionalOfferUseCase()
-        loadPromotionalOfferUseCase.mockedProduct = product
-        loadPromotionalOfferUseCase.mockedPromoOfferDetails = promoOfferDetails
-        let signedData = PromotionalOffer.SignedData(identifier: "id",
-                                                     keyIdentifier: "key_i",
-                                                     nonce: UUID(),
-                                                     signature: "a signature",
-                                                     timestamp: 1234)
-        let discount = MockStoreProductDiscount(offerIdentifier: offerIdentifier,
-                                                currencyCode: "usd",
-                                                price: 1,
-                                                localizedPriceString: "$1.00",
-                                                paymentMode: .payAsYouGo,
-                                                subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .month),
-                                                numberOfPeriods: 1,
-                                                type: .introductory)
 
-        loadPromotionalOfferUseCase.mockedPromotionalOffer = PromotionalOffer(discount: discount,
-                                                                              signedData: signedData)
+            let customerInfo = CustomerInfoFixtures.customerInfo(
+                subscriptions: subscriptions.map { subscription in
+                    CustomerInfoFixtures.Subscription(
+                        id: subscription.id,
+                        store: "app_store",
+                        purchaseDate: purchaseDate,
+                        expirationDate: subscription.exp
+                    )
+                },
+                entitlements: [
+                    CustomerInfoFixtures.Entitlement(
+                        entitlementId: "premium",
+                        productId: productIdOne,
+                        purchaseDate: purchaseDate,
+                        expirationDate: expirationDateFirst
+                    )
+                ]
+            )
 
-        let viewModel = ManageSubscriptionsViewModel(screen: PurchaseInformationFixtures.screenWithIneligiblePromo,
-                                                     customerCenterActionHandler: nil,
-                                                     purchasesProvider: MockManageSubscriptionsPurchases(
-                                                        customerInfo: customerInfo,
-                                                        products: products
-                                                     ),
-                                                     loadPromotionalOfferUseCase: loadPromotionalOfferUseCase)
+            let promoOfferDetails = CustomerCenterConfigData.HelpPath.PromotionalOffer(
+                iosOfferId: offerIdentifier,
+                eligible: false,
+                title: "Wait",
+                subtitle: "Here's an offer for you",
+                productMapping: [
+                    "product_id": "offer_id"
+                ]
+            )
+            let loadPromotionalOfferUseCase = MockLoadPromotionalOfferUseCase()
+            loadPromotionalOfferUseCase.mockedProduct = product
+            loadPromotionalOfferUseCase.mockedPromoOfferDetails = promoOfferDetails
+            let signedData = PromotionalOffer.SignedData(
+                identifier: "id",
+                keyIdentifier: "key_i",
+                nonce: UUID(),
+                signature: "a signature",
+                timestamp: 1234
+            )
+            let discount = MockStoreProductDiscount(
+                offerIdentifier: offerIdentifier,
+                currencyCode: "usd",
+                price: 1,
+                localizedPriceString: "$1.00",
+                paymentMode: .payAsYouGo,
+                subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .month),
+                numberOfPeriods: 1,
+                type: .introductory
+            )
 
-        await viewModel.loadScreen()
+            loadPromotionalOfferUseCase.mockedPromotionalOffer = PromotionalOffer(
+                discount: discount,
+                signedData: signedData
+            )
 
-        let screen = try XCTUnwrap(viewModel.screen)
-        expect(viewModel.state) == .success
+            let viewModel = ManageSubscriptionsViewModel(
+                screen: PurchaseInformationFixtures.screenWithIneligiblePromo,
+                customerCenterActionHandler: nil,
+                purchasesProvider: MockManageSubscriptionsPurchases(
+                    customerInfo: customerInfo,
+                    products: products
+                ),
+                loadPromotionalOfferUseCase: loadPromotionalOfferUseCase
+            )
 
-        let pathWithPromotionalOffer = try XCTUnwrap(screen.paths.first { path in
-            if case .promotionalOffer = path.detail {
-                return true
-            }
-            return false
-        })
+            await viewModel.loadScreen()
 
-        expect(loadPromotionalOfferUseCase.offerToLoadPromoFor).to(beNil())
+            let screen = try XCTUnwrap(viewModel.screen)
+            expect(viewModel.state) == .success
 
-        await viewModel.determineFlow(for: pathWithPromotionalOffer)
+            let pathWithPromotionalOffer = try XCTUnwrap(screen.paths.first { path in
+                if case .promotionalOffer = path.detail {
+                    return true
+                }
+                return false
+            })
 
-        expect(loadPromotionalOfferUseCase.offerToLoadPromoFor).to(beNil())
+            expect(loadPromotionalOfferUseCase.offerToLoadPromoFor).to(beNil())
+
+            await viewModel.determineFlow(for: pathWithPromotionalOffer)
+
+            expect(loadPromotionalOfferUseCase.offerToLoadPromoFor).to(beNil())
+        }
     }
 
     // Helper methods
@@ -648,29 +709,32 @@ class ManageSubscriptionsViewModelTests: TestCase {
         let expirationDateSecond = "2062-05-12T00:03:35Z"
 
         let product = PurchaseInformationFixtures.product(id: productIdOne,
-                                                              title: "yearly",
-                                                              duration: .year,
-                                                              price: 29.99,
-                                                              offerIdentifier: offerIdentifierInProduct)
+                                                          title: "yearly",
+                                                          duration: .year,
+                                                          price: Decimal(29.99),
+                                                          offerIdentifier: offerIdentifierInProduct)
         let products = [
             product,
             PurchaseInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
         ]
+
+        // Test both possible subscription array orders
+        let subscriptionOrders = [
+            [(id: productIdOne, exp: expirationDateFirst),
+             (id: productIdTwo, exp: expirationDateSecond)],
+            [(id: productIdTwo, exp: expirationDateSecond),
+             (id: productIdOne, exp: expirationDateFirst)]
+        ]
+
         let customerInfo = CustomerInfoFixtures.customerInfo(
-            subscriptions: [
+            subscriptions: subscriptionOrders[0].map { subscription in
                 CustomerInfoFixtures.Subscription(
-                    id: productIdOne,
+                    id: subscription.id,
                     store: "app_store",
                     purchaseDate: purchaseDate,
-                    expirationDate: expirationDateFirst
-                ),
-                CustomerInfoFixtures.Subscription(
-                    id: productIdTwo,
-                    store: "app_store",
-                    purchaseDate: purchaseDate,
-                    expirationDate: expirationDateSecond
+                    expirationDate: subscription.exp
                 )
-            ].shuffled(),
+            },
             entitlements: [
                 CustomerInfoFixtures.Entitlement(
                     entitlementId: "premium",
@@ -680,6 +744,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
                 )
             ]
         )
+
         let promoOfferDetails =
         CustomerCenterConfigData.HelpPath.PromotionalOffer(iosOfferId: offerIdentifierInJSON,
                                                            eligible: true,
@@ -775,9 +840,9 @@ final class MockManageSubscriptionsPurchases: ManageSubscriptionsPurchaseType {
         customerInfoError: Error? = nil,
         products: [RevenueCat.StoreProduct] =
         [PurchaseInformationFixtures.product(id: "com.revenuecat.product",
-                                                 title: "title",
-                                                 duration: .month,
-                                                 price: 2.99)],
+                                             title: "title",
+                                             duration: .month,
+                                             price: 2.99)],
         showManageSubscriptionsError: Error? = nil,
         beginRefundShouldFail: Bool = false
     ) {

--- a/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
@@ -39,6 +39,10 @@ class ManageSubscriptionsViewModelTests: TestCase {
         }
     }
 
+    private func formatPrice(_ price: Decimal) -> String {
+        "$\(String(format: "%.2f", NSDecimalNumber(decimal: price).doubleValue))"
+    }
+
     func testInitialState() {
         let viewModel = ManageSubscriptionsViewModel(screen: ManageSubscriptionsViewModelTests.screen,
                                                      customerCenterActionHandler: nil)
@@ -206,7 +210,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
             // Should always show yearly subscription since it expires first
             expect(purchaseInformation.title) == yearlyProduct.title
             expect(purchaseInformation.durationTitle) == yearlyProduct.duration
-            expect(purchaseInformation.price) == .paid("$\(String(format: "%.2f", NSDecimalNumber(decimal: yearlyProduct.price).doubleValue))")
+            expect(purchaseInformation.price) == .paid(formatPrice(yearlyProduct.price))
 
             let expirationOrRenewal = try XCTUnwrap(purchaseInformation.expirationOrRenewal)
             expect(expirationOrRenewal.label) == .nextBillingDate
@@ -431,7 +435,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
             // Should always show yearly subscription since it expires first
             expect(purchaseInformation.title) == yearlyProduct.title
             expect(purchaseInformation.durationTitle) == yearlyProduct.duration
-            expect(purchaseInformation.price) == .paid("$\(String(format: "%.2f", NSDecimalNumber(decimal: yearlyProduct.price).doubleValue))")
+            expect(purchaseInformation.price) == .paid(formatPrice(yearlyProduct.price))
 
             let expirationOrRenewal = try XCTUnwrap(purchaseInformation.expirationOrRenewal)
             expect(expirationOrRenewal.label) == .nextBillingDate
@@ -517,7 +521,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
             // We expect to see the monthly one, because the yearly one is a Google subscription
             expect(purchaseInformation.title) == appleProduct.title
             expect(purchaseInformation.durationTitle) == appleProduct.duration
-            expect(purchaseInformation.price) == .paid("$\(String(format: "%.2f", NSDecimalNumber(decimal: appleProduct.price).doubleValue))")
+            expect(purchaseInformation.price) == .paid(formatPrice(appleProduct.price))
 
             let expirationOrRenewal = try XCTUnwrap(purchaseInformation.expirationOrRenewal)
             expect(expirationOrRenewal.label) == .nextBillingDate

--- a/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
@@ -44,7 +44,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
                                                      customerCenterActionHandler: nil)
 
         expect(viewModel.state) == CustomerCenterViewState.notLoaded
-        expect(viewModel.subscriptionInformation).to(beNil())
+        expect(viewModel.purchaseInformation).to(beNil())
         expect(viewModel.refundRequestStatus).to(beNil())
         expect(viewModel.screen).toNot(beNil())
         expect(viewModel.showRestoreAlert) == false
@@ -81,7 +81,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
         let productId = "com.revenuecat.product"
         let purchaseDate = "2022-04-12T00:03:28Z"
         let expirationDate = "2062-04-12T00:03:35Z"
-        let products = [SubscriptionInformationFixtures.product(id: productId,
+        let products = [PurchaseInformationFixtures.product(id: productId,
                                                                 title: "title",
                                                                 duration: .month,
                                                                 price: 2.99)]
@@ -119,17 +119,17 @@ class ManageSubscriptionsViewModelTests: TestCase {
         expect(viewModel.screen).toNot(beNil())
         expect(viewModel.state) == .success
 
-        let subscriptionInformation = try XCTUnwrap(viewModel.subscriptionInformation)
-        expect(subscriptionInformation.title) == "title"
-        expect(subscriptionInformation.durationTitle) == "1 month"
+        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        expect(purchaseInformation.title) == "title"
+        expect(purchaseInformation.durationTitle) == "1 month"
 
-        expect(subscriptionInformation.price) == .paid("$2.99")
+        expect(purchaseInformation.price) == .paid("$2.99")
 
-        let expirationOrRenewal = try XCTUnwrap(subscriptionInformation.expirationOrRenewal)
+        let expirationOrRenewal = try XCTUnwrap(purchaseInformation.expirationOrRenewal)
         expect(expirationOrRenewal.label) == .nextBillingDate
         expect(expirationOrRenewal.date) == .date(reformat(ISO8601Date: expirationDate))
 
-        expect(subscriptionInformation.productIdentifier) == productId
+        expect(purchaseInformation.productIdentifier) == productId
     }
 
     func testShouldShowEarliestExpiration_whenUserHasTwoActiveSubscriptionsOneEntitlement() async throws {
@@ -140,8 +140,8 @@ class ManageSubscriptionsViewModelTests: TestCase {
         let expirationDateFirst = "2062-04-12T00:03:35Z"
         let expirationDateSecond = "2062-05-12T00:03:35Z"
         let products = [
-            SubscriptionInformationFixtures.product(id: productIdOne, title: "yearly", duration: .year, price: 29.99),
-            SubscriptionInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
+            PurchaseInformationFixtures.product(id: productIdOne, title: "yearly", duration: .year, price: 29.99),
+            PurchaseInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
         ]
         let customerInfo = CustomerInfoFixtures.customerInfo(
             subscriptions: [
@@ -183,17 +183,17 @@ class ManageSubscriptionsViewModelTests: TestCase {
         expect(viewModel.screen).toNot(beNil())
         expect(viewModel.state) == .success
 
-        let subscriptionInformation = try XCTUnwrap(viewModel.subscriptionInformation)
-        expect(subscriptionInformation.title) == "yearly"
-        expect(subscriptionInformation.durationTitle) == "1 year"
+        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        expect(purchaseInformation.title) == "yearly"
+        expect(purchaseInformation.durationTitle) == "1 year"
 
-        expect(subscriptionInformation.price) == .paid("$29.99")
+        expect(purchaseInformation.price) == .paid("$29.99")
 
-        let expirationOrRenewal = try XCTUnwrap(subscriptionInformation.expirationOrRenewal)
+        let expirationOrRenewal = try XCTUnwrap(purchaseInformation.expirationOrRenewal)
         expect(expirationOrRenewal.label) == .nextBillingDate
         expect(expirationOrRenewal.date) == .date(reformat(ISO8601Date: expirationDateFirst))
 
-        expect(subscriptionInformation.productIdentifier) == productIdOne
+        expect(purchaseInformation.productIdentifier) == productIdOne
     }
 
     func testShouldShowEarliestExpiration_whenUserHasLifetimeAndSubscriptionsOneEntitlement() async throws {
@@ -207,15 +207,15 @@ class ManageSubscriptionsViewModelTests: TestCase {
         let expirationDateYearly = "2025-11-21T16:04:45Z"
 
         let products = [
-            SubscriptionInformationFixtures.product(id: productIdLifetime,
+            PurchaseInformationFixtures.product(id: productIdLifetime,
                                                     title: "lifetime",
                                                     duration: nil,
                                                     price: 29.99),
-            SubscriptionInformationFixtures.product(id: productIdMonthly,
+            PurchaseInformationFixtures.product(id: productIdMonthly,
                                                     title: "monthly",
                                                     duration: .month,
                                                     price: 2.99),
-            SubscriptionInformationFixtures.product(id: productIdYearly,
+            PurchaseInformationFixtures.product(id: productIdYearly,
                                                     title: "yearly",
                                                     duration: .year,
                                                     price: 29.99)
@@ -267,13 +267,13 @@ class ManageSubscriptionsViewModelTests: TestCase {
         expect(viewModel.screen).toNot(beNil())
         expect(viewModel.state) == .success
 
-        let subscriptionInformation = try XCTUnwrap(viewModel.subscriptionInformation)
-        expect(subscriptionInformation.title) == "lifetime"
-        expect(subscriptionInformation.durationTitle).to(beNil())
-        expect(subscriptionInformation.price) == .paid("$29.99")
-        expect(subscriptionInformation.productIdentifier) == productIdLifetime
+        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        expect(purchaseInformation.title) == "lifetime"
+        expect(purchaseInformation.durationTitle).to(beNil())
+        expect(purchaseInformation.price) == .paid("$29.99")
+        expect(purchaseInformation.productIdentifier) == productIdLifetime
 
-        expect(subscriptionInformation.expirationOrRenewal?.date) == .never
+        expect(purchaseInformation.expirationOrRenewal?.date) == .never
     }
 
     func testShouldShowLifetim_whenUserHasLifetimeOneEntitlement() async throws {
@@ -281,7 +281,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
         let purchaseDateLifetime = "2024-11-21T16:04:20Z"
 
         let products = [
-            SubscriptionInformationFixtures.product(id: productIdLifetime,
+            PurchaseInformationFixtures.product(id: productIdLifetime,
                                                     title: "lifetime",
                                                     duration: nil,
                                                     price: 29.99)
@@ -320,13 +320,13 @@ class ManageSubscriptionsViewModelTests: TestCase {
         expect(viewModel.screen).toNot(beNil())
         expect(viewModel.state) == .success
 
-        let subscriptionInformation = try XCTUnwrap(viewModel.subscriptionInformation)
-        expect(subscriptionInformation.title) == "lifetime"
-        expect(subscriptionInformation.durationTitle).to(beNil())
-        expect(subscriptionInformation.price) == .paid("$29.99")
-        expect(subscriptionInformation.productIdentifier) == productIdLifetime
+        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        expect(purchaseInformation.title) == "lifetime"
+        expect(purchaseInformation.durationTitle).to(beNil())
+        expect(purchaseInformation.price) == .paid("$29.99")
+        expect(purchaseInformation.productIdentifier) == productIdLifetime
 
-        expect(subscriptionInformation.expirationOrRenewal?.date) == .never
+        expect(purchaseInformation.expirationOrRenewal?.date) == .never
     }
 
     func testShouldShowEarliestExpiration_whenUserHasTwoActiveSubscriptionsTwoEntitlements() async throws {
@@ -337,8 +337,8 @@ class ManageSubscriptionsViewModelTests: TestCase {
         let expirationDateFirst = "2062-04-12T00:03:35Z"
         let expirationDateSecond = "2062-05-12T00:03:35Z"
         let products = [
-            SubscriptionInformationFixtures.product(id: productIdOne, title: "yearly", duration: .year, price: 29.99),
-            SubscriptionInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
+            PurchaseInformationFixtures.product(id: productIdOne, title: "yearly", duration: .year, price: 29.99),
+            PurchaseInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
         ]
         let customerInfo = CustomerInfoFixtures.customerInfo(
             subscriptions: [
@@ -386,16 +386,16 @@ class ManageSubscriptionsViewModelTests: TestCase {
         expect(viewModel.screen).toNot(beNil())
         expect(viewModel.state) == .success
 
-        let subscriptionInformation = try XCTUnwrap(viewModel.subscriptionInformation)
-        expect(subscriptionInformation.title) == "yearly"
-        expect(subscriptionInformation.durationTitle) == "1 year"
-        expect(subscriptionInformation.price) == .paid("$29.99")
+        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        expect(purchaseInformation.title) == "yearly"
+        expect(purchaseInformation.durationTitle) == "1 year"
+        expect(purchaseInformation.price) == .paid("$29.99")
 
-        let expirationOrRenewal = try XCTUnwrap(subscriptionInformation.expirationOrRenewal)
+        let expirationOrRenewal = try XCTUnwrap(purchaseInformation.expirationOrRenewal)
         expect(expirationOrRenewal.label) == .nextBillingDate
         expect(expirationOrRenewal.date) == .date(reformat(ISO8601Date: expirationDateFirst))
 
-        expect(subscriptionInformation.productIdentifier) == productIdOne
+        expect(purchaseInformation.productIdentifier) == productIdOne
     }
 
     func testShouldShowAppleSubscription_whenUserHasBothGoogleAndAppleSubscriptions() async throws {
@@ -406,8 +406,8 @@ class ManageSubscriptionsViewModelTests: TestCase {
         let expirationDateFirst = "2062-04-12T00:03:35Z"
         let expirationDateSecond = "2062-05-12T00:03:35Z"
         let products = [
-            SubscriptionInformationFixtures.product(id: productIdOne, title: "yearly", duration: .year, price: 29.99),
-            SubscriptionInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
+            PurchaseInformationFixtures.product(id: productIdOne, title: "yearly", duration: .year, price: 29.99),
+            PurchaseInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
         ]
         let customerInfo = CustomerInfoFixtures.customerInfo(
             subscriptions: [
@@ -455,18 +455,18 @@ class ManageSubscriptionsViewModelTests: TestCase {
         expect(viewModel.screen).toNot(beNil())
         expect(viewModel.state) == .success
 
-        let subscriptionInformation = try XCTUnwrap(viewModel.subscriptionInformation)
+        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
         // We expect to see the monthly one, because the yearly one is a Google subscription.
-        expect(subscriptionInformation.title) == "monthly"
-        expect(subscriptionInformation.durationTitle) == "1 month"
+        expect(purchaseInformation.title) == "monthly"
+        expect(purchaseInformation.durationTitle) == "1 month"
 
-        expect(subscriptionInformation.price) == .paid("$2.99")
+        expect(purchaseInformation.price) == .paid("$2.99")
 
-        let expirationOrRenewal = try XCTUnwrap(subscriptionInformation.expirationOrRenewal)
+        let expirationOrRenewal = try XCTUnwrap(purchaseInformation.expirationOrRenewal)
         expect(expirationOrRenewal.label) == .nextBillingDate
         expect(expirationOrRenewal.date) == .date(reformat(ISO8601Date: expirationDateSecond))
 
-        expect(subscriptionInformation.productIdentifier) == productIdTwo
+        expect(purchaseInformation.productIdentifier) == productIdTwo
     }
 
     func testLoadScreenNoActiveSubscription() async {
@@ -479,7 +479,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
 
         await viewModel.loadScreen()
 
-        expect(viewModel.subscriptionInformation).to(beNil())
+        expect(viewModel.purchaseInformation).to(beNil())
         expect(viewModel.state) == .error(CustomerCenterError.couldNotFindSubscriptionInformation)
     }
 
@@ -492,7 +492,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
 
         await viewModel.loadScreen()
 
-        expect(viewModel.subscriptionInformation).to(beNil())
+        expect(viewModel.purchaseInformation).to(beNil())
         expect(viewModel.state) == .error(error)
     }
 
@@ -529,14 +529,14 @@ class ManageSubscriptionsViewModelTests: TestCase {
         let expirationDateFirst = "2062-04-12T00:03:35Z"
         let expirationDateSecond = "2062-05-12T00:03:35Z"
         let offerIdentifier = "offer_id"
-        let product = SubscriptionInformationFixtures.product(id: productIdOne,
+        let product = PurchaseInformationFixtures.product(id: productIdOne,
                                                               title: "yearly",
                                                               duration: .year,
                                                               price: 29.99,
                                                               offerIdentifier: offerIdentifier)
         let products = [
             product,
-            SubscriptionInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
+            PurchaseInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
         ]
         let customerInfo = CustomerInfoFixtures.customerInfo(
             subscriptions: [
@@ -590,7 +590,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
         loadPromotionalOfferUseCase.mockedPromotionalOffer = PromotionalOffer(discount: discount,
                                                                               signedData: signedData)
 
-        let viewModel = ManageSubscriptionsViewModel(screen: SubscriptionInformationFixtures.screenWithIneligiblePromo,
+        let viewModel = ManageSubscriptionsViewModel(screen: PurchaseInformationFixtures.screenWithIneligiblePromo,
                                                      customerCenterActionHandler: nil,
                                                      purchasesProvider: MockManageSubscriptionsPurchases(
                                                         customerInfo: customerInfo,
@@ -627,14 +627,14 @@ class ManageSubscriptionsViewModelTests: TestCase {
         let expirationDateFirst = "2062-04-12T00:03:35Z"
         let expirationDateSecond = "2062-05-12T00:03:35Z"
 
-        let product = SubscriptionInformationFixtures.product(id: productIdOne,
+        let product = PurchaseInformationFixtures.product(id: productIdOne,
                                                               title: "yearly",
                                                               duration: .year,
                                                               price: 29.99,
                                                               offerIdentifier: offerIdentifierInProduct)
         let products = [
             product,
-            SubscriptionInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
+            PurchaseInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
         ]
         let customerInfo = CustomerInfoFixtures.customerInfo(
             subscriptions: [
@@ -688,7 +688,7 @@ class ManageSubscriptionsViewModelTests: TestCase {
         loadPromotionalOfferUseCase.mockedPromotionalOffer = PromotionalOffer(discount: discount,
                                                                               signedData: signedData)
 
-        let screen = SubscriptionInformationFixtures.screenWithPromo(offerID: offerIdentifierInJSON)
+        let screen = PurchaseInformationFixtures.screenWithPromo(offerID: offerIdentifierInJSON)
         let viewModel = ManageSubscriptionsViewModel(screen: screen,
                                                      customerCenterActionHandler: nil,
                                                      purchasesProvider: MockManageSubscriptionsPurchases(
@@ -754,7 +754,7 @@ final class MockManageSubscriptionsPurchases: ManageSubscriptionsPurchaseType {
         customerInfo: CustomerInfo = CustomerInfoFixtures.customerInfoWithAppleSubscriptions,
         customerInfoError: Error? = nil,
         products: [RevenueCat.StoreProduct] =
-        [SubscriptionInformationFixtures.product(id: "com.revenuecat.product",
+        [PurchaseInformationFixtures.product(id: "com.revenuecat.product",
                                                  title: "title",
                                                  duration: .month,
                                                  price: 2.99)],

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationFixtures.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationFixtures.swift
@@ -22,7 +22,7 @@ enum SubscriptionInformationFixtures {
     static func product(
         id: String,
         title: String,
-        duration: SKProduct.PeriodUnit,
+        duration: SKProduct.PeriodUnit?,
         price: Decimal,
         priceLocale: String = "en_US",
         offerIdentifier: String? = nil
@@ -32,7 +32,11 @@ enum SubscriptionInformationFixtures {
         let sk1Product = MockSK1Product(mockProductIdentifier: id, mockLocalizedTitle: title)
         sk1Product.mockPrice = price
         sk1Product.mockPriceLocale = Locale(identifier: priceLocale)
-        sk1Product.mockSubscriptionPeriod = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: duration)
+        if let duration = duration {
+            sk1Product.mockSubscriptionPeriod = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: duration)
+        } else {
+            sk1Product.mockSubscriptionPeriod = nil
+        }
         if let offerIdentifier = offerIdentifier {
             sk1Product.mockDiscount = SKProductDiscount(identifier: offerIdentifier)
         }

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationFixtures.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationFixtures.swift
@@ -7,7 +7,7 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  SubscriptionInformationFixtures.swift
+//  PurchaseInformationFixtures.swift
 //
 //  Created by Cesar de la Vega on 10/25/24.
 
@@ -17,7 +17,7 @@ import Foundation
 import StoreKit
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-enum SubscriptionInformationFixtures {
+enum PurchaseInformationFixtures {
 
     static func product(
         id: String,

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationTests.swift
@@ -50,8 +50,8 @@ class PurchaseInformationTests: TestCase {
         )
 
         let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
-                                                                     subscribedProduct: mockProduct.toStoreProduct(),
-                                                                     dateFormatter: Self.mockDateFormatter))
+                                                                 subscribedProduct: mockProduct.toStoreProduct(),
+                                                                 dateFormatter: Self.mockDateFormatter))
         expect(subscriptionInfo.title) == "Monthly Product"
         expect(subscriptionInfo.durationTitle) == "1 month"
         expect(subscriptionInfo.explanation) == .earliestRenewal
@@ -83,8 +83,8 @@ class PurchaseInformationTests: TestCase {
         )
 
         let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
-                                                                     subscribedProduct: mockProduct.toStoreProduct(),
-                                                                     dateFormatter: Self.mockDateFormatter))
+                                                                 subscribedProduct: mockProduct.toStoreProduct(),
+                                                                 dateFormatter: Self.mockDateFormatter))
         expect(subscriptionInfo.title) == "Monthly Product"
         expect(subscriptionInfo.durationTitle) == "1 month"
         expect(subscriptionInfo.explanation) == .earliestExpiration
@@ -116,8 +116,8 @@ class PurchaseInformationTests: TestCase {
         )
 
         let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
-                                                                     subscribedProduct: mockProduct.toStoreProduct(),
-                                                                     dateFormatter: Self.mockDateFormatter))
+                                                                 subscribedProduct: mockProduct.toStoreProduct(),
+                                                                 dateFormatter: Self.mockDateFormatter))
         expect(subscriptionInfo.title) == "Monthly Product"
         expect(subscriptionInfo.durationTitle) == "1 month"
         expect(subscriptionInfo.explanation) == .expired
@@ -136,7 +136,7 @@ class PurchaseInformationTests: TestCase {
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
         let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
-                                                                     dateFormatter: Self.mockDateFormatter))
+                                                                 dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -156,7 +156,7 @@ class PurchaseInformationTests: TestCase {
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
         let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
-                                                                     dateFormatter: Self.mockDateFormatter))
+                                                                 dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -176,7 +176,7 @@ class PurchaseInformationTests: TestCase {
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
         let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
-                                                                     dateFormatter: Self.mockDateFormatter))
+                                                                 dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -196,7 +196,7 @@ class PurchaseInformationTests: TestCase {
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
         let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
-                                                                     dateFormatter: Self.mockDateFormatter))
+                                                                 dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -216,7 +216,7 @@ class PurchaseInformationTests: TestCase {
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
         let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
-                                                                     dateFormatter: Self.mockDateFormatter))
+                                                                 dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -236,7 +236,7 @@ class PurchaseInformationTests: TestCase {
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
         let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
-                                                                     dateFormatter: Self.mockDateFormatter))
+                                                                 dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -256,7 +256,7 @@ class PurchaseInformationTests: TestCase {
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
         let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
-                                                                     dateFormatter: Self.mockDateFormatter))
+                                                                 dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -276,7 +276,7 @@ class PurchaseInformationTests: TestCase {
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
         let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
-                                                                     dateFormatter: Self.mockDateFormatter))
+                                                                 dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -310,8 +310,8 @@ class PurchaseInformationTests: TestCase {
 
         let testDate = Self.mockDateFormatter.date(from: "Apr 12, 2062")!
         let subscriptionInfo = try XCTUnwrap(PurchaseInformation(product: mockProduct.toStoreProduct(),
-                                                                     expirationDate: testDate,
-                                                                     dateFormatter: Self.mockDateFormatter))
+                                                                 expirationDate: testDate,
+                                                                 dateFormatter: Self.mockDateFormatter))
         expect(subscriptionInfo.title) == "Monthly Product"
         expect(subscriptionInfo.explanation) == .earliestRenewal
         expect(subscriptionInfo.durationTitle) == "1 month"

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationTests.swift
@@ -49,7 +49,7 @@ class PurchaseInformationTests: TestCase {
             locale: Self.locale
         )
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+        let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
                                                                      subscribedProduct: mockProduct.toStoreProduct(),
                                                                      dateFormatter: Self.mockDateFormatter))
         expect(subscriptionInfo.title) == "Monthly Product"
@@ -82,7 +82,7 @@ class PurchaseInformationTests: TestCase {
             locale: Self.locale
         )
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+        let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
                                                                      subscribedProduct: mockProduct.toStoreProduct(),
                                                                      dateFormatter: Self.mockDateFormatter))
         expect(subscriptionInfo.title) == "Monthly Product"
@@ -115,7 +115,7 @@ class PurchaseInformationTests: TestCase {
             locale: Self.locale
         )
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+        let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
                                                                      subscribedProduct: mockProduct.toStoreProduct(),
                                                                      dateFormatter: Self.mockDateFormatter))
         expect(subscriptionInfo.title) == "Monthly Product"
@@ -135,7 +135,7 @@ class PurchaseInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithGoogleSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+        let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
                                                                      dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
@@ -155,7 +155,7 @@ class PurchaseInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithNonRenewingGoogleSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+        let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
                                                                      dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
@@ -175,7 +175,7 @@ class PurchaseInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithExpiredGoogleSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+        let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
                                                                      dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
@@ -195,7 +195,7 @@ class PurchaseInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithPromotional
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+        let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
                                                                      dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
@@ -215,7 +215,7 @@ class PurchaseInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithLifetimePromotional
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+        let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
                                                                      dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
@@ -235,7 +235,7 @@ class PurchaseInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithStripeSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+        let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
                                                                      dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
@@ -255,7 +255,7 @@ class PurchaseInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithNonRenewingStripeSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+        let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
                                                                      dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
@@ -275,7 +275,7 @@ class PurchaseInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithExpiredStripeSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+        let subscriptionInfo = try XCTUnwrap(PurchaseInformation(entitlement: entitlement,
                                                                      dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
@@ -309,7 +309,7 @@ class PurchaseInformationTests: TestCase {
         )
 
         let testDate = Self.mockDateFormatter.date(from: "Apr 12, 2062")!
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(product: mockProduct.toStoreProduct(),
+        let subscriptionInfo = try XCTUnwrap(PurchaseInformation(product: mockProduct.toStoreProduct(),
                                                                      expirationDate: testDate,
                                                                      dateFormatter: Self.mockDateFormatter))
         expect(subscriptionInfo.title) == "Monthly Product"

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationTests.swift
@@ -7,7 +7,7 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  SubscriptionInformationTests.swift
+//  PurchaseInformationTests.swift
 //
 //  Created by Cesar de la Vega on 10/25/24.
 
@@ -21,7 +21,7 @@ import RevenueCat
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-class SubscriptionInformationTests: TestCase {
+class PurchaseInformationTests: TestCase {
 
     static let locale: Locale = .current
     static let mockDateFormatter: DateFormatter = {

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationTests.swift
@@ -53,9 +53,7 @@ class SubscriptionInformationTests: TestCase {
         expect(expirationOrRenewal.label) == .nextBillingDate
         expect(expirationOrRenewal.date) == .date("Apr 12, 2062")
 
-        expect(subscriptionInfo.willRenew) == true
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
-        expect(subscriptionInfo.active) == true
         expect(subscriptionInfo.store) == .appStore
     }
 
@@ -87,9 +85,7 @@ class SubscriptionInformationTests: TestCase {
         expect(expirationOrRenewal.label) == .expires
         expect(expirationOrRenewal.date) == .date("Apr 12, 2062")
 
-        expect(subscriptionInfo.willRenew) == false
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
-        expect(subscriptionInfo.active) == true
         expect(subscriptionInfo.store) == .appStore
     }
 
@@ -121,9 +117,7 @@ class SubscriptionInformationTests: TestCase {
         expect(expirationOrRenewal.label) == .expired
         expect(expirationOrRenewal.date) == .date("Apr 12, 2000")
 
-        expect(subscriptionInfo.willRenew) == true
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
-        expect(subscriptionInfo.active) == false
         expect(subscriptionInfo.store) == .appStore
     }
 
@@ -142,9 +136,7 @@ class SubscriptionInformationTests: TestCase {
         expect(expirationOrRenewal.label) == .nextBillingDate
         expect(expirationOrRenewal.date) == .date("Apr 12, 2062")
 
-        expect(subscriptionInfo.willRenew) == true
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
-        expect(subscriptionInfo.active) == true
         expect(subscriptionInfo.store) == .playStore
     }
 
@@ -163,9 +155,7 @@ class SubscriptionInformationTests: TestCase {
         expect(expirationOrRenewal.label) == .expires
         expect(expirationOrRenewal.date) == .date("Apr 12, 2062")
 
-        expect(subscriptionInfo.willRenew) == false
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
-        expect(subscriptionInfo.active) == true
         expect(subscriptionInfo.store) == .playStore
     }
 
@@ -184,9 +174,7 @@ class SubscriptionInformationTests: TestCase {
         expect(expirationOrRenewal.label) == .expired
         expect(expirationOrRenewal.date) == .date("Apr 12, 2000")
 
-        expect(subscriptionInfo.willRenew) == true
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
-        expect(subscriptionInfo.active) == false
         expect(subscriptionInfo.store) == .playStore
     }
 
@@ -205,9 +193,7 @@ class SubscriptionInformationTests: TestCase {
         expect(expirationOrRenewal.label) == .expires
         expect(expirationOrRenewal.date) == .date("Apr 12, 2062")
 
-        expect(subscriptionInfo.willRenew) == false
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
-        expect(subscriptionInfo.active) == true
         expect(subscriptionInfo.store) == .promotional
     }
 
@@ -226,9 +212,7 @@ class SubscriptionInformationTests: TestCase {
         expect(expirationOrRenewal.label) == .expires
         expect(expirationOrRenewal.date) == .never
 
-        expect(subscriptionInfo.willRenew) == false
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
-        expect(subscriptionInfo.active) == true
         expect(subscriptionInfo.store) == .promotional
     }
 
@@ -247,9 +231,7 @@ class SubscriptionInformationTests: TestCase {
         expect(expirationOrRenewal.label) == .nextBillingDate
         expect(expirationOrRenewal.date) == .date("Apr 12, 2062")
 
-        expect(subscriptionInfo.willRenew) == true
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
-        expect(subscriptionInfo.active) == true
         expect(subscriptionInfo.store) == .stripe
     }
 
@@ -268,9 +250,7 @@ class SubscriptionInformationTests: TestCase {
         expect(expirationOrRenewal.label) == .expires
         expect(expirationOrRenewal.date) == .date("Apr 12, 2062")
 
-        expect(subscriptionInfo.willRenew) == false
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
-        expect(subscriptionInfo.active) == true
         expect(subscriptionInfo.store) == .stripe
     }
 
@@ -289,9 +269,7 @@ class SubscriptionInformationTests: TestCase {
         expect(expirationOrRenewal.label) == .expired
         expect(expirationOrRenewal.date) == .date("Apr 12, 2000")
 
-        expect(subscriptionInfo.willRenew) == true
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
-        expect(subscriptionInfo.active) == false
         expect(subscriptionInfo.store) == .stripe
     }
 

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionInformationTests.swift
@@ -24,6 +24,13 @@ import RevenueCat
 class SubscriptionInformationTests: TestCase {
 
     static let locale: Locale = .current
+    static let mockDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM dd, yyyy"
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.timeZone = TimeZone(identifier: "UTC")!
+        return formatter
+    }()
 
     func testAppleEntitlementAndSubscribedProduct() throws {
         let customerInfo = CustomerInfoFixtures.customerInfoWithAppleSubscriptions
@@ -43,7 +50,8 @@ class SubscriptionInformationTests: TestCase {
         )
 
         let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
-                                                                     subscribedProduct: mockProduct.toStoreProduct()))
+                                                                     subscribedProduct: mockProduct.toStoreProduct(),
+                                                                     dateFormatter: Self.mockDateFormatter))
         expect(subscriptionInfo.title) == "Monthly Product"
         expect(subscriptionInfo.durationTitle) == "1 month"
         expect(subscriptionInfo.explanation) == .earliestRenewal
@@ -75,7 +83,8 @@ class SubscriptionInformationTests: TestCase {
         )
 
         let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
-                                                                     subscribedProduct: mockProduct.toStoreProduct()))
+                                                                     subscribedProduct: mockProduct.toStoreProduct(),
+                                                                     dateFormatter: Self.mockDateFormatter))
         expect(subscriptionInfo.title) == "Monthly Product"
         expect(subscriptionInfo.durationTitle) == "1 month"
         expect(subscriptionInfo.explanation) == .earliestExpiration
@@ -107,7 +116,8 @@ class SubscriptionInformationTests: TestCase {
         )
 
         let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
-                                                                     subscribedProduct: mockProduct.toStoreProduct()))
+                                                                     subscribedProduct: mockProduct.toStoreProduct(),
+                                                                     dateFormatter: Self.mockDateFormatter))
         expect(subscriptionInfo.title) == "Monthly Product"
         expect(subscriptionInfo.durationTitle) == "1 month"
         expect(subscriptionInfo.explanation) == .expired
@@ -125,7 +135,8 @@ class SubscriptionInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithGoogleSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement))
+        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+                                                                     dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -144,7 +155,8 @@ class SubscriptionInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithNonRenewingGoogleSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement))
+        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+                                                                     dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -163,7 +175,8 @@ class SubscriptionInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithExpiredGoogleSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement))
+        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+                                                                     dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -182,7 +195,8 @@ class SubscriptionInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithPromotional
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement))
+        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+                                                                     dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -201,7 +215,8 @@ class SubscriptionInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithLifetimePromotional
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement))
+        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+                                                                     dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -220,7 +235,8 @@ class SubscriptionInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithStripeSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement))
+        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+                                                                     dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -239,7 +255,8 @@ class SubscriptionInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithNonRenewingStripeSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement))
+        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+                                                                     dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -258,7 +275,8 @@ class SubscriptionInformationTests: TestCase {
         let customerInfo = CustomerInfoFixtures.customerInfoWithExpiredStripeSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 
-        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement))
+        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(entitlement: entitlement,
+                                                                     dateFormatter: Self.mockDateFormatter))
 
         expect(subscriptionInfo.title).to(beNil())
         expect(subscriptionInfo.durationTitle).to(beNil())
@@ -271,6 +289,40 @@ class SubscriptionInformationTests: TestCase {
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .stripe
+    }
+
+    func testLoadingOnlyWithProductInformation() throws {
+        let customerInfo = CustomerInfoFixtures.customerInfoWithNonRenewingAppleSubscriptions
+        let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
+
+        let mockProduct = TestStoreProduct(
+            localizedTitle: "Monthly Product",
+            price: 6.99,
+            localizedPriceString: "$6.99",
+            productIdentifier: entitlement.productIdentifier,
+            productType: .autoRenewableSubscription,
+            localizedDescription: "PRO monthly",
+            subscriptionGroupIdentifier: "group",
+            subscriptionPeriod: .init(value: 1, unit: .month),
+            introductoryDiscount: nil,
+            locale: Self.locale
+        )
+
+        let testDate = Self.mockDateFormatter.date(from: "Apr 12, 2062")!
+        let subscriptionInfo = try XCTUnwrap(SubscriptionInformation(product: mockProduct.toStoreProduct(),
+                                                                     expirationDate: testDate,
+                                                                     dateFormatter: Self.mockDateFormatter))
+        expect(subscriptionInfo.title) == "Monthly Product"
+        expect(subscriptionInfo.explanation) == .earliestRenewal
+        expect(subscriptionInfo.durationTitle) == "1 month"
+        expect(subscriptionInfo.price) == .paid("$6.99")
+
+        let expirationOrRenewal = try XCTUnwrap(subscriptionInfo.expirationOrRenewal)
+        expect(expirationOrRenewal.label) == .expires
+        expect(expirationOrRenewal.date) == .date("Apr 12, 2062")
+
+        expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
+        expect(subscriptionInfo.store) == .appStore
     }
 
 }


### PR DESCRIPTION
| Header | Header |
|--------|--------|
| Lifetime (there's an entitlement and a non subscription) | ![simulator_screenshot_B11812CC-D3EA-4320-8E48-8AAD5F16E810](https://github.com/user-attachments/assets/038260bd-4c10-47ee-aadb-09935cebd651) |
| Monthly + Lifetime: displays lifetime because the entitlement is assigned to the Lifetime. We should display the monthly information but we are missing CustomerInfo information | !![simulator_screenshot_B11812CC-D3EA-4320-8E48-8AAD5F16E810](https://github.com/user-attachments/assets/038260bd-4c10-47ee-aadb-09935cebd651) |
| Base case monthly assigned to an entitlement | ![simulator_screenshot_40CA9FE8-DB93-4591-9253-CFAAC015AB43](https://github.com/user-attachments/assets/b015ea42-7e94-4675-9f57-5c96f0a4bb20) |