### PR TITLE
Update refund granted default string

### DIFF
--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -134,7 +134,7 @@ public struct CustomerCenterConfigData {
                 case .refundErrorGeneric:
                     return "An error occurred while processing the refund request. Please try again."
                 case .refundGranted:
-                    return "Refund submitted"
+                    return "Refund requested"
                 case .refundStatus:
                     return "Refund status"
                 case .subEarliestExpiration:

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -134,7 +134,7 @@ public struct CustomerCenterConfigData {
                 case .refundErrorGeneric:
                     return "An error occurred while processing the refund request. Please try again."
                 case .refundGranted:
-                    return "Refund granted successfully!"
+                    return "Refund submitted"
                 case .refundStatus:
                     return "Refund status"
                 case .subEarliestExpiration:


### PR DESCRIPTION
### Motivation
When a refund request completes successfully, it's not necessarily granted yet, as Apple reviews refund requests and can deny them.

### Description
This PR updates the default refund granted string to state that the refund has been requested. This copy is consistent with the primary button on the refund sheet, which says "Request Refund".

### Follow Up Items
- The string's default value will need to be updated in the backend as well
