### PR TITLE
Make presentCustomerCenter's onDismiss optional

### DIFF
--- a/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
+++ b/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
@@ -44,7 +44,7 @@ extension View {
         isPresented: Binding<Bool>,
         customerCenterActionHandler: CustomerCenterActionHandler? = nil,
         presentationMode: CustomerCenterPresentationMode = .default,
-        onDismiss: @escaping () -> Void
+        onDismiss: (() -> Void)? = nil
     ) -> some View {
         return self.modifier(PresentingCustomerCenterModifier(
             isPresented: isPresented,
@@ -65,11 +65,11 @@ private struct PresentingCustomerCenterModifier: ViewModifier {
 
     let customerCenterActionHandler: CustomerCenterActionHandler?
     let presentationMode: CustomerCenterPresentationMode
-    let onDismiss: (() -> Void)
+    let onDismiss: (() -> Void)?
 
     init(
         isPresented: Binding<Bool>,
-        onDismiss: @escaping () -> Void,
+        onDismiss: (() -> Void)?,
         myAppPurchaseLogic: MyAppPurchaseLogic?,
         customerCenterActionHandler: CustomerCenterActionHandler?,
         presentationMode: CustomerCenterPresentationMode,

--- a/Tests/APITesters/AllAPITests/AllAPITests.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/AllAPITests/AllAPITests.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		35370AC52CFF8304004F0A64 /* RCSubscriptionInfoAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 35370AC42CFF82F8004F0A64 /* RCSubscriptionInfoAPI.h */; };
 		35370AC82CFF8317004F0A64 /* RCSubscriptionInfoAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 35370AC72CFF8312004F0A64 /* RCSubscriptionInfoAPI.m */; };
 		FD33CD732D03587E000D13A4 /* CustomerCenterViewControllerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD33CD722D035876000D13A4 /* CustomerCenterViewControllerAPI.swift */; };
+		FDCC983A2D0A0FD500F5854B /* CustomerCenterViewAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCC98392D0A0FD500F5854B /* CustomerCenterViewAPI.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -354,6 +355,7 @@
 		35370AC42CFF82F8004F0A64 /* RCSubscriptionInfoAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCSubscriptionInfoAPI.h; sourceTree = "<group>"; };
 		35370AC72CFF8312004F0A64 /* RCSubscriptionInfoAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCSubscriptionInfoAPI.m; sourceTree = "<group>"; };
 		FD33CD722D035876000D13A4 /* CustomerCenterViewControllerAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterViewControllerAPI.swift; sourceTree = "<group>"; };
+		FDCC98392D0A0FD500F5854B /* CustomerCenterViewAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterViewAPI.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -602,6 +604,7 @@
 				2D4C622B2C5ADA6700A29FD2 /* PaywallViewControllerAPI.swift */,
 				2D4C622C2C5ADA6700A29FD2 /* main.swift */,
 				2D4C62232C5ADA2400A29FD2 /* RevenueCatUISwiftAPITester.h */,
+				FDCC98392D0A0FD500F5854B /* CustomerCenterViewAPI.swift */,
 			);
 			path = RevenueCatUISwiftAPITester;
 			sourceTree = "<group>";
@@ -1055,6 +1058,7 @@
 			files = (
 				FD33CD732D03587E000D13A4 /* CustomerCenterViewControllerAPI.swift in Sources */,
 				2D4C622F2C5ADA6700A29FD2 /* main.swift in Sources */,
+				FDCC983A2D0A0FD500F5854B /* CustomerCenterViewAPI.swift in Sources */,
 				2D4C62302C5ADA6700A29FD2 /* PaywallViewControllerAPI.swift in Sources */,
 				1E8A60812CDCF29D0034ACF3 /* RedeemWebPurchasesAPI.swift in Sources */,
 				2D4C622E2C5ADA6700A29FD2 /* PaywallViewAPI.swift in Sources */,

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CustomerCenterViewAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CustomerCenterViewAPI.swift
@@ -1,0 +1,31 @@
+//
+//  CustomerCenterViewAPI.swift
+//  RevenueCatUISwiftAPITester
+//
+//  Created by Will Taylor on 12/11/24.
+//
+
+import SwiftUI
+import RevenueCat
+import RevenueCatUI
+
+#if canImport(UIKit) && os(iOS)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+struct TestViewPlusPresentCustomerCenter: View {
+
+    @State private var isPresented = false
+
+    var body: some View {
+        EmptyView()
+            .presentCustomerCenter(isPresented: $isPresented)
+            .presentCustomerCenter(isPresented: $isPresented, onDismiss: {})
+            .presentCustomerCenter(
+                isPresented: $isPresented,
+                customerCenterActionHandler: { _ in
+
+                },
+                onDismiss: {}
+            )
+    }
+}
+#endif


### PR DESCRIPTION
### Description
- Makes `presentCustomerCenter`'s `onDismiss` parameter optional and defaults to `nil`
- Adds API tester for the `presentCustomerCenter` view modifier
