### PR TITLE
[Paywalls] Fix iOS 13/14 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1491,4 +1491,5 @@ workflows:
       - api-tests
       - deploy-purchase-tester:
           dry_run: true
+      - emerge_purchases_ui_snapshot_tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1491,5 +1491,4 @@ workflows:
       - api-tests
       - deploy-purchase-tester:
           dry_run: true
-      - emerge_purchases_ui_snapshot_tests
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
     {
       "identity" : "snapshotpreviews",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/EmergeTools/SnapshotPreviews",
+      "location" : "https://github.com/EmergeTools/SnapshotPreviews.git",
       "state" : {
-        "revision" : "cdbf9cc5cb63a88f1329b958428f9706a6af557e",
-        "version" : "0.10.18"
+        "revision" : "e29969072e600518867af25d4d2acd0d1d2ffd5f",
+        "version" : "0.10.20"
       }
     },
     {

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1651,6 +1651,7 @@
 		4D322E372B7E7B170004AF53 /* PurchasesOrchestratorSK2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesOrchestratorSK2Tests.swift; sourceTree = "<group>"; };
 		4D322E392B7E7B570004AF53 /* PurchasesOrchestratorSK1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesOrchestratorSK1Tests.swift; sourceTree = "<group>"; };
 		4D322E3B2B7E7E250004AF53 /* PurchasesOrchestratorCommonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesOrchestratorCommonTests.swift; sourceTree = "<group>"; };
+		4D4CADED2D09B06C004E85B7 /* SnapshotTestingStub */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SnapshotTestingStub; sourceTree = "<group>"; };
 		4D6ABB0B2AF13F9400BB2A08 /* StoreKit2Receipt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreKit2Receipt.swift; sourceTree = "<group>"; };
 		4D6ABB0D2AF13FB100BB2A08 /* StoreEnvironment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreEnvironment.swift; sourceTree = "<group>"; };
 		4D6ABB0F2AF13FBD00BB2A08 /* SK2AppTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SK2AppTransaction.swift; sourceTree = "<group>"; };
@@ -3028,6 +3029,7 @@
 				2DD500402C519EB4009C19B7 /* ci_scripts */,
 				2DD5008E2C519EB4009C19B7 /* PaywallsTester */,
 				4D6F4BE62CFE2FAB00353AF6 /* PaywallsTesterTests */,
+				4D4CADED2D09B06C004E85B7 /* SnapshotTestingStub */,
 				2DD5008F2C519EB4009C19B7 /* PaywallsTester.xcodeproj */,
 				2DD500902C519EB4009C19B7 /* PaywallsTester.xcworkspace */,
 				2DD500912C519EB4009C19B7 /* Postprocessor.sh */,

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2DBCEDFD2AC4BC060064C274 /* PaywallViewMode+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBCEDFC2AC4BC060064C274 /* PaywallViewMode+Extensions.swift */; };
+		4D5E92D92D09B09B0067D908 /* SnapshotTestingStub in Frameworks */ = {isa = PBXBuildFile; productRef = 4D5E92D82D09B09B0067D908 /* SnapshotTestingStub */; };
 		4F102E272A840ECC0059EED6 /* CustomPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F102E262A840ECC0059EED6 /* CustomPaywall.swift */; };
 		4F217A102A6DB6FB000B092D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4FC046BF2A572E3700A28BCF /* Assets.xcassets */; };
 		4F34FF632A60AD9A00AADF11 /* AppContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F34FF622A60AD9A00AADF11 /* AppContentView.swift */; };
@@ -58,7 +59,6 @@
 		88DFC1932BCF490400273B6D /* OfferingsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC1922BCF490400273B6D /* OfferingsResponse.swift */; };
 		88DFC1942BCF490400273B6D /* PaywallsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC1912BCF490400273B6D /* PaywallsResponse.swift */; };
 		88DFC1972BCF4A5100273B6D /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC1952BCF4A4300273B6D /* MockData.swift */; };
-		FA29FBB22CCAA7A500DA1976 /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = FA29FBB12CCAA7A500DA1976 /* SnapshottingTests */; };
 		FD33CD622D0351BE000D13A4 /* CustomerCenterUIKitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD33CD612D0351BE000D13A4 /* CustomerCenterUIKitView.swift */; };
 /* End PBXBuildFile section */
 
@@ -88,6 +88,7 @@
 /* Begin PBXFileReference section */
 		2DBCEDFC2AC4BC060064C274 /* PaywallViewMode+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaywallViewMode+Extensions.swift"; sourceTree = "<group>"; };
 		4D2E84DB2D00EDA100C639D9 /* PaywallsTesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallsTesterTests.swift; sourceTree = "<group>"; };
+		4D5E92F82D09B21B0067D908 /* SnapshotTestingStub */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SnapshotTestingStub; sourceTree = "<group>"; };
 		4F0B5EA02A97CD9300DB0FC9 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4F0B5EA12A97CDAC00DB0FC9 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4F102E262A840ECC0059EED6 /* CustomPaywall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPaywall.swift; sourceTree = "<group>"; };
@@ -170,7 +171,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA29FBB22CCAA7A500DA1976 /* SnapshottingTests in Frameworks */,
+				4D5E92D92D09B09B0067D908 /* SnapshotTestingStub in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -202,6 +203,7 @@
 				4F4EE7D02A5731CF00D7EAE1 /* purchases-ios */,
 				4FC046BB2A572E3700A28BCF /* PaywallsTester */,
 				4D2E84DC2D00EDA100C639D9 /* PaywallsTesterTests */,
+				4D5E92F82D09B21B0067D908 /* SnapshotTestingStub */,
 				4F6BED9B2A26A64200CD9322 /* Products */,
 				4F6BEDCC2A26A68E00CD9322 /* Frameworks */,
 			);
@@ -420,7 +422,7 @@
 			);
 			name = PaywallsTesterTests;
 			packageProductDependencies = (
-				FA29FBB12CCAA7A500DA1976 /* SnapshottingTests */,
+				4D5E92D82D09B09B0067D908 /* SnapshotTestingStub */,
 			);
 			productName = PaywallsTesterTests;
 			productReference = FA29FBA82CCAA79800DA1976 /* PaywallsTesterTests.xctest */;
@@ -461,7 +463,6 @@
 			);
 			mainGroup = 4F6BED912A26A64200CD9322;
 			packageReferences = (
-				FA29FBA12CCAA76E00DA1976 /* XCRemoteSwiftPackageReference "SnapshotPreviews" */,
 			);
 			productRefGroup = 4F6BED9B2A26A64200CD9322 /* Products */;
 			projectDirPath = "";
@@ -873,18 +874,11 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		FA29FBA12CCAA76E00DA1976 /* XCRemoteSwiftPackageReference "SnapshotPreviews" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/EmergeTools/SnapshotPreviews";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.10.16;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
+		4D5E92D82D09B09B0067D908 /* SnapshotTestingStub */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SnapshotTestingStub;
+		};
 		4F4EE7D12A5731E800D7EAE1 /* RevenueCat */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = RevenueCat;
@@ -892,11 +886,6 @@
 		4FC80B1F2A5DE8E300E95DB0 /* RevenueCatUI */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = RevenueCatUI;
-		};
-		FA29FBB12CCAA7A500DA1976 /* SnapshottingTests */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = FA29FBA12CCAA76E00DA1976 /* XCRemoteSwiftPackageReference "SnapshotPreviews" */;
-			productName = SnapshottingTests;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/TestingApps/PaywallsTester/SnapshotTestingStub/.gitignore
+++ b/Tests/TestingApps/PaywallsTester/SnapshotTestingStub/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/TestingApps/PaywallsTester/SnapshotTestingStub/Package.swift
+++ b/Tests/TestingApps/PaywallsTester/SnapshotTestingStub/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SnapshotTestingStub",
+    platforms: [.iOS(.v15), .macOS(.v12), .watchOS(.v9)],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "SnapshotTestingStub",
+            targets: ["SnapshotTestingStub"]),
+    ],
+    // Why is SnapshotTestingStub needed?
+    //
+    // At the time of the writing, we still support iOS 13 and iOS 14, which need macOS 12 to run tests in the simulator.
+    // CircleCI bundles Xcode 14.2 with the macOS 12 image, which comes with Swift 5.7.
+    // Emerge's SnapshotPreviews package currently has a dependency on the https://github.com/swhitty/FlyingFox package version 0.16 which requires Swift 5.8.
+    // When we open Revenuecat.xcodeproj in Xcode 14.2, it tries to pull all dependencies, including SnapshotPreviews, and fails to build because of the FlyingFox dependency.
+    // This prevents us from running tests in the iOS 13 and iOS 14 simulators.
+    // It is not possible to add a package to an Xcode project conditionally on the Swift version used, but we can create a stub package that only depends on SnapshotPreviews,
+    // and only pulls the dependency for Swift 5.8.
+    dependencies: [
+        .package(url: "https://github.com/EmergeTools/SnapshotPreviews.git", .upToNextMajor(from: "0.10.20")),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "SnapshotTestingStub", dependencies: [.product(name: "SnapshottingTests", package: "SnapshotPreviews")]),
+
+    ]
+)

--- a/Tests/TestingApps/PaywallsTester/SnapshotTestingStub/Package@swift-5.7.swift
+++ b/Tests/TestingApps/PaywallsTester/SnapshotTestingStub/Package@swift-5.7.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SnapshotTestingStub",
+    platforms: [.iOS(.v15), .macOS(.v12), .watchOS(.v9)],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(name: "SnapshotTestingStub", targets: ["SnapshotTestingStub"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(name: "SnapshotTestingStub"),
+    ]
+)

--- a/Tests/TestingApps/PaywallsTester/SnapshotTestingStub/Sources/SnapshotTestingStub/SnapshotTestingStub.swift
+++ b/Tests/TestingApps/PaywallsTester/SnapshotTestingStub/Sources/SnapshotTestingStub/SnapshotTestingStub.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -74,13 +74,13 @@ Creates PR changing version to next minor adding a -SNAPSHOT suffix
 
 Setup development environment
 
-### ios build_paywalls_test
+### ios build_paywalls_tester_for_emerge
 
 ```sh
-[bundle exec] fastlane ios build_paywalls_test
+[bundle exec] fastlane ios build_paywalls_tester_for_emerge
 ```
 
-Builds the Paywalls Test app
+Build the Paywalls Test app for Emerge Snapshots
 
 ### ios test_ios
 


### PR DESCRIPTION
This PR fixes running iOS 13/14 tests with Xcode 14 by removing the direct dependency on the `SnapshotPreviews` package and instead depending on it through a `SnapshotTestingStub` package.

Why is SnapshotTestingStub needed?

At the time of the writing, we still support iOS 13 and iOS 14, which need macOS 12 to run tests in the simulator.
CircleCI bundles Xcode 14.2 with the macOS 12 image, which comes with Swift 5.7.
Emerge's SnapshotPreviews package currently has a dependency on the https://github.com/swhitty/FlyingFox package version 0.16 which requires Swift 5.8.
When we open Revenuecat.xcodeproj in Xcode 14.2, it tries to pull all dependencies, including SnapshotPreviews, and fails to build because of the FlyingFox dependency.
This prevents us from running tests in the iOS 13 and iOS 14 simulators.
It is not possible to add a package to an Xcode project conditionally on the Swift version used, but we can create a stub package that only depends on SnapshotPreviews,
and only pulls the dependency for Swift 5.8.