### PR TITLE
Pass transactionData to handleReceiptPost in syncPurchasesSK2

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1347,7 +1347,7 @@ private extension PurchasesOrchestrator {
                                   appTransaction: appTransactionJWS) { result in
 
                     self.handleReceiptPost(result: result,
-                                           transactionData: nil,
+                                           transactionData: transactionData,
                                            subscriberAttributes: unsyncedAttributes,
                                            adServicesToken: nil,
                                            completion: completion)


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
While investigating another issue, we noticed we were not passing `transactionData` to `handleReceiptPost` in `syncPurchasesSK2`.

The only place it's used down the line is here when re-caching the paywall in case of a failure, but this cannot happen since `syncPurchases` would never have an associated paywall.

https://github.com/RevenueCat/purchases-ios/blob/c85c6ecb62c32e7a94c9f58ae10d073551a860d3/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift#L1413

Regardless, we can fix it just in case we want to use `purchaseData` down the line in the future for other reasons.

### Description
