### PR TITLE
Fixing text, image, and footer render issues

### DIFF
--- a/RevenueCatUI/Modifiers/FitToAspectRatio.swift
+++ b/RevenueCatUI/Modifiers/FitToAspectRatio.swift
@@ -17,10 +17,12 @@ import SwiftUI
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 extension Image {
 
-    func fitToAspect(_ aspectRatio: Double, contentMode: SwiftUI.ContentMode) -> some View {
+    func fitToAspect(_ aspectRatio: Double, contentMode: SwiftUI.ContentMode, containerContentMode: SwiftUI.ContentMode? = nil) -> some View {
         self.resizable()
             .scaledToFill()
-            .modifier(FitToAspectRatio(aspectRatio: aspectRatio, contentMode: contentMode))
+            .modifier(FitToAspectRatio(aspectRatio: aspectRatio,
+                                       contentMode: contentMode,
+                                       containerContentMode: containerContentMode))
     }
 
 }
@@ -30,10 +32,15 @@ private struct FitToAspectRatio: ViewModifier {
 
     let aspectRatio: Double
     let contentMode: SwiftUI.ContentMode
+    let containerContentMode: SwiftUI.ContentMode?
+    
+    private let paywallsV1ContainerContentMode: SwiftUI.ContentMode = .fit
 
     func body(content: Content) -> some View {
         Color.clear
-            .aspectRatio(self.aspectRatio, contentMode: self.contentMode) // DONT COMMIT THIS YET PLEASE
+            .aspectRatio(
+                self.aspectRatio,
+                contentMode: self.containerContentMode ?? self.paywallsV1ContainerContentMode)
             .overlay(
                 content.aspectRatio(nil, contentMode: self.contentMode)
             )

--- a/RevenueCatUI/Modifiers/FitToAspectRatio.swift
+++ b/RevenueCatUI/Modifiers/FitToAspectRatio.swift
@@ -33,7 +33,7 @@ private struct FitToAspectRatio: ViewModifier {
 
     func body(content: Content) -> some View {
         Color.clear
-            .aspectRatio(self.aspectRatio, contentMode: .fit)
+            .aspectRatio(self.aspectRatio, contentMode: self.contentMode) // DONT COMMIT THIS YET PLEASE
             .overlay(
                 content.aspectRatio(nil, contentMode: self.contentMode)
             )

--- a/RevenueCatUI/Modifiers/FitToAspectRatio.swift
+++ b/RevenueCatUI/Modifiers/FitToAspectRatio.swift
@@ -17,7 +17,9 @@ import SwiftUI
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 extension Image {
 
-    func fitToAspect(_ aspectRatio: Double, contentMode: SwiftUI.ContentMode, containerContentMode: SwiftUI.ContentMode? = nil) -> some View {
+    func fitToAspect(_ aspectRatio: Double,
+                     contentMode: SwiftUI.ContentMode,
+                     containerContentMode: SwiftUI.ContentMode? = nil) -> some View {
         self.resizable()
             .scaledToFill()
             .modifier(FitToAspectRatio(aspectRatio: aspectRatio,
@@ -33,7 +35,7 @@ private struct FitToAspectRatio: ViewModifier {
     let aspectRatio: Double
     let contentMode: SwiftUI.ContentMode
     let containerContentMode: SwiftUI.ContentMode?
-    
+
     private let paywallsV1ContainerContentMode: SwiftUI.ContentMode = .fit
 
     func body(content: Content) -> some View {

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -119,8 +119,8 @@ struct ImageComponentView_Previews: PreviewProvider {
                     component: .init(
                         source: .init(
                             light: .init(
-                                width: 1,
-                                height: 1,
+                                width: 750,
+                                height: 530,
                                 original: catUrl,
                                 heic: catUrl,
                                 heicLowRes: catUrl
@@ -147,8 +147,8 @@ struct ImageComponentView_Previews: PreviewProvider {
                     component: .init(
                         source: .init(
                             light: .init(
-                                width: 1,
-                                height: 1,
+                                width: 750,
+                                height: 530,
                                 original: catUrl,
                                 heic: catUrl,
                                 heicLowRes: catUrl
@@ -175,8 +175,8 @@ struct ImageComponentView_Previews: PreviewProvider {
                     component: .init(
                         source: .init(
                             light: .init(
-                                width: 1,
-                                height: 1,
+                                width: 750,
+                                height: 530,
                                 original: catUrl,
                                 heic: catUrl,
                                 heicLowRes: catUrl
@@ -206,8 +206,8 @@ struct ImageComponentView_Previews: PreviewProvider {
                     component: .init(
                         source: .init(
                             light: .init(
-                                width: 1,
-                                height: 1,
+                                width: 750,
+                                height: 530,
                                 original: catUrl,
                                 heic: catUrl,
                                 heicLowRes: catUrl

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -78,7 +78,8 @@ struct ImageComponentView: View {
         image
             .fitToAspect(
                 self.aspectRatio(style: style),
-                contentMode: style.contentMode
+                contentMode: style.contentMode,
+                containerContentMode: style.contentMode
             )
             .frame(maxWidth: .infinity)
             .accessibilityHidden(true)

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -82,6 +82,7 @@ struct ImageComponentView: View {
                 containerContentMode: style.contentMode
             )
             .frame(maxWidth: .infinity)
+            // WIP: Fix this later when accessibility info is available
             .accessibilityHidden(true)
             // WIP: Need to replace this gradient with the better one
             .overlay(

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -31,10 +31,10 @@ struct ImageComponentView: View {
 
     @Environment(\.screenCondition)
     private var screenCondition
-    
+
     @Environment(\.colorScheme)
     private var colorScheme
-    
+
     let viewModel: ImageComponentViewModel
 
     var body: some View {
@@ -57,12 +57,12 @@ struct ImageComponentView: View {
             .clipped()
         }
     }
-    
+
     private func aspectRatio(style: ImageComponentStyle) -> Double {
         let (width, height) = self.imageSize(style: style)
         return Double(width) / Double(height)
     }
-    
+
     private func imageSize(style: ImageComponentStyle) -> (width: Int, height: Int) {
         switch self.colorScheme {
         case .light:
@@ -82,7 +82,7 @@ struct ImageComponentView: View {
             )
             .frame(maxWidth: .infinity)
             .accessibilityHidden(true)
-            // TODO: Need to replace this gradient with the better one
+            // WIP: Need to replace this gradient with the better one
             .overlay(
                 LinearGradient(
                     gradient: Gradient(colors: style.gradientColors),
@@ -90,8 +90,8 @@ struct ImageComponentView: View {
                     endPoint: .bottom
                 )
             )
-            // TODO: this needs more shapes and borders
-            // TODO: this might also need dropshadow
+            // WIP: this needs more shapes and borders
+            // WIP: this might also need dropshadow
             .shape(border: nil,
                    shape: style.shape)
     }

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -31,7 +31,10 @@ struct ImageComponentView: View {
 
     @Environment(\.screenCondition)
     private var screenCondition
-
+    
+    @Environment(\.colorScheme)
+    private var colorScheme
+    
     let viewModel: ImageComponentViewModel
 
     var body: some View {
@@ -48,17 +51,38 @@ struct ImageComponentView: View {
                 darkUrl: style.darkUrl,
                 darkLowResUrl: style.darkLowResUrl
             ) { (image, size) in
-                renderImage(image, size, with: style)
+                self.renderImage(image, size, with: style)
             }
             .size(style.size)
             .clipped()
         }
     }
+    
+    private func aspectRatio(style: ImageComponentStyle) -> Double {
+        let (width, height) = self.imageSize(style: style)
+        return Double(width) / Double(height)
+    }
+    
+    private func imageSize(style: ImageComponentStyle) -> (width: Int, height: Int) {
+        switch self.colorScheme {
+        case .light:
+            return (style.widthLight, style.heightLight)
+        case .dark:
+            return (style.widthDark ?? style.widthLight, style.heightDark ?? style.heightLight)
+        @unknown default:
+            return (style.widthLight, style.heightLight)
+        }
+    }
 
     private func renderImage(_ image: Image, _ size: CGSize, with style: ImageComponentStyle) -> some View {
         image
-            .resizable()
-            .aspectRatio(contentMode: style.contentMode)
+            .fitToAspect(
+                self.aspectRatio(style: style),
+                contentMode: style.contentMode
+            )
+            .frame(maxWidth: .infinity)
+            .accessibilityHidden(true)
+            // TODO: Need to replace this gradient with the better one
             .overlay(
                 LinearGradient(
                     gradient: Gradient(colors: style.gradientColors),
@@ -66,6 +90,8 @@ struct ImageComponentView: View {
                     endPoint: .bottom
                 )
             )
+            // TODO: this needs more shapes and borders
+            // TODO: this might also need dropshadow
             .shape(border: nil,
                    shape: style.shape)
     }
@@ -92,6 +118,8 @@ struct ImageComponentView_Previews: PreviewProvider {
                     component: .init(
                         source: .init(
                             light: .init(
+                                width: 1,
+                                height: 1,
                                 original: catUrl,
                                 heic: catUrl,
                                 heicLowRes: catUrl
@@ -118,6 +146,8 @@ struct ImageComponentView_Previews: PreviewProvider {
                     component: .init(
                         source: .init(
                             light: .init(
+                                width: 1,
+                                height: 1,
                                 original: catUrl,
                                 heic: catUrl,
                                 heicLowRes: catUrl
@@ -144,6 +174,8 @@ struct ImageComponentView_Previews: PreviewProvider {
                     component: .init(
                         source: .init(
                             light: .init(
+                                width: 1,
+                                height: 1,
                                 original: catUrl,
                                 heic: catUrl,
                                 heicLowRes: catUrl
@@ -173,6 +205,8 @@ struct ImageComponentView_Previews: PreviewProvider {
                     component: .init(
                         source: .init(
                             light: .init(
+                                width: 1,
+                                height: 1,
                                 original: catUrl,
                                 heic: catUrl,
                                 heicLowRes: catUrl

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
@@ -118,6 +118,10 @@ extension LocalizedImagePartial {
 struct ImageComponentStyle {
 
     let visible: Bool
+    let widthLight: Int
+    let heightLight: Int
+    let widthDark: Int?
+    let heightDark: Int?
     let url: URL
     let lowResUrl: URL?
     let darkUrl: URL?
@@ -136,6 +140,10 @@ struct ImageComponentStyle {
         gradientColors: [PaywallComponent.ColorHex]? = nil
     ) {
         self.visible = visible
+        self.widthLight = source.light.width
+        self.heightLight = source.light.height
+        self.widthDark = source.dark?.width
+        self.heightDark = source.dark?.height
         self.url = source.light.heic
         self.lowResUrl = source.light.heicLowRes
         self.darkUrl = source.dark?.heic

--- a/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
@@ -34,7 +34,8 @@ struct RootView: View {
             StackComponentView(viewModel: viewModel.stackViewModel, onDismiss: onDismiss)
         }.applyIfLet(viewModel.stickyFooterViewModel) { stackView, stickyFooterViewModel in
             stackView
-                .safeAreaInset(edge: .bottom) {
+                // Using overlay because safeAreaInsert with fixedSize
+                .overlay(
                     StackComponentView(
                         viewModel: stickyFooterViewModel.stackViewModel,
                         onDismiss: onDismiss,
@@ -45,7 +46,10 @@ struct RootView: View {
                             trailing: 0
                         )
                     )
-                }
+                    .fixedSize(horizontal: false, vertical: true)
+                    .edgesIgnoringSafeArea(.bottom),
+                    alignment: .bottom
+                )
                 // First we ensure our footer draws in the bottom safe area. Then we add additional padding, so its
                 // background shows in that same bottom safe area.
                 .ignoresSafeArea(edges: .bottom)

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -49,7 +49,7 @@ struct TextComponentView: View {
         ) { style in
             Group {
                 if style.visible {
-                    Text(style.text)
+                    Text(.init(style.text))
                         .font(style.fontSize)
                         .fontWeight(style.fontWeight)
                         .fixedSize(horizontal: false, vertical: true)

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -26,8 +26,8 @@ private enum Template1Preview {
     static let catImage = PaywallComponent.ImageComponent(
         source: .init(
             light: .init(
-                width: 1,
-                height: 1,
+                width: 750,
+                height: 530,
                 original: catUrl,
                 heic: catUrl,
                 heicLowRes: catUrl

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -26,6 +26,8 @@ private enum Template1Preview {
     static let catImage = PaywallComponent.ImageComponent(
         source: .init(
             light: .init(
+                width: 1,
+                height: 1,
                 original: catUrl,
                 heic: catUrl,
                 heicLowRes: catUrl

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template5Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template5Preview.swift
@@ -32,8 +32,8 @@ private enum Template5Preview {
     static let catImage = PaywallComponent.ImageComponent(
         source: .init(
             light: .init(
-                width: 1,
-                height: 1,
+                width: 750,
+                height: 530,
                 original: catUrl,
                 heic: catUrl,
                 heicLowRes: catUrl

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template5Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template5Preview.swift
@@ -32,6 +32,8 @@ private enum Template5Preview {
     static let catImage = PaywallComponent.ImageComponent(
         source: .init(
             light: .init(
+                width: 1,
+                height: 1,
                 original: catUrl,
                 heic: catUrl,
                 heicLowRes: catUrl

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -170,15 +170,15 @@ struct BackgrounDStyle_Previews: PreviewProvider {
         testContent
             .backgroundStyle(.image(.init(
                 light: .init(
-                    width: 0,
-                    height: 0,
+                    width: 750,
+                    height: 530,
                     original: lightUrl,
                     heic: lightUrl,
                     heicLowRes: lightUrl
                 ),
                 dark: .init(
-                    width: 0,
-                    height: 0,
+                    width: 1024,
+                    height: 853,
                     original: darkUrl,
                     heic: darkUrl,
                     heicLowRes: darkUrl
@@ -191,15 +191,15 @@ struct BackgrounDStyle_Previews: PreviewProvider {
         testContent
             .backgroundStyle(.image(.init(
                 light: .init(
-                    width: 0,
-                    height: 0,
+                    width: 750,
+                    height: 530,
                     original: lightUrl,
                     heic: lightUrl,
                     heicLowRes: lightUrl
                 ),
                 dark: .init(
-                    width: 0,
-                    height: 0,
+                    width: 1024,
+                    height: 853,
                     original: darkUrl,
                     heic: darkUrl,
                     heicLowRes: darkUrl

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -170,11 +170,15 @@ struct BackgrounDStyle_Previews: PreviewProvider {
         testContent
             .backgroundStyle(.image(.init(
                 light: .init(
+                    width: 0,
+                    height: 0,
                     original: lightUrl,
                     heic: lightUrl,
                     heicLowRes: lightUrl
                 ),
                 dark: .init(
+                    width: 0,
+                    height: 0,
                     original: darkUrl,
                     heic: darkUrl,
                     heicLowRes: darkUrl
@@ -187,11 +191,15 @@ struct BackgrounDStyle_Previews: PreviewProvider {
         testContent
             .backgroundStyle(.image(.init(
                 light: .init(
+                    width: 0,
+                    height: 0,
                     original: lightUrl,
                     heic: lightUrl,
                     heicLowRes: lightUrl
                 ),
                 dark: .init(
+                    width: 0,
+                    height: 0,
                     original: darkUrl,
                     heic: darkUrl,
                     heicLowRes: darkUrl

--- a/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
@@ -32,12 +32,16 @@ public extension PaywallComponent {
 
     struct ImageUrls: Codable, Sendable, Hashable, Equatable {
 
-        public init(original: URL, heic: URL, heicLowRes: URL) {
+        public init(width: Int, height: Int, original: URL, heic: URL, heicLowRes: URL) {
+            self.width = width
+            self.height = height
             self.original = original
             self.heic = heic
             self.heicLowRes = heicLowRes
         }
 
+        public let width: Int
+        public let height: Int
         public let original: URL
         public let heic: URL
         public let heicLowRes: URL


### PR DESCRIPTION
### Motivation

- Text was not rendering markdown
- Images where growing the width of its parent
- Footer was expanding whole height

### Description

- Text
  - Use the `.init` initializers
- Image
  - Use the `.fitToAspect` modifier and get the aspect ratio from the width and heigh property of an image
- Footer
  - Render with `.fixedSize` so it doesn't expand entire vertical view
  - But use `.overlay` because SwiftUI was locking up with `.safeAreaInset`