### PR TITLE
Adds `subscriptions` to `CustomerInfo`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 		35D83300262FAD8000E60AC5 /* ETagManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D832FF262FAD8000E60AC5 /* ETagManagerTests.swift */; };
 		35D8330A262FBA9A00E60AC5 /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357D16038F07915D7825D /* MockUserDefaults.swift */; };
 		35D83312262FBD4200E60AC5 /* MockETagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D83311262FBD4200E60AC5 /* MockETagManager.swift */; };
+		35DE0DB62CEF9E8F00EB83E9 /* SubscriptionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DE0DB52CEF9E8C00EB83E9 /* SubscriptionInfo.swift */; };
 		35E840CC270FB70D00899AE2 /* ManageSubscriptionsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E840C5270FB47C00899AE2 /* ManageSubscriptionsHelper.swift */; };
 		35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E840CD2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift */; };
 		35F249CA2C493D970058993A /* LoadPromotionalOfferUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F249C92C493D970058993A /* LoadPromotionalOfferUseCase.swift */; };
@@ -1536,6 +1537,7 @@
 		35D832F3262E606500E60AC5 /* HTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse.swift; sourceTree = "<group>"; };
 		35D832FF262FAD8000E60AC5 /* ETagManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ETagManagerTests.swift; sourceTree = "<group>"; };
 		35D83311262FBD4200E60AC5 /* MockETagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockETagManager.swift; sourceTree = "<group>"; };
+		35DE0DB52CEF9E8C00EB83E9 /* SubscriptionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionInfo.swift; sourceTree = "<group>"; };
 		35E1CE1F26E022C20008560A /* TrialOrIntroPriceEligibilityCheckerSK1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrialOrIntroPriceEligibilityCheckerSK1Tests.swift; sourceTree = "<group>"; };
 		35E840C5270FB47C00899AE2 /* ManageSubscriptionsHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsHelper.swift; sourceTree = "<group>"; };
 		35E840CD2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockManageSubscriptionsHelper.swift; sourceTree = "<group>"; };
@@ -4767,6 +4769,7 @@
 		B3A36AAC26BC76230059EDEA /* Identity */ = {
 			isa = PBXGroup;
 			children = (
+				35DE0DB52CEF9E8C00EB83E9 /* SubscriptionInfo.swift */,
 				A56F9AB026990E9200AFC48F /* CustomerInfo.swift */,
 				57F3C10429B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift */,
 				4F15B4A02A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift */,
@@ -5733,6 +5736,7 @@
 				FD43D2FC2C41864000077235 /* TimeInterval+Extensions.swift in Sources */,
 				4F7DBFBD2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift in Sources */,
 				5766AB4728401B8400FA6091 /* PackageType.swift in Sources */,
+				35DE0DB62CEF9E8F00EB83E9 /* SubscriptionInfo.swift in Sources */,
 				B3F3E8DA277158FE0047A5B9 /* DNSChecker.swift in Sources */,
 				A525BF4B26C320D100C354C4 /* SubscriberAttributesManager.swift in Sources */,
 				2D1015DA275959840086173F /* StoreTransaction.swift in Sources */,

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -12,6 +12,7 @@
 //  Created by Madeline Beyl on 7/9/21.
 //
 
+// swiftlint:disable file_length
 import Foundation
 
 /**

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -29,7 +29,9 @@ public typealias ProductIdentifier = String
     @objc public let entitlements: EntitlementInfos
 
     /// All *subscription* product identifiers with expiration dates in the future.
-    @objc public var activeSubscriptions: Set<ProductIdentifier> { self.activeKeys(dates: self.expirationDatesByProductId) }
+    @objc public var activeSubscriptions: Set<ProductIdentifier> {
+        self.activeKeys(dates: self.expirationDatesByProductId)
+    }
 
     /// All product identifiers purchases by the user regardless of expiration.
     @objc public let allPurchasedProductIdentifiers: Set<ProductIdentifier>

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -225,7 +225,8 @@ import Foundation
                 ownershipType: subscriptionData.ownershipType,
                 periodType: subscriptionData.periodType,
                 refundedAt: subscriptionData.refundedAt,
-                storeTransactionId: subscriptionData.storeTransactionId
+                storeTransactionId: subscriptionData.storeTransactionId,
+                requestDate: response.requestDate
             )
         }
     }

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -212,8 +212,9 @@ import Foundation
         self.allPurchasedProductIdentifiers = Set(self.expirationDatesByProductId.keys)
             .union(self.nonSubscriptions.map { $0.productIdentifier })
 
-        self.subscriptions = subscriber.subscriptions.mapValues { subscriptionData in
-            SubscriptionInfo(
+        self.subscriptions = Dictionary(uniqueKeysWithValues: subscriber.subscriptions.map { (key, subscriptionData) in
+            (key, SubscriptionInfo(
+                productIdentifier: key,
                 purchaseDate: subscriptionData.purchaseDate,
                 originalPurchaseDate: subscriptionData.originalPurchaseDate,
                 expiresDate: subscriptionData.expiresDate,
@@ -227,8 +228,8 @@ import Foundation
                 refundedAt: subscriptionData.refundedAt,
                 storeTransactionId: subscriptionData.storeTransactionId,
                 requestDate: response.requestDate
-            )
-        }
+            ))
+        })
     }
 
     private let expirationDatesByProductId: [String: Date?]

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -88,6 +88,9 @@ import Foundation
      */
     @objc public let originalApplicationVersion: String?
 
+    /// Dictionary of all subscription product identifiers and their subscription info
+    @objc public let subscriptions: [String: SubscriptionInfo]
+
     /// Get the expiration date for a given product identifier. You should use Entitlements though!
     /// - Parameter productIdentifier: Product identifier for product
     /// - Returns:  The expiration date for `productIdentifier`, `nil` if product never purchased
@@ -208,6 +211,23 @@ import Foundation
         self.purchaseDatesByProductId = Self.extractPurchaseDates(subscriber)
         self.allPurchasedProductIdentifiers = Set(self.expirationDatesByProductId.keys)
             .union(self.nonSubscriptions.map { $0.productIdentifier })
+
+        self.subscriptions = subscriber.subscriptions.mapValues { subscriptionData in
+            SubscriptionInfo(
+                purchaseDate: subscriptionData.purchaseDate,
+                originalPurchaseDate: subscriptionData.originalPurchaseDate,
+                expiresDate: subscriptionData.expiresDate,
+                store: subscriptionData.store,
+                isSandbox: subscriptionData.isSandbox,
+                unsubscribeDetectedAt: subscriptionData.unsubscribeDetectedAt,
+                billingIssuesDetectedAt: subscriptionData.billingIssuesDetectedAt,
+                gracePeriodExpiresDate: subscriptionData.gracePeriodExpiresDate,
+                ownershipType: subscriptionData.ownershipType,
+                periodType: subscriptionData.periodType,
+                refundedAt: subscriptionData.refundedAt,
+                storeTransactionId: subscriptionData.storeTransactionId
+            )
+        }
     }
 
     private let expirationDatesByProductId: [String: Date?]

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -13,6 +13,7 @@
 
 import Foundation
 
+/// Subscription purchases of the Customer
 @objc(RCSubscriptionInfo) public final class SubscriptionInfo: NSObject {
 
     /// The product identifier.

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -1,0 +1,80 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SubscriptionInfo.swift
+//
+//  Created by Cesar de la Vega on 21/11/24.
+
+import Foundation
+
+@objc(RCSubscriptionInfo) public final class SubscriptionInfo: NSObject {
+
+    @objc public let purchaseDate: Date?
+    @objc public let originalPurchaseDate: Date?
+    @objc public let expiresDate: Date?
+    @objc public let store: Store
+    @objc public let isSandbox: Bool
+    @objc public let unsubscribeDetectedAt: Date?
+    @objc public let billingIssuesDetectedAt: Date?
+    @objc public let gracePeriodExpiresDate: Date?
+    @objc public let ownershipType: PurchaseOwnershipType
+    @objc public let periodType: PeriodType
+    @objc public let refundedAt: Date?
+    @objc public let storeTransactionId: String
+
+    init(purchaseDate: Date?,
+         originalPurchaseDate: Date?,
+         expiresDate: Date?,
+         store: Store,
+         isSandbox: Bool,
+         unsubscribeDetectedAt: Date?,
+         billingIssuesDetectedAt: Date?,
+         gracePeriodExpiresDate: Date?,
+         ownershipType: PurchaseOwnershipType,
+         periodType: PeriodType,
+         refundedAt: Date?,
+         storeTransactionId: String) {
+        self.purchaseDate = purchaseDate
+        self.originalPurchaseDate = originalPurchaseDate
+        self.expiresDate = expiresDate
+        self.store = store
+        self.isSandbox = isSandbox
+        self.unsubscribeDetectedAt = unsubscribeDetectedAt
+        self.billingIssuesDetectedAt = billingIssuesDetectedAt
+        self.gracePeriodExpiresDate = gracePeriodExpiresDate
+        self.ownershipType = ownershipType
+        self.periodType = periodType
+        self.refundedAt = refundedAt
+        self.storeTransactionId = storeTransactionId
+
+        super.init()
+    }
+
+    public override var description: String {
+        return """
+        SubscriptionInfo {
+            purchaseDate: \(String(describing: purchaseDate)),
+            originalPurchaseDate: \(String(describing: originalPurchaseDate)),
+            expiresDate: \(String(describing: expiresDate)),
+            store: \(store),
+            isSandbox: \(isSandbox),
+            unsubscribeDetectedAt: \(String(describing: unsubscribeDetectedAt)),
+            billingIssuesDetectedAt: \(String(describing: billingIssuesDetectedAt)),
+            gracePeriodExpiresDate: \(String(describing: gracePeriodExpiresDate)),
+            ownershipType: \(ownershipType),
+            periodType: \(String(describing: periodType)),
+            refundedAt: \(String(describing: refundedAt)),
+            storeTransactionId: \(storeTransactionId)
+        }
+        """
+    }
+
+}
+
+extension SubscriptionInfo: Sendable {}

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -15,6 +15,8 @@ import Foundation
 
 @objc(RCSubscriptionInfo) public final class SubscriptionInfo: NSObject {
 
+    /// The product identifier.
+    @objc public let productIdentifier: String
     @objc public let purchaseDate: Date
     @objc public let originalPurchaseDate: Date?
     @objc public let expiresDate: Date?
@@ -29,7 +31,8 @@ import Foundation
     @objc public let storeTransactionId: String?
     @objc public let isActive: Bool
 
-    init(purchaseDate: Date,
+    init(productIdentifier: String,
+         purchaseDate: Date,
          originalPurchaseDate: Date?,
          expiresDate: Date?,
          store: Store,
@@ -42,6 +45,7 @@ import Foundation
          refundedAt: Date?,
          storeTransactionId: String?,
          requestDate: Date) {
+        self.productIdentifier = productIdentifier
         self.purchaseDate = purchaseDate
         self.originalPurchaseDate = originalPurchaseDate
         self.expiresDate = expiresDate

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -27,6 +27,7 @@ import Foundation
     @objc public let periodType: PeriodType
     @objc public let refundedAt: Date?
     @objc public let storeTransactionId: String?
+    @objc public let isActive: Bool
 
     init(purchaseDate: Date,
          originalPurchaseDate: Date?,
@@ -39,7 +40,8 @@ import Foundation
          ownershipType: PurchaseOwnershipType,
          periodType: PeriodType,
          refundedAt: Date?,
-         storeTransactionId: String?) {
+         storeTransactionId: String?,
+         requestDate: Date) {
         self.purchaseDate = purchaseDate
         self.originalPurchaseDate = originalPurchaseDate
         self.expiresDate = expiresDate
@@ -52,6 +54,7 @@ import Foundation
         self.periodType = periodType
         self.refundedAt = refundedAt
         self.storeTransactionId = storeTransactionId
+        self.isActive = CustomerInfo.isDateActive(expirationDate: expiresDate, for: requestDate)
 
         super.init()
     }
@@ -70,7 +73,8 @@ import Foundation
             ownershipType: \(ownershipType),
             periodType: \(String(describing: periodType)),
             refundedAt: \(String(describing: refundedAt)),
-            storeTransactionId: \(storeTransactionId)
+            storeTransactionId: \(String(describing: storeTransactionId)),
+            isActive: \(isActive)
         }
         """
     }

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -17,7 +17,7 @@ import Foundation
 @objc(RCSubscriptionInfo) public final class SubscriptionInfo: NSObject {
 
     /// The product identifier.
-    @objc public let productIdentifier: String
+    @objc public let productIdentifier: ProductIdentifier
 
     /// Date when the last subscription period started.
     @objc public let purchaseDate: Date

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -15,7 +15,7 @@ import Foundation
 
 @objc(RCSubscriptionInfo) public final class SubscriptionInfo: NSObject {
 
-    @objc public let purchaseDate: Date?
+    @objc public let purchaseDate: Date
     @objc public let originalPurchaseDate: Date?
     @objc public let expiresDate: Date?
     @objc public let store: Store
@@ -26,9 +26,9 @@ import Foundation
     @objc public let ownershipType: PurchaseOwnershipType
     @objc public let periodType: PeriodType
     @objc public let refundedAt: Date?
-    @objc public let storeTransactionId: String
+    @objc public let storeTransactionId: String?
 
-    init(purchaseDate: Date?,
+    init(purchaseDate: Date,
          originalPurchaseDate: Date?,
          expiresDate: Date?,
          store: Store,
@@ -39,7 +39,7 @@ import Foundation
          ownershipType: PurchaseOwnershipType,
          periodType: PeriodType,
          refundedAt: Date?,
-         storeTransactionId: String) {
+         storeTransactionId: String?) {
         self.purchaseDate = purchaseDate
         self.originalPurchaseDate = originalPurchaseDate
         self.expiresDate = expiresDate

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -50,14 +50,14 @@ import Foundation
     @objc public let gracePeriodExpiresDate: Date?
 
     /// How the Customer received access to this subscription:
-    /// - ``purchased``: The customer bought the subscription.
-    /// - ``familyShared``: The Customer has access to the product via their family.
+    /// - ``PurchaseOwnershipType/purchased``: The customer bought the subscription.
+    /// - ``PurchaseOwnershipType/familyShared``: The Customer has access to the product via their family.
     @objc public let ownershipType: PurchaseOwnershipType
 
     /// Type of the current subscription period:
-    /// - ``normal``: The product is in a normal period (default)
-    /// - ``trial``: The product is in a free trial period
-    /// - ``intro``: The product is in an introductory pricing period
+    /// - ``PeriodType/normal``: The product is in a normal period (default)
+    /// - ``PeriodType/trial``: The product is in a free trial period
+    /// - ``PeriodType/intro``: The product is in an introductory pricing period
     @objc public let periodType: PeriodType
 
     /// Date when RevenueCat detected a refund of this subscription.

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -17,19 +17,58 @@ import Foundation
 
     /// The product identifier.
     @objc public let productIdentifier: String
+
+    /// Date when the last subscription period started.
     @objc public let purchaseDate: Date
+
+    /// Date when this subscription first started. This property does not update with renewals.
+    /// This property also does not update for product changes within a subscription group or 
+    /// resubscriptions by lapsed subscribers.
     @objc public let originalPurchaseDate: Date?
+
+    /// Date when the subscription expires/expired
     @objc public let expiresDate: Date?
+
+    /// Store where the subscription was purchased.
     @objc public let store: Store
+
+    /// Whether or not the purchase was made in sandbox mode.
     @objc public let isSandbox: Bool
+
+    /// Date when RevenueCat detected that auto-renewal was turned off for this subsription.
+    /// Note the subscription may still be active, check the ``expiresDate`` attribute.
     @objc public let unsubscribeDetectedAt: Date?
+
+    /// Date when RevenueCat detected any billing issues with this subscription.
+    /// If and when the billing issue gets resolved, this field is set to nil.
+    /// Note the subscription may still be active, check the ``expiresDate`` attribute.
     @objc public let billingIssuesDetectedAt: Date?
+
+    /// Date when any grace period for this subscription expires/expired.
+    /// nil if the customer has never been in a grace period.
     @objc public let gracePeriodExpiresDate: Date?
+
+    /// How the Customer received access to this subscription:
+    /// - ``purchased``: The customer bought the subscription.
+    /// - ``familyShared``: The Customer has access to the product via their family.
     @objc public let ownershipType: PurchaseOwnershipType
+
+    /// Type of the current subscription period:
+    /// - ``normal``: The product is in a normal period (default)
+    /// - ``trial``: The product is in a free trial period
+    /// - ``intro``: The product is in an introductory pricing period
     @objc public let periodType: PeriodType
+
+    /// Date when RevenueCat detected a refund of this subscription.
     @objc public let refundedAt: Date?
+
+    /// The transaction id in the store of the subscription.
     @objc public let storeTransactionId: String?
+
+    /// Whether the subscription is currently active.
     @objc public let isActive: Bool
+
+    /// Whether the subscription will renew at the next billing period.
     @objc public let willRenew: Bool
 
     init(productIdentifier: String,

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -30,6 +30,7 @@ import Foundation
     @objc public let refundedAt: Date?
     @objc public let storeTransactionId: String?
     @objc public let isActive: Bool
+    @objc public let willRenew: Bool
 
     init(productIdentifier: String,
          purchaseDate: Date,
@@ -59,6 +60,10 @@ import Foundation
         self.refundedAt = refundedAt
         self.storeTransactionId = storeTransactionId
         self.isActive = CustomerInfo.isDateActive(expirationDate: expiresDate, for: requestDate)
+        self.willRenew = EntitlementInfo.willRenewWithExpirationDate(expirationDate: expiresDate,
+                                                                     store: store,
+                                                                     unsubscribeDetectedAt: unsubscribeDetectedAt,
+                                                                     billingIssueDetectedAt: billingIssuesDetectedAt)
 
         super.init()
     }
@@ -78,7 +83,8 @@ import Foundation
             periodType: \(String(describing: periodType)),
             refundedAt: \(String(describing: refundedAt)),
             storeTransactionId: \(String(describing: storeTransactionId)),
-            isActive: \(isActive)
+            isActive: \(isActive),
+            willRenew: \(willRenew)
         }
         """
     }

--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -49,7 +49,9 @@ extension CustomerInfoResponse {
 
         @IgnoreDecodeErrors<PeriodType>
         var periodType: PeriodType
+        // TODO: verify if nullable
         var purchaseDate: Date?
+        // TODO: verify if nullable
         var originalPurchaseDate: Date?
         var expiresDate: Date?
         @IgnoreDecodeErrors<Store>
@@ -62,6 +64,10 @@ extension CustomerInfoResponse {
         var ownershipType: PurchaseOwnershipType
         var productPlanIdentifier: String?
         var metadata: [String: String]?
+        var gracePeriodExpiresDate: Date?
+        var refundedAt: Date?
+        // TODO: verify if nullable
+        var storeTransactionId: String
 
     }
 
@@ -209,7 +215,8 @@ extension CustomerInfoResponse.Subscription {
         isSandbox: Bool,
         unsubscribeDetectedAt: Date? = nil,
         billingIssuesDetectedAt: Date? = nil,
-        ownershipType: PurchaseOwnershipType = .defaultValue
+        ownershipType: PurchaseOwnershipType = .defaultValue,
+        storeTransactionId: String = ""
     ) {
         self.periodType = periodType
         self.purchaseDate = purchaseDate
@@ -220,6 +227,7 @@ extension CustomerInfoResponse.Subscription {
         self.unsubscribeDetectedAt = unsubscribeDetectedAt
         self.billingIssuesDetectedAt = billingIssuesDetectedAt
         self.ownershipType = ownershipType
+        self.storeTransactionId = storeTransactionId
     }
 
     var asTransaction: CustomerInfoResponse.Transaction {

--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -70,7 +70,7 @@ extension CustomerInfoResponse {
 
     struct Transaction {
 
-        var purchaseDate: Date?
+        var purchaseDate: Date
         var originalPurchaseDate: Date?
         var transactionIdentifier: String?
         var storeTransactionIdentifier: String?
@@ -177,7 +177,7 @@ extension CustomerInfoResponse.Subscriber {
 extension CustomerInfoResponse.Transaction {
 
     init(
-        purchaseDate: Date?,
+        purchaseDate: Date,
         originalPurchaseDate: Date?,
         transactionIdentifier: String?,
         storeTransactionIdentifier: String?,
@@ -205,7 +205,7 @@ extension CustomerInfoResponse.Subscription {
 
     init(
         periodType: PeriodType = .defaultValue,
-        purchaseDate: Date? = nil,
+        purchaseDate: Date,
         originalPurchaseDate: Date? = nil,
         expiresDate: Date? = nil,
         store: Store = .defaultValue,

--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -213,7 +213,7 @@ extension CustomerInfoResponse.Subscription {
         unsubscribeDetectedAt: Date? = nil,
         billingIssuesDetectedAt: Date? = nil,
         ownershipType: PurchaseOwnershipType = .defaultValue,
-        storeTransactionId: String = ""
+        storeTransactionId: String? = nil
     ) {
         self.periodType = periodType
         self.purchaseDate = purchaseDate

--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -49,9 +49,7 @@ extension CustomerInfoResponse {
 
         @IgnoreDecodeErrors<PeriodType>
         var periodType: PeriodType
-        // TODO: verify if nullable
-        var purchaseDate: Date?
-        // TODO: verify if nullable
+        var purchaseDate: Date
         var originalPurchaseDate: Date?
         var expiresDate: Date?
         @IgnoreDecodeErrors<Store>
@@ -66,8 +64,7 @@ extension CustomerInfoResponse {
         var metadata: [String: String]?
         var gracePeriodExpiresDate: Date?
         var refundedAt: Date?
-        // TODO: verify if nullable
-        var storeTransactionId: String
+        var storeTransactionId: String?
 
     }
 

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -299,7 +299,7 @@ public extension EntitlementInfo {
 
 // MARK: - Internal
 
-private extension EntitlementInfo {
+extension EntitlementInfo {
 
     static func willRenewWithExpirationDate(expirationDate: Date?,
                                             store: Store,

--- a/Sources/Purchasing/NonSubscriptionTransaction.swift
+++ b/Sources/Purchasing/NonSubscriptionTransaction.swift
@@ -35,7 +35,7 @@ public final class NonSubscriptionTransaction: NSObject {
     @objc public let storeTransactionIdentifier: String
 
     /**
-     * The ``Store``tore where this transaction was performed from.
+     * The ``Store`` where this transaction was performed.
      */
     @objc public let store: Store
 

--- a/Sources/Purchasing/NonSubscriptionTransaction.swift
+++ b/Sources/Purchasing/NonSubscriptionTransaction.swift
@@ -36,8 +36,7 @@ public final class NonSubscriptionTransaction: NSObject {
 
     init?(with transaction: CustomerInfoResponse.Transaction, productID: String) {
         guard let transactionIdentifier = transaction.transactionIdentifier,
-              let storeTransactionIdentifier = transaction.storeTransactionIdentifier,
-              let purchaseDate = transaction.purchaseDate else {
+              let storeTransactionIdentifier = transaction.storeTransactionIdentifier else {
             Logger.error("Couldn't initialize NonSubscriptionTransaction. " +
                          "Reason: missing data: \(transaction).")
             return nil
@@ -45,7 +44,7 @@ public final class NonSubscriptionTransaction: NSObject {
 
         self.transactionIdentifier = transactionIdentifier
         self.storeTransactionIdentifier = storeTransactionIdentifier
-        self.purchaseDate = purchaseDate
+        self.purchaseDate = transaction.purchaseDate
         self.productIdentifier = productID
     }
 

--- a/Sources/Purchasing/NonSubscriptionTransaction.swift
+++ b/Sources/Purchasing/NonSubscriptionTransaction.swift
@@ -34,6 +34,11 @@ public final class NonSubscriptionTransaction: NSObject {
     /// The unique identifier for the transaction created by the Store.
     @objc public let storeTransactionIdentifier: String
 
+    /**
+     * The ``Store``tore where this transaction was performed from.
+     */
+    @objc public let store: Store
+
     init?(with transaction: CustomerInfoResponse.Transaction, productID: String) {
         guard let transactionIdentifier = transaction.transactionIdentifier,
               let storeTransactionIdentifier = transaction.storeTransactionIdentifier else {
@@ -46,6 +51,7 @@ public final class NonSubscriptionTransaction: NSObject {
         self.storeTransactionIdentifier = storeTransactionIdentifier
         self.purchaseDate = transaction.purchaseDate
         self.productIdentifier = productID
+        self.store = transaction.store
     }
 
     public override var description: String {

--- a/Tests/APITesters/AllAPITests/AllAPITests.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/AllAPITests/AllAPITests.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		2D4C62D62C5D41E200A29FD2 /* RevenueCat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2D4C62D42C5D41E200A29FD2 /* RevenueCat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2D4C62D92C5D41EC00A29FD2 /* RevenueCat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D4C62D82C5D41EC00A29FD2 /* RevenueCat.framework */; };
 		2D4C62DA2C5D41EC00A29FD2 /* RevenueCat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2D4C62D82C5D41EC00A29FD2 /* RevenueCat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3502630E2CF61E9F00894270 /* SubscriptionInfoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3502630D2CF61E9A00894270 /* SubscriptionInfoAPI.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -342,6 +343,7 @@
 		2D4C62D02C5D41D400A29FD2 /* ReceiptParser.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ReceiptParser.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D4C62D42C5D41E200A29FD2 /* RevenueCat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RevenueCat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D4C62D82C5D41EC00A29FD2 /* RevenueCat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RevenueCat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3502630D2CF61E9A00894270 /* SubscriptionInfoAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionInfoAPI.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -529,6 +531,7 @@
 		2D4C61B42C5AD61800A29FD2 /* SwiftAPITester */ = {
 			isa = PBXGroup;
 			children = (
+				3502630D2CF61E9A00894270 /* SubscriptionInfoAPI.swift */,
 				2D4C61D32C5AD62900A29FD2 /* AttributionNetworkAPI.swift */,
 				2D4C61CC2C5AD62900A29FD2 /* AttributionAPI.swift */,
 				2D4C61D42C5AD62900A29FD2 /* ConfigurationAPI.swift */,
@@ -989,6 +992,7 @@
 				2D4C61DA2C5AD62A00A29FD2 /* RefundRequestStatusAPI.swift in Sources */,
 				2D4C61F52C5AD62A00A29FD2 /* PromotionalOfferAPI.swift in Sources */,
 				2D4C61E92C5AD62A00A29FD2 /* StoreProductAPI.swift in Sources */,
+				3502630E2CF61E9F00894270 /* SubscriptionInfoAPI.swift in Sources */,
 				2D4C61EA2C5AD62A00A29FD2 /* StorefrontAPI.swift in Sources */,
 				2D4C61E42C5AD62A00A29FD2 /* main.swift in Sources */,
 				2D4C61E62C5AD62A00A29FD2 /* StoreProductDiscountAPI.swift in Sources */,

--- a/Tests/APITesters/AllAPITests/AllAPITests.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/AllAPITests/AllAPITests.xcodeproj/project.pbxproj
@@ -122,6 +122,8 @@
 		2D4C62D92C5D41EC00A29FD2 /* RevenueCat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D4C62D82C5D41EC00A29FD2 /* RevenueCat.framework */; };
 		2D4C62DA2C5D41EC00A29FD2 /* RevenueCat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2D4C62D82C5D41EC00A29FD2 /* RevenueCat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3502630E2CF61E9F00894270 /* SubscriptionInfoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3502630D2CF61E9A00894270 /* SubscriptionInfoAPI.swift */; };
+		35370AC52CFF8304004F0A64 /* RCSubscriptionInfoAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 35370AC42CFF82F8004F0A64 /* RCSubscriptionInfoAPI.h */; };
+		35370AC82CFF8317004F0A64 /* RCSubscriptionInfoAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 35370AC72CFF8312004F0A64 /* RCSubscriptionInfoAPI.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -344,6 +346,8 @@
 		2D4C62D42C5D41E200A29FD2 /* RevenueCat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RevenueCat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D4C62D82C5D41EC00A29FD2 /* RevenueCat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RevenueCat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3502630D2CF61E9A00894270 /* SubscriptionInfoAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionInfoAPI.swift; sourceTree = "<group>"; };
+		35370AC42CFF82F8004F0A64 /* RCSubscriptionInfoAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCSubscriptionInfoAPI.h; sourceTree = "<group>"; };
+		35370AC72CFF8312004F0A64 /* RCSubscriptionInfoAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCSubscriptionInfoAPI.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -458,6 +462,8 @@
 		2D4C613E2C5AD30400A29FD2 /* ObjcAPITester */ = {
 			isa = PBXGroup;
 			children = (
+				35370AC72CFF8312004F0A64 /* RCSubscriptionInfoAPI.m */,
+				35370AC42CFF82F8004F0A64 /* RCSubscriptionInfoAPI.h */,
 				2D4C61732C5AD31900A29FD2 /* main.m */,
 				2D4C61582C5AD31600A29FD2 /* RCAttributionAPI.h */,
 				2D4C614C2C5AD31500A29FD2 /* RCAttributionAPI.m */,
@@ -640,6 +646,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2D4C61402C5AD30400A29FD2 /* ObjcAPITester.h in Headers */,
+				35370AC52CFF8304004F0A64 /* RCSubscriptionInfoAPI.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -977,6 +984,7 @@
 				2D4C617C2C5AD31A00A29FD2 /* RCStoreKitVersionAPI.m in Sources */,
 				2D4C61902C5AD31A00A29FD2 /* main.m in Sources */,
 				2D4C61932C5AD31A00A29FD2 /* RCPurchasesAPI.m in Sources */,
+				35370AC82CFF8317004F0A64 /* RCSubscriptionInfoAPI.m in Sources */,
 				2D4C618C2C5AD31A00A29FD2 /* RCPurchasesDiagnosticsAPI.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCSubscriptionInfoAPI.h
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCSubscriptionInfoAPI.h
@@ -1,0 +1,19 @@
+//
+//  RCSubscriptionInfoAPI.h
+//  AllAPITests
+//
+//  Created by Cesar de la Vega on 3/12/24.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCSubscriptionInfoAPI : NSObject
+
++ (void)checkAPI;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCSubscriptionInfoAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCSubscriptionInfoAPI.m
@@ -1,0 +1,34 @@
+//
+//  RCSubscriptionInfoAPI.m
+//  AllAPITests
+//
+//  Created by Cesar de la Vega on 3/12/24.
+//
+
+#import "RCSubscriptionInfoAPI.h"
+
+@import RevenueCat;
+
+@implementation RCSubscriptionInfoAPI
+
++ (void)checkAPI {
+    RCSubscriptionInfo *subscription;
+    
+    NSString *productIdentifier __unused = subscription.productIdentifier;
+    NSDate *purchaseDate __unused = subscription.purchaseDate;
+    NSDate *originalPurchaseDate __unused = subscription.originalPurchaseDate;
+    NSDate *expiresDate __unused = subscription.expiresDate;
+    RCStore store __unused = subscription.store;
+    BOOL isSandbox __unused = subscription.isSandbox;
+    NSDate *unsubscribeDetectedAt __unused = subscription.unsubscribeDetectedAt;
+    NSDate *billingIssuesDetectedAt __unused = subscription.billingIssuesDetectedAt;
+    NSDate *gracePeriodExpiresDate __unused = subscription.gracePeriodExpiresDate;
+    RCPurchaseOwnershipType ownershipType __unused = subscription.ownershipType;
+    RCPeriodType periodType __unused = subscription.periodType;
+    NSDate *refundedAt __unused = subscription.refundedAt;
+    NSString *storeTransactionId __unused = subscription.storeTransactionId;
+    BOOL isActive __unused = subscription.isActive;
+    BOOL willRenew __unused = subscription.willRenew;
+}
+
+@end

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerInfoAPI.swift
@@ -17,7 +17,9 @@ import RevenueCat
 var customerInfo: CustomerInfo!
 func checkCustomerInfoAPI() {
     let entitlementInfo: EntitlementInfos = customerInfo.entitlements
+    let asubsp: Set<ProductIdentifier> = customerInfo.activeSubscriptions
     let asubs: Set<String> = customerInfo.activeSubscriptions
+    let appisp: Set<ProductIdentifier> = customerInfo.allPurchasedProductIdentifiers
     let appis: Set<String> = customerInfo.allPurchasedProductIdentifiers
     let led: Date? = customerInfo.latestExpirationDate
 
@@ -40,7 +42,9 @@ func checkCustomerInfoAPI() {
 
     let _: String = customerInfo.id
 
-    let subs: [String: SubscriptionInfo] = customerInfo.subscriptions
+    let subs: [String: SubscriptionInfo] = customerInfo.subscriptionsByProductIdentifier
+
+    let subsp: [ProductIdentifier: SubscriptionInfo] = customerInfo.subscriptionsByProductIdentifier
 
     print(customerInfo!, entitlementInfo, asubs, appis, led!, nst, oav!, opd!, rDate!, fSeen,
           oaud!, murl!, edfpi!, pdfpi!, exdf!, pdfe!, desc, rawData, subs)

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerInfoAPI.swift
@@ -40,8 +40,10 @@ func checkCustomerInfoAPI() {
 
     let _: String = customerInfo.id
 
+    let subs: [String: SubscriptionInfo] = customerInfo.subscriptions
+
     print(customerInfo!, entitlementInfo, asubs, appis, led!, nst, oav!, opd!, rDate!, fSeen,
-          oaud!, murl!, edfpi!, pdfpi!, exdf!, pdfe!, desc, rawData)
+          oaud!, murl!, edfpi!, pdfpi!, exdf!, pdfe!, desc, rawData, subs)
 }
 
 func checkCacheFetchPolicyEnum(_ policy: CacheFetchPolicy) {

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/SubscriptionInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/SubscriptionInfoAPI.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SubscriptionInfoAPI.swift
+//
+//  Created by Cesar de la Vega on 26/11/24.
+
+import Foundation
+import RevenueCat
+
+var subscription: SubscriptionInfo!
+func checkSubscriptionInfoAPI() {
+    let pId: String = subscription.productIdentifier
+    let pd: Date = subscription.purchaseDate
+    let opd: Date? = subscription.originalPurchaseDate
+    let eDate: Date? = subscription.expiresDate
+    let store: Store = subscription.store
+    let iss: Bool = subscription.isSandbox
+    let uda: Date? = subscription.unsubscribeDetectedAt
+    let bida: Date? = subscription.billingIssuesDetectedAt
+    let gped: Date? = subscription.gracePeriodExpiresDate
+    let oType: PurchaseOwnershipType = subscription.ownershipType
+    let pType: PeriodType = subscription.periodType
+    let rAt: Date? = subscription.refundedAt
+    let txId: String? = subscription.storeTransactionId
+    let isActive: Bool = subscription.isActive
+    let willRenew: Bool = subscription.willRenew
+}

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/SubscriptionInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/SubscriptionInfoAPI.swift
@@ -17,6 +17,7 @@ import RevenueCat
 var subscription: SubscriptionInfo!
 func checkSubscriptionInfoAPI() {
     let pId: String = subscription.productIdentifier
+    let pIdP: ProductIdentifier = subscription.productIdentifier
     let pd: Date = subscription.purchaseDate
     let opd: Date? = subscription.originalPurchaseDate
     let eDate: Date? = subscription.expiresDate

--- a/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
+++ b/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
@@ -238,7 +238,7 @@ private extension BeginRefundRequestHelperTests {
                 "first_seen": "2019-06-17T16:05:33Z",
                 "non_subscriptions": [:] as [String: Any],
                 "subscriptions": [
-                    "onemonth_freetrial": [:] as [String: Any]
+                    "onemonth_freetrial": ["purchase_date": "2018-10-26T23:17:53Z"] as [String: Any]
                 ],
                 "entitlements": [
                     "\(mockEntitlementID)": [
@@ -260,8 +260,8 @@ private extension BeginRefundRequestHelperTests {
                 "first_seen": "2019-06-17T16:05:33Z",
                 "non_subscriptions": [:] as [String: Any],
                 "subscriptions": [
-                    "onemonth_freetrial": [:] as [String: Any],
-                    "onemonth_freetrial2": [:] as [String: Any]
+                    "onemonth_freetrial": ["purchase_date": "2018-10-26T23:17:53Z"] as [String: Any],
+                    "onemonth_freetrial2": ["purchase_date": "2018-10-26T23:17:53Z"] as [String: Any]
                 ],
                 "entitlements": [
                     "\(mockEntitlementID)": [
@@ -287,7 +287,9 @@ private extension BeginRefundRequestHelperTests {
                 "original_application_version": "2083",
                 "first_seen": "2019-06-17T16:05:33Z",
                 "non_subscriptions": [:] as [String: Any],
-                "subscriptions": [:] as [String: Any],
+                "subscriptions": [
+                    "onemonth_freetrial": ["purchase_date": "2018-10-26T23:17:53Z"] as [String: Any],
+                ],
                 "entitlements": [
                     "\(mockEntitlementID)": [
                         "expires_date": "2000-08-30T02:40:36Z",
@@ -307,7 +309,9 @@ private extension BeginRefundRequestHelperTests {
                 "original_application_version": "2083",
                 "first_seen": "2019-06-17T16:05:33Z",
                 "non_subscriptions": [:] as [String: Any],
-                "subscriptions": [:] as [String: Any],
+                "subscriptions": [
+                    "onemonth_freetrial": ["purchase_date": "2018-10-26T23:17:53Z"] as [String: Any],
+                ],
                 "entitlements": [
                     "pro": [
                         "expires_date": "2100-08-30T02:40:36Z",

--- a/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
+++ b/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
@@ -288,7 +288,7 @@ private extension BeginRefundRequestHelperTests {
                 "first_seen": "2019-06-17T16:05:33Z",
                 "non_subscriptions": [:] as [String: Any],
                 "subscriptions": [
-                    "onemonth_freetrial": ["purchase_date": "2018-10-26T23:17:53Z"] as [String: Any],
+                    "onemonth_freetrial": ["purchase_date": "2018-10-26T23:17:53Z"] as [String: Any]
                 ],
                 "entitlements": [
                     "\(mockEntitlementID)": [
@@ -310,7 +310,7 @@ private extension BeginRefundRequestHelperTests {
                 "first_seen": "2019-06-17T16:05:33Z",
                 "non_subscriptions": [:] as [String: Any],
                 "subscriptions": [
-                    "onemonth_freetrial": ["purchase_date": "2018-10-26T23:17:53Z"] as [String: Any],
+                    "onemonth_freetrial": ["purchase_date": "2018-10-26T23:17:53Z"] as [String: Any]
                 ],
                 "entitlements": [
                     "pro": [

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -267,27 +267,77 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                     "product_a": [
                         "purchase_date": "2098-04-27T06:24:50Z",
                         "expires_date": "2098-05-27T06:24:50Z",
-                        "period_type": "normal"
+                        "period_type": "normal",
+                        "billing_issues_detected_at": nil,
+                        "grace_period_expires_date": nil,
+                        "is_sandbox": true,
+                        "original_purchase_date": "2022-04-12T00:03:28Z",
+                        "store": "app_store",
+                        "unsubscribe_detected_at": nil,
+                        "ownership_type": "PURCHASED",
+                        "refunded_at": nil,
+                        "store_transaction_id": "1",
+                        "auto_resume_date": nil
                     ],
                     "Product_B": [
-                        "purchase_date": "2098-04-27T06:24:50Z",
+                        "purchase_date": "2022-04-12T00:03:28Z",
                         "expires_date": "2098-05-27T06:24:50Z",
-                        "period_type": "normal"
+                        "period_type": "normal",
+                        "billing_issues_detected_at": "2098-05-18T06:24:50Z",
+                        "grace_period_expires_date": nil,
+                        "is_sandbox": true,
+                        "original_purchase_date": "2022-04-12T00:03:28Z",
+                        "store": "app_store",
+                        "unsubscribe_detected_at": "2098-05-14T06:24:50Z",
+                        "ownership_type": "PURCHASED",
+                        "refunded_at": "2098-05-16T06:24:50Z",
+                        "store_transaction_id": "1",
+                        "auto_resume_date": nil
                     ],
                     "ProductC": [
                         "purchase_date": "2098-04-27T06:24:50Z",
                         "expires_date": "2098-05-27T06:24:50Z",
-                        "period_type": "normal"
+                        "period_type": "normal",
+                        "billing_issues_detected_at": nil,
+                        "grace_period_expires_date": nil,
+                        "is_sandbox": true,
+                        "original_purchase_date": "2022-04-12T00:03:28Z",
+                        "store": "app_store",
+                        "unsubscribe_detected_at": nil,
+                        "ownership_type": "PURCHASED",
+                        "refunded_at": nil,
+                        "store_transaction_id": "1",
+                        "auto_resume_date": nil
                     ],
                     "Pro": [
                         "purchase_date": "2098-04-27T06:24:50Z",
                         "expires_date": "2098-05-27T06:24:50Z",
-                        "period_type": "normal"
+                        "period_type": "normal",
+                        "billing_issues_detected_at": nil,
+                        "grace_period_expires_date": nil,
+                        "is_sandbox": true,
+                        "original_purchase_date": "2022-04-12T00:03:28Z",
+                        "store": "app_store",
+                        "unsubscribe_detected_at": nil,
+                        "ownership_type": "PURCHASED",
+                        "refunded_at": nil,
+                        "store_transaction_id": "1",
+                        "auto_resume_date": nil
                     ],
                     "ProductD": [
                         "purchase_date": "2018-04-27T06:24:50Z",
                         "expires_date": "2018-05-27T06:24:50Z",
-                        "period_type": "normal"
+                        "period_type": "normal",
+                        "billing_issues_detected_at": nil,
+                        "grace_period_expires_date": nil,
+                        "is_sandbox": true,
+                        "original_purchase_date": "2022-04-12T00:03:28Z",
+                        "store": "app_store",
+                        "unsubscribe_detected_at": nil,
+                        "ownership_type": "PURCHASED",
+                        "refunded_at": nil,
+                        "store_transaction_id": "1",
+                        "auto_resume_date": nil
                     ]
                 ]  as [String: Any],
                 "other_purchases": [:] as [String: Any]
@@ -324,7 +374,17 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                     "product_a": [
                         "purchase_date": "2018-04-27T06:24:50Z",
                         "expires_date": "2018-05-27T06:24:50Z",
-                        "period_type": "normal"
+                        "period_type": "normal",
+                        "billing_issues_detected_at": nil,
+                        "grace_period_expires_date": nil,
+                        "is_sandbox": true,
+                        "original_purchase_date": "2022-04-12T00:03:28Z",
+                        "store": "app_store",
+                        "unsubscribe_detected_at": nil,
+                        "ownership_type": "PURCHASED",
+                        "refunded_at": nil,
+                        "store_transaction_id": "1",
+                        "auto_resume_date": nil
                     ]
                 ],
                 "other_purchases": [:] as [String: Any]
@@ -359,7 +419,17 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                     "product_a": [
                         "purchase_date": "2018-04-27T06:24:50Z",
                         "expires_date": "2018-05-27T06:24:50Z",
-                        "period_type": "normal"
+                        "period_type": "normal",
+                        "billing_issues_detected_at": nil,
+                        "grace_period_expires_date": nil,
+                        "is_sandbox": true,
+                        "original_purchase_date": "2022-04-12T00:03:28Z",
+                        "store": "app_store",
+                        "unsubscribe_detected_at": nil,
+                        "ownership_type": "PURCHASED",
+                        "refunded_at": nil,
+                        "store_transaction_id": "1",
+                        "auto_resume_date": nil
                     ]
                 ],
                 "other_purchases": [:] as [String: Any]
@@ -386,7 +456,17 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                     "product_a": [
                         "purchase_date": "2018-04-27T06:24:50Z",
                         "expires_date": "2018-05-27T06:24:50Z",
-                        "period_type": "normal"
+                        "period_type": "normal",
+                        "billing_issues_detected_at": nil,
+                        "grace_period_expires_date": nil,
+                        "is_sandbox": true,
+                        "original_purchase_date": "2022-04-12T00:03:28Z",
+                        "store": "app_store",
+                        "unsubscribe_detected_at": nil,
+                        "ownership_type": "PURCHASED",
+                        "refunded_at": nil,
+                        "store_transaction_id": "1",
+                        "auto_resume_date": nil
                     ]
                 ],
                 "other_purchases": [:] as [String: Any]

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -264,11 +264,31 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": [
-                    "product_a": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
-                    "Product_B": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
-                    "ProductC": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
-                    "Pro": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
-                    "ProductD": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]
+                    "product_a": [
+                        "purchase_date": "2098-04-27T06:24:50Z",
+                        "expires_date": "2098-05-27T06:24:50Z",
+                        "period_type": "normal"
+                    ],
+                    "Product_B": [
+                        "purchase_date": "2098-04-27T06:24:50Z",
+                        "expires_date": "2098-05-27T06:24:50Z",
+                        "period_type": "normal"
+                    ],
+                    "ProductC": [
+                        "purchase_date": "2098-04-27T06:24:50Z",
+                        "expires_date": "2098-05-27T06:24:50Z",
+                        "period_type": "normal"
+                    ],
+                    "Pro": [
+                        "purchase_date": "2098-04-27T06:24:50Z",
+                        "expires_date": "2098-05-27T06:24:50Z",
+                        "period_type": "normal"
+                    ],
+                    "ProductD": [
+                        "purchase_date": "2018-04-27T06:24:50Z",
+                        "expires_date": "2018-05-27T06:24:50Z",
+                        "period_type": "normal"
+                    ]
                 ]  as [String: Any],
                 "other_purchases": [:] as [String: Any]
             ]  as [String: Any]
@@ -300,7 +320,13 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
             "subscriber": [
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
-                "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
+                "subscriptions": [
+                    "product_a": [
+                        "purchase_date": "2018-04-27T06:24:50Z",
+                        "expires_date": "2018-05-27T06:24:50Z",
+                        "period_type": "normal"
+                    ]
+                ],
                 "other_purchases": [:] as [String: Any]
             ]  as [String: Any]
         ])
@@ -329,7 +355,13 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
             "subscriber": [
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
-                "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
+                "subscriptions": [
+                    "product_a": [
+                        "purchase_date": "2018-04-27T06:24:50Z",
+                        "expires_date": "2018-05-27T06:24:50Z",
+                        "period_type": "normal"
+                    ]
+                ],
                 "other_purchases": [:] as [String: Any]
             ] as [String: Any]
         ]
@@ -350,7 +382,13 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
             "subscriber": [
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
-                "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
+                "subscriptions": [
+                    "product_a": [
+                        "purchase_date": "2018-04-27T06:24:50Z",
+                        "expires_date": "2018-05-27T06:24:50Z",
+                        "period_type": "normal"
+                    ]
+                ],
                 "other_purchases": [:] as [String: Any]
             ]  as [String: Any]
         ]

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -109,11 +109,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "user",
-                "subscriptions": [
-                    "com.revenuecat.product": [
-                        "purchase_date": "2017-07-30T02:40:36Z"
-                    ]
-                ] as [String: Any]
+                "subscriptions": [:] as [String: Any]
             ] as [String: Any]
         ]
         let path: HTTPRequest.Path = .getCustomerInfo(appUserID: Self.userID)

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -109,7 +109,9 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "user",
-                "subscriptions": [:] as [String: Any]
+                "subscriptions": [
+                    "purchase_date": "2017-07-30T02:40:36Z"
+                ] as [String: Any]
             ] as [String: Any]
         ]
         let path: HTTPRequest.Path = .getCustomerInfo(appUserID: Self.userID)

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -110,7 +110,9 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "user",
                 "subscriptions": [
-                    "purchase_date": "2017-07-30T02:40:36Z"
+                    "com.revenuecat.product": [
+                        "purchase_date": "2017-07-30T02:40:36Z"
+                    ]
                 ] as [String: Any]
             ] as [String: Any]
         ]

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -595,7 +595,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
         var dateComponent = DateComponents()
         dateComponent.month = 1
         let futureDateString = ISO8601DateFormatter()
-            .string(from: Calendar.current.date(byAdding: dateComponent, to: Date())!)
+            .string(from: Calendar.current.date(byAdding: dateComponent, to: today)!)
 
         let getCustomerInfoPath: HTTPRequest.Path = .getCustomerInfo(appUserID: Self.userID)
 
@@ -606,6 +606,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
                 "original_app_user_id": "ORIGINAL",
                 "subscriptions": [
                     "onemonth_freetrial": [
+                        "purchase_date": "2024-11-25T00:05:54Z",
                         "expires_date": futureDateString
                     ]
                 ]
@@ -619,9 +620,11 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
                 "original_app_user_id": "UPDATED",
                 "subscriptions": [
                     "onemonth_freetrial": [
+                        "purchase_date": "2024-11-25T00:05:54Z",
                         "expires_date": futureDateString
                     ],
                     "twomonth_awesome": [
+                        "purchase_date": "2024-11-25T00:05:54Z",
                         "expires_date": futureDateString
                     ]
                 ]

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -594,6 +594,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
     func testGetsUpdatedSubscriberInfoAfterPost() {
         var dateComponent = DateComponents()
         dateComponent.month = 1
+        let today = Date()
         let futureDateString = ISO8601DateFormatter()
             .string(from: Calendar.current.date(byAdding: dateComponent, to: today)!)
 

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -148,6 +148,7 @@ extension BaseBackendTests {
             "original_app_user_id": "",
             "subscriptions": [
                 "onemonth_freetrial": [
+                    "purchase_date": "2017-07-30T02:40:36Z",
                     "expires_date": "2017-08-30T02:40:36Z"
                 ]
             ]

--- a/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
+++ b/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
@@ -390,7 +390,7 @@ private extension BaseCustomerInfoResponseHandlerTests {
 
     static let purchasedProduct: PurchasedSK2Product = .init(
         productIdentifier: "product",
-        subscription: .init(),
+        subscription: .init(purchaseDate: Date()),
         entitlement: .init(productIdentifier: "entitlement", rawData: [:])
     )
     static let mapping: ProductEntitlementMapping = .init(entitlementsByProduct: [

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -22,14 +22,6 @@ class EmptyCustomerInfoTests: TestCase {
 
 class BasicCustomerInfoTests: TestCase {
 
-    private static func date(withDaysAgo days: Int) throws -> Date {
-        return try XCTUnwrap(Calendar.current.date(byAdding: .day, value: days, to: Date()))
-    }
-
-    private static let expiredSubscriptionDate = ISO8601DateFormatter.default.string(
-        // swiftlint:disable:next force_try
-        from: try! BasicCustomerInfoTests.date(withDaysAgo: -1)
-    )
     static let validSubscriberResponse: [String: Any] = [
         "request_date": "2018-10-19T02:40:36Z",
         "request_date_ms": Int64(1563379533946),
@@ -915,35 +907,6 @@ class BasicCustomerInfoTests: TestCase {
         expect(self.customerInfo.copy(with: .verifiedOnDevice).isComputedOffline) == true
     }
 
-    // MARK: - Private
-
-    private func verifyCopy(
-        of customerInfo: CustomerInfo,
-        onlyModifiesEntitlementVerification newVerification: VerificationResult
-    ) {
-        let copy = customerInfo.copy(with: newVerification)
-        expect(customerInfo) != copy
-
-        expect(copy.entitlements.verification) == newVerification
-
-        let copyWithOriginalVerification = copy.copy(with: customerInfo.entitlements.verification)
-        expect(copyWithOriginalVerification) == customerInfo
-    }
-
-    private func verifyCopy(
-        of customerInfo: CustomerInfo,
-        onlyModifiesRequestDate newRequestDate: Date
-    ) {
-        let originalDate = customerInfo.requestDate
-
-        let copy = customerInfo.copy(with: newRequestDate)
-        expect(copy.requestDate) == newRequestDate
-        expect(customerInfo.requestDate) == originalDate
-
-        let copyWithOriginalDate = copy.copy(with: originalDate)
-        expect(copyWithOriginalDate) == customerInfo
-    }
-
 }
 
 extension CustomerInfo {
@@ -957,6 +920,46 @@ extension CustomerInfo {
 
             return nil
         }
+    }
+
+}
+
+private extension BasicCustomerInfoTests {
+
+    static func date(withDaysAgo days: Int) throws -> Date {
+        return try XCTUnwrap(Calendar.current.date(byAdding: .day, value: days, to: Date()))
+    }
+
+    static let expiredSubscriptionDate = ISO8601DateFormatter.default.string(
+        // swiftlint:disable:next force_try
+        from: try! BasicCustomerInfoTests.date(withDaysAgo: -1)
+    )
+    
+    func verifyCopy(
+        of customerInfo: CustomerInfo,
+        onlyModifiesEntitlementVerification newVerification: VerificationResult
+    ) {
+        let copy = customerInfo.copy(with: newVerification)
+        expect(customerInfo) != copy
+
+        expect(copy.entitlements.verification) == newVerification
+
+        let copyWithOriginalVerification = copy.copy(with: customerInfo.entitlements.verification)
+        expect(copyWithOriginalVerification) == customerInfo
+    }
+
+    func verifyCopy(
+        of customerInfo: CustomerInfo,
+        onlyModifiesRequestDate newRequestDate: Date
+    ) {
+        let originalDate = customerInfo.requestDate
+
+        let copy = customerInfo.copy(with: newRequestDate)
+        expect(copy.requestDate) == newRequestDate
+        expect(customerInfo.requestDate) == originalDate
+
+        let copyWithOriginalDate = copy.copy(with: originalDate)
+        expect(copyWithOriginalDate) == customerInfo
     }
 
 }

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -43,6 +43,7 @@ class BasicCustomerInfoTests: TestCase {
             ] as [String: Any],
             "subscriptions": [
                 "onemonth_freetrial": [
+                    "purchase_date": "2100-07-30T02:40:36Z",
                     "expires_date": "2100-08-30T02:40:36Z",
                     "period_type": "normal",
                     "is_sandbox": false
@@ -55,6 +56,7 @@ class BasicCustomerInfoTests: TestCase {
                     "purchase_date": "2018-05-20T06:24:50Z"
                 ],
                 "onemonth": [
+                    "purchase_date": "2000-07-30T02:40:36Z",
                     "expires_date": BasicCustomerInfoTests.expiredSubscriptionDate,
                     "period_type": "normal",
                     "is_sandbox": false
@@ -95,17 +97,29 @@ class BasicCustomerInfoTests: TestCase {
         ] as [String: Any]
     ]
 
-    static let validTwoProductsJSON = "{" +
-            "\"request_date\": \"2018-05-20T06:24:50Z\"," +
-            "\"subscriber\": {" +
-            "\"first_seen\": \"2018-05-20T06:24:50Z\"," +
-            "\"original_application_version\": \"1.0\"," +
-            "\"original_app_user_id\": \"abcd\"," +
-            "\"other_purchases\": {}," +
-            "\"subscriptions\":{" +
-                "\"product_a\": {\"expires_date\": \"2018-05-27T06:24:50Z\",\"period_type\": \"normal\"}," +
-                "\"product_b\": {\"expires_date\": \"2018-05-27T05:24:50Z\",\"period_type\": \"normal\"}" +
-            "}}}"
+    static let validTwoProductsJSON = """
+        {
+            "request_date": "2018-05-20T06:24:50Z",
+            "subscriber": {
+                "first_seen": "2018-05-20T06:24:50Z",
+                "original_application_version": "1.0",
+                "original_app_user_id": "abcd",
+                "other_purchases": {},
+                "subscriptions": {
+                    "product_a": {
+                        "purchase_date": "2018-04-27T06:24:50Z",
+                        "expires_date": "2018-05-27T06:24:50Z",
+                        "period_type": "normal"
+                    },
+                    "product_b": {
+                        "purchase_date": "2018-04-27T05:24:50Z",
+                        "expires_date": "2018-05-27T05:24:50Z",
+                        "period_type": "normal"
+                    }
+                }
+            }
+        }
+        """
 
     private var customerInfo: CustomerInfo!
 
@@ -389,18 +403,22 @@ class BasicCustomerInfoTests: TestCase {
                 ],
                 "subscriptions": [
                     "onemonth_freetrial": [
+                        "purchase_date": "2100-07-30T02:40:36Z",
                         "expires_date": "2100-08-30T02:40:36Z",
                         "period_type": "normal"
                     ],
                     "threemonth_freetrial": [
+                        "purchase_date": "1989-08-30T02:40:36Z",
                         "expires_date": "1990-08-30T02:40:36Z",
                         "period_type": "normal"
                     ],
                     "pro.1": [
+                        "purchase_date": "2100-07-30T02:40:36Z",
                         "expires_date": "2100-08-30T02:40:36Z",
                         "period_type": "normal"
                     ],
                     "pro.2": [
+                        "purchase_date": "1990-07-30T02:40:36Z",
                         "expires_date": "1990-08-30T02:40:36Z",
                         "period_type": "normal"
                     ]
@@ -460,9 +478,11 @@ class BasicCustomerInfoTests: TestCase {
                 ],
                 "subscriptions": [
                     "onemonth_freetrial": [
+                        "purchase_date": "2100-07-30T02:40:36Z",
                         "expires_date": "2100-08-30T02:40:36Z"
                     ],
                     "threemonth_freetrial": [
+                        "purchase_date": "1990-08-30T02:40:36Z",
                         "expires_date": "1990-08-30T02:40:36Z"
                     ]
                 ],
@@ -539,6 +559,7 @@ class BasicCustomerInfoTests: TestCase {
                 "original_app_user_id": "",
                 "subscriptions": [
                     "pro.1": [
+                        "purchase_date": "2018-07-30T02:40:36Z",
                         "expires_date": "2018-12-19T02:40:36Z"
                     ]],
                 "other_purchases": [:] as [String: Any],
@@ -557,6 +578,7 @@ class BasicCustomerInfoTests: TestCase {
                 "original_app_user_id": "",
                 "subscriptions": [
                     "pro.1": [
+                        "purchase_date": "2018-07-30T02:40:36Z",
                         "expires_date": "2018-12-19T02:40:36Z"
                     ]
                 ],
@@ -776,13 +798,16 @@ class BasicCustomerInfoTests: TestCase {
                 "non_subscriptions": [:] as [String: Any],
                 "subscriptions": [
                     "onemonth_freetrial": [
+                        "purchase_date": "2100-07-30T02:40:36Z",
                         "expires_date": "2100-08-30T02:40:36Z",
                         "period_type": "normal"
                     ],
                     "twomonth_freetrial": [
+                        "purchase_date": "2100-07-30T02:40:36Z",
                         "period_type": "normal"
                     ],
                     "threemonth_freetrial": [
+                        "purchase_date": "1990-07-30T02:40:36Z",
                         "expires_date": "1990-08-30T02:40:36Z"
                     ]
                 ],
@@ -820,13 +845,16 @@ class BasicCustomerInfoTests: TestCase {
                 "non_subscriptions": [:] as [String: Any],
                 "subscriptions": [
                     "onemonth_freetrial": [
+                        "purchase_date": "2100-07-30T02:40:36Z",
                         "expires_date": "2100-08-30T02:40:36Z",
                         "period_type": "normal"
                     ],
                     "twomonth_freetrial": [
+                        "purchase_date": "2100-07-30T02:40:36Z",
                         "period_type": "normal"
                     ],
                     "threemonth_freetrial": [
+                        "purchase_date": "1990-07-30T02:40:36Z",
                         "expires_date": "1990-08-30T02:40:36Z"
                     ]
                 ],
@@ -934,7 +962,7 @@ private extension BasicCustomerInfoTests {
         // swiftlint:disable:next force_try
         from: try! BasicCustomerInfoTests.date(withDaysAgo: -1)
     )
-    
+
     func verifyCopy(
         of customerInfo: CustomerInfo,
         onlyModifiesEntitlementVerification newVerification: VerificationResult

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -41,6 +41,7 @@ class BackendSubscriberAttributesTests: TestCase {
             "original_app_user_id": "app_user_id",
             "subscriptions": [
                 "onemonth_freetrial": [
+                    "purchase_date": "2017-07-30T02:40:36Z",
                     "expires_date": "2017-08-30T02:40:36Z"
                 ]
             ]


### PR DESCRIPTION
We had more information we were not exposing in the CustomerInfo JSON

This PR adds `CustomerInfo.subscriptions` which has some useful information for devs that don't use the entitlements system