### PR TITLE
Use #file instead of #fileID to avoid including the full path in the compiled binary

### DIFF
--- a/RevenueCatUI/Helpers/Logger.swift
+++ b/RevenueCatUI/Helpers/Logger.swift
@@ -19,7 +19,7 @@ enum Logger {
 
     static func verbose(
         _ text: CustomStringConvertible,
-        file: String = #file,
+        file: String = #fileID,
         function: String = #function,
         line: UInt = #line
     ) {
@@ -35,7 +35,7 @@ enum Logger {
 
     static func debug(
         _ text: CustomStringConvertible,
-        file: String = #file,
+        file: String = #fileID,
         function: String = #function,
         line: UInt = #line
     ) {
@@ -50,7 +50,7 @@ enum Logger {
 
     static func warning(
         _ text: CustomStringConvertible,
-        file: String = #file,
+        file: String = #fileID,
         function: String = #function,
         line: UInt = #line
     ) {
@@ -65,7 +65,7 @@ enum Logger {
 
     static func error(
         _ text: CustomStringConvertible,
-        file: String = #file,
+        file: String = #fileID,
         function: String = #function,
         line: UInt = #line
     ) {
@@ -81,7 +81,7 @@ enum Logger {
     private static func log(
         _ text: CustomStringConvertible,
         _ level: LogLevel,
-        file: String = #file,
+        file: String = #fileID,
         function: String = #function,
         line: UInt = #line
     ) {

--- a/Sources/Error Handling/Assertions.swift
+++ b/Sources/Error Handling/Assertions.swift
@@ -19,7 +19,7 @@ import Foundation
 func RCTestAssert(
     _ condition: @autoclosure () -> Bool,
     _ message: @autoclosure () -> String,
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line
 ) {
     #if DEBUG
@@ -32,7 +32,7 @@ func RCTestAssert(
 @inline(__always)
 func RCTestAssertNotMainThread(
     function: StaticString = #function,
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line
 ) {
     #if DEBUG


### PR DESCRIPTION
These were the only non-test files where we were using #file instead of #fileID

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
