### PR TITLE
[Paywalls] Add Emerge Snapshot Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1348,6 +1348,7 @@ workflows:
       - pod-lib-lint
       - run-revenuecat-ui-ios-17
       - run-revenuecat-ui-ios-18
+      - emerge_purchases_ui_snapshot_tests
 
   create-tag:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1293,7 +1293,7 @@ jobs:
       - update-spm-installation-commit
       - run:
           name: Build Paywalls Tester
-          command: bundle exec fastlane build_paywalls_test
+          command: bundle exec fastlane build_paywalls_tester_for_emerge
 
   deploy-to-spm:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1292,7 +1292,7 @@ jobs:
       - install-dependencies
       - update-spm-installation-commit
       - run:
-          name: Submit Purchase Tester
+          name: Build Paywalls Tester
           command: bundle exec fastlane build_paywalls_test
 
   deploy-to-spm:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ aliases:
   release-tags: &release-tags
     filters:
       tags:
-        ignore: 
+        ignore:
           - /^.*-SNAPSHOT/
           - /^.*-customercenter.alpha.*/
       branches:
@@ -1282,6 +1282,19 @@ jobs:
           name: Submit Purchase Tester
           command: bundle exec fastlane deploy_purchase_tester dry_run:<< parameters.dry_run >>
 
+  emerge_purchases_ui_snapshot_tests:
+    executor:
+      name: macos-executor
+    steps:
+      - checkout
+      - setup-git-credentials
+      - trust-github-key
+      - install-dependencies
+      - update-spm-installation-commit
+      - run:
+          name: Submit Purchase Tester
+          command: bundle exec fastlane build_paywalls_test
+
   deploy-to-spm:
     docker:
       - image: cimg/base:stable
@@ -1335,13 +1348,14 @@ workflows:
       - pod-lib-lint
       - run-revenuecat-ui-ios-17
       - run-revenuecat-ui-ios-18
+      - emerge_purchases_ui_snapshot_tests
 
   create-tag:
     when:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - matches: 
+        - matches:
             pattern: "^release/.*$"
             value: << pipeline.git.branch >>
     jobs:
@@ -1426,7 +1440,7 @@ workflows:
       - docs-deploy
 
   # To trigger tests manually, log into circleCI, select the project, a branch, and then click "Trigger Pipeline"
-  # in the top right hand corner of the screen. In the modal that appears, set the following parameter fields 
+  # in the top right hand corner of the screen. In the modal that appears, set the following parameter fields
   # and click "Trigger Pipeline" to begin the pipeline:
   #   - Parameter Type: string
   #   - Name: action
@@ -1434,13 +1448,13 @@ workflows:
   all-tests:
     when:
       or:
-        - matches: 
+        - matches:
             pattern: "^release/.*$"
             value: << pipeline.git.branch >>
         - equal:
             - "run-manual-tests"
             - << pipeline.parameters.action >>
-        - equal: 
+        - equal:
             - "run-from-github-comments"
             - << pipeline.parameters.GHA_Meta >>
     jobs:
@@ -1475,4 +1489,5 @@ workflows:
       - api-tests
       - deploy-purchase-tester:
           dry_run: true
-      
+      - emerge_purchases_ui_snapshot_tests
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1348,7 +1348,6 @@ workflows:
       - pod-lib-lint
       - run-revenuecat-ui-ios-17
       - run-revenuecat-ui-ios-18
-      - emerge_purchases_ui_snapshot_tests
 
   create-tag:
     when:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,8 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
+    fastlane-plugin-emerge (0.10.6)
+      faraday (~> 1.1)
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
     ffi (1.17.0-arm64-darwin)
@@ -371,6 +373,7 @@ DEPENDENCIES
   danger
   fastlane
   fastlane-plugin-create_xcframework!
+  fastlane-plugin-emerge
   fastlane-plugin-revenuecat_internal!
   nokogiri
   rest-client

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1176,6 +1176,13 @@
 			remoteGlobalIDString = 2DEAC2D926EFE46E006914ED;
 			remoteInfo = UnitTestsHostApp;
 		};
+		4D6F4BE82CFE2FAB00353AF6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2DD5008F2C519EB4009C19B7 /* PaywallsTester.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = FA29FBA82CCAA79800DA1976;
+			remoteInfo = PaywallsTesterTests;
+		};
 		4F6BEE082A27B02400CD9322 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 352629F51F7C4B9100C04F2C /* Project object */;
@@ -1631,6 +1638,7 @@
 		4D6ABB0D2AF13FB100BB2A08 /* StoreEnvironment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreEnvironment.swift; sourceTree = "<group>"; };
 		4D6ABB0F2AF13FBD00BB2A08 /* SK2AppTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SK2AppTransaction.swift; sourceTree = "<group>"; };
 		4D6F4BCF2CF69DE300353AF6 /* ForegroundColorScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForegroundColorScheme.swift; sourceTree = "<group>"; };
+		4D6F4BE52CFE2FAB00353AF6 /* PaywallsTesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallsTesterTests.swift; sourceTree = "<group>"; };
 		4D7A3E272B85729E00ABDE67 /* PurchasesOrchestratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesOrchestratorTests.swift; sourceTree = "<group>"; };
 		4DBC30952B1DFA97001D33C7 /* StoreKitVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitVersion.swift; sourceTree = "<group>"; };
 		4DBF1F352B4D572400D52354 /* LocalReceiptFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalReceiptFetcher.swift; sourceTree = "<group>"; };
@@ -2999,6 +3007,7 @@
 			children = (
 				2DD500402C519EB4009C19B7 /* ci_scripts */,
 				2DD5008E2C519EB4009C19B7 /* PaywallsTester */,
+				4D6F4BE62CFE2FAB00353AF6 /* PaywallsTesterTests */,
 				2DD5008F2C519EB4009C19B7 /* PaywallsTester.xcodeproj */,
 				2DD500902C519EB4009C19B7 /* PaywallsTester.xcworkspace */,
 				2DD500912C519EB4009C19B7 /* Postprocessor.sh */,
@@ -3154,6 +3163,7 @@
 			isa = PBXGroup;
 			children = (
 				2DD500F82C519EB4009C19B7 /* PaywallsTester.app */,
+				4D6F4BE92CFE2FAB00353AF6 /* PaywallsTesterTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3858,6 +3868,14 @@
 				2DDF41AA24F6F37C005BC22D /* InAppPurchase.swift */,
 			);
 			path = BasicTypes;
+			sourceTree = "<group>";
+		};
+		4D6F4BE62CFE2FAB00353AF6 /* PaywallsTesterTests */ = {
+			isa = PBXGroup;
+			children = (
+				4D6F4BE52CFE2FAB00353AF6 /* PaywallsTesterTests.swift */,
+			);
+			path = PaywallsTesterTests;
 			sourceTree = "<group>";
 		};
 		4F1428A52A4A1330006CD196 /* Test Data */ = {
@@ -5400,6 +5418,13 @@
 			fileType = wrapper.framework;
 			path = Core.framework;
 			remoteRef = 2DD501092C519EB4009C19B7 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		4D6F4BE92CFE2FAB00353AF6 /* PaywallsTesterTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = PaywallsTesterTests.xctest;
+			remoteRef = 4D6F4BE82CFE2FAB00353AF6 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -58,7 +58,18 @@
 		88DFC1932BCF490400273B6D /* OfferingsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC1922BCF490400273B6D /* OfferingsResponse.swift */; };
 		88DFC1942BCF490400273B6D /* PaywallsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC1912BCF490400273B6D /* PaywallsResponse.swift */; };
 		88DFC1972BCF4A5100273B6D /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC1952BCF4A4300273B6D /* MockData.swift */; };
+		FA29FBB22CCAA7A500DA1976 /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = FA29FBB12CCAA7A500DA1976 /* SnapshottingTests */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		FA29FBAC2CCAA79800DA1976 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4F6BED922A26A64200CD9322 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4F6BED992A26A64200CD9322;
+			remoteInfo = PaywallsTester;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		4F6BEDD72A26A68E00CD9322 /* Embed Frameworks */ = {
@@ -138,7 +149,12 @@
 		88DFC1912BCF490400273B6D /* PaywallsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallsResponse.swift; sourceTree = "<group>"; };
 		88DFC1922BCF490400273B6D /* OfferingsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingsResponse.swift; sourceTree = "<group>"; };
 		88DFC1952BCF4A4300273B6D /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
+		FA29FBA82CCAA79800DA1976 /* PaywallsTesterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PaywallsTesterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		FA29FBA92CCAA79800DA1976 /* PaywallsTesterTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = PaywallsTesterTests; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		4F6BED972A26A64200CD9322 /* Frameworks */ = {
@@ -148,6 +164,14 @@
 				4FCA01FB2A3A1CBD00B262C0 /* StoreKit.framework in Frameworks */,
 				4F4EE7D22A5731E800D7EAE1 /* RevenueCat in Frameworks */,
 				4FC80B202A5DE8E300E95DB0 /* RevenueCatUI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FA29FBA52CCAA79800DA1976 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA29FBB22CCAA7A500DA1976 /* SnapshottingTests in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -170,6 +194,7 @@
 				773C13462CB5865400219E42 /* Local.xcconfig */,
 				4F4EE7D02A5731CF00D7EAE1 /* purchases-ios */,
 				4FC046BB2A572E3700A28BCF /* PaywallsTester */,
+				FA29FBA92CCAA79800DA1976 /* PaywallsTesterTests */,
 				4F6BED9B2A26A64200CD9322 /* Products */,
 				4F6BEDCC2A26A68E00CD9322 /* Frameworks */,
 			);
@@ -179,6 +204,7 @@
 			isa = PBXGroup;
 			children = (
 				4F6BED9A2A26A64200CD9322 /* PaywallsTester.app */,
+				FA29FBA82CCAA79800DA1976 /* PaywallsTesterTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -371,6 +397,30 @@
 			productReference = 4F6BED9A2A26A64200CD9322 /* PaywallsTester.app */;
 			productType = "com.apple.product-type.application";
 		};
+		FA29FBA72CCAA79800DA1976 /* PaywallsTesterTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FA29FBAE2CCAA79800DA1976 /* Build configuration list for PBXNativeTarget "PaywallsTesterTests" */;
+			buildPhases = (
+				FA29FBA42CCAA79800DA1976 /* Sources */,
+				FA29FBA52CCAA79800DA1976 /* Frameworks */,
+				FA29FBA62CCAA79800DA1976 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FA29FBAD2CCAA79800DA1976 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				FA29FBA92CCAA79800DA1976 /* PaywallsTesterTests */,
+			);
+			name = PaywallsTesterTests;
+			packageProductDependencies = (
+				FA29FBB12CCAA7A500DA1976 /* SnapshottingTests */,
+			);
+			productName = PaywallsTesterTests;
+			productReference = FA29FBA82CCAA79800DA1976 /* PaywallsTesterTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -378,11 +428,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1430;
+				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					4F6BED992A26A64200CD9322 = {
 						CreatedOnToolsVersion = 14.3;
+					};
+					FA29FBA72CCAA79800DA1976 = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = 4F6BED992A26A64200CD9322;
 					};
 				};
 			};
@@ -402,12 +456,14 @@
 			);
 			mainGroup = 4F6BED912A26A64200CD9322;
 			packageReferences = (
+				FA29FBA12CCAA76E00DA1976 /* XCRemoteSwiftPackageReference "SnapshotPreviews" */,
 			);
 			productRefGroup = 4F6BED9B2A26A64200CD9322 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				4F6BED992A26A64200CD9322 /* PaywallsTester */,
+				FA29FBA72CCAA79800DA1976 /* PaywallsTesterTests */,
 			);
 		};
 /* End PBXProject section */
@@ -420,6 +476,13 @@
 				4F217A102A6DB6FB000B092D /* Assets.xcassets in Resources */,
 				880B2AF22BEC2D62006B9393 /* Preprocessor.sh in Resources */,
 				4F4557E22A6FFE6A00160521 /* Localizable.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FA29FBA62CCAA79800DA1976 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -478,7 +541,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FA29FBA42CCAA79800DA1976 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		FA29FBAD2CCAA79800DA1976 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4F6BED992A26A64200CD9322 /* PaywallsTester */;
+			targetProxy = FA29FBAC2CCAA79800DA1976 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		4F4557E42A6FFE6A00160521 /* Localizable.strings */ = {
@@ -709,6 +787,54 @@
 			};
 			name = Release;
 		};
+		FA29FBAF2CCAA79800DA1976 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.PaywallsTesterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PaywallsTester.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PaywallsTester";
+			};
+			name = Debug;
+		};
+		FA29FBB02CCAA79800DA1976 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.PaywallsTesterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PaywallsTester.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PaywallsTester";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -730,7 +856,27 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		FA29FBAE2CCAA79800DA1976 /* Build configuration list for PBXNativeTarget "PaywallsTesterTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FA29FBAF2CCAA79800DA1976 /* Debug */,
+				FA29FBB02CCAA79800DA1976 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		FA29FBA12CCAA76E00DA1976 /* XCRemoteSwiftPackageReference "SnapshotPreviews" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/EmergeTools/SnapshotPreviews";
+			requirement = {
+				kind = exactVersion;
+				version = 0.10.16;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		4F4EE7D12A5731E800D7EAE1 /* RevenueCat */ = {
@@ -740,6 +886,11 @@
 		4FC80B1F2A5DE8E300E95DB0 /* RevenueCatUI */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = RevenueCatUI;
+		};
+		FA29FBB12CCAA7A500DA1976 /* SnapshottingTests */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FA29FBA12CCAA76E00DA1976 /* XCRemoteSwiftPackageReference "SnapshotPreviews" */;
+			productName = SnapshottingTests;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -872,8 +872,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/EmergeTools/SnapshotPreviews";
 			requirement = {
-				kind = exactVersion;
-				version = 0.10.16;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.10.16;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - Live Config.xcscheme
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - Live Config.xcscheme
@@ -64,6 +64,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA29FBA72CCAA79800DA1976"
+               BuildableName = "PaywallsTesterTests.xctest"
+               BlueprintName = "PaywallsTesterTests"
+               ReferencedContainer = "container:PaywallsTester.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - SK config.xcscheme
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - SK config.xcscheme
@@ -64,6 +64,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA29FBA72CCAA79800DA1976"
+               BuildableName = "PaywallsTesterTests.xctest"
+               BlueprintName = "PaywallsTesterTests"
+               ReferencedContainer = "container:PaywallsTester.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "accessibilitysnapshot",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/EmergeTools/AccessibilitySnapshot.git",
+      "state" : {
+        "revision" : "54046d8fa44b9fa9f0e2229526f6ed89cb5e0ec2",
+        "version" : "1.0.2"
+      }
+    },
+    {
       "identity" : "cwlcatchexception",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlCatchException.git",
@@ -19,12 +28,30 @@
       }
     },
     {
+      "identity" : "flyingfox",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swhitty/FlyingFox.git",
+      "state" : {
+        "revision" : "f7829d4aca8cbfecb410a1cce872b1b045224aa1",
+        "version" : "0.16.0"
+      }
+    },
+    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:Quick/Nimble.git",
       "state" : {
         "revision" : "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
         "version" : "10.0.0"
+      }
+    },
+    {
+      "identity" : "snapshotpreviews",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/EmergeTools/SnapshotPreviews",
+      "state" : {
+        "revision" : "0b0438a52ac22b2eed9a3a9acf2691005d7f9127",
+        "version" : "0.10.16"
       }
     },
     {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
@@ -90,6 +90,7 @@ struct AppContentView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
             AppContentView()
+              .environmentObject(ApplicationData())
         }
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/PaywallsTesterTests.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/PaywallsTesterTests.swift
@@ -1,0 +1,13 @@
+//
+//  PaywallsTesterTests.swift
+//  PaywallsTesterTests
+//
+//  Created by Noah Martin on 10/24/24.
+//
+
+import XCTest
+import SnapshottingTests
+
+final class PaywallsTesterTests: SnapshotTest {
+
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -130,8 +130,8 @@ platform :ios do
     end
   end
 
-  desc "Builds the Paywalls Test app"
-  lane :build_paywalls_test do |options|
+  desc "Build the Paywalls Test app for Emerge Snapshots"
+  lane :build_paywalls_tester_for_emerge do |options|
     File.write("Local.xcconfig", "SWIFT_ACTIVE_COMPILATION_CONDITIONS = \$(inherited) PAYWALL_COMPONENTS")
     replace_text_in_files(
       previous_text: "\/\/ REPLACE_WITH_DEFINES_HERE",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -132,6 +132,14 @@ platform :ios do
 
   desc "Builds the Paywalls Test app"
   lane :build_paywalls_test do |options|
+    File.write("Local.xcconfig", "SWIFT_ACTIVE_COMPILATION_CONDITIONS = \$(inherited) PAYWALL_COMPONENTS")
+    replace_text_in_files(
+      previous_text: "\/\/ REPLACE_WITH_DEFINES_HERE",
+      new_text: ".define("PAYWALL_COMPONENTS")",
+      paths_of_files_to_update: [
+        './Package.swift',
+      ]
+    )
     scan(
       workspace: "Tests/TestingApps/PaywallsTester/PaywallsTester.xcworkspace",
       scheme: "PaywallsTester - Live Config",
@@ -824,7 +832,7 @@ platform :ios do
     purchase_tester_root = "#{project_root}/Tests/TestingApps/PurchaseTesterSwiftUI"
     xcodeproj_path = "#{purchase_tester_root}/PurchaseTester.xcodeproj"
 
-    # The following commands use configuration that lives in the PurchaseTesterSwiftUI directory, 
+    # The following commands use configuration that lives in the PurchaseTesterSwiftUI directory,
     # like the Matchfile. So we move to that project's directory to run them.
     Dir.chdir("#{purchase_tester_root}/fastlane") do
       match(readonly: true, platform: "ios")
@@ -833,7 +841,7 @@ platform :ios do
         xcodeproj: xcodeproj_path,
       )
     end
-    
+
     build_ios_app(
       workspace: 'RevenueCat.xcworkspace',
       scheme: "PurchaseTester",
@@ -858,7 +866,7 @@ platform :ios do
       UI.message("Dry run mode enabled. Skipping upload to TestFlight")
     end
 
-    # The following commands use configuration that lives in the PurchaseTesterSwiftUI directory, 
+    # The following commands use configuration that lives in the PurchaseTesterSwiftUI directory,
     # like the Matchfile. So we move to that project's directory to run them.
     Dir.chdir("#{purchase_tester_root}/fastlane") do
       match(readonly: true, platform: "macos", additional_cert_types: "mac_installer_distribution")
@@ -891,7 +899,7 @@ platform :ios do
     else
         UI.message("Dry run mode enabled. Skipping upload to TestFlight")
     end
-    
+
   end
 
   desc "Clones or updates snapshots repo"
@@ -929,7 +937,7 @@ platform :ios do
   lane :deploy_to_spm do
     source_repo = ENV["CIRCLE_REPOSITORY_URL"] || "https://github.com/revenuecat/#{repo_name}"
     destination_repo = source_repo.sub(/\.git\z/, "-spm.git")
-  
+
     git_clone_and_push(
       source_repo: source_repo,
       destination_repo: destination_repo
@@ -971,7 +979,7 @@ platform :ios do
     rescue => ex
       UI.error("Failed to enable customer center. Error while applying changes from commit #{commit_hash}")
       UI.error(ex.message)
-      
+
       if UI.confirm("Do you want to abort the customer center enablement?")
         sh("git", "cherry-pick", "--abort")
         UI.message("Customer center enablement aborted")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -130,6 +130,16 @@ platform :ios do
     end
   end
 
+  desc "Builds the Paywalls Test app"
+  lane :build_paywalls_test do |options|
+    scan(
+      workspace: "Tests/TestingApps/PaywallsTester/PaywallsTester.xcworkspace",
+      scheme: "PaywallsTester - Live Config",
+      build_for_testing: true,
+    )
+    emerge
+  end
+
   desc "Runs all the iOS tests"
   lane :test_ios do |options|
     generate_snapshots = ENV["CIRCLECI_TESTS_GENERATE_SNAPSHOTS"] == "true"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -135,7 +135,7 @@ platform :ios do
     File.write("Local.xcconfig", "SWIFT_ACTIVE_COMPILATION_CONDITIONS = \$(inherited) PAYWALL_COMPONENTS")
     replace_text_in_files(
       previous_text: "\/\/ REPLACE_WITH_DEFINES_HERE",
-      new_text: ".define("PAYWALL_COMPONENTS")",
+      new_text: ".define(\"PAYWALL_COMPONENTS\")",
       paths_of_files_to_update: [
         './Package.swift',
       ]

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -4,3 +4,4 @@
 
 gem 'fastlane-plugin-create_xcframework', git: "https://github.com/RevenueCat/fastlane-plugin-create_xcframework"
 gem "fastlane-plugin-revenuecat_internal", git: "https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal"
+gem 'fastlane-plugin-emerge'

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -74,6 +74,14 @@ Creates PR changing version to next minor adding a -SNAPSHOT suffix
 
 Setup development environment
 
+### ios build_paywalls_test
+
+```sh
+[bundle exec] fastlane ios build_paywalls_test
+```
+
+Builds the Paywalls Test app
+
 ### ios test_ios
 
 ```sh


### PR DESCRIPTION
This PR:
- Adds a test target to `PaywallTester`.
- Adds Emerge's `SnapshotPreviews` package to the test target.
- Adds Emerge's Fastlane plugin and a new lane which uploads `PaywallsTester` to Emerge.
- Adds a CircleCI job to run the lane.

Shoutout to @noahsmartin for all the help!