### PR TITLE
Fix loading Customer Center when entitlement is granted by another Apple app

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -215,7 +215,9 @@ private extension CustomerCenterViewModel {
                     transaction: transaction
                 )
             } else {
-                Logger.warning(Strings.could_not_find_product_loading_without_product_information(transaction.productIdentifier))
+                Logger.warning(
+                    Strings.could_not_find_product_loading_without_product_information(transaction.productIdentifier)
+                )
 
                 return PurchaseInformation(
                     entitlement: entitlement,

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -208,21 +208,27 @@ private extension CustomerCenterViewModel {
     func createPurchaseInformation(for transaction: Transaction,
                                    entitlement: EntitlementInfo?) async throws -> PurchaseInformation {
         if transaction.store == .appStore {
-            guard let product = await purchasesProvider.products([transaction.productIdentifier]).first else {
-                Logger.warning(Strings.could_not_find_subscription_information)
-                throw CustomerCenterError.couldNotFindSubscriptionInformation
+            if let product = await purchasesProvider.products([transaction.productIdentifier]).first {
+                return PurchaseInformation(
+                    entitlement: entitlement,
+                    subscribedProduct: product,
+                    transaction: transaction
+                )
+            } else {
+                Logger.warning(Strings.could_not_find_product_loading_without_product_information(transaction.productIdentifier))
+
+                return PurchaseInformation(
+                    entitlement: entitlement,
+                    transaction: transaction
+                )
             }
-            return PurchaseInformation(
-                entitlement: entitlement,
-                subscribedProduct: product,
-                transaction: transaction
-            )
-        } else {
-            return PurchaseInformation(
-                entitlement: entitlement,
-                transaction: transaction
-            )
         }
+        Logger.warning(Strings.active_product_is_not_apple_loading_without_product_information(transaction.store))
+
+        return PurchaseInformation(
+            entitlement: entitlement,
+            transaction: transaction
+        )
     }
 
 }

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -214,7 +214,8 @@ extension Strings: CustomStringConvertible {
             return "Could not determine the type of custom URL, the URL will be opened externally."
 
         case .active_product_is_not_apple_loading_without_product_information(let store):
-            return "Active product for user is not an Apple subscription (\(store)). Loading without product information."
+            return "Active product for user is not an Apple subscription (\(store))." +
+            " Loading without product information."
 
         case .could_not_find_product_loading_without_product_information(let product):
             return "Could not find product with id \(product). Loading without product information."

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -68,6 +68,8 @@ enum Strings {
     case error_fetching_promotional_offer(Error)
     case promo_offer_not_loaded
     case could_not_determine_type_of_custom_url
+    case active_product_is_not_apple_loading_without_product_information(Store)
+    case could_not_find_product_loading_without_product_information(String)
 
 }
 
@@ -210,6 +212,12 @@ extension Strings: CustomStringConvertible {
 
         case .could_not_determine_type_of_custom_url:
             return "Could not determine the type of custom URL, the URL will be opened externally."
+            
+        case .active_product_is_not_apple_loading_without_product_information(let store):
+            return "Active product for user is not an Apple subscription (\(store)). Loading without product information."
+
+        case .could_not_find_product_loading_without_product_information(let product):
+            return "Could not find product with id \(product). Loading without product information."
 
         }
     }

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -212,7 +212,7 @@ extension Strings: CustomStringConvertible {
 
         case .could_not_determine_type_of_custom_url:
             return "Could not determine the type of custom URL, the URL will be opened externally."
-            
+
         case .active_product_is_not_apple_loading_without_product_information(let store):
             return "Active product for user is not an Apple subscription (\(store)). Loading without product information."
 


### PR DESCRIPTION
Projects with multiple apps fail to load when the entitlement is granted by another app in the project. For example this Customer Info response:

```
{
  "request_date": "2024-12-17T13:47:05Z",
  "request_date_ms": 1734443225832,
  "subscriber": {
    "entitlements": {
      "pro": {
        "expires_date": "2024-12-17T14:01:33Z",
        "grace_period_expires_date": null,
        "product_identifier": "premiumyearly",
        "purchase_date": "2024-12-16T14:01:33Z"
      }
    },
    "first_seen": "2024-04-29T06:37:25Z",
    "last_seen": "2024-12-16T15:24:53Z",
    "management_url": "https://apps.apple.com/account/subscriptions",
    "non_subscriptions": {
    },
    "original_app_user_id": "_",
    "original_application_version": "1.0",
    "original_purchase_date": "2019-05-09T08:20:34Z",
    "other_purchases": {
    },
    "subscriptions": {
      "premiumyearly": {
        "auto_resume_date": null,
        "billing_issues_detected_at": null,
        "expires_date": "2024-12-17T14:01:33Z",
        "grace_period_expires_date": null,
        "is_sandbox": true,
        "original_purchase_date": "2024-02-16T14:02:22Z",
        "ownership_type": "PURCHASED",
        "period_type": "normal",
        "purchase_date": "2024-12-16T14:01:33Z",
        "refunded_at": null,
        "store": "app_store",
        "store_transaction_id": "000",
        "unsubscribe_detected_at": null
      }
    }
  }
}
```

This also fixes the Customer Center when the product fails to load by displaying the available information.