### PR TITLE
Use `ManageSubscriptionsView` for users without active subscriptions

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		35272E2226D0048D00F22C3B /* HTTPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E353CBE9CF2572A72A347F /* HTTPClientTests.swift */; };
 		352B7D7927BD919B002A47DD /* DangerousSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352B7D7827BD919B002A47DD /* DangerousSettings.swift */; };
 		35316DAA2BD14BFD00E4A970 /* MockDiagnosticsSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35316DA82BD14BFD00E4A970 /* MockDiagnosticsSynchronizer.swift */; };
+		3531DF882CFE138D00D454BF /* ManageSubscriptionsButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3531DF872CFE138800D454BF /* ManageSubscriptionsButtonsView.swift */; };
 		353756522C382BC700A1B8D6 /* PreferredLocalesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353756512C382BC700A1B8D6 /* PreferredLocalesProvider.swift */; };
 		353756652C382C2800A1B8D6 /* CustomerCenterConfigTestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353756532C382C2800A1B8D6 /* CustomerCenterConfigTestData.swift */; };
 		353756662C382C2800A1B8D6 /* CustomerCenterError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353756542C382C2800A1B8D6 /* CustomerCenterError.swift */; };
@@ -1511,6 +1512,7 @@
 		352B7D7827BD919B002A47DD /* DangerousSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DangerousSettings.swift; sourceTree = "<group>"; };
 		3530C18822653E8F00D6DF52 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		35316DA82BD14BFD00E4A970 /* MockDiagnosticsSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDiagnosticsSynchronizer.swift; sourceTree = "<group>"; };
+		3531DF872CFE138800D454BF /* ManageSubscriptionsButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsButtonsView.swift; sourceTree = "<group>"; };
 		353756512C382BC700A1B8D6 /* PreferredLocalesProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferredLocalesProvider.swift; sourceTree = "<group>"; };
 		353756532C382C2800A1B8D6 /* CustomerCenterConfigTestData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerCenterConfigTestData.swift; sourceTree = "<group>"; };
 		353756542C382C2800A1B8D6 /* CustomerCenterError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerCenterError.swift; sourceTree = "<group>"; };
@@ -3528,6 +3530,7 @@
 		353756602C382C2800A1B8D6 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				3531DF872CFE138800D454BF /* ManageSubscriptionsButtonsView.swift */,
 				2D2AFE8E2C6A9D8700D1B0B4 /* CompatibilityContentUnavailableView.swift */,
 				2C4C36122C6FBA8B00AE959B /* CompatibilityTopBarTrailing.swift */,
 				3537565B2C382C2800A1B8D6 /* CustomerCenterView.swift */,
@@ -6564,6 +6567,7 @@
 				77BA1AB32CCBB6EE009BF0EA /* RootView.swift in Sources */,
 				887A606C2C1D037000E1A461 /* Constants.swift in Sources */,
 				887A60BF2C1D037000E1A461 /* PaywallViewController.swift in Sources */,
+				3531DF882CFE138D00D454BF /* ManageSubscriptionsButtonsView.swift in Sources */,
 				2CC791552CC0452100FBE120 /* PurchaseButtonComponentViewModel.swift in Sources */,
 				2CC791562CC0452100FBE120 /* PackageComponentView.swift in Sources */,
 				2CC791592CC0452100FBE120 /* PurchaseButtonComponentView.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
@@ -27,6 +27,7 @@ import SwiftUI
 class ManageSubscriptionsViewModel: ObservableObject {
 
     let screen: CustomerCenterConfigData.Screen
+    let paths: [CustomerCenterConfigData.HelpPath]
 
     @Published
     var showRestoreAlert: Bool = false
@@ -66,6 +67,7 @@ class ManageSubscriptionsViewModel: ObservableObject {
          purchasesProvider: ManageSubscriptionsPurchaseType = ManageSubscriptionPurchases(),
          loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType? = nil) {
         self.screen = screen
+        self.paths = screen.filteredPaths
         self.purchasesProvider = purchasesProvider
         self.customerCenterActionHandler = customerCenterActionHandler
         self.loadPromotionalOfferUseCase = loadPromotionalOfferUseCase ?? LoadPromotionalOfferUseCase()
@@ -77,6 +79,7 @@ class ManageSubscriptionsViewModel: ObservableObject {
          customerCenterActionHandler: CustomerCenterActionHandler?,
          refundRequestStatus: RefundRequestStatus? = nil) {
         self.screen = screen
+        self.paths = screen.filteredPaths
         self.purchaseInformation = purchaseInformation
         self.purchasesProvider = ManageSubscriptionPurchases()
         self.refundRequestStatus = refundRequestStatus
@@ -257,6 +260,20 @@ private final class ManageSubscriptionPurchases: ManageSubscriptionsPurchaseType
 
     func products(_ productIdentifiers: [String]) async -> [StoreProduct] {
         await Purchases.shared.products(productIdentifiers)
+    }
+
+}
+
+private extension CustomerCenterConfigData.Screen {
+
+    var filteredPaths: [CustomerCenterConfigData.HelpPath] {
+        return self.paths.filter { path in
+            #if targetEnvironment(macCatalyst)
+                return path.type == .refundRequest
+            #else
+                return path.type != .unknown
+            #endif
+        }
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -112,7 +112,13 @@ private extension CustomerCenterView {
                 WrongPlatformView()
             }
         } else {
-            NoSubscriptionsView(configuration: configuration)
+            if let screen = configuration.screens[.noActive] {
+                ManageSubscriptionsView(screen: screen,
+                                        customerCenterActionHandler: viewModel.customerCenterActionHandler)
+            } else {
+                // Fallback with a restore button
+                NoSubscriptionsView(configuration: configuration)
+            }
         }
     }
 

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsButtonsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsButtonsView.swift
@@ -1,0 +1,77 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ManageSubscriptionsButtonsView.swift
+//
+//  Created by Cesar de la Vega on 2/12/24.
+
+import Foundation
+import RevenueCat
+import SwiftUI
+
+#if os(iOS)
+
+@available(iOS 15.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct ManageSubscriptionsButtonsView: View {
+
+    @ObservedObject
+    var viewModel: ManageSubscriptionsViewModel
+    @Binding
+    var loadingPath: CustomerCenterConfigData.HelpPath?
+    @Environment(\.openURL)
+    var openURL
+
+    @Environment(\.localization)
+    private var localization: CustomerCenterConfigData.Localization
+
+    var body: some View {
+        let filteredPaths = self.viewModel.screen.paths.filter { path in
+#if targetEnvironment(macCatalyst)
+            return path.type == .refundRequest
+#else
+            return path.type != .unknown
+#endif
+        }
+        ForEach(filteredPaths, id: \.id) { path in
+            ManageSubscriptionButton(path: path, viewModel: self.viewModel)
+        }
+    }
+
+}
+
+@available(iOS 15.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct ManageSubscriptionButton: View {
+
+    let path: CustomerCenterConfigData.HelpPath
+    @ObservedObject var viewModel: ManageSubscriptionsViewModel
+
+    @Environment(\.appearance) private var appearance: CustomerCenterConfigData.Appearance
+
+    var body: some View {
+        AsyncButton(action: {
+            await self.viewModel.determineFlow(for: path)
+        }, label: {
+            if self.viewModel.loadingPath?.id == path.id {
+                TintedProgressView()
+            } else {
+                Text(path.title)
+            }
+        })
+        .disabled(self.viewModel.loadingPath != nil)
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsButtonsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsButtonsView.swift
@@ -34,14 +34,7 @@ struct ManageSubscriptionsButtonsView: View {
     private var localization: CustomerCenterConfigData.Localization
 
     var body: some View {
-        let filteredPaths = self.viewModel.screen.paths.filter { path in
-#if targetEnvironment(macCatalyst)
-            return path.type == .refundRequest
-#else
-            return path.type != .unknown
-#endif
-        }
-        ForEach(filteredPaths, id: \.id) { path in
+        ForEach(self.viewModel.paths, id: \.id) { path in
             ManageSubscriptionButton(path: path, viewModel: self.viewModel)
         }
     }

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -86,17 +86,32 @@ struct ManageSubscriptionsView: View {
                                 purchaseInformation: purchaseInformation,
                                 refundRequestStatus: self.viewModel.refundRequestStatus)
                         }
-                    }
+                        Section {
+                            ManageSubscriptionsButtonsView(viewModel: self.viewModel,
+                                                           loadingPath: self.$viewModel.loadingPath)
+                        } header: {
+                            if let subtitle = self.viewModel.screen.subtitle {
+                                Text(subtitle)
+                                    .textCase(nil)
+                            }
+                        }
+                    } else {
+                        let fallbackDescription = "We can try checking your Apple account for any previous purchases"
 
-                    Section {
-                        ManageSubscriptionsButtonsView(viewModel: self.viewModel,
-                                                       loadingPath: self.$viewModel.loadingPath)
-                    } header: {
-                        if let subtitle = self.viewModel.screen.subtitle {
-                            Text(subtitle)
-                                .textCase(nil)
+                        Section {
+                            CompatibilityContentUnavailableView(
+                                self.viewModel.screen.title,
+                                systemImage: "exclamationmark.triangle.fill",
+                                description: Text(self.viewModel.screen.subtitle ?? fallbackDescription)
+                            )
+                        }
+
+                        Section {
+                            ManageSubscriptionsButtonsView(viewModel: self.viewModel,
+                                                           loadingPath: self.$viewModel.loadingPath)
                         }
                     }
+
                 }
             } else {
                 TintedProgressView()

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -96,7 +96,8 @@ struct ManageSubscriptionsView: View {
                             }
                         }
                     } else {
-                        let fallbackDescription = "We can try checking your Apple account for any previous purchases"
+                        let fallbackDescription = "You currently have no active subscriptions. " +
+                        "We can try checking your Apple account for any previous purchases"
 
                         Section {
                             CompatibilityContentUnavailableView(
@@ -147,8 +148,10 @@ struct ManageSubscriptionsView: View {
         }, content: { inAppBrowserURL in
             SafariView(url: inAppBrowserURL.url)
         })
-        .navigationTitle(self.viewModel.screen.title)
-        .navigationBarTitleDisplayMode(.inline)
+        .applyIf(self.viewModel.screen.type == .management, apply: {
+            $0.navigationTitle(self.viewModel.screen.title).navigationBarTitleDisplayMode(.inline)
+        })
+
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -96,8 +96,7 @@ struct ManageSubscriptionsView: View {
                             }
                         }
                     } else {
-                        let fallbackDescription = "You currently have no active subscriptions. " +
-                        "We can try checking your Apple account for any previous purchases"
+                        let fallbackDescription = localization.commonLocalizedString(for: .tryCheckRestore)
 
                         Section {
                             CompatibilityContentUnavailableView(

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -152,63 +152,6 @@ private extension ManageSubscriptionsView {
 
 }
 
-@available(iOS 15.0, *)
-@available(macOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
-struct ManageSubscriptionsButtonsView: View {
-
-    @ObservedObject
-    var viewModel: ManageSubscriptionsViewModel
-    @Binding
-    var loadingPath: CustomerCenterConfigData.HelpPath?
-    @Environment(\.openURL)
-    var openURL
-
-    @Environment(\.localization)
-    private var localization: CustomerCenterConfigData.Localization
-
-    var body: some View {
-        let filteredPaths = self.viewModel.screen.paths.filter { path in
-#if targetEnvironment(macCatalyst)
-            return path.type == .refundRequest
-#else
-            return path.type != .unknown
-#endif
-        }
-        ForEach(filteredPaths, id: \.id) { path in
-            ManageSubscriptionButton(path: path, viewModel: self.viewModel)
-        }
-    }
-
-}
-
-@available(iOS 15.0, *)
-@available(macOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
-struct ManageSubscriptionButton: View {
-
-    let path: CustomerCenterConfigData.HelpPath
-    @ObservedObject var viewModel: ManageSubscriptionsViewModel
-
-    @Environment(\.appearance) private var appearance: CustomerCenterConfigData.Appearance
-
-    var body: some View {
-        AsyncButton(action: {
-            await self.viewModel.determineFlow(for: path)
-        }, label: {
-            if self.viewModel.loadingPath?.id == path.id {
-                TintedProgressView()
-            } else {
-                Text(path.title)
-            }
-        })
-        .disabled(self.viewModel.loadingPath != nil)
-    }
-
-}
-
 #if DEBUG
 @available(iOS 15.0, *)
 @available(macOS, unavailable)

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -40,7 +40,8 @@ struct NoSubscriptionsView: View {
     }
 
     var body: some View {
-        let fallbackDescription = "We can try checking your Apple account for any previous purchases"
+        let fallbackDescription = "You currently have no active subscriptions. " +
+        "We can try checking your Apple account for any previous purchases"
 
         List {
             Section {
@@ -57,10 +58,6 @@ struct NoSubscriptionsView: View {
                     showRestoreAlert = true
                 }
                 .restorePurchasesAlert(isPresented: $showRestoreAlert)
-            } header: {
-                let subtitle = localization.commonLocalizedString(for: .tryCheckRestore)
-                Text(subtitle)
-                    .textCase(nil)
             }
 
         }

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -40,13 +40,13 @@ struct NoSubscriptionsView: View {
     }
 
     var body: some View {
-        let fallbackDescription = "You currently have no active subscriptions. " +
-        "We can try checking your Apple account for any previous purchases"
+        let fallbackDescription = localization.commonLocalizedString(for: .tryCheckRestore)
+        let fallbackTitle = localization.commonLocalizedString(for: .noSubscriptionsFound)
 
         List {
             Section {
                 CompatibilityContentUnavailableView(
-                    self.configuration.screens[.noActive]?.title ?? "No subscriptions found",
+                    self.configuration.screens[.noActive]?.title ?? fallbackTitle,
                     systemImage: "exclamationmark.triangle.fill",
                     description:
                         Text(self.configuration.screens[.noActive]?.subtitle ?? fallbackDescription)


### PR DESCRIPTION
We let devs configure the screen that's displayed to users with NO active subscriptions, but the `NoSubscriptionsView` is not dynamically built. This PR changes the logic so `ManageSubscriptionsView` is also used with the data in the `NO_ACTIVE` screen of the configuration.

I had to change the view a little bit since the Missing purchase option is optional and it doesn't make sense it always displays the "We can try checking your Apple account for any previous purchases"

| Before | After |
|--------|--------|
| <img width="600" alt="Screenshot 2024-12-02 at 17 54 02" src="https://github.com/user-attachments/assets/bb6e81e9-f03e-4952-a9fd-f204e28ef0e1"> | <img width="600" alt="Screenshot 2024-12-02 at 17 54 02" src="https://github.com/user-attachments/assets/d556027f-ea9b-40ec-838e-db5cac6b5329">|
