### PR TITLE
[Paywalls V2] Fix border being hidden by next sibling component

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
@@ -194,6 +194,8 @@ private struct BorderRoundedCornerShape: Shape {
     func path(in rect: CGRect) -> Path {
         var path = Path()
 
+        let maxY = rect.maxY - 1
+
         // Start from the top-left corner
         path.move(to: CGPoint(x: rect.minX + topLeft, y: rect.minY))
 
@@ -203,13 +205,13 @@ private struct BorderRoundedCornerShape: Shape {
                           control: CGPoint(x: rect.maxX, y: rect.minY))
 
         // Right edge and bottom-right corner
-        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - bottomRight))
-        path.addQuadCurve(to: CGPoint(x: rect.maxX - bottomRight, y: rect.maxY),
-                          control: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: maxY - bottomRight))
+        path.addQuadCurve(to: CGPoint(x: rect.maxX - bottomRight, y: maxY),
+                          control: CGPoint(x: rect.maxX, y: maxY))
 
         // Bottom edge and bottom-left corner
-        path.addLine(to: CGPoint(x: rect.minX + bottomLeft, y: rect.maxY))
-        path.addQuadCurve(to: CGPoint(x: rect.minX, y: rect.maxY - bottomLeft),
+        path.addLine(to: CGPoint(x: rect.minX + bottomLeft, y: maxY))
+        path.addQuadCurve(to: CGPoint(x: rect.minX, y: maxY - bottomLeft),
                           control: CGPoint(x: rect.minX, y: rect.maxY))
 
         // Left edge and top-left corner

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -179,6 +179,13 @@ struct APIKeyDashboardList: View {
                 .onRestoreCompleted { _ in
                     self.presentedPaywall = nil
                 }
+                #if PAYWALL_COMPONENTS
+                .onAppear {
+                    if let errorInfo = paywall.offering.paywallComponentsData?.errorInfo {
+                        print("Paywall V2 Error:", errorInfo.debugDescription)
+                    }
+                }
+                #endif
         }
     }
 


### PR DESCRIPTION
## Motivation

There was an issue where a sibiling component would overlap the border and make it look like border didn't exist

## Description

Just needed to subtract 1 from the max y 

### Screenshots

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 Pro - 2024-11-26 at 20 10 03](https://github.com/user-attachments/assets/2200e6d2-352a-498c-aa67-df6b660b88bf) | ![Simulator Screenshot - iPhone 16 Pro - 2024-11-26 at 20 11 06](https://github.com/user-attachments/assets/f7eb2b76-c40c-4eba-95d7-b25deff9d8ea) | 
