### PR TITLE
[DO NOT MERGE] Use refund requested string when refund request is successfully submitted

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
@@ -100,7 +100,7 @@ struct SubscriptionDetailsView: View {
         case .error:
             return localization.commonLocalizedString(for: .refundErrorGeneric)
         case .success:
-            return localization.commonLocalizedString(for: .refundGranted)
+            return localization.commonLocalizedString(for: .refundRequested)
         case .userCancelled:
             return nil
         @unknown default:

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -67,6 +67,7 @@ public struct CustomerCenterConfigData {
             case refundErrorGeneric = "refund_error_generic"
             case refundGranted = "refund_granted"
             case refundStatus = "refund_status"
+            case refundRequested = "refund_requested"
             case subEarliestExpiration = "sub_earliest_expiration"
             case subEarliestRenewal = "sub_earliest_renewal"
             case subExpired = "sub_expired"
@@ -135,6 +136,8 @@ public struct CustomerCenterConfigData {
                     return "An error occurred while processing the refund request. Please try again."
                 case .refundGranted:
                     return "Refund granted successfully!"
+                case .refundRequested:
+                    return "Refund requested"
                 case .refundStatus:
                     return "Refund status"
                 case .subEarliestExpiration:


### PR DESCRIPTION
### DO NOT MERGE 
[ ] Do not merge until the string has been added to the backend and dashboard

### Motivation
When a refund request completes successfully, it's not necessarily granted yet, as Apple reviews refund requests and can deny them. We currently show that the refund was granted when it's only been requested.

### Description
This PR introduces a new `refundRequeted` string to show that the refund has been requested. This copy is consistent with the primary button on the refund sheet, which says "Request Refund". It then shows this string under the "Refund Status" label when a refund has been requested successfully.

### Follow Up Items
- The string will need to be added in the backend and frontend as well
