### PR TITLE
Dont show refund cancelled message when user cancels refund

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
@@ -102,7 +102,7 @@ struct SubscriptionDetailsView: View {
         case .success:
             return localization.commonLocalizedString(for: .refundGranted)
         case .userCancelled:
-            return localization.commonLocalizedString(for: .refundCanceled)
+            return nil
         @unknown default:
             return nil
         }


### PR DESCRIPTION
### Motivation
Currently, when the user cancels a refund, we show the following message on the SubscriptionDetailsView screen under the "Refund Status" message:

<img src="https://github.com/user-attachments/assets/722d9106-4b6b-42a5-a479-8d4c37198367" width="200" />


This message is a little confusing because it implies that a refund was created and was then cancelled, when one was never created in the first place. When I saw the message, my first thought was, "do I have the money, or does the developer?".

### Description

This PR modifies the behavior so that the "Refund Status" section doesn't display at all when the user dismisses the refund screen without creating a refund, since the user already knows that they cancelled it.

The PR doesn't remove the `refundCanceled` localized string in case we need it in the future here or on another platform.