### PR TITLE
[FIX] Update License Copywrite

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Jacob Eiting
+Copyright (c) 2024 RevenueCat, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
My mom sent me a screenshot of our license page she saw in an app she was using because she's so proud of me but I realized that the copyright still said 2017 (c) Jacob Eiting, so I updated it.


![Screenshot 2024-11-21 at 4 11 01 PM](https://github.com/user-attachments/assets/0d61c265-3ea4-49f6-a883-128480d9cc0b)

