### PR TITLE
[Paywalls] Remove lazy stack usages and fix alignment issues

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Stack/FlexHStack.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/FlexHStack.swift
@@ -46,17 +46,17 @@ struct FlexHStack: View {
                 ForEach(0..<componentViewModels.count, id: \.self) { index in
                     ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
                 }
-                Spacer()
+                Spacer(minLength: 0)
 
             case .center:
-                Spacer()
+                Spacer(minLength: 0)
                 ForEach(0..<componentViewModels.count, id: \.self) { index in
                     ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
                 }
-                Spacer()
+                Spacer(minLength: 0)
 
             case .end:
-                Spacer()
+                Spacer(minLength: 0)
                 ForEach(0..<componentViewModels.count, id: \.self) { index in
                     ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
                 }
@@ -65,26 +65,23 @@ struct FlexHStack: View {
                 ForEach(0..<componentViewModels.count, id: \.self) { index in
                     ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
                     if index < self.componentViewModels.count - 1 {
-                        Spacer()
+                        Spacer(minLength: 0)
                     }
                 }
 
             case .spaceAround:
-                Spacer()
                 ForEach(0..<componentViewModels.count, id: \.self) { index in
+                    Spacer(minLength: 0)
                     ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
-                    if index < self.componentViewModels.count - 1 {
-                        Spacer()
-                    }
+                    Spacer(minLength: 0)
                 }
-                Spacer()
 
             case .spaceEvenly:
                 ForEach(0..<componentViewModels.count, id: \.self) { index in
-                    Spacer()
+                    Spacer(minLength: 0)
                     ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
                 }
-                Spacer()
+                Spacer(minLength: 0)
             }
         }
     }

--- a/RevenueCatUI/Templates/V2/Components/Stack/FlexVStack.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/FlexVStack.swift
@@ -45,17 +45,17 @@ struct FlexVStack: View {
                 ForEach(0..<componentViewModels.count, id: \.self) { index in
                     ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
                 }
-                Spacer()
+                Spacer(minLength: 0)
 
             case .center:
-                Spacer()
+                Spacer(minLength: 0)
                 ForEach(0..<componentViewModels.count, id: \.self) { index in
                     ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
                 }
                 Spacer()
 
             case .end:
-                Spacer()
+                Spacer(minLength: 0)
                 ForEach(0..<componentViewModels.count, id: \.self) { index in
                     ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
                 }
@@ -64,26 +64,23 @@ struct FlexVStack: View {
                 ForEach(0..<componentViewModels.count, id: \.self) { index in
                     ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
                     if index < self.componentViewModels.count - 1 {
-                        Spacer()
+                        Spacer(minLength: 0)
                     }
                 }
 
             case .spaceAround:
-                Spacer()
                 ForEach(0..<componentViewModels.count, id: \.self) { index in
+                    Spacer(minLength: 0)
                     ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
-                    if index < self.componentViewModels.count - 1 {
-                        Spacer()
-                    }
+                    Spacer(minLength: 0)
                 }
-                Spacer()
 
             case .spaceEvenly:
                 ForEach(0..<componentViewModels.count, id: \.self) { index in
-                    Spacer()
+                    Spacer(minLength: 0)
                     ComponentsView(componentViewModels: [self.componentViewModels[index]], onDismiss: self.onDismiss)
                 }
-                Spacer()
+                Spacer(minLength: 0)
             }
         }
     }

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -67,6 +67,7 @@ struct StackComponentView: View {
                     viewModels: self.viewModel.viewModels,
                     onDismiss: self.onDismiss
                 )
+                // This alignment positions the inner VStack horizontally.
                 .size(style.size, alignment: horizontalAlignment.frameAlignment)
             case .horizontal(let verticalAlignment, let distribution):
                 HorizontalStack(
@@ -76,6 +77,7 @@ struct StackComponentView: View {
                     viewModels: self.viewModel.viewModels,
                     onDismiss: self.onDismiss
                 )
+                // This alignment positions the inner HStack vertically.
                 .size(style.size, alignment: verticalAlignment.frameAlignment)
             case .zlayer(let alignment):
                 ZStack(alignment: alignment.stackAlignment) {
@@ -117,6 +119,7 @@ struct VerticalStack: View {
         case .normal:
             // VStack when not many things
             VStack(
+                // This alignment positions inner items horizontally relative to each other
                 alignment: horizontalAlignment.stackAlignment,
                 spacing: style.spacing
             ) {
@@ -125,6 +128,7 @@ struct VerticalStack: View {
                     onDismiss: self.onDismiss
                 )
             }
+            // This alignment positions the items vertically within its parent
             .frame(maxHeight: .infinity, alignment: distribution.verticalFrameAlignment)
         case .flex:
             FlexVStack(
@@ -152,9 +156,14 @@ struct HorizontalStack: View {
     var body: some View {
         switch style.hstackStrategy {
         case .normal:
-            HStack(alignment: verticalAlignment.stackAlignment, spacing: style.spacing) {
+            HStack(
+                // This alignment positions inner items vertically relative to each other
+                alignment: verticalAlignment.stackAlignment,
+                spacing: style.spacing
+            ) {
                 ComponentsView(componentViewModels: self.viewModels, onDismiss: self.onDismiss)
             }
+            // This alignment positions the items horizontally within its parent
             .frame(maxWidth: .infinity, alignment: distribution.horizontalFrameAlignment)
         case .flex:
             FlexHStack(

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -125,17 +125,7 @@ struct VerticalStack: View {
                     onDismiss: self.onDismiss
                 )
             }
-        case .lazy:
-            // LazyVStack needed for performance when loading
-            LazyVStack(
-                alignment: horizontalAlignment.stackAlignment,
-                spacing: style.spacing
-            ) {
-                ComponentsView(
-                    componentViewModels: self.viewModels,
-                    onDismiss: self.onDismiss
-                )
-            }
+            .frame(maxHeight: .infinity, alignment: distribution.verticalFrameAlignment)
         case .flex:
             FlexVStack(
                 alignment: horizontalAlignment.stackAlignment,
@@ -161,10 +151,11 @@ struct HorizontalStack: View {
 
     var body: some View {
         switch style.hstackStrategy {
-        case .normal, .lazy:
+        case .normal:
             HStack(alignment: verticalAlignment.stackAlignment, spacing: style.spacing) {
                 ComponentsView(componentViewModels: self.viewModels, onDismiss: self.onDismiss)
             }
+            .frame(maxWidth: .infinity, alignment: distribution.horizontalFrameAlignment)
         case .flex:
             FlexHStack(
                 alignment: verticalAlignment.stackAlignment,

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
@@ -92,7 +92,7 @@ extension PresentedStackPartial: PresentedPartial {
 struct StackComponentStyle {
 
     enum StackStrategy {
-        case normal, lazy, flex
+        case normal, flex
     }
 
     let visible: Bool
@@ -136,39 +136,24 @@ struct StackComponentStyle {
             return .normal
         }
 
-        // Normal strategy for fit
-        switch self.size.height {
-        case .fit:
+        switch distribution {
+        case .start, .center, .end:
             return .normal
-        case .fill, .fixed:
-            break
-        }
-
-        // Normal strategy if start
-        guard case .start = distribution else {
+        case .spaceBetween, .spaceAround, .spaceEvenly:
             return .flex
         }
-
-        // WIP: Look deeper in tree
-//        if self.components.count > 3 {
-//            return .lazy
-//        } else {
-//            return .normal
-//        }
-        return .lazy
     }
 
     var hstackStrategy: StackStrategy {
         // Ensure horizontal
-        guard case .horizontal = self.dimension else {
+        guard case let .horizontal(_, distribution) = self.dimension else {
             return .normal
         }
 
-        // Not strategy for fit
-        switch self.size.width {
-        case .fit:
+        switch distribution {
+        case .start, .center, .end:
             return .normal
-        case .fill, .fixed:
+        case .spaceBetween, .spaceAround, .spaceEvenly:
             return .flex
         }
     }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
@@ -175,6 +175,36 @@ extension PaywallComponent.HorizontalAlignment {
 
 }
 
+extension PaywallComponent.FlexDistribution {
+
+    var verticalFrameAlignment: SwiftUI.Alignment {
+        switch self {
+        case .start:
+            return .top
+        case .center:
+            return .center
+        case .end:
+            return .bottom
+        default:
+            return .top
+        }
+    }
+
+    var horizontalFrameAlignment: SwiftUI.Alignment {
+        switch self {
+        case .start:
+            return .leading
+        case .center:
+            return .center
+        case .end:
+            return .trailing
+        default:
+            return .leading
+        }
+    }
+
+}
+
 extension PaywallComponent.Padding {
     var edgeInsets: EdgeInsets {
             EdgeInsets(top: top, leading: leading, bottom: bottom, trailing: trailing)


### PR DESCRIPTION
Cramped three related things together in this PR:
- **Set the min length of `Spacer` to zero:** otherwise, there is a minimum size that depends on the platform but it's > 0 and could make a view overflow its parent if has fixed size and the sum of its child views + spacers exceeds it.
- **Removed usages of `LazyVStack` and `LazyHStack`:** they cannot have a child view with width/height type `fill` because the lazy rendering makes it impossible to know how much space they can occupy. There is not much potential for performance wins since the paywalls should be static and not have a lot of scrolling.
- **Fixed alignment issues to make rendering the view below possible:**

<img width="325" alt="Screenshot 2024-11-22 at 17 52 41" src="https://github.com/user-attachments/assets/cfc0482c-d8cd-4837-a5ae-cfd61272c1ac">

3 alignments are needed to achieve this layout:
1- Align green box to the top of the red box
2- Align yellow boxes to the left of the green box.
3- Align yellow boxes to the top within each other.

I added code level comments to clarify what each alignment is doing, and PR comments on the lines where each of these three alignments are performed for extra clarity.