### PR TITLE
Support not showing Contact Customer Support if the user isn't on the most recent app version

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -111,7 +111,7 @@ enum CustomerCenterConfigTestData {
                     "back": "Back"
                 ]
             ),
-            support: .init(email: "test-support@revenuecat.com"),
+            support: .init(email: "test-support@revenuecat.com", shouldWarnCustomerToUpdate: true),
             lastPublishedAppVersion: lastPublishedAppVersion,
             productId: 1
         )

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -116,7 +116,7 @@ enum CustomerCenterConfigTestData {
             ),
             support: .init(
                 email: "test-support@revenuecat.com",
-                shouldWarnCustomerToUpdate: true
+                shouldWarnCustomerToUpdate: shouldWarnCustomerToUpdate
             ),
             lastPublishedAppVersion: lastPublishedAppVersion,
             productId: 1

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -20,7 +20,10 @@ enum CustomerCenterConfigTestData {
 
     @available(iOS 14.0, *)
     // swiftlint:disable:next function_body_length
-    static func customerCenterData(lastPublishedAppVersion: String?) -> CustomerCenterConfigData {
+    static func customerCenterData(
+        lastPublishedAppVersion: String?,
+        shouldWarnCustomerToUpdate: Bool = false
+    ) -> CustomerCenterConfigData {
         CustomerCenterConfigData(
             screens: [.management:
                     .init(
@@ -111,7 +114,10 @@ enum CustomerCenterConfigTestData {
                     "back": "Back"
                 ]
             ),
-            support: .init(email: "test-support@revenuecat.com", shouldWarnCustomerToUpdate: true),
+            support: .init(
+                email: "test-support@revenuecat.com",
+                shouldWarnCustomerToUpdate: true
+            ),
             lastPublishedAppVersion: lastPublishedAppVersion,
             productId: 1
         )

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -44,7 +44,7 @@ import RevenueCat
 
     /// Whether or not the user needs to update their app version to contact support.
     var appUpdateRequiredToContactSupport: Bool {
-        // For now, we're using the same flag as the app update warning.
+        // We're intentionally using the same flag as the app update warning.
         return self.shouldShowAppUpdateWarning
     }
 

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -38,9 +38,14 @@ import RevenueCat
     private(set) var appIsLatestVersion: Bool = defaultAppIsLatestVersion
     private(set) var purchasesProvider: CustomerCenterPurchasesType
 
+    var shouldShowAppUpdateWarning: Bool {
+        return !appIsLatestVersion && (configuration?.support.shouldWarnCustomerToUpdate ?? false)
+    }
+
     /// Whether or not the user needs to update their app version to contact support.
     var appUpdateRequiredToContactSupport: Bool {
-        return !appIsLatestVersion && (configuration?.support.shouldWarnCustomerToUpdate ?? false)
+        // For now, we're using the same flag as the app update warning.
+        return self.shouldShowAppUpdateWarning
     }
 
     // @PublicForExternalTesting

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -38,6 +38,11 @@ import RevenueCat
     private(set) var appIsLatestVersion: Bool = defaultAppIsLatestVersion
     private(set) var purchasesProvider: CustomerCenterPurchasesType
 
+    /// Whether or not the user needs to update their app version to contact support.
+    var appUpdateRequiredToContactSupport: Bool {
+        return !appIsLatestVersion && (configuration?.support.shouldWarnCustomerToUpdate ?? false)
+    }
+
     // @PublicForExternalTesting
     @Published
     var state: CustomerCenterViewState {

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -101,34 +101,35 @@ private extension CustomerCenterView {
 
     @ViewBuilder
     func destinationContent(configuration: CustomerCenterConfigData) -> some View {
-        if viewModel.hasActiveProducts {
-            if viewModel.hasAppleEntitlement,
-               let screen = configuration.screens[.management] {
-                if let productId = configuration.productId, !ignoreAppUpdateWarning && !viewModel.appIsLatestVersion {
-                    AppUpdateWarningView(
-                        productId: productId,
-                        onContinueAnywayClick: {
-                            withAnimation {
-                                ignoreAppUpdateWarning = true
-                            }
-                        }
-                    )
-                } else {
-                    ManageSubscriptionsView(screen: screen,
-                                            customerCenterActionHandler: viewModel.customerCenterActionHandler)
-                }
-            } else {
-                WrongPlatformView()
-            }
-        } else {
-            if let screen = configuration.screens[.noActive] {
-                ManageSubscriptionsView(screen: screen,
-                                        customerCenterActionHandler: viewModel.customerCenterActionHandler)
-            } else {
-                // Fallback with a restore button
-                NoSubscriptionsView(configuration: configuration)
-            }
-        }
+        WrongPlatformView()
+//        if viewModel.hasActiveProducts {
+//            if viewModel.hasAppleEntitlement,
+//               let screen = configuration.screens[.management] {
+//                if let productId = configuration.productId, !ignoreAppUpdateWarning && !viewModel.appIsLatestVersion {
+//                    AppUpdateWarningView(
+//                        productId: productId,
+//                        onContinueAnywayClick: {
+//                            withAnimation {
+//                                ignoreAppUpdateWarning = true
+//                            }
+//                        }
+//                    )
+//                } else {
+//                    ManageSubscriptionsView(screen: screen,
+//                                            customerCenterActionHandler: viewModel.customerCenterActionHandler)
+//                }
+//            } else {
+//                WrongPlatformView()
+//            }
+//        } else {
+//            if let screen = configuration.screens[.noActive] {
+//                ManageSubscriptionsView(screen: screen,
+//                                        customerCenterActionHandler: viewModel.customerCenterActionHandler)
+//            } else {
+//                // Fallback with a restore button
+//                NoSubscriptionsView(configuration: configuration)
+//            }
+//        }
     }
 
     @ViewBuilder

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -101,35 +101,34 @@ private extension CustomerCenterView {
 
     @ViewBuilder
     func destinationContent(configuration: CustomerCenterConfigData) -> some View {
-        WrongPlatformView()
-//        if viewModel.hasActiveProducts {
-//            if viewModel.hasAppleEntitlement,
-//               let screen = configuration.screens[.management] {
-//                if let productId = configuration.productId, !ignoreAppUpdateWarning && !viewModel.appIsLatestVersion {
-//                    AppUpdateWarningView(
-//                        productId: productId,
-//                        onContinueAnywayClick: {
-//                            withAnimation {
-//                                ignoreAppUpdateWarning = true
-//                            }
-//                        }
-//                    )
-//                } else {
-//                    ManageSubscriptionsView(screen: screen,
-//                                            customerCenterActionHandler: viewModel.customerCenterActionHandler)
-//                }
-//            } else {
-//                WrongPlatformView()
-//            }
-//        } else {
-//            if let screen = configuration.screens[.noActive] {
-//                ManageSubscriptionsView(screen: screen,
-//                                        customerCenterActionHandler: viewModel.customerCenterActionHandler)
-//            } else {
-//                // Fallback with a restore button
-//                NoSubscriptionsView(configuration: configuration)
-//            }
-//        }
+        if viewModel.hasActiveProducts {
+            if viewModel.hasAppleEntitlement,
+               let screen = configuration.screens[.management] {
+                if let productId = configuration.productId, !ignoreAppUpdateWarning && !viewModel.appIsLatestVersion {
+                    AppUpdateWarningView(
+                        productId: productId,
+                        onContinueAnywayClick: {
+                            withAnimation {
+                                ignoreAppUpdateWarning = true
+                            }
+                        }
+                    )
+                } else {
+                    ManageSubscriptionsView(screen: screen,
+                                            customerCenterActionHandler: viewModel.customerCenterActionHandler)
+                }
+            } else {
+                WrongPlatformView()
+            }
+        } else {
+            if let screen = configuration.screens[.noActive] {
+                ManageSubscriptionsView(screen: screen,
+                                        customerCenterActionHandler: viewModel.customerCenterActionHandler)
+            } else {
+                // Fallback with a restore button
+                NoSubscriptionsView(configuration: configuration)
+            }
+        }
     }
 
     @ViewBuilder

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -104,7 +104,8 @@ private extension CustomerCenterView {
         if viewModel.hasActiveProducts {
             if viewModel.hasAppleEntitlement,
                let screen = configuration.screens[.management] {
-                if let productId = configuration.productId, !ignoreAppUpdateWarning && !viewModel.appIsLatestVersion {
+                if let productId = configuration.productId,
+                    !ignoreAppUpdateWarning && viewModel.shouldShowAppUpdateWarning {
                     AppUpdateWarningView(
                         productId: productId,
                         onContinueAnywayClick: {

--- a/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
@@ -83,7 +83,7 @@ struct RestorePurchasesAlert: ViewModifier {
 
                 case .purchasesNotFound:
                     let message = Text(localization.commonLocalizedString(for: .purchasesNotRecovered))
-                    if let url = supportURL {
+                    if let url = supportURL, !customerCenterViewModel.appUpdateRequiredToContactSupport {
                         return Alert(title: Text(""),
                                      message: message,
                                      primaryButton: .default(

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -32,6 +32,9 @@ struct WrongPlatformView: View {
     @State
     private var subscriptionInformation: PurchaseInformation?
 
+    @EnvironmentObject
+    private var customerCenterViewModel: CustomerCenterViewModel
+
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
     @Environment(\.appearance)
@@ -80,7 +83,7 @@ struct WrongPlatformView: View {
                     }
                 }
             }
-            if let url = supportURL {
+            if let url = supportURL, !customerCenterViewModel.appUpdateRequiredToContactSupport {
                 Section {
                     AsyncButton {
                         openURL(url)

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -412,9 +412,14 @@ public struct CustomerCenterConfigData {
     public struct Support {
 
         public let email: String
+        public let shouldWarnCustomerToUpdate: Bool
 
-        public init(email: String) {
+        public init(
+            email: String,
+            shouldWarnCustomerToUpdate: Bool
+        ) {
             self.email = email
+            self.shouldWarnCustomerToUpdate = shouldWarnCustomerToUpdate
         }
 
     }
@@ -550,6 +555,7 @@ extension CustomerCenterConfigData.Support {
 
     init(from response: CustomerCenterConfigResponse.Support) {
         self.email = response.email
+        self.shouldWarnCustomerToUpdate = response.shouldWarnCustomerToUpdate ?? false
     }
 
 }

--- a/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
+++ b/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
@@ -134,11 +134,6 @@ struct CustomerCenterConfigResponse {
         let email: String
         let shouldWarnCustomerToUpdate: Bool?
 
-//        enum CodingKeys: String, CodingKey {
-//            case email = "email"
-//            case shouldWarnCustomerToUpdate = "should_warn_customer_to_update"
-//        }
-
     }
 
 }

--- a/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
+++ b/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
@@ -132,6 +132,12 @@ struct CustomerCenterConfigResponse {
     struct Support {
 
         let email: String
+        let shouldWarnCustomerToUpdate: Bool?
+
+//        enum CodingKeys: String, CodingKey {
+//            case email = "email"
+//            case shouldWarnCustomerToUpdate = "should_warn_customer_to_update"
+//        }
 
     }
 

--- a/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
@@ -18,7 +18,10 @@ import XCTest
 
 class ContactSupportUtilitiesTest: TestCase {
 
-    private let support: CustomerCenterConfigData.Support = .init(email: "support@example.com")
+    private let support: CustomerCenterConfigData.Support = .init(
+        email: "support@example.com",
+        shouldWarnCustomerToUpdate: false
+    )
     private let localization: CustomerCenterConfigData.Localization = .init(locale: "en_US", localizedStrings: [:])
 
     func testSupportEmailBodyWithDefaultDataIsCorrect() {

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -20,6 +20,7 @@ import XCTest
 
 #if os(iOS)
 
+// swiftlint:disable file_length
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
@@ -216,6 +217,55 @@ class CustomerCenterViewModelTests: TestCase {
         if case .impression = trackedEvent {} else {
             fail("Expected an impression event")
         }
+    }
+
+    func testAppUpdateRequiredToContactSupport_true() {
+        let mockPurchases = MockCustomerCenterPurchases()
+        let latestVersion = "3.0.0"
+        let currentVersion = "2.0.0"
+        let viewModel = CustomerCenterViewModel(
+            customerCenterActionHandler: nil,
+            currentVersionFetcher: { return currentVersion },
+            purchasesProvider: mockPurchases
+        )
+        viewModel.configuration = CustomerCenterConfigTestData.customerCenterData(
+            lastPublishedAppVersion: latestVersion,
+            shouldWarnCustomerToUpdate: true
+        )
+
+        expect(viewModel.appUpdateRequiredToContactSupport).to(beTrue())
+    }
+
+    func testAppUpdateRequiredToContactSupport_false() {
+        let mockPurchases = MockCustomerCenterPurchases()
+        let latestVersion = "3.0.0"
+        let viewModel = CustomerCenterViewModel(
+            customerCenterActionHandler: nil,
+            currentVersionFetcher: { return latestVersion },
+            purchasesProvider: mockPurchases
+        )
+        viewModel.configuration = CustomerCenterConfigTestData.customerCenterData(
+            lastPublishedAppVersion: latestVersion,
+            shouldWarnCustomerToUpdate: true
+        )
+
+        expect(viewModel.appUpdateRequiredToContactSupport).to(beFalse())
+    }
+
+    func testAppUpdateRequiredToContactSupport_false_blocked_by_config() {
+        let mockPurchases = MockCustomerCenterPurchases()
+        let latestVersion = "3.0.0"
+        let viewModel = CustomerCenterViewModel(
+            customerCenterActionHandler: nil,
+            currentVersionFetcher: { return latestVersion },
+            purchasesProvider: mockPurchases
+        )
+        viewModel.configuration = CustomerCenterConfigTestData.customerCenterData(
+            lastPublishedAppVersion: latestVersion,
+            shouldWarnCustomerToUpdate: true
+        )
+
+        expect(viewModel.appUpdateRequiredToContactSupport).to(beFalse())
     }
 
 }

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -219,7 +219,7 @@ class CustomerCenterViewModelTests: TestCase {
         }
     }
 
-    func testAppUpdateRequiredToContactSupport_true() {
+    func testAppUpdateRequiredToContactSupportTrue() {
         let mockPurchases = MockCustomerCenterPurchases()
         let latestVersion = "3.0.0"
         let currentVersion = "2.0.0"
@@ -236,7 +236,7 @@ class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.appUpdateRequiredToContactSupport).to(beTrue())
     }
 
-    func testAppUpdateRequiredToContactSupport_false() {
+    func testAppUpdateRequiredToContactSupportFalse() {
         let mockPurchases = MockCustomerCenterPurchases()
         let latestVersion = "3.0.0"
         let viewModel = CustomerCenterViewModel(
@@ -252,7 +252,7 @@ class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.appUpdateRequiredToContactSupport).to(beFalse())
     }
 
-    func testAppUpdateRequiredToContactSupport_false_blocked_by_config() {
+    func testAppUpdateRequiredToContactSupportReturnsFalseIfBlockedByConfig() {
         let mockPurchases = MockCustomerCenterPurchases()
         let latestVersion = "3.0.0"
         let viewModel = CustomerCenterViewModel(

--- a/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
+++ b/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
@@ -106,7 +106,10 @@ class CustomerCenterConfigDataTests: TestCase {
                     )
                 ],
                 localization: .init(locale: "en_US", localizedStrings: ["key": "value"]),
-                support: .init(email: "support@example.com")
+                support: .init(
+                    email: "support@example.com",
+                    shouldWarnCustomerToUpdate: false
+                )
             ),
             lastPublishedAppVersion: "1.2.3",
             itunesTrackId: 123

--- a/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
+++ b/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
@@ -181,6 +181,8 @@ class CustomerCenterConfigDataTests: TestCase {
 
         expect(configData.lastPublishedAppVersion) == "1.2.3"
         expect(configData.productId) == 123
+
+        expect(configData.support.shouldWarnCustomerToUpdate) == false
     }
 
     func testUnknownValuesHandling() throws {


### PR DESCRIPTION
### Description
This PR updates the Customer Center to support the "Require users to update to the latest version of your app before contacting support" checkbox in the dashboard. The checkbox now controls:
- Whether users must be on the most recent app version to contact support
- Whether the `AppUpdateWarningView` is shown when the Customer Center is shown and the user is on an old app version

### Testing
- Tested manually
- Added unit tests for the new `CustomerCenterViewModel.appUpdateRequiredToContactSupport`
