### PR TITLE
Support non-JSON object decodable values in `getMetadataValue`

### DIFF
--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -310,8 +310,7 @@ extension Offering {
     }
 
     /// - Returns: The `metadata` value associated to `key` for the expected `Decodable` type,
-    /// or `nil` if not found.
-    /// - Throws: Error if the content couldn't be deserialized to the expected type.
+    /// or `nil` if not found or if the content couldn't be deserialized to the expected type..
     /// - Note: This decodes JSON using `JSONDecoder.KeyDecodingStrategy.convertFromSnakeCase`.
     public func getMetadataValue<T: Decodable>(for key: String) -> T? {
         guard let value = self.metadata[key] else { return nil }

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -315,17 +315,13 @@ extension Offering {
     public func getMetadataValue<T: Decodable>(for key: String) -> T? {
         guard let value = self.metadata[key] else { return nil }
 
-        if JSONSerialization.isValidJSONObject(value) {
-            do {
-                let data = try JSONSerialization.data(withJSONObject: value)
-                return try JSONDecoder.default.decode(
-                                T.self,
-                                jsonData: data,
-                                logErrors: true
-                            )
-            } catch {
-                return nil
-            }
+        if JSONSerialization.isValidJSONObject(value),
+            let data = try? JSONSerialization.data(withJSONObject: value) {
+            return try? JSONDecoder.default.decode(
+                            T.self,
+                            jsonData: data,
+                            logErrors: true
+                        )
         } else if let value = value as? T {
             return value
         } else {

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -314,16 +314,22 @@ extension Offering {
     /// - Throws: Error if the content couldn't be deserialized to the expected type.
     /// - Note: This decodes JSON using `JSONDecoder.KeyDecodingStrategy.convertFromSnakeCase`.
     public func getMetadataValue<T: Decodable>(for key: String) -> T? {
-        do {
-            guard let value = self.metadata[key] else { return nil }
-            let data = try JSONSerialization.data(withJSONObject: value)
+        guard let value = self.metadata[key] else { return nil }
 
-            return try JSONDecoder.default.decode(
-                T.self,
-                jsonData: data,
-                logErrors: true
-            )
-        } catch {
+        if JSONSerialization.isValidJSONObject(value) {
+            do {
+                let data = try JSONSerialization.data(withJSONObject: value)
+                return try JSONDecoder.default.decode(
+                                T.self,
+                                jsonData: data,
+                                logErrors: true
+                            )
+            } catch {
+                return nil
+            }
+        } else if let value = value as? T {
+            return value
+        } else {
             return nil
         }
     }

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -310,7 +310,7 @@ extension Offering {
     }
 
     /// - Returns: The `metadata` value associated to `key` for the expected `Decodable` type,
-    /// or `nil` if not found or if the content couldn't be deserialized to the expected type..
+    /// or `nil` if not found or if the content couldn't be deserialized to the expected type.
     /// - Note: This decodes JSON using `JSONDecoder.KeyDecodingStrategy.convertFromSnakeCase`.
     public func getMetadataValue<T: Decodable>(for key: String) -> T? {
         guard let value = self.metadata[key] else { return nil }

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -410,6 +410,18 @@ class OfferingsTests: TestCase {
         let wrongMetadataType = offeringA.getMetadataValue(for: "string", default: 5.5)
         expect(wrongMetadataType) == 5.5
 
+        let intWithoutDefault: Int? = offeringA.getMetadataValue(for: "int")
+        expect(intWithoutDefault) == 5
+
+        let doubleWithoutDefault: Double? = offeringA.getMetadataValue(for: "double")
+        expect(doubleWithoutDefault) == 5.5
+
+        let boolWithoutDefault: Bool? = offeringA.getMetadataValue(for: "boolean")
+        expect(boolWithoutDefault) == true
+
+        let stringWithoutDefault: String? = offeringA.getMetadataValue(for: "string")
+        expect(stringWithoutDefault) == "five"
+
         struct Data: Decodable, Equatable {
             var number: Int
         }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
When fetching an offering metadata value with `getMetadataValue(for:)` (without a default value), a primitive Decodable (like `String`) causes the JSON decoder to crash, as it assumes the value is a JSON object, but it isn't a valid top-level JSON type.

### Description
- Use JSONSerializer's `isValidJSONObject` method before attempting to serialize values
- If it's not a valid JSON object, attempt to return the metadata value as the provided decodable type
