### PR TITLE
Bump timeout for deferred purchase tests for CI

### DIFF
--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
@@ -26,6 +26,7 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
     }
 
     private var product: MockSK1Product!
+    private let timeoutInterval = DispatchTimeInterval(TimeInterval(4))
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -42,7 +43,7 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
                                                                shouldAddStorePayment: payment,
                                                                for: self.product)
 
-        waitUntil { completed in
+        waitUntil(timeout: timeoutInterval) { completed in
             if self.purchasesDelegate.makeDeferredPurchase != nil {
                 completed()
             }
@@ -65,7 +66,7 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
                                                                shouldAddStorePayment: payment,
                                                                for: self.product)
 
-        waitUntil { completed in
+        waitUntil(timeout: timeoutInterval) { completed in
             if self.purchasesDelegate.makeDeferredPurchase != nil {
                 completed()
             }


### PR DESCRIPTION
While they run okay locally, the updated tests for https://github.com/RevenueCat/purchases-ios/pull/4584 have been flaky in CI in iOS <17. This PR increases the timeout interval to make them less flaky.