### PR TITLE
Hide mode from public init in `CustomerCenterView`

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -39,8 +39,16 @@ public struct CustomerCenterView: View {
     /// - Parameters:
     ///   - customerCenterActionHandler: An optional `CustomerCenterActionHandler` to handle actions
     ///   from the customer center.
-    public init(customerCenterActionHandler: CustomerCenterActionHandler? = nil,
-                mode: CustomerCenterPresentationMode = CustomerCenterPresentationMode.default) {
+    public init(customerCenterActionHandler: CustomerCenterActionHandler? = nil) {
+        self.init(customerCenterActionHandler: customerCenterActionHandler, mode: .default)
+    }
+
+    /// Create a view to handle common customer support tasks
+    /// - Parameters:
+    ///   - customerCenterActionHandler: An optional `CustomerCenterActionHandler` to handle actions
+    ///   from the customer center.
+    init(customerCenterActionHandler: CustomerCenterActionHandler? = nil,
+         mode: CustomerCenterPresentationMode) {
         self._viewModel = .init(wrappedValue:
                                     CustomerCenterViewModel(customerCenterActionHandler: customerCenterActionHandler))
         self.mode = mode


### PR DESCRIPTION
Hides the `mode` parameter from the public constructor. This is really only used for the `presentCustomerCenterView` functions