### PR TITLE
Fix wrong discriminator on `CustomerCenterAnswerSubmittedEvent`

### DIFF
--- a/Sources/CustomerCenter/Events/CustomerCenterEvent.swift
+++ b/Sources/CustomerCenter/Events/CustomerCenterEvent.swift
@@ -59,7 +59,7 @@ public enum CustomerCenterEvent: FeatureEvent, CustomerCenterEventType {
 /// An event to be sent by the `RevenueCatUI` SDK.
 public enum CustomerCenterAnswerSubmittedEvent: FeatureEvent, CustomerCenterEventType {
 
-    var eventDiscriminator: String? { CustomerCenterEventDiscriminator.lifecycle.rawValue }
+    var eventDiscriminator: String? { CustomerCenterEventDiscriminator.answerSubmitted.rawValue }
 
     /// A feedback survey was completed with a particular option.
     case answerSubmitted(CustomerCenterEventCreationData, Data)


### PR DESCRIPTION
Made some last minute changes in #4528  and added the wrong discriminator to the `CustomerCenterAnswerSubmittedEvent`