### PR TITLE
Adds missing revisionId to CustomerCenter impression event

### DIFF
--- a/Sources/CustomerCenter/Events/EventsRequest+CustomerCenter.swift
+++ b/Sources/CustomerCenter/Events/EventsRequest+CustomerCenter.swift
@@ -27,6 +27,7 @@ extension EventsRequest {
         var locale: String
         var isSandbox: Bool
         var displayMode: CustomerCenterPresentationMode
+        var revisionId: Int
 
     }
 
@@ -68,7 +69,8 @@ extension EventsRequest.CustomerCenterEvent {
                 darkMode: data.darkMode,
                 locale: data.localeIdentifier,
                 isSandbox: data.isSandbox,
-                displayMode: data.displayMode
+                displayMode: data.displayMode,
+                revisionId: 1
             )
         } catch {
             return nil
@@ -108,6 +110,7 @@ extension EventsRequest.CustomerCenterEvent: Encodable {
         case locale
         case isSandbox = "isSandbox"
         case displayMode = "displayMode"
+        case revisionId = "revisionId"
 
     }
 

--- a/Tests/UnitTests/CustomerCenter/Events/__Snapshots__/CustomerCenterEventsRequestTests/testCanInitFromDeserializedEvent.1.json
+++ b/Tests/UnitTests/CustomerCenter/Events/__Snapshots__/CustomerCenterEventsRequestTests/testCanInitFromDeserializedEvent.1.json
@@ -6,6 +6,7 @@
   "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
   "is_sandbox" : true,
   "locale" : "en_US",
+  "revision_id" : 1,
   "timestamp" : 1694029328000,
   "type" : "customer_center_impression",
   "version" : 1

--- a/Tests/UnitTests/CustomerCenter/Events/__Snapshots__/CustomerCenterEventsRequestTests/testImpressionEvent.1.json
+++ b/Tests/UnitTests/CustomerCenter/Events/__Snapshots__/CustomerCenterEventsRequestTests/testImpressionEvent.1.json
@@ -6,6 +6,7 @@
   "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
   "is_sandbox" : true,
   "locale" : "es_ES",
+  "revision_id" : 1,
   "timestamp" : 1694029328000,
   "type" : "customer_center_impression",
   "version" : 1


### PR DESCRIPTION
We were missing the revision id for Customer Center impression events which the backend expects. I had that in another PR but not in `main`

It's hardcoded to 1 for now, since the config JSON doesn't have revision ids yet