### PR TITLE
[Customer Center] Slight improvement to the Customer Center Promotional Offer view

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -111,7 +111,9 @@ struct PromotionalOfferView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
                     .shadow(radius: 10)
             } else {
-                EmptyView()
+                Color.clear
+                    // keep the same size as the image would have taken to ensure layout still looks good
+                    .frame(width: 100, height: 100)
             }
         }
     }

--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -102,6 +102,7 @@ struct PromotionalOfferView: View {
     }
 
     private struct AppIconView: View {
+
         var body: some View {
             if let appIcon = AppIconHelper.getAppIcon() {
                 Image(uiImage: appIcon)
@@ -116,27 +117,21 @@ struct PromotionalOfferView: View {
                     .frame(width: 70, height: 50)
             }
         }
+
     }
 
     private enum AppIconHelper {
-        static func getAppIcon() -> UIImage? {
-            if let image = UIImage(named: "AppIcon") { return image }
 
+        static func getAppIcon() -> UIImage? {
             guard let iconsDictionary = Bundle.main.infoDictionary?["CFBundleIcons"] as? [String: Any],
                   let primaryIcons = iconsDictionary["CFBundlePrimaryIcon"] as? [String: Any],
-                  let iconFiles = primaryIcons["CFBundleIconFiles"] as? [String] else {
+                  let iconFiles = primaryIcons["CFBundleIconFiles"] as? [String],
+                  let lastIcon = iconFiles.last else {
                 return nil
             }
-
-            // Try to load the @3x version explicitly if available
-            let highestResolutionIcon = iconFiles.last { $0.contains("@3x") } ?? iconFiles.last
-
-            if let highestResolutionIcon = highestResolutionIcon {
-                return UIImage(named: highestResolutionIcon)
-            }
-
-            return nil
+            return UIImage(named: lastIcon)
         }
+
     }
 }
 

--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -62,6 +62,12 @@ struct PromotionalOfferView: View {
 
             VStack {
                 if self.viewModel.error == nil {
+
+                    AppIconView()
+                        .padding(.top, 100)
+                        .padding(.bottom)
+                        .padding(.horizontal)
+
                     PromotionalOfferHeaderView(viewModel: self.viewModel)
 
                     Spacer()
@@ -94,6 +100,33 @@ struct PromotionalOfferView: View {
     ) {
         self.onDismissPromotionalOfferView(action) // Forward results to parent view
     }
+
+    private struct AppIconView: View {
+        var body: some View {
+            if let appIcon = AppIconHelper.getAppIcon() {
+                Image(uiImage: appIcon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 100, height: 100)
+                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                    .shadow(radius: 10)
+            } else {
+                EmptyView()
+            }
+        }
+    }
+
+    private enum AppIconHelper {
+        static func getAppIcon() -> UIImage? {
+            guard let iconsDictionary = Bundle.main.infoDictionary?["CFBundleIcons"] as? [String: Any],
+                  let primaryIcons = iconsDictionary["CFBundlePrimaryIcon"] as? [String: Any],
+                  let iconFiles = primaryIcons["CFBundleIconFiles"] as? [String],
+                  let lastIcon = iconFiles.last else {
+                return nil
+            }
+            return UIImage(named: lastIcon)
+        }
+    }
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -110,7 +143,6 @@ struct PromotionalOfferHeaderView: View {
     private(set) var viewModel: PromotionalOfferViewModel
 
     private let spacing: CGFloat = 30
-    private let topPadding: CGFloat = 150
     private let horizontalPadding: CGFloat = 40
 
     var body: some View {
@@ -121,7 +153,7 @@ struct PromotionalOfferHeaderView: View {
                     .font(.title)
                     .fontWeight(.bold)
                     .multilineTextAlignment(.center)
-                    .padding(.top, topPadding)
+                    .padding(.top)
 
                 Text(details.subtitle)
                     .font(.body)

--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -107,13 +107,13 @@ struct PromotionalOfferView: View {
                 Image(uiImage: appIcon)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 100, height: 100)
-                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                    .frame(width: 70, height: 70)
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                     .shadow(radius: 10)
             } else {
                 Color.clear
                     // keep a size similar to what the image would have occuppied so layout looks correct
-                    .frame(width: 100, height: 50)
+                    .frame(width: 70, height: 50)
             }
         }
     }

--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -112,21 +112,30 @@ struct PromotionalOfferView: View {
                     .shadow(radius: 10)
             } else {
                 Color.clear
-                    // keep the same size as the image would have taken to ensure layout still looks good
-                    .frame(width: 100, height: 100)
+                    // keep a size similar to what the image would have occuppied so layout looks correct
+                    .frame(width: 100, height: 50)
             }
         }
     }
 
     private enum AppIconHelper {
         static func getAppIcon() -> UIImage? {
+            if let image = UIImage(named: "AppIcon") { return image }
+
             guard let iconsDictionary = Bundle.main.infoDictionary?["CFBundleIcons"] as? [String: Any],
                   let primaryIcons = iconsDictionary["CFBundlePrimaryIcon"] as? [String: Any],
-                  let iconFiles = primaryIcons["CFBundleIconFiles"] as? [String],
-                  let lastIcon = iconFiles.last else {
+                  let iconFiles = primaryIcons["CFBundleIconFiles"] as? [String] else {
                 return nil
             }
-            return UIImage(named: lastIcon)
+
+            // Try to load the @3x version explicitly if available
+            let highestResolutionIcon = iconFiles.last { $0.contains("@3x") } ?? iconFiles.last
+
+            if let highestResolutionIcon = highestResolutionIcon {
+                return UIImage(named: highestResolutionIcon)
+            }
+
+            return nil
         }
     }
 }


### PR DESCRIPTION
The promo offer view felt pretty barren. This is a very small update, but I feel like it looks significantly better this way. 

All I'm doing is reading the icon from the bundle if available. If the image cannot be loaded, it looks exactly the same as it used to. 

| Before | After |
| :-: | :-: |
|  <img width="458" alt="Screenshot 2024-12-05 at 6 18 10 PM" src="https://github.com/user-attachments/assets/17cb4292-3d99-445a-9488-0df2242f3a37"> | <img width="470" alt="Screenshot 2024-12-05 at 6 17 30 PM" src="https://github.com/user-attachments/assets/4309904b-80e4-4917-9b28-6bb7a136de1a"> |
| <img width="473" alt="Screenshot 2024-12-05 at 6 22 21 PM" src="https://github.com/user-attachments/assets/01cc736e-aead-48d5-b7b8-966fbf83a375"> | <img width="474" alt="image" src="https://github.com/user-attachments/assets/3fd16e3f-6d75-45ac-b152-9f2ea3cf3ed5"> |

