### PR TITLE
Customer Center deeplinks should always be opened externally

### DIFF
--- a/RevenueCatUI/CustomerCenter/URLUtilities.swift
+++ b/RevenueCatUI/CustomerCenter/URLUtilities.swift
@@ -77,7 +77,12 @@ enum URLUtilities {
 extension URL {
 
     var isDeeplink: Bool {
-        !(scheme?.hasPrefix("http") ?? false)
+        switch scheme?.lowercased() {
+        case "http", "https":
+            return false
+        default:
+            return true
+        }
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/URLUtilities.swift
+++ b/RevenueCatUI/CustomerCenter/URLUtilities.swift
@@ -74,6 +74,14 @@ enum URLUtilities {
 
 }
 
+extension URL {
+
+    var isDeeplink: Bool {
+        !(scheme?.hasPrefix("http") ?? false)
+    }
+
+}
+
 private extension URLUtilities {
 
     static var isAppExtension: Bool {

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
@@ -232,6 +232,7 @@ private extension ManageSubscriptionsViewModel {
             case .inApp:
                 self.inAppBrowserURL = .init(url: url)
             @unknown default:
+                Logger.warning(Strings.could_not_determine_type_of_custom_url)
                 URLUtilities.openURLIfNotAppExtension(url)
             }
         default:

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
@@ -226,10 +226,13 @@ private extension ManageSubscriptionsViewModel {
                 return
             }
             switch openMethod {
-            case .external:
+            case .external,
+                _ where url.isDeeplink:
                 URLUtilities.openURLIfNotAppExtension(url)
             case .inApp:
                 self.inAppBrowserURL = .init(url: url)
+            @unknown default:
+                URLUtilities.openURLIfNotAppExtension(url)
             }
         default:
             break

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -67,6 +67,7 @@ enum Strings {
     case could_not_offer_for_active_subscriptions(String, String)
     case error_fetching_promotional_offer(Error)
     case promo_offer_not_loaded
+    case could_not_determine_type_of_custom_url
 
 }
 
@@ -206,6 +207,9 @@ extension Strings: CustomStringConvertible {
 
         case .could_not_offer_for_active_subscriptions(let discount, let subscription):
             return "Could not find offer with id \(discount) for active subscription \(subscription)"
+
+        case .could_not_determine_type_of_custom_url:
+            return "Could not determine the type of custom URL, the URL will be opened externally."
 
         }
     }


### PR DESCRIPTION
Deeplinks should always be configured as `external`, if someone configures a deeplink as inapp, we'll try to open that link with a Safari view, which crashes. This PR makes sure deeplinks are always opened correctly.

There should be an update in the UI as well to make sure deeplinks are configured correctly