### PR TITLE
Renames isDeeplink to isWebLink

### DIFF
--- a/RevenueCatUI/CustomerCenter/URLUtilities.swift
+++ b/RevenueCatUI/CustomerCenter/URLUtilities.swift
@@ -76,12 +76,12 @@ enum URLUtilities {
 
 extension URL {
 
-    var isDeeplink: Bool {
+    var isWebLink: Bool {
         switch scheme?.lowercased() {
         case "http", "https":
-            return false
-        default:
             return true
+        default:
+            return false
         }
     }
 

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
@@ -227,7 +227,7 @@ private extension ManageSubscriptionsViewModel {
             }
             switch openMethod {
             case .external,
-                _ where url.isDeeplink:
+                _ where !url.isWebLink:
                 URLUtilities.openURLIfNotAppExtension(url)
             case .inApp:
                 self.inAppBrowserURL = .init(url: url)


### PR DESCRIPTION
Followup on #4533 after @JayShortway comment on deeplinks also having http as prefix