### PR TITLE
Customer Center DocC updates

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
 #if os(iOS)
 
-/// Use the Customer Center in your app to help your customers manage their subscriptions on their own.
+/// Use the Customer Center in your app to help your customers manage common support tasks.
 ///
 /// Customer Center is a self-service UI that can be added to your app to help
 /// your customers manage their subscriptions on their own. With it, you can prevent

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -18,9 +18,17 @@ import SwiftUI
 
 #if os(iOS)
 
-/// Warning: This is currently in beta and subject to change.
+/// Use the Customer Center in your app to help your customers manage their subscriptions on their own.
 ///
-/// A SwiftUI view for displaying a customer support common tasks
+/// Customer Center is a self-service UI that can be added to your app to help
+/// your customers manage their subscriptions on their own. With it, you can prevent
+/// churn with pre-emptive promotional offers, capture actionable customer data with
+/// exit feedback prompts, and lower support volumes for common inquiries — all
+/// without any help from your support team.
+///
+/// The `CustomerCenterView` can be used to integrate the Customer Center directly in your app with SwiftUI.
+///
+/// For more information, see the [Customer Center docs](https://www.revenuecat.com/docs/tools/customer-center).
 @available(iOS 15.0, *)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
@@ -38,7 +46,7 @@ public struct CustomerCenterView: View {
     /// Create a view to handle common customer support tasks
     /// - Parameters:
     ///   - customerCenterActionHandler: An optional `CustomerCenterActionHandler` to handle actions
-    ///   from the customer center.
+    ///   from the Customer Center.
     public init(customerCenterActionHandler: CustomerCenterActionHandler? = nil,
                 mode: CustomerCenterPresentationMode = CustomerCenterPresentationMode.default) {
         self._viewModel = .init(wrappedValue:

--- a/RevenueCatUI/CustomerCenter/Views/UIKit Compatibility/CustomerCenterViewController.swift
+++ b/RevenueCatUI/CustomerCenter/Views/UIKit Compatibility/CustomerCenterViewController.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 #if canImport(UIKit) && os(iOS)
 
-/// Use the Customer Center in your app to help your customers manage their subscriptions on their own.
+/// Use the Customer Center in your app to help your customers manage common support tasks.
 ///
 /// Customer Center is a self-service UI that can be added to your app to help
 /// your customers manage their subscriptions on their own. With it, you can prevent

--- a/RevenueCatUI/CustomerCenter/Views/UIKit Compatibility/CustomerCenterViewController.swift
+++ b/RevenueCatUI/CustomerCenter/Views/UIKit Compatibility/CustomerCenterViewController.swift
@@ -16,7 +16,17 @@ import SwiftUI
 
 #if canImport(UIKit) && os(iOS)
 
-/// A UIKit ViewController for displaying a customer support common tasks
+/// Use the Customer Center in your app to help your customers manage their subscriptions on their own.
+///
+/// Customer Center is a self-service UI that can be added to your app to help
+/// your customers manage their subscriptions on their own. With it, you can prevent
+/// churn with pre-emptive promotional offers, capture actionable customer data with
+/// exit feedback prompts, and lower support volumes for common inquiries — all
+/// without any help from your support team.
+///
+/// The `CustomerCenterViewController` can be used to integrate the Customer Center directly in your app with UIKit.
+///
+/// For more information, see the [Customer Center docs](https://www.revenuecat.com/docs/tools/customer-center).
 @available(iOS 15.0, *)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)

--- a/Sources/CustomerCenter/CustomerCenterPresentationMode.swift
+++ b/Sources/CustomerCenter/CustomerCenterPresentationMode.swift
@@ -18,10 +18,10 @@ import Foundation
 /// Presentation options to use with the [presentCustomerCenter](x-source-tag://presentCustomerCenter) View modifiers.
 public enum CustomerCenterPresentationMode {
 
-    /// Customer center presented using SwiftUI's `.sheet`.
+    /// Customer Center presented using SwiftUI's `.sheet`.
     case sheet
 
-    /// Customer center presented using SwiftUI's `.fullScreenCover`.
+    /// Customer Center presented using SwiftUI's `.fullScreenCover`.
     case fullScreen
 
 }

--- a/Sources/CustomerCenter/Events/CustomerCenterEvent.swift
+++ b/Sources/CustomerCenter/Events/CustomerCenterEvent.swift
@@ -18,7 +18,7 @@ public enum CustomerCenterEvent: FeatureEvent {
 
     // swiftlint:disable type_name
 
-    /// An identifier that represents a customer center event.
+    /// An identifier that represents a Customer Center event.
     public typealias ID = UUID
 
     // swiftlint:enable type_name

--- a/Sources/CustomerCenter/Events/CustomerCenterEvent.swift
+++ b/Sources/CustomerCenter/Events/CustomerCenterEvent.swift
@@ -22,9 +22,6 @@ extension CustomerCenterEventType {
 
 }
 
-/// An identifier that represents a Customer Center event.
-public typealias ID = UUID
-
 enum CustomerCenterEventDiscriminator: String {
 
     case lifecycle = "lifecycle"

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1277,7 +1277,7 @@ public extension Purchases {
         }
     }
 
-    /// Used by `RevenueCatUI` to download customer center data
+    /// Used by `RevenueCatUI` to download Customer Center data
     func loadCustomerCenter() async throws -> CustomerCenterConfigData {
         let response = try await Async.call { completion in
             self.backend.customerCenterConfig.getCustomerCenterConfig(appUserID: self.appUserID,


### PR DESCRIPTION
This PR is a follow-up to some comments from https://github.com/RevenueCat/purchases-ios/pull/4560 's review and updates some of the Customer Center's DocC documentation. It:
- Includes a high-level overview of the feature in the DoC for the `CustomerCenterView` and `CustomerCenterViewController` class/structs, taken from the public docs here: https://www.revenuecat.com/docs/tools/customer-center#overview
- Brands the "Customer Center" by changing all references to the feature to be upper cased.