### PR TITLE
Fix translucent navigation bar on paywalls by making it fully transparent (on iOS 16+)

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -503,12 +503,23 @@ struct LoadedOfferingPaywallView: View {
 
         if self.displayCloseButton {
             NavigationView {
-                view
-                    .toolbar {
-                        self.makeToolbar(
-                            color: self.getCloseButtonColor(configuration: configuration)
-                        )
-                    }
+                // Prevents navigation bar from being showing as translucent
+                if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                    view
+                        .toolbar {
+                            self.makeToolbar(
+                                color: self.getCloseButtonColor(configuration: configuration)
+                            )
+                        }
+                        .toolbarBackground(.hidden, for: .navigationBar)
+                } else {
+                    view
+                        .toolbar {
+                            self.makeToolbar(
+                                color: self.getCloseButtonColor(configuration: configuration)
+                            )
+                        }
+                }
             }
             .navigationViewStyle(.stack)
         } else {


### PR DESCRIPTION
## Motivation

There was a translucent navigation bar on some of the paywall templates when scrolling. We don't want that.

## Description

- Set `.toolbarBackground(.hidden, for: .navigationBar)` (if available)


### Before

https://github.com/user-attachments/assets/74672ead-5ac9-4d97-8362-554479033176

### After

https://github.com/user-attachments/assets/b43c907f-f38c-4a82-a22b-c069063f16ff
