### PR TITLE
WebPurchaseRedemption: Rename `alreadyRedeemed` result to `purchaseBelongsToOtherUser`

### DIFF
--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -27,7 +27,7 @@ enum BackendError: Error, Equatable {
     case invalidAppleSubscriptionKey(Source)
     case unexpectedBackendResponse(UnexpectedBackendResponseError, extraContext: String?, Source)
     case invalidWebRedemptionToken
-    case webPurchaseAlreadyRedeemed
+    case purchaseBelongsToOtherUser
     case expiredWebRedemptionToken(obfuscatedEmail: String)
 
 }
@@ -131,8 +131,8 @@ extension BackendError: PurchasesErrorConvertible {
             let code = BackendErrorCode.invalidWebRedemptionToken
             return ErrorUtils.backendError(withBackendCode: code,
                                            originalBackendErrorCode: code.rawValue)
-        case .webPurchaseAlreadyRedeemed:
-            let code = BackendErrorCode.webPurchaseAlreadyRedeemed
+        case .purchaseBelongsToOtherUser:
+            let code = BackendErrorCode.purchaseBelongsToOtherUser
             return ErrorUtils.backendError(withBackendCode: code,
                                            originalBackendErrorCode: code.rawValue)
         case let .expiredWebRedemptionToken(obfuscatedEmail):
@@ -181,7 +181,7 @@ extension BackendError {
              .missingCachedCustomerInfo,
              .unexpectedBackendResponse,
              .invalidWebRedemptionToken,
-             .webPurchaseAlreadyRedeemed,
+             .purchaseBelongsToOtherUser,
              .expiredWebRedemptionToken:
             return nil
         }
@@ -203,7 +203,7 @@ extension BackendError {
                 .missingTransactionProductIdentifier,
                 .missingCachedCustomerInfo,
                 .invalidWebRedemptionToken,
-                .webPurchaseAlreadyRedeemed,
+                .purchaseBelongsToOtherUser,
                 .expiredWebRedemptionToken:
             return nil
 

--- a/Sources/Error Handling/BackendErrorCode.swift
+++ b/Sources/Error Handling/BackendErrorCode.swift
@@ -44,7 +44,7 @@ enum BackendErrorCode: Int, Error {
     case invalidSubscriberAttributesBody = 7264
     case purchasedProductMissingInAppleReceipt = 7712
     case invalidWebRedemptionToken = 7849
-    case webPurchaseAlreadyRedeemed = 7852
+    case purchaseBelongsToOtherUser = 7852
     case expiredWebRedemptionToken = 7853
 
     /**
@@ -123,8 +123,8 @@ extension BackendErrorCode {
             return .unknownBackendError
         case .invalidWebRedemptionToken:
             return .invalidWebPurchaseToken
-        case .webPurchaseAlreadyRedeemed:
-            return .alreadyRedeemedWebPurchaseToken
+        case .purchaseBelongsToOtherUser:
+            return .purchaseBelongsToOtherUser
         case .expiredWebRedemptionToken:
             return .expiredWebPurchaseToken
         case .unknownError:

--- a/Sources/Error Handling/ErrorCode.swift
+++ b/Sources/Error Handling/ErrorCode.swift
@@ -62,7 +62,7 @@ import Foundation
     @objc(RCSignatureVerificationFailed) case signatureVerificationFailed = 37
     @objc(RCFeatureNotSupportedWithStoreKit1) case featureNotSupportedWithStoreKit1 = 38
     @objc(RCInvalidWebPurchaseToken) case invalidWebPurchaseToken = 39
-    @objc(RCAlreadyRedeemedWebPurchaseToken) case alreadyRedeemedWebPurchaseToken = 40
+    @objc(RCPurchaseBelongsToOtherUser) case purchaseBelongsToOtherUser = 40
     @objc(RCExpiredWebPurchaseToken) case expiredWebPurchaseToken = 41
 
     // swiftlint:enable missing_docs
@@ -190,8 +190,8 @@ extension ErrorCode: DescribableError {
 
         case .invalidWebPurchaseToken:
             return "The link you provided does not contain a valid purchase token."
-        case .alreadyRedeemedWebPurchaseToken:
-            return "The link you provided has already been redeemed."
+        case .purchaseBelongsToOtherUser:
+            return "The web purchase already belongs to other user."
         case .expiredWebPurchaseToken:
             return "The link you provided has expired. A new one will be sent to the email used to make the purchase."
         @unknown default:
@@ -298,7 +298,7 @@ extension ErrorCode {
             return "FEATURE_NOT_SUPPORTED_WITH_STOREKIT1"
         case .invalidWebPurchaseToken:
             return "INVALID_WEB_PURCHASE_TOKEN"
-        case .alreadyRedeemedWebPurchaseToken:
+        case .purchaseBelongsToOtherUser:
             return "ALREADY_REDEEMED_WEB_PURCHASE_TOKEN"
         case .expiredWebPurchaseToken:
             return "EXPIRED_WEB_PURCHASE_TOKEN"

--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -680,7 +680,7 @@ private extension ErrorUtils {
                 .signatureVerificationFailed,
                 .featureNotSupportedWithStoreKit1,
                 .invalidWebPurchaseToken,
-                .alreadyRedeemedWebPurchaseToken,
+                .purchaseBelongsToOtherUser,
                 .expiredWebPurchaseToken:
                 Logger.error(
                     localizedDescription,

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -277,9 +277,9 @@ final class PurchasesOrchestrator {
                 let userInfo: [String: Any] = [:]
                 let error = PurchasesError(error: .invalidWebPurchaseToken, userInfo: userInfo)
                 completion(nil, error.asPublicError)
-            case .alreadyRedeemed:
+            case .purchaseBelongsToOtherUser:
                 let userInfo: [String: Any] = [:]
-                let error = PurchasesError(error: .alreadyRedeemedWebPurchaseToken, userInfo: userInfo)
+                let error = PurchasesError(error: .purchaseBelongsToOtherUser, userInfo: userInfo)
                 completion(nil, error.asPublicError)
             case let .expired(obfuscatedEmail):
                 let userInfo: [NSError.UserInfoKey: Any] = [

--- a/Sources/WebPurchaseRedemption/WebPurchaseRedemptionHelper.swift
+++ b/Sources/WebPurchaseRedemption/WebPurchaseRedemptionHelper.swift
@@ -50,8 +50,8 @@ actor WebPurchaseRedemptionHelper: WebPurchaseRedemptionHelperType {
                     switch purchasesError.errorCode {
                     case ErrorCode.invalidWebPurchaseToken.rawValue:
                         continuation.resume(returning: .invalidToken)
-                    case ErrorCode.alreadyRedeemedWebPurchaseToken.rawValue:
-                        continuation.resume(returning: .alreadyRedeemed)
+                    case ErrorCode.purchaseBelongsToOtherUser.rawValue:
+                        continuation.resume(returning: .purchaseBelongsToOtherUser)
                     case ErrorCode.expiredWebPurchaseToken.rawValue:
                         guard let obfuscatedEmail = purchasesError.userInfo[ErrorDetails.obfuscatedEmailKey] as? String
                         else {

--- a/Sources/WebPurchaseRedemption/WebPurchaseRedemptionResult.swift
+++ b/Sources/WebPurchaseRedemption/WebPurchaseRedemptionResult.swift
@@ -25,8 +25,8 @@ public enum WebPurchaseRedemptionResult: Sendable {
     case error(_ error: PublicError)
     /// Represents that the token was not a valid redemption token. Maybe the link was invalid or incomplete.
     case invalidToken
-    /// Indicates that the web purchase has already been redeemed and can't be redeemed again.
-    case alreadyRedeemed
+    /// Indicates that the web purchase belongs to a different user and can't be redeemed again.
+    case purchaseBelongsToOtherUser
     /// Indicates that the redemption token has expired. An email with a new redemption token
     /// might be sent if a new one wasn't already sent recently.
     /// The email where it will be sent is indicated by the [obfuscatedEmail].

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
@@ -366,7 +366,7 @@ func checkWebPurchaseRedemptionResult(result: WebPurchaseRedemptionResult) -> Bo
         return true
     case .invalidToken:
         return true
-    case .alreadyRedeemed:
+    case .purchaseBelongsToOtherUser:
         return true
     case let .expired(obfuscatedEmail):
         let _: String = obfuscatedEmail

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorCommonTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorCommonTests.swift
@@ -230,12 +230,12 @@ class PurchasesOrchestratorCommonTests: BasePurchasesOrchestratorTests {
     func testRedeemWebPurchaseWiresResultAppropriately() async {
         self.setUpOrchestrator()
 
-        self.webPurchaseRedemptionHelper.stubbedHandleRedeemWebPurchaseResult = .alreadyRedeemed
+        self.webPurchaseRedemptionHelper.stubbedHandleRedeemWebPurchaseResult = .purchaseBelongsToOtherUser
 
         var expectedResultCalled = false
         let result = await self.orchestrator.redeemWebPurchase(.init(redemptionToken: "test-redemption-token"))
         switch result {
-        case .alreadyRedeemed:
+        case .purchaseBelongsToOtherUser:
             expectedResultCalled = true
         default:
             XCTFail("Unexpected result: \(result)")

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/PaywallsPreview.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/PaywallsPreview.swift
@@ -52,7 +52,7 @@ struct PaywallsPreview: App {
                         message = "Web purchase redemption failed: \(error.localizedDescription)"
                     case .invalidToken:
                         message = "Web purchase redemption failed due to invalid token"
-                    case .alreadyRedeemed:
+                    case .purchaseBelongsToOtherUser:
                         message = "Redemption link has already been redeemed. Cannot be redeemed again."
                     case let .expired(obfuscatedEmail):
                         message = "Redemption link expired. A new one has been sent to \(obfuscatedEmail)"

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
@@ -80,8 +80,8 @@ struct PurchaseTesterApp: App {
                             alertMessage = "RevenueCat errored redeeming deep link: \(error.localizedDescription)"
                         case .invalidToken:
                             alertMessage = "The provided purchase redemption token is invalid."
-                        case .alreadyRedeemed:
-                            alertMessage = "RevenueCat purchase link was already redeemed."
+                        case .purchaseBelongsToOtherUser:
+                            alertMessage = "RevenueCat purchase belongs to other user."
                         case let .expired(obfuscatedEmail):
                             alertMessage = "RevenueCat purchase link expired. Email " +
                                 "was sent to \(obfuscatedEmail)"

--- a/Tests/UnitTests/DeepLink/WebPurchaseRedemptionHelperTests.swift
+++ b/Tests/UnitTests/DeepLink/WebPurchaseRedemptionHelperTests.swift
@@ -90,18 +90,18 @@ class WebPurchaseRedemptionHelperTests: TestCase {
         expect(receivedExpectedError) == true
     }
 
-    func testHandleRedeemWebPurchaseAlreadyRedeemed() async throws {
-        self.redeemWebPurchaseAPI.stubbedPostRedeemWebPurchaseResult = .failure(.webPurchaseAlreadyRedeemed)
+    func testHandleRedeemWebPurchaseBelongsToOtherUser() async throws {
+        self.redeemWebPurchaseAPI.stubbedPostRedeemWebPurchaseResult = .failure(.purchaseBelongsToOtherUser)
 
         let result = await self.helper.handleRedeemWebPurchase(redemptionToken: "test-redemption-token")
 
         var receivedExpectedError: Bool = false
 
         switch result {
-        case .alreadyRedeemed:
+        case .purchaseBelongsToOtherUser:
             receivedExpectedError = true
         default:
-            XCTFail("Should be a already redeemed error.")
+            XCTFail("Should be a purchase belongs to other user error.")
         }
 
         expect(receivedExpectedError) == true

--- a/Tests/UnitTests/Networking/Backend/BackendPostRedeemWebPurchaseTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostRedeemWebPurchaseTests.swift
@@ -77,9 +77,9 @@ class BackendPostRedeemWebPurchaseTests: BaseBackendTests {
         ))
     }
 
-    func testPostRedeemWebPurchaseReturnsAlreadyRedeemedTokenError() {
-        let backendErrorCode = BackendErrorCode.webPurchaseAlreadyRedeemed
-        let message = "Already redeeemed."
+    func testPostRedeemWebPurchaseReturnsPurchaseBelongsToOtherUserError() {
+        let backendErrorCode = BackendErrorCode.purchaseBelongsToOtherUser
+        let message = "Purchase belongs to other user."
         let errorResponse = ErrorResponse(code: backendErrorCode,
                                           originalCode: backendErrorCode.rawValue,
                                           message: message)
@@ -97,9 +97,9 @@ class BackendPostRedeemWebPurchaseTests: BaseBackendTests {
         expect(result).to(beFailure())
 
         let error: PurchasesError? = result?.error?.asPurchasesError
-        expect(error?.errorCode).to(equal(ErrorCode.alreadyRedeemedWebPurchaseToken.rawValue))
+        expect(error?.errorCode).to(equal(ErrorCode.purchaseBelongsToOtherUser.rawValue))
         expect(error?.localizedDescription).to(equal(
-            "The link you provided has already been redeemed. Already redeeemed."
+            "The web purchase already belongs to other user. Purchase belongs to other user."
         ))
     }
 

--- a/Tests/UnitTests/Purchasing/ErrorCodeTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorCodeTests.swift
@@ -188,8 +188,8 @@ class ErrorCodeTests: TestCase {
                                               expectedRawValue: 39)
     }
 
-    func testAlreadyRedeemedWebPurchaseTokenError() {
-        ensureEnumCaseMatchesExpectedRawValue(errorCode: .alreadyRedeemedWebPurchaseToken,
+    func testPurchaseBelongsToOtherUserError() {
+        ensureEnumCaseMatchesExpectedRawValue(errorCode: .purchaseBelongsToOtherUser,
                                               expectedRawValue: 40)
     }
 


### PR DESCRIPTION
### Description
We decided to rename this redemption result value to better represent the meaning of the result. Note that the API is marked as experimental and the feature is still not enabled in our backend, so it should be ok to rename it.