### PR TITLE
[Paywalls] Fix stack alignment issues by applying frame alignment to the size modifier

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -67,6 +67,7 @@ struct StackComponentView: View {
                     viewModels: self.viewModel.viewModels,
                     onDismiss: self.onDismiss
                 )
+                .size(style.size, alignment: horizontalAlignment.frameAlignment)
             case .horizontal(let verticalAlignment, let distribution):
                 HorizontalStack(
                     style: style,
@@ -75,15 +76,16 @@ struct StackComponentView: View {
                     viewModels: self.viewModel.viewModels,
                     onDismiss: self.onDismiss
                 )
+                .size(style.size, alignment: verticalAlignment.frameAlignment)
             case .zlayer(let alignment):
                 ZStack(alignment: alignment.stackAlignment) {
                     ComponentsView(componentViewModels: self.viewModel.viewModels, onDismiss: self.onDismiss)
                 }
+                .size(style.size)
             }
         }
         .padding(style.padding)
         .padding(additionalPadding)
-        .size(style.size)
         .backgroundStyle(style.backgroundStyle)
         .shape(border: style.border,
                shape: style.shape)

--- a/RevenueCatUI/Templates/V2/ViewHelpers/SizeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/SizeModifier.swift
@@ -24,7 +24,7 @@ struct SizeModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .applyWidth(size.width, alignment: alignment)
-            .applyHeight(size.height)
+            .applyHeight(size.height, alignment: alignment)
     }
 
 }
@@ -46,16 +46,16 @@ fileprivate extension View {
     }
 
     @ViewBuilder
-    func applyHeight(_ sizeConstraint: PaywallComponent.SizeConstraint) -> some View {
+    func applyHeight(_ sizeConstraint: PaywallComponent.SizeConstraint, alignment: Alignment) -> some View {
         switch sizeConstraint {
         case .fit:
             self
         case .fill:
             self
-                .frame(maxHeight: .infinity)
+                .frame(maxHeight: .infinity, alignment: alignment)
         case .fixed(let value):
             self
-                .frame(height: CGFloat(value))
+                .frame(height: CGFloat(value), alignment: alignment)
         }
     }
 

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
@@ -98,6 +98,17 @@ extension PaywallComponent.VerticalAlignment {
         }
     }
 
+    var frameAlignment: SwiftUI.Alignment {
+        switch self {
+        case .top:
+            return .top
+        case .center:
+            return .center
+        case .bottom:
+            return .bottom
+        }
+    }
+
 }
 
 extension PaywallComponent.TwoDimensionAlignment {


### PR DESCRIPTION
So far, we were setting the alignment in the H/VStack initialiser, but that affects the alignment of the children items relative to each other. In order to affect their alignment with respect to their container, we need to apply the `.frame(alignment:)` modifier as well.