### PR TITLE
Fix PaywallEvents failing to deserialize

### DIFF
--- a/Sources/Paywalls/Events/PaywallEventsManager.swift
+++ b/Sources/Paywalls/Events/PaywallEventsManager.swift
@@ -45,7 +45,7 @@ actor PaywallEventsManager: PaywallEventsManagerType {
     }
 
     func track(paywallEvent: PaywallEvent) async {
-        guard let event: StoredEvent = .init(event: AnyEncodable(paywallEvent),
+        guard let event: StoredEvent = .init(event: paywallEvent,
                                              userID: self.userProvider.currentAppUserID,
                                              feature: .paywalls) else {
             Logger.error(Strings.paywalls.event_cannot_serialize)


### PR DESCRIPTION
It looks like `PaywallEvents` are broken since 5.8.0

![image](https://github.com/user-attachments/assets/148fa7f9-7181-44e7-b484-7c027c3b08d5)

The issue is that paywall_revision is being serialized as a boolean in the file, because AnyEncodable is interpreting it the 0 as a boolean