### PR TITLE
[Paywalls] Add support for gradient backgrounds

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		37E3578711F5FDD5DC6458A8 /* AttributionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3521731D8DC16873F55F3 /* AttributionFetcher.swift */; };
 		37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3507939634ED5A9280544 /* Strings.swift */; };
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
+		4D21041E2CF548790095D254 /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D21041D2CF548790095D254 /* GradientView.swift */; };
 		4D2A00682CD1EED3008318CA /* PurchaseParamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D2A00672CD1EED2008318CA /* PurchaseParamsTests.swift */; };
 		4D2C7D0B2CC40A35002562BC /* PurchaseParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D2C7D0A2CC40A35002562BC /* PurchaseParams.swift */; };
 		4D322E382B7E7B170004AF53 /* PurchasesOrchestratorSK2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D322E372B7E7B170004AF53 /* PurchasesOrchestratorSK2Tests.swift */; };
@@ -1590,6 +1591,7 @@
 		37E35EEE7783629CDE41B70C /* SystemInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemInfoTests.swift; sourceTree = "<group>"; };
 		37E35F783903362B65FB7AF3 /* MockProductsRequestFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockProductsRequestFactory.swift; sourceTree = "<group>"; };
 		37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateFormatter+ExtensionsTests.swift"; sourceTree = "<group>"; };
+		4D21041D2CF548790095D254 /* GradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
 		4D24EF3F2B04EA6000E586D2 /* StoreEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreEnvironmentTests.swift; sourceTree = "<group>"; };
 		4D2A00672CD1EED2008318CA /* PurchaseParamsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseParamsTests.swift; sourceTree = "<group>"; };
 		4D2C7D0A2CC40A35002562BC /* PurchaseParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseParams.swift; sourceTree = "<group>"; };
@@ -4410,6 +4412,7 @@
 				887A60562C1D037000E1A461 /* FooterView.swift */,
 				887A60572C1D037000E1A461 /* IconView.swift */,
 				887A60582C1D037000E1A461 /* IntroEligibilityStateView.swift */,
+				4D21041D2CF548790095D254 /* GradientView.swift */,
 				887A60592C1D037000E1A461 /* LoadingPaywallView.swift */,
 				887A605A2C1D037000E1A461 /* PackageButtonStyle.swift */,
 				887A605B2C1D037000E1A461 /* ProgressView.swift */,
@@ -6409,6 +6412,7 @@
 				887A60672C1D037000E1A461 /* PaywallError.swift in Sources */,
 				2C74574B2CEA6B80004ACE52 /* LocalizationProvider.swift in Sources */,
 				77BA1AB12CCBAB80009BF0EA /* RootViewModel.swift in Sources */,
+				4D21041E2CF548790095D254 /* GradientView.swift in Sources */,
 				88A543E52C37A4AF0039C6A5 /* ConsistentTierContentView.swift in Sources */,
 				3525D8A42C4AB3D600C21D99 /* CustomerCenterEnvironment.swift in Sources */,
 				35C496062C482ACC0023E924 /* PromotionalOfferData.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -319,6 +319,7 @@
 		4D6ABB0C2AF13F9400BB2A08 /* StoreKit2Receipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6ABB0B2AF13F9400BB2A08 /* StoreKit2Receipt.swift */; };
 		4D6ABB0E2AF13FB100BB2A08 /* StoreEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6ABB0D2AF13FB100BB2A08 /* StoreEnvironment.swift */; };
 		4D6ABB102AF13FBD00BB2A08 /* SK2AppTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6ABB0F2AF13FBD00BB2A08 /* SK2AppTransaction.swift */; };
+		4D6F4BD02CF69DE400353AF6 /* ForegroundColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6F4BCF2CF69DE300353AF6 /* ForegroundColorScheme.swift */; };
 		4D72E8622B221EA600BF9EFE /* StoreEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D24EF3F2B04EA6000E586D2 /* StoreEnvironmentTests.swift */; };
 		4D7A3E282B85729E00ABDE67 /* PurchasesOrchestratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D7A3E272B85729E00ABDE67 /* PurchasesOrchestratorTests.swift */; };
 		4DBC30962B1DFA97001D33C7 /* StoreKitVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBC30952B1DFA97001D33C7 /* StoreKitVersion.swift */; };
@@ -1601,6 +1602,7 @@
 		4D6ABB0B2AF13F9400BB2A08 /* StoreKit2Receipt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreKit2Receipt.swift; sourceTree = "<group>"; };
 		4D6ABB0D2AF13FB100BB2A08 /* StoreEnvironment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreEnvironment.swift; sourceTree = "<group>"; };
 		4D6ABB0F2AF13FBD00BB2A08 /* SK2AppTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SK2AppTransaction.swift; sourceTree = "<group>"; };
+		4D6F4BCF2CF69DE300353AF6 /* ForegroundColorScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForegroundColorScheme.swift; sourceTree = "<group>"; };
 		4D7A3E272B85729E00ABDE67 /* PurchasesOrchestratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesOrchestratorTests.swift; sourceTree = "<group>"; };
 		4DBC30952B1DFA97001D33C7 /* StoreKitVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitVersion.swift; sourceTree = "<group>"; };
 		4DBF1F352B4D572400D52354 /* LocalReceiptFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalReceiptFetcher.swift; sourceTree = "<group>"; };
@@ -2414,6 +2416,7 @@
 			children = (
 				2C7457872CEDF7AC004ACE52 /* BackgroundStyle.swift */,
 				77089F9D2CD39EC100848CD5 /* ShadowModifier.swift */,
+				4D6F4BCF2CF69DE300353AF6 /* ForegroundColorScheme.swift */,
 				2C91068D2CE2481800189565 /* SizeModifier.swift */,
 				2CAB87F62CAAB13200247013 /* Shape.swift */,
 			);
@@ -6433,6 +6436,7 @@
 				88B1BAF82C813A3C001B7EE5 /* LinkButtonComponentViewModel.swift in Sources */,
 				887A60BA2C1D037000E1A461 /* Template3View.swift in Sources */,
 				887A607D2C1D037000E1A461 /* ImageLoader.swift in Sources */,
+				4D6F4BD02CF69DE400353AF6 /* ForegroundColorScheme.swift in Sources */,
 				887A60822C1D037000E1A461 /* PreviewHelpers.swift in Sources */,
 				887A60B92C1D037000E1A461 /* Template2View.swift in Sources */,
 				3537566D2C382C2800A1B8D6 /* NoSubscriptionsView.swift in Sources */,

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -54,7 +54,7 @@ struct TextComponentView: View {
                         .fontWeight(style.fontWeight)
                         .fixedSize(horizontal: false, vertical: true)
                         .multilineTextAlignment(style.textAlignment)
-                        .foregroundStyle(style.color)
+                        .foregroundColorScheme(style.color)
                         .padding(style.padding)
                         .size(style.size, alignment: style.horizontalAlignment)
                         .backgroundStyle(style.backgroundStyle)
@@ -93,6 +93,38 @@ struct TextComponentView_Previews: PreviewProvider {
         .previewRequiredEnvironmentProperties()
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Default")
+
+        // Default
+        TextComponentView(
+            // swiftlint:disable:next force_try
+            viewModel: try! .init(
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("Hello, world")
+                    ]
+                ),
+                component: .init(
+                    text: "id_1",
+                    color: PaywallComponent.ColorScheme(
+                        light: .linear(30, [
+                            .init(color: "#0433FF", percent: 0),
+                            .init(color: "#FF40FF", percent: 50),
+                            .init(color: "#00FDFF", percent: 100)
+                        ]),
+                        dark: .linear(30, [
+                            .init(color: "#0433FF", percent: 0),
+                            .init(color: "#FF40FF", percent: 50),
+                            .init(color: "#00FDFF", percent: 100)
+                        ])
+                      ),
+                    fontSize: .headingXXL
+                )
+            )
+        )
+        .previewRequiredEnvironmentProperties()
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Gradient")
 
         // Customizations
         TextComponentView(

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -157,7 +157,7 @@ struct TextComponentStyle {
     let visible: Bool
     let text: String
     let fontWeight: Font.Weight
-    let color: Color
+    let color: PaywallComponent.ColorScheme
     let fontSize: Font
     let horizontalAlignment: Alignment
     let textAlignment: TextAlignment
@@ -182,7 +182,7 @@ struct TextComponentStyle {
         self.visible = visible
         self.text = text
         self.fontWeight = fontWeight.fontWeight
-        self.color = color.toDynamicColor()
+        self.color = color
 
         // WIP: Take into account the fontFamily mapping
         self.fontSize = fontSize.font

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -20,7 +20,6 @@ enum BackgroundStyle {
 
     case color(PaywallComponent.ColorScheme)
     case image(PaywallComponent.ThemeImageUrls)
-    case gradient
 
 }
 
@@ -47,7 +46,26 @@ fileprivate extension View {
     func apply(backgroundStyle: BackgroundStyle) -> some View {
         switch backgroundStyle {
         case .color(let color):
-            self.background(color.toDynamicColor())
+            switch color.light {
+            case .hex, .alias:
+                self.background(color.toDynamicColor())
+            case .linear(let degrees, _):
+                self.background {
+                    GradientView(
+                        lightGradient: color.light.toGradient(),
+                        darkGradient: color.dark?.toGradient(),
+                        gradientType: .linear(degrees)
+                    )
+                }
+            case .radial:
+                self.background {
+                    GradientView(
+                        lightGradient: color.light.toGradient(),
+                        darkGradient: color.dark?.toGradient(),
+                        gradientType: .radial
+                    )
+                }
+            }
         case .image(let imageInfo):
             self.background {
                 RemoteImage(
@@ -61,10 +79,6 @@ fileprivate extension View {
                         .scaledToFill()
                         .ignoresSafeArea()
                 }
-            }
-        case .gradient:
-            self.background {
-                // WIP: Add you gradient
             }
         }
     }
@@ -183,6 +197,81 @@ struct BackgrounDStyle_Previews: PreviewProvider {
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Image - Dark (should be japan cats)")
+
+        testContent
+            .backgroundStyle(
+                BackgroundStyle.color(
+                    PaywallComponent.ColorScheme.init(
+                        light: .linear(30, [
+                            .init(color: "#000000", percent: 0),
+                            .init(color: "#ffffff", percent: 100)
+                        ]),
+                        dark: .linear(30, [
+                            .init(color: "#ff0000", percent: 0),
+                            .init(color: "#E58984", percent: 100)
+                        ])
+                      )
+                 )
+            )
+            .preferredColorScheme(.dark)
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("Linear Gradient - Dark (should be red)")
+
+        testContent
+            .backgroundStyle(
+                BackgroundStyle.color(
+                    PaywallComponent.ColorScheme.init(
+                        light: .linear(30, [
+                            .init(color: "#000000", percent: 0),
+                            .init(color: "#ffffff", percent: 100)
+                        ]),
+                        dark: .linear(30, [
+                            .init(color: "#00E519", percent: 0),
+                            .init(color: "#9DEAD3", percent: 100)
+                        ])
+                      )
+                 )
+            )
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("Linear Gradient - Light (should be green")
+
+        testContent
+            .backgroundStyle(
+                BackgroundStyle.color(
+                    PaywallComponent.ColorScheme.init(
+                        light: .radial([
+                            .init(color: "#000000", percent: 0),
+                            .init(color: "#ffffff", percent: 100)
+                        ]),
+                        dark: .radial([
+                            .init(color: "#ff0000", percent: 0),
+                            .init(color: "#E58984", percent: 100)
+                        ])
+                      )
+                 )
+            )
+            .preferredColorScheme(.dark)
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("Radial Gradient - Dark (should be red)")
+
+        testContent
+            .backgroundStyle(
+                BackgroundStyle.color(
+                    PaywallComponent.ColorScheme.init(
+                        light: .radial([
+
+                            .init(color: "#00E519", percent: 0),
+                            .init(color: "#9DEAD3", percent: 100)
+                        ]),
+                        dark: .radial([
+                            .init(color: "#000000", percent: 0),
+                            .init(color: "#ffffff", percent: 100)
+                        ])
+                      )
+                 )
+            )
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("Radial Gradient - Light (should be green")
     }
 }
 

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -26,12 +26,15 @@ enum BackgroundStyle {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct BackgroundStyleModifier: ViewModifier {
 
+    @Environment(\.colorScheme)
+    var colorScheme
+
     var backgroundStyle: BackgroundStyle?
 
     func body(content: Content) -> some View {
         if let backgroundStyle {
             content
-                .apply(backgroundStyle: backgroundStyle)
+                .apply(backgroundStyle: backgroundStyle, colorScheme: colorScheme)
         } else {
             content
         }
@@ -43,10 +46,10 @@ struct BackgroundStyleModifier: ViewModifier {
 fileprivate extension View {
 
     @ViewBuilder
-    func apply(backgroundStyle: BackgroundStyle) -> some View {
+    func apply(backgroundStyle: BackgroundStyle, colorScheme: ColorScheme) -> some View {
         switch backgroundStyle {
         case .color(let color):
-            switch color.light {
+            switch color.effectiveColor(for: colorScheme) {
             case .hex, .alias:
                 self.background(color.toDynamicColor())
             case .linear(let degrees, _):
@@ -54,7 +57,7 @@ fileprivate extension View {
                     GradientView(
                         lightGradient: color.light.toGradient(),
                         darkGradient: color.dark?.toGradient(),
-                        gradientType: .linear(degrees)
+                        gradientStyle: .linear(degrees)
                     )
                 }
             case .radial:
@@ -62,7 +65,7 @@ fileprivate extension View {
                     GradientView(
                         lightGradient: color.light.toGradient(),
                         darkGradient: color.dark?.toGradient(),
-                        gradientType: .radial
+                        gradientStyle: .radial
                     )
                 }
             }

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ForegroundColorScheme.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ForegroundColorScheme.swift
@@ -1,0 +1,73 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ForegroundColorScheme.swift
+//
+//  Created by MarkVillacampa on 27/11/24.
+
+import RevenueCat
+import SwiftUI
+
+#if PAYWALL_COMPONENTS
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct ForegroundColorSchemeModifier: ViewModifier {
+
+    @Environment(\.colorScheme)
+    var colorScheme
+
+    var foregroundColorScheme: PaywallComponent.ColorScheme
+
+    func body(content: Content) -> some View {
+        content.foregroundColorScheme(foregroundColorScheme, colorScheme: colorScheme)
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension View {
+    func foregroundColorScheme(_ colorScheme: PaywallComponent.ColorScheme) -> some View {
+        self.modifier(ForegroundColorSchemeModifier(foregroundColorScheme: colorScheme))
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+fileprivate extension View {
+    @ViewBuilder
+    func foregroundColorScheme(_ color: PaywallComponent.ColorScheme, colorScheme: ColorScheme) -> some View {
+        switch color.effectiveColor(for: colorScheme) {
+        case .hex, .alias:
+            self.foregroundColor(color.toDynamicColor())
+        case .linear(let degrees, _):
+            self.overlay {
+                GradientView(
+                    lightGradient: color.light.toGradient(),
+                    darkGradient: color.dark?.toGradient(),
+                    gradientStyle: .linear(degrees)
+                )
+                .mask(
+                    self
+                )
+            }
+        case .radial:
+            self.overlay {
+                GradientView(
+                    lightGradient: color.light.toGradient(),
+                    darkGradient: color.dark?.toGradient(),
+                    gradientStyle: .radial
+                )
+                .mask(
+                    self
+                )
+            }
+        }
+    }
+}
+
+#endif

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
@@ -232,8 +232,38 @@ extension PaywallComponent.ColorInfo {
         case .alias:
             // WIP: Need to implement this when we actually have alias implemented
             return fallback
+        case .linear:
+            return fallback
+        case .radial:
+            return fallback
         }
     }
+
+    func toGradient() -> Gradient {
+        switch self {
+        case .hex:
+            return Gradient(colors: [.clear])
+        case .alias:
+            return Gradient(colors: [.clear])
+        case .linear(_, let points):
+            let stops = points.map { point in
+                Gradient.Stop(
+                    color: point.color.toColor(fallback: Color.clear),
+                    location: CGFloat(point.percent/100)
+                )
+            }
+            return Gradient(stops: stops)
+        case .radial(let points):
+            let stops = points.map { point in
+                Gradient.Stop(
+                    color: point.color.toColor(fallback: Color.clear),
+                    location: CGFloat(point.percent/100)
+                )
+            }
+            return Gradient(stops: stops)
+        }
+    }
+
 }
 
 extension PaywallComponent.ColorHex {

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
@@ -232,9 +232,7 @@ extension PaywallComponent.ColorInfo {
         case .alias:
             // WIP: Need to implement this when we actually have alias implemented
             return fallback
-        case .linear:
-            return fallback
-        case .radial:
+        case .linear, .radial:
             return fallback
         }
     }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
@@ -241,9 +241,7 @@ extension PaywallComponent.ColorInfo {
 
     func toGradient() -> Gradient {
         switch self {
-        case .hex:
-            return Gradient(colors: [.clear])
-        case .alias:
+        case .hex, .alias:
             return Gradient(colors: [.clear])
         case .linear(_, let points), .radial(let points):
             let stops = points.map { point in

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
@@ -245,7 +245,7 @@ extension PaywallComponent.ColorInfo {
             let stops = points.map { point in
                 Gradient.Stop(
                     color: point.color.toColor(fallback: Color.clear),
-                    location: CGFloat(point.percent/100)
+                    location: CGFloat(point.percent)/100
                 )
             }
             return Gradient(stops: stops)
@@ -317,6 +317,17 @@ extension PaywallComponent.ColorScheme {
                 return UIColor(lightModeColor.toColor(fallback: Color.clear))
             }
         })
+    }
+
+    func effectiveColor(for colorScheme: ColorScheme) -> PaywallComponent.ColorInfo {
+        switch colorScheme {
+        case .light:
+            return light
+        case .dark:
+            return dark ?? light
+        @unknown default:
+            return light
+        }
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
@@ -245,15 +245,7 @@ extension PaywallComponent.ColorInfo {
             return Gradient(colors: [.clear])
         case .alias:
             return Gradient(colors: [.clear])
-        case .linear(_, let points):
-            let stops = points.map { point in
-                Gradient.Stop(
-                    color: point.color.toColor(fallback: Color.clear),
-                    location: CGFloat(point.percent/100)
-                )
-            }
-            return Gradient(stops: stops)
-        case .radial(let points):
+        case .linear(_, let points), .radial(let points):
             let stops = points.map { point in
                 Gradient.Stop(
                     color: point.color.toColor(fallback: Color.clear),

--- a/RevenueCatUI/Views/GradientView.swift
+++ b/RevenueCatUI/Views/GradientView.swift
@@ -58,6 +58,47 @@ struct GradientView: View {
     }
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct GradientView_Previews: PreviewProvider {
+
+    static var previews: some View {
+        GradientView(
+            lightGradient: .init(colors: .init([.red, .white])),
+            darkGradient: .init(colors: .init([.blue, .white])),
+            gradientStyle: .radial
+        )
+        .preferredColorScheme(.dark)
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Radial - Dark (should be blue)")
+
+        GradientView(
+            lightGradient: .init(colors: .init([.red, .white])),
+            darkGradient: .init(colors: .init([.blue, .white])),
+            gradientStyle: .radial
+        )
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Radial - Light (should be red)")
+
+        GradientView(
+            lightGradient: .init(colors: .init([.red, .white])),
+            darkGradient: .init(colors: .init([.blue, .white])),
+            gradientStyle: .linear(45)
+        )
+        .preferredColorScheme(.dark)
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Linear 45º - Dark (should be blue)")
+
+        GradientView(
+            lightGradient: .init(colors: .init([.red, .white])),
+            darkGradient: .init(colors: .init([.blue, .white])),
+            gradientStyle: .linear(90)
+        )
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Linear 90º - Light (should be red)")
+    }
+
+}
+
 private extension UnitPoint {
 
     init(angle: Angle) {

--- a/RevenueCatUI/Views/GradientView.swift
+++ b/RevenueCatUI/Views/GradientView.swift
@@ -28,7 +28,7 @@ struct GradientView: View {
     let darkGradient: Gradient?
     let gradientStyle: GradientStyle
 
-    var gradient: Gradient {
+    private var gradient: Gradient {
         switch colorScheme {
         case .light:
             lightGradient
@@ -44,8 +44,8 @@ struct GradientView: View {
         case .linear(let degrees):
             LinearGradient(
                 gradient: gradient,
-                startPoint: .init(angle: Angle(degrees: Double(degrees))),
-                endPoint: .init(angle: Angle(degrees: Double(degrees+180)))
+                startPoint: UnitPoint(angle: Angle(degrees: Double(degrees))),
+                endPoint: UnitPoint(angle: Angle(degrees: Double(degrees+180)))
             )
         case .radial:
             RadialGradient(

--- a/RevenueCatUI/Views/GradientView.swift
+++ b/RevenueCatUI/Views/GradientView.swift
@@ -16,7 +16,7 @@ import SwiftUI
 #if PAYWALL_COMPONENTS
 
 struct GradientView: View {
-    enum GradientType {
+    enum GradientStyle {
         case linear(Int)
         case radial
     }
@@ -26,7 +26,7 @@ struct GradientView: View {
 
     let lightGradient: Gradient
     let darkGradient: Gradient?
-    let gradientType: GradientType
+    let gradientStyle: GradientStyle
 
     var gradient: Gradient {
         switch colorScheme {
@@ -40,7 +40,7 @@ struct GradientView: View {
     }
 
     var body: some View {
-        switch gradientType {
+        switch gradientStyle {
         case .linear(let degrees):
             LinearGradient(
                 gradient: gradient,

--- a/RevenueCatUI/Views/GradientView.swift
+++ b/RevenueCatUI/Views/GradientView.swift
@@ -1,0 +1,84 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  GradientView.swift
+//
+//  Created by Mark Villacampa on 2024-11-24.
+
+import SwiftUI
+
+#if PAYWALL_COMPONENTS
+
+struct GradientView: View {
+    enum GradientType {
+        case linear(Int)
+        case radial
+    }
+
+    @Environment(\.colorScheme)
+    private var colorScheme
+
+    let lightGradient: Gradient
+    let darkGradient: Gradient?
+    let gradientType: GradientType
+
+    var gradient: Gradient {
+        switch colorScheme {
+        case .light:
+            lightGradient
+        case .dark:
+            darkGradient ?? lightGradient
+        @unknown default:
+            lightGradient
+        }
+    }
+
+    var body: some View {
+        switch gradientType {
+        case .linear(let degrees):
+            LinearGradient(
+                gradient: gradient,
+                startPoint: .init(angle: Angle(degrees: Double(degrees))),
+                endPoint: .init(angle: Angle(degrees: Double(degrees+180)))
+            )
+        case .radial:
+            RadialGradient(
+                gradient: gradient,
+                center: .center,
+                startRadius: 0,
+                endRadius: 100
+            )
+        }
+    }
+}
+
+private extension UnitPoint {
+
+    init(angle: Angle) {
+        // Convert the angle to radians
+        let radians = angle.radians
+
+        // Calculate the normalized x and y positions
+        let xPosition = cos(radians)
+        let yPosition = sin(radians)
+
+        // Determine the scaling factor to move the point to the edge of the enclosing square
+        let scaleFactor = max(abs(xPosition), abs(yPosition))
+
+        // Scale the x and y coordinates
+        let scaledX = xPosition / scaleFactor
+        let scaledY = yPosition / scaleFactor
+
+        // Convert the scaled coordinates to a UnitPoint
+        self.init(x: (scaledX + 1) / 2, y: (1 - scaledY) / 2)
+    }
+
+}
+
+#endif

--- a/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
@@ -43,6 +43,18 @@ public extension PaywallComponent {
         public let heicLowRes: URL
     }
 
+    struct GradientPoint: Codable, Sendable, Hashable, Equatable {
+
+        public let color: ColorHex
+        public let percent: Int
+
+        public init(color: ColorHex, percent: Int) {
+            self.color = color
+            self.percent = percent
+        }
+
+    }
+
     struct ColorScheme: Codable, Sendable, Hashable, Equatable {
 
         public init(light: ColorInfo, dark: ColorInfo? = nil) {
@@ -59,6 +71,8 @@ public extension PaywallComponent {
 
         case hex(ColorHex)
         case alias(String)
+        case linear(Int, [GradientPoint])
+        case radial([GradientPoint])
 
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
@@ -70,6 +84,13 @@ public extension PaywallComponent {
             case .alias(let alias):
                 try container.encode(ColorInfoTypes.alias.rawValue, forKey: .type)
                 try container.encode(alias, forKey: .value)
+            case .linear(let degrees, let points):
+                try container.encode(ColorInfoTypes.linear.rawValue, forKey: .type)
+                try container.encode(degrees, forKey: .degrees)
+                try container.encode(points, forKey: .points)
+            case .radial(let points):
+                try container.encode(ColorInfoTypes.radial.rawValue, forKey: .type)
+                try container.encode(points, forKey: .points)
             }
         }
 
@@ -84,6 +105,13 @@ public extension PaywallComponent {
             case .alias:
                 let value = try container.decode(String.self, forKey: .value)
                 self = .alias(value)
+            case .linear:
+                let points = try container.decode([GradientPoint].self, forKey: .points)
+                let degrees = try container.decode(Int.self, forKey: .degrees)
+                self = .linear(degrees, points)
+            case .radial:
+                let points = try container.decode([GradientPoint].self, forKey: .points)
+                self = .radial(points)
             }
         }
 
@@ -92,6 +120,8 @@ public extension PaywallComponent {
 
             case type
             case value
+            case degrees
+            case points
 
         }
 
@@ -100,6 +130,8 @@ public extension PaywallComponent {
 
             case hex
             case alias
+            case linear
+            case radial
 
         }
 


### PR DESCRIPTION
This PR adds support for gradient backgrounds.

Supported gradient types are Radial and Linear.

<img width="304" alt="Screenshot 2024-11-26 at 11 35 52" src="https://github.com/user-attachments/assets/9d881a6c-ad25-4d58-ac88-3d6bdd038e67">
<img width="315" alt="Screenshot 2024-11-26 at 11 36 03" src="https://github.com/user-attachments/assets/cd577dcb-fce0-4315-9dcd-c084452d2c1d">

Additionally, gradients as text foreground style are now supported:

![Screenshot 2024-11-27 at 01 17 02](https://github.com/user-attachments/assets/da98220a-9544-4f87-b180-26d4ee0dcf52)
