### PR TITLE
Support toggling update warnings & show update in restore flow

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -111,7 +111,7 @@ enum CustomerCenterConfigTestData {
                     "back": "Back"
                 ]
             ),
-            support: .init(email: "test-support@revenuecat.com"),
+            support: .init(email: "test-support@revenuecat.com", shouldWarnCustomerToUpdate: true),
             lastPublishedAppVersion: lastPublishedAppVersion,
             productId: 1
         )

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -116,7 +116,7 @@ enum CustomerCenterConfigTestData {
             ),
             support: .init(
                 email: "test-support@revenuecat.com",
-                shouldWarnCustomerToUpdate: true
+                shouldWarnCustomerToUpdate: shouldWarnCustomerToUpdate
             ),
             lastPublishedAppVersion: lastPublishedAppVersion,
             productId: 1

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -20,7 +20,10 @@ enum CustomerCenterConfigTestData {
 
     @available(iOS 14.0, *)
     // swiftlint:disable:next function_body_length
-    static func customerCenterData(lastPublishedAppVersion: String?) -> CustomerCenterConfigData {
+    static func customerCenterData(
+        lastPublishedAppVersion: String?,
+        shouldWarnCustomerToUpdate: Bool = false
+    ) -> CustomerCenterConfigData {
         CustomerCenterConfigData(
             screens: [.management:
                     .init(
@@ -111,7 +114,10 @@ enum CustomerCenterConfigTestData {
                     "back": "Back"
                 ]
             ),
-            support: .init(email: "test-support@revenuecat.com", shouldWarnCustomerToUpdate: true),
+            support: .init(
+                email: "test-support@revenuecat.com",
+                shouldWarnCustomerToUpdate: true
+            ),
             lastPublishedAppVersion: lastPublishedAppVersion,
             productId: 1
         )

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -44,7 +44,7 @@ import RevenueCat
 
     /// Whether or not the user needs to update their app version to contact support.
     var appUpdateRequiredToContactSupport: Bool {
-        // For now, we're using the same flag as the app update warning.
+        // We're intentionally using the same flag as the app update warning.
         return self.shouldShowAppUpdateWarning
     }
 

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -38,9 +38,14 @@ import RevenueCat
     private(set) var appIsLatestVersion: Bool = defaultAppIsLatestVersion
     private(set) var purchasesProvider: CustomerCenterPurchasesType
 
+    var shouldShowAppUpdateWarning: Bool {
+        return !appIsLatestVersion && (configuration?.support.shouldWarnCustomerToUpdate ?? false)
+    }
+
     /// Whether or not the user needs to update their app version to contact support.
     var appUpdateRequiredToContactSupport: Bool {
-        return !appIsLatestVersion && (configuration?.support.shouldWarnCustomerToUpdate ?? false)
+        // For now, we're using the same flag as the app update warning.
+        return self.shouldShowAppUpdateWarning
     }
 
     // @PublicForExternalTesting

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -38,6 +38,7 @@ import RevenueCat
     private(set) var appIsLatestVersion: Bool = defaultAppIsLatestVersion
     private(set) var purchasesProvider: CustomerCenterPurchasesType
 
+    @Published
     private(set) var onUpdateAppClick: (() -> Void)?
 
     /// Whether or not the Customer Center should warn the customer that they're on an outdated version of the app.

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -43,7 +43,7 @@ import RevenueCat
 
     /// Whether or not the Customer Center should warn the customer that they're on an outdated version of the app.
     var shouldShowAppUpdateWarnings: Bool {
-        return !appIsLatestVersion && (configuration?.support.shouldWarnCustomerToUpdate ?? false)
+        return !appIsLatestVersion && (configuration?.support.shouldWarnCustomerToUpdate ?? true)
     }
 
     // @PublicForExternalTesting

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -38,6 +38,11 @@ import RevenueCat
     private(set) var appIsLatestVersion: Bool = defaultAppIsLatestVersion
     private(set) var purchasesProvider: CustomerCenterPurchasesType
 
+    /// Whether or not the user needs to update their app version to contact support.
+    var appUpdateRequiredToContactSupport: Bool {
+        return !appIsLatestVersion && (configuration?.support.shouldWarnCustomerToUpdate ?? false)
+    }
+
     // @PublicForExternalTesting
     @Published
     var state: CustomerCenterViewState {

--- a/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
@@ -29,17 +29,6 @@ struct AppUpdateWarningView: View {
         self.onContinueAnywayClick = onContinueAnywayClick
     }
 
-    init(productId: UInt, onContinueAnywayClick: @escaping () -> Void) {
-        self.init(
-            onUpdateAppClick: {
-                // productId is a positive integer, so it should be safe to construct a URL from it.
-                let url = URL(string: "https://itunes.apple.com/app/id\(productId)")!
-                URLUtilities.openURLIfNotAppExtension(url)
-            },
-            onContinueAnywayClick: onContinueAnywayClick
-        )
-    }
-
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
     @Environment(\.appearance)

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -101,34 +101,35 @@ private extension CustomerCenterView {
 
     @ViewBuilder
     func destinationContent(configuration: CustomerCenterConfigData) -> some View {
-        if viewModel.hasActiveProducts {
-            if viewModel.hasAppleEntitlement,
-               let screen = configuration.screens[.management] {
-                if let productId = configuration.productId, !ignoreAppUpdateWarning && !viewModel.appIsLatestVersion {
-                    AppUpdateWarningView(
-                        productId: productId,
-                        onContinueAnywayClick: {
-                            withAnimation {
-                                ignoreAppUpdateWarning = true
-                            }
-                        }
-                    )
-                } else {
-                    ManageSubscriptionsView(screen: screen,
-                                            customerCenterActionHandler: viewModel.customerCenterActionHandler)
-                }
-            } else {
-                WrongPlatformView()
-            }
-        } else {
-            if let screen = configuration.screens[.noActive] {
-                ManageSubscriptionsView(screen: screen,
-                                        customerCenterActionHandler: viewModel.customerCenterActionHandler)
-            } else {
-                // Fallback with a restore button
-                NoSubscriptionsView(configuration: configuration)
-            }
-        }
+        WrongPlatformView()
+//        if viewModel.hasActiveProducts {
+//            if viewModel.hasAppleEntitlement,
+//               let screen = configuration.screens[.management] {
+//                if let productId = configuration.productId, !ignoreAppUpdateWarning && !viewModel.appIsLatestVersion {
+//                    AppUpdateWarningView(
+//                        productId: productId,
+//                        onContinueAnywayClick: {
+//                            withAnimation {
+//                                ignoreAppUpdateWarning = true
+//                            }
+//                        }
+//                    )
+//                } else {
+//                    ManageSubscriptionsView(screen: screen,
+//                                            customerCenterActionHandler: viewModel.customerCenterActionHandler)
+//                }
+//            } else {
+//                WrongPlatformView()
+//            }
+//        } else {
+//            if let screen = configuration.screens[.noActive] {
+//                ManageSubscriptionsView(screen: screen,
+//                                        customerCenterActionHandler: viewModel.customerCenterActionHandler)
+//            } else {
+//                // Fallback with a restore button
+//                NoSubscriptionsView(configuration: configuration)
+//            }
+//        }
     }
 
     @ViewBuilder

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -101,35 +101,34 @@ private extension CustomerCenterView {
 
     @ViewBuilder
     func destinationContent(configuration: CustomerCenterConfigData) -> some View {
-        WrongPlatformView()
-//        if viewModel.hasActiveProducts {
-//            if viewModel.hasAppleEntitlement,
-//               let screen = configuration.screens[.management] {
-//                if let productId = configuration.productId, !ignoreAppUpdateWarning && !viewModel.appIsLatestVersion {
-//                    AppUpdateWarningView(
-//                        productId: productId,
-//                        onContinueAnywayClick: {
-//                            withAnimation {
-//                                ignoreAppUpdateWarning = true
-//                            }
-//                        }
-//                    )
-//                } else {
-//                    ManageSubscriptionsView(screen: screen,
-//                                            customerCenterActionHandler: viewModel.customerCenterActionHandler)
-//                }
-//            } else {
-//                WrongPlatformView()
-//            }
-//        } else {
-//            if let screen = configuration.screens[.noActive] {
-//                ManageSubscriptionsView(screen: screen,
-//                                        customerCenterActionHandler: viewModel.customerCenterActionHandler)
-//            } else {
-//                // Fallback with a restore button
-//                NoSubscriptionsView(configuration: configuration)
-//            }
-//        }
+        if viewModel.hasActiveProducts {
+            if viewModel.hasAppleEntitlement,
+               let screen = configuration.screens[.management] {
+                if let productId = configuration.productId, !ignoreAppUpdateWarning && !viewModel.appIsLatestVersion {
+                    AppUpdateWarningView(
+                        productId: productId,
+                        onContinueAnywayClick: {
+                            withAnimation {
+                                ignoreAppUpdateWarning = true
+                            }
+                        }
+                    )
+                } else {
+                    ManageSubscriptionsView(screen: screen,
+                                            customerCenterActionHandler: viewModel.customerCenterActionHandler)
+                }
+            } else {
+                WrongPlatformView()
+            }
+        } else {
+            if let screen = configuration.screens[.noActive] {
+                ManageSubscriptionsView(screen: screen,
+                                        customerCenterActionHandler: viewModel.customerCenterActionHandler)
+            } else {
+                // Fallback with a restore button
+                NoSubscriptionsView(configuration: configuration)
+            }
+        }
     }
 
     @ViewBuilder

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -104,10 +104,10 @@ private extension CustomerCenterView {
         if viewModel.hasActiveProducts {
             if viewModel.hasAppleEntitlement,
                let screen = configuration.screens[.management] {
-                if let productId = configuration.productId,
-                    !ignoreAppUpdateWarning && viewModel.shouldShowAppUpdateWarning {
+                if let onUpdateAppClick = viewModel.onUpdateAppClick,
+                    !ignoreAppUpdateWarning && viewModel.shouldShowAppUpdateWarnings {
                     AppUpdateWarningView(
-                        productId: productId,
+                        onUpdateAppClick: onUpdateAppClick,
                         onContinueAnywayClick: {
                             withAnimation {
                                 ignoreAppUpdateWarning = true

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -104,7 +104,8 @@ private extension CustomerCenterView {
         if viewModel.hasActiveProducts {
             if viewModel.hasAppleEntitlement,
                let screen = configuration.screens[.management] {
-                if let productId = configuration.productId, !ignoreAppUpdateWarning && !viewModel.appIsLatestVersion {
+                if let productId = configuration.productId,
+                    !ignoreAppUpdateWarning && viewModel.shouldShowAppUpdateWarning {
                     AppUpdateWarningView(
                         productId: productId,
                         onContinueAnywayClick: {

--- a/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
@@ -83,7 +83,7 @@ struct RestorePurchasesAlert: ViewModifier {
 
                 case .purchasesNotFound:
                     let message = Text(localization.commonLocalizedString(for: .purchasesNotRecovered))
-                    if let url = supportURL {
+                    if let url = supportURL, !customerCenterViewModel.appUpdateRequiredToContactSupport {
                         return Alert(title: Text(""),
                                      message: message,
                                      primaryButton: .default(

--- a/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
@@ -116,6 +116,7 @@ struct RestorePurchasesAlert: ViewModifier {
                 onUpdateAppClick()
             } label: {
                 Text(localization.commonLocalizedString(for: .updateWarningUpdate))
+                    .bold()
             }
         }
 

--- a/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
@@ -90,7 +90,7 @@ struct RestorePurchasesAlert: ViewModifier {
         }
 
         Button(role: .cancel) {
-            self.isPresented = false
+            dismissAlert()
         } label: {
             Text(localization.commonLocalizedString(for: .cancel))
         }
@@ -100,7 +100,7 @@ struct RestorePurchasesAlert: ViewModifier {
     // swiftlint:disable:next identifier_name
     private func PurchasesRecoveredActions() -> some View {
         Button(role: .cancel) {
-            self.isPresented = false
+            dismissAlert()
         } label: {
             Text(localization.commonLocalizedString(for: .dismiss))
         }
@@ -131,7 +131,7 @@ struct RestorePurchasesAlert: ViewModifier {
         }
 
         Button(role: .cancel) {
-            self.isPresented = false
+            dismissAlert()
         } label: {
             Text(localization.commonLocalizedString(for: .dismiss))
         }
@@ -162,6 +162,11 @@ struct RestorePurchasesAlert: ViewModifier {
         case .restorePurchases:
             return localization.commonLocalizedString(for: .goingToCheckPurchases)
         }
+    }
+
+    private func dismissAlert() {
+        self.alertType = .restorePurchases
+        dismiss()
     }
 }
 

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -32,6 +32,9 @@ struct WrongPlatformView: View {
     @State
     private var subscriptionInformation: PurchaseInformation?
 
+    @EnvironmentObject
+    private var customerCenterViewModel: CustomerCenterViewModel
+
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
     @Environment(\.appearance)
@@ -80,7 +83,7 @@ struct WrongPlatformView: View {
                     }
                 }
             }
-            if let url = supportURL {
+            if let url = supportURL, !customerCenterViewModel.appUpdateRequiredToContactSupport {
                 Section {
                     AsyncButton {
                         openURL(url)

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -83,7 +83,7 @@ struct WrongPlatformView: View {
                     }
                 }
             }
-            if let url = supportURL, !customerCenterViewModel.appUpdateRequiredToContactSupport {
+            if let url = supportURL {
                 Section {
                     AsyncButton {
                         openURL(url)

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -34,7 +34,7 @@ struct WrongPlatformView: View {
 
     @EnvironmentObject
     private var customerCenterViewModel: CustomerCenterViewModel
-  
+
     private let screen: CustomerCenterConfigData.Screen?
 
     @Environment(\.localization)

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -555,7 +555,7 @@ extension CustomerCenterConfigData.Support {
 
     init(from response: CustomerCenterConfigResponse.Support) {
         self.email = response.email
-        self.shouldWarnCustomerToUpdate = response.shouldWarnCustomerToUpdate ?? false
+        self.shouldWarnCustomerToUpdate = response.shouldWarnCustomerToUpdate ?? true
     }
 
 }

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -412,9 +412,14 @@ public struct CustomerCenterConfigData {
     public struct Support {
 
         public let email: String
+        public let shouldWarnCustomerToUpdate: Bool
 
-        public init(email: String) {
+        public init(
+            email: String,
+            shouldWarnCustomerToUpdate: Bool
+        ) {
             self.email = email
+            self.shouldWarnCustomerToUpdate = shouldWarnCustomerToUpdate
         }
 
     }
@@ -550,6 +555,7 @@ extension CustomerCenterConfigData.Support {
 
     init(from response: CustomerCenterConfigResponse.Support) {
         self.email = response.email
+        self.shouldWarnCustomerToUpdate = response.shouldWarnCustomerToUpdate ?? false
     }
 
 }

--- a/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
+++ b/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
@@ -134,11 +134,6 @@ struct CustomerCenterConfigResponse {
         let email: String
         let shouldWarnCustomerToUpdate: Bool?
 
-//        enum CodingKeys: String, CodingKey {
-//            case email = "email"
-//            case shouldWarnCustomerToUpdate = "should_warn_customer_to_update"
-//        }
-
     }
 
 }

--- a/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
+++ b/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
@@ -132,6 +132,12 @@ struct CustomerCenterConfigResponse {
     struct Support {
 
         let email: String
+        let shouldWarnCustomerToUpdate: Bool?
+
+//        enum CodingKeys: String, CodingKey {
+//            case email = "email"
+//            case shouldWarnCustomerToUpdate = "should_warn_customer_to_update"
+//        }
 
     }
 

--- a/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
@@ -18,7 +18,10 @@ import XCTest
 
 class ContactSupportUtilitiesTest: TestCase {
 
-    private let support: CustomerCenterConfigData.Support = .init(email: "support@example.com")
+    private let support: CustomerCenterConfigData.Support = .init(
+        email: "support@example.com",
+        shouldWarnCustomerToUpdate: false
+    )
     private let localization: CustomerCenterConfigData.Localization = .init(locale: "en_US", localizedStrings: [:])
 
     func testSupportEmailBodyWithDefaultDataIsCorrect() {

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -20,6 +20,7 @@ import XCTest
 
 #if os(iOS)
 
+// swiftlint:disable file_length
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
@@ -216,6 +217,55 @@ class CustomerCenterViewModelTests: TestCase {
         if case .impression = trackedEvent {} else {
             fail("Expected an impression event")
         }
+    }
+
+    func testAppUpdateRequiredToContactSupport_true() {
+        let mockPurchases = MockCustomerCenterPurchases()
+        let latestVersion = "3.0.0"
+        let currentVersion = "2.0.0"
+        let viewModel = CustomerCenterViewModel(
+            customerCenterActionHandler: nil,
+            currentVersionFetcher: { return currentVersion },
+            purchasesProvider: mockPurchases
+        )
+        viewModel.configuration = CustomerCenterConfigTestData.customerCenterData(
+            lastPublishedAppVersion: latestVersion,
+            shouldWarnCustomerToUpdate: true
+        )
+
+        expect(viewModel.appUpdateRequiredToContactSupport).to(beTrue())
+    }
+
+    func testAppUpdateRequiredToContactSupport_false() {
+        let mockPurchases = MockCustomerCenterPurchases()
+        let latestVersion = "3.0.0"
+        let viewModel = CustomerCenterViewModel(
+            customerCenterActionHandler: nil,
+            currentVersionFetcher: { return latestVersion },
+            purchasesProvider: mockPurchases
+        )
+        viewModel.configuration = CustomerCenterConfigTestData.customerCenterData(
+            lastPublishedAppVersion: latestVersion,
+            shouldWarnCustomerToUpdate: true
+        )
+
+        expect(viewModel.appUpdateRequiredToContactSupport).to(beFalse())
+    }
+
+    func testAppUpdateRequiredToContactSupport_false_blocked_by_config() {
+        let mockPurchases = MockCustomerCenterPurchases()
+        let latestVersion = "3.0.0"
+        let viewModel = CustomerCenterViewModel(
+            customerCenterActionHandler: nil,
+            currentVersionFetcher: { return latestVersion },
+            purchasesProvider: mockPurchases
+        )
+        viewModel.configuration = CustomerCenterConfigTestData.customerCenterData(
+            lastPublishedAppVersion: latestVersion,
+            shouldWarnCustomerToUpdate: true
+        )
+
+        expect(viewModel.appUpdateRequiredToContactSupport).to(beFalse())
     }
 
 }

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -219,7 +219,7 @@ class CustomerCenterViewModelTests: TestCase {
         }
     }
 
-    func testAppUpdateRequiredToContactSupportTrue() {
+    func testShouldShowAppUpdateWarningsTrue() {
         let mockPurchases = MockCustomerCenterPurchases()
         let latestVersion = "3.0.0"
         let currentVersion = "2.0.0"
@@ -233,10 +233,10 @@ class CustomerCenterViewModelTests: TestCase {
             shouldWarnCustomerToUpdate: true
         )
 
-        expect(viewModel.appUpdateRequiredToContactSupport).to(beTrue())
+        expect(viewModel.shouldShowAppUpdateWarnings).to(beTrue())
     }
 
-    func testAppUpdateRequiredToContactSupportFalse() {
+    func testShouldShowAppUpdateWarningsFalse() {
         let mockPurchases = MockCustomerCenterPurchases()
         let latestVersion = "3.0.0"
         let viewModel = CustomerCenterViewModel(
@@ -249,10 +249,10 @@ class CustomerCenterViewModelTests: TestCase {
             shouldWarnCustomerToUpdate: true
         )
 
-        expect(viewModel.appUpdateRequiredToContactSupport).to(beFalse())
+        expect(viewModel.shouldShowAppUpdateWarnings).to(beFalse())
     }
 
-    func testAppUpdateRequiredToContactSupportReturnsFalseIfBlockedByConfig() {
+    func testShouldShowAppUpdateWarningsFalseIfBlockedByConfig() {
         let mockPurchases = MockCustomerCenterPurchases()
         let latestVersion = "3.0.0"
         let viewModel = CustomerCenterViewModel(
@@ -265,7 +265,7 @@ class CustomerCenterViewModelTests: TestCase {
             shouldWarnCustomerToUpdate: true
         )
 
-        expect(viewModel.appUpdateRequiredToContactSupport).to(beFalse())
+        expect(viewModel.shouldShowAppUpdateWarnings).to(beFalse())
     }
 
 }

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -262,7 +262,7 @@ class CustomerCenterViewModelTests: TestCase {
         )
         viewModel.configuration = CustomerCenterConfigTestData.customerCenterData(
             lastPublishedAppVersion: latestVersion,
-            shouldWarnCustomerToUpdate: true
+            shouldWarnCustomerToUpdate: false
         )
 
         expect(viewModel.shouldShowAppUpdateWarnings).to(beFalse())

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -219,7 +219,7 @@ class CustomerCenterViewModelTests: TestCase {
         }
     }
 
-    func testAppUpdateRequiredToContactSupport_true() {
+    func testAppUpdateRequiredToContactSupportTrue() {
         let mockPurchases = MockCustomerCenterPurchases()
         let latestVersion = "3.0.0"
         let currentVersion = "2.0.0"
@@ -236,7 +236,7 @@ class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.appUpdateRequiredToContactSupport).to(beTrue())
     }
 
-    func testAppUpdateRequiredToContactSupport_false() {
+    func testAppUpdateRequiredToContactSupportFalse() {
         let mockPurchases = MockCustomerCenterPurchases()
         let latestVersion = "3.0.0"
         let viewModel = CustomerCenterViewModel(
@@ -252,7 +252,7 @@ class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.appUpdateRequiredToContactSupport).to(beFalse())
     }
 
-    func testAppUpdateRequiredToContactSupport_false_blocked_by_config() {
+    func testAppUpdateRequiredToContactSupportReturnsFalseIfBlockedByConfig() {
         let mockPurchases = MockCustomerCenterPurchases()
         let latestVersion = "3.0.0"
         let viewModel = CustomerCenterViewModel(

--- a/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
+++ b/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
@@ -106,7 +106,10 @@ class CustomerCenterConfigDataTests: TestCase {
                     )
                 ],
                 localization: .init(locale: "en_US", localizedStrings: ["key": "value"]),
-                support: .init(email: "support@example.com")
+                support: .init(
+                    email: "support@example.com",
+                    shouldWarnCustomerToUpdate: false
+                )
             ),
             lastPublishedAppVersion: "1.2.3",
             itunesTrackId: 123

--- a/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
+++ b/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
@@ -181,6 +181,8 @@ class CustomerCenterConfigDataTests: TestCase {
 
         expect(configData.lastPublishedAppVersion) == "1.2.3"
         expect(configData.productId) == 123
+
+        expect(configData.support.shouldWarnCustomerToUpdate) == false
     }
 
     func testUnknownValuesHandling() throws {


### PR DESCRIPTION
### Description
This PR:
- Uses the `Support.shouldWarnCustomerToUpdate` boolean from the backend to determine if update warnings should be displayed to the user
- Switches the restore flow from using a SwiftUI `Alert` to a `ConfirmationDialog` since we have up to 3 actions that a user can take, and `Alert` only supports a max of 2
- Adds message & button to the restore flow to instruct the user to update their app if no purchases are found, `Support.shouldWarnCustomerToUpdate` is enabled, and the user is an old app version

> [!WARNING]
> This PR is a breaking change from a UI standpoint because it now requires `Support.shouldWarnCustomerToUpdate` to be set for the AppUpdateWarningView to be displayed. This hasn't been enabled by default yet, so most people using Customer Center so far will need to enable the checkbox to see the warnings.

### Follow-Up Actions
- Update the copy of the checkbox in the dashboard from "Require users to update to the latest version of your app before contacting support" to something like "Show a warning to users not on the latest version of your app"
- Consider enabling the checkbox by default

### Screenshots
#### Restore Flow
##### iOS 
![01_RESTORE_PURCHASES_CHECK_PAST_PURCHASES](https://github.com/user-attachments/assets/9b1ed6db-bbd7-4d94-a25f-4d913e8f215a)
![02_RESTORE_PURCHASES_CONTACT_SUPPORT](https://github.com/user-attachments/assets/7be33b5e-721b-4532-b9db-f6f65853aa17)
![03_RESTORE_PURCHASES_SHOW_UPDATE](https://github.com/user-attachments/assets/c32624ff-a847-43bf-b227-6ecea6bd9af8)

##### iPadOS
![simulator_screenshot_ED2960CA-C996-4717-80D1-970ED4776529](https://github.com/user-attachments/assets/8bf40da5-3f0a-4313-a370-440b81298354)

##### macOS (Designed for iPad)
![image](https://github.com/user-attachments/assets/025c47e1-ed40-49de-ab31-f9b7b8991a5d)


