### PR TITLE
Adds API Test for `jwsRepresentation` in obj-c

### DIFF
--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCTransactionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCTransactionAPI.m
@@ -17,7 +17,8 @@
     NSString *rci = rct.transactionIdentifier;
     NSString *pid = rct.productIdentifier;
     NSDate *date = rct.purchaseDate;
-    NSLog(rct, rci, pid, date);
+    NSString *jws = rct.jwsRepresentation;
+    NSLog(rct, rci, pid, date, jws);
 }
 
 @end

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCTransactionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCTransactionAPI.m
@@ -17,7 +17,7 @@
     NSString *rci = rct.transactionIdentifier;
     NSString *pid = rct.productIdentifier;
     NSDate *date = rct.purchaseDate;
-    NSString *jws = rct.jwsRepresentation;
+    NSString * _Nullable jws = rct.jwsRepresentation;
     NSLog(rct, rci, pid, date, jws);
 }
 


### PR DESCRIPTION
Adds an API Test for the `jwsRepresentation` property in `RCTransaction`, which is available exclusively in Objective-C