### PR TITLE
Revert "Always call readyForPromotedProduct on the main actor"

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1597,13 +1597,7 @@ extension Purchases: PurchasesOrchestratorDelegate {
      */
     func readyForPromotedProduct(_ product: StoreProduct,
                                  purchase startPurchase: @escaping StartPurchaseBlock) {
-        OperationDispatcher.dispatchOnMainActor {
-            self.delegate?.purchases?(
-                self,
-                readyForPromotedProduct: product,
-                purchase: startPurchase
-            )
-        }
+        self.delegate?.purchases?(self, readyForPromotedProduct: product, purchase: startPurchase)
     }
 
 #if os(iOS) || targetEnvironment(macCatalyst) || VISION_OS

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
@@ -42,12 +42,6 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
                                                                shouldAddStorePayment: payment,
                                                                for: self.product)
 
-        waitUntil { completed in
-            if self.purchasesDelegate.makeDeferredPurchase != nil {
-                completed()
-            }
-        }
-
         expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
         expect(self.storeKit1Wrapper.payment).to(beNil())
 
@@ -64,12 +58,6 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
         _ = try self.storeKit1WrapperDelegate.storeKit1Wrapper(storeKit1Wrapper,
                                                                shouldAddStorePayment: payment,
                                                                for: self.product)
-
-        waitUntil { completed in
-            if self.purchasesDelegate.makeDeferredPurchase != nil {
-                completed()
-            }
-        }
 
         expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
         expect(self.storeKit1Wrapper.payment).to(beNil())
@@ -99,7 +87,7 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
                                                                shouldAddStorePayment: payment,
                                                                for: self.product)
 
-        expect(self.purchasesDelegate.promoProduct).toEventually(equal(StoreProduct(sk1Product: self.product)))
+        expect(self.purchasesDelegate.promoProduct) == StoreProduct(sk1Product: self.product)
     }
 
     func testShouldAddStorePaymentReturnsFalseForNilProductIdentifier() throws {
@@ -189,9 +177,10 @@ class PurchaseDeferredPurchasesSK2Tests: BasePurchasesTests {
             for: self.product
         )
 
-        expect(self.purchasesDelegate.makeDeferredPurchase).toEventuallyNot(beNil())
-        expect(self.purchasesDelegate.promoProduct).toEventually(equal(StoreProduct(sk1Product: self.product)))
-        expect(self.purchasesDelegate.makeDeferredPurchase).toEventuallyNot(beNil())
+        expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
+
+        expect(self.purchasesDelegate.promoProduct) == StoreProduct(sk1Product: self.product)
+        expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
     }
 
 }


### PR DESCRIPTION
### Description
Despite passing fine locally, these changes have been flaky in the CI for iOS 14-16. This PR reverts the changes in https://github.com/RevenueCat/purchases-ios/pull/4584 out of an abundance of caution
