### PR TITLE
Always call readyForPromotedProduct on the main actor

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1599,7 +1599,13 @@ extension Purchases: PurchasesOrchestratorDelegate {
      */
     func readyForPromotedProduct(_ product: StoreProduct,
                                  purchase startPurchase: @escaping StartPurchaseBlock) {
-        self.delegate?.purchases?(self, readyForPromotedProduct: product, purchase: startPurchase)
+        OperationDispatcher.dispatchOnMainActor {
+            self.delegate?.purchases?(
+                self,
+                readyForPromotedProduct: product,
+                purchase: startPurchase
+            )
+        }
     }
 
 #if os(iOS) || targetEnvironment(macCatalyst) || VISION_OS

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
@@ -42,6 +42,12 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
                                                                shouldAddStorePayment: payment,
                                                                for: self.product)
 
+        waitUntil { completed in
+            if self.purchasesDelegate.makeDeferredPurchase != nil {
+                completed()
+            }
+        }
+
         expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
         expect(self.storeKit1Wrapper.payment).to(beNil())
 
@@ -58,6 +64,12 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
         _ = try self.storeKit1WrapperDelegate.storeKit1Wrapper(storeKit1Wrapper,
                                                                shouldAddStorePayment: payment,
                                                                for: self.product)
+
+        waitUntil { completed in
+            if self.purchasesDelegate.makeDeferredPurchase != nil {
+                completed()
+            }
+        }
 
         expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
         expect(self.storeKit1Wrapper.payment).to(beNil())
@@ -87,7 +99,7 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
                                                                shouldAddStorePayment: payment,
                                                                for: self.product)
 
-        expect(self.purchasesDelegate.promoProduct) == StoreProduct(sk1Product: self.product)
+        expect(self.purchasesDelegate.promoProduct).toEventually(equal(StoreProduct(sk1Product: self.product)))
     }
 
     func testShouldAddStorePaymentReturnsFalseForNilProductIdentifier() throws {
@@ -177,10 +189,9 @@ class PurchaseDeferredPurchasesSK2Tests: BasePurchasesTests {
             for: self.product
         )
 
-        expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
-
-        expect(self.purchasesDelegate.promoProduct) == StoreProduct(sk1Product: self.product)
-        expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
+        expect(self.purchasesDelegate.makeDeferredPurchase).toEventuallyNot(beNil())
+        expect(self.purchasesDelegate.promoProduct).toEventually(equal(StoreProduct(sk1Product: self.product)))
+        expect(self.purchasesDelegate.makeDeferredPurchase).toEventuallyNot(beNil())
     }
 
 }


### PR DESCRIPTION
### Motivation
This PR is a potential fix for https://github.com/RevenueCat/purchases-ios/issues/4582. A customer is reporting occasional crashes when the `PurchaseDelegate`'s `readyForPromotedProduct`. The stacktraces indicate that this is happening in both SK1 & SK2 flows. My current theory is that we are calling the `readyForPromotedProduct` function on a background thread when the calling code expects it to be on the main actor/thread.

Update: We heard back from the creator of the issue, and the code that their calling code is in a @MainActor class.

### Description
This PR:
- Always calls the PurchaseDelegate's `readyForPromotedProduct` on the main actor
- Updates `PurchaseDeferredPurchasesTests` and `PurchaseDeferredPurchasesSK2Tests` to wait for the callback to be completed since it's now called asynchronusly
