### PR TITLE
Add workaround for failed payments on iOS 18.2

### DIFF
--- a/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
+++ b/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
@@ -11,16 +11,15 @@
 //
 //  Created by Andrés Boedo on 8/20/21.
 
-#if os(iOS) || VISION_OS
+#if os(iOS) || os(tvOS) || VISION_OS
 import UIKit
 
 extension UIApplication {
 
-    @available(iOS 13.0, macCatalyst 13.1, *)
+    @available(iOS 13.0, macCatalyst 13.1, tvOS 13.0, *)
     @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(watchOSApplicationExtension, unavailable)
-    @available(tvOS, unavailable)
     @MainActor
     var currentWindowScene: UIWindowScene? {
         var scenes = self
@@ -38,7 +37,7 @@ extension UIApplication {
         return scenes.first as? UIWindowScene
     }
 
-    @available(iOS 15.0, *)
+    @available(iOS 15.0, tvOS 15.0, *)
     var currentViewController: UIViewController? {
         guard let rootViewController = currentWindowScene?.keyWindow?.rootViewController else {
             return nil

--- a/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
+++ b/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
@@ -50,10 +50,9 @@ extension UIApplication {
             return getTopViewController(from: presentedViewController)
         } else if let navigationController = viewController as? UINavigationController {
             return navigationController.visibleViewController
-        } else if let tabBarController = viewController as? UITabBarController {
-            if let selected = tabBarController.selectedViewController {
-                return getTopViewController(from: selected)
-            }
+        } else if let tabBarController = viewController as? UITabBarController,
+                  let selected = tabBarController.selectedViewController {
+            return getTopViewController(from: selected)
         }
         return viewController
     }

--- a/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
+++ b/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
@@ -39,10 +39,18 @@ extension UIApplication {
 
     @available(iOS 15.0, tvOS 15.0, *)
     var currentViewController: UIViewController? {
-        guard let rootViewController = currentWindowScene?.keyWindow?.rootViewController else {
+        var rootViewController = currentWindowScene?.keyWindow?.rootViewController
+
+        if rootViewController == nil {
+            // Fallback for application extensions where scenes are not supported
+            rootViewController = (value(forKey: "keyWindow") as? UIWindow)?.rootViewController
+        }
+
+        guard let resolvedRootViewController = rootViewController else {
             return nil
         }
-        return getTopViewController(from: rootViewController)
+
+        return getTopViewController(from: resolvedRootViewController)
     }
 
     private func getTopViewController(from viewController: UIViewController) -> UIViewController? {

--- a/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
+++ b/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
@@ -38,6 +38,27 @@ extension UIApplication {
         return scenes.first as? UIWindowScene
     }
 
+    @available(iOS 15.0, *)
+    var currentViewController: UIViewController? {
+        guard let rootViewController = currentWindowScene?.keyWindow?.rootViewController else {
+            return nil
+        }
+        return getTopViewController(from: rootViewController)
+    }
+
+    private func getTopViewController(from viewController: UIViewController) -> UIViewController? {
+        if let presentedViewController = viewController.presentedViewController {
+            return getTopViewController(from: presentedViewController)
+        } else if let navigationController = viewController as? UINavigationController {
+            return navigationController.visibleViewController
+        } else if let tabBarController = viewController as? UITabBarController {
+            if let selected = tabBarController.selectedViewController {
+                return getTopViewController(from: selected)
+            }
+        }
+        return viewController
+    }
+
 }
 
 #endif

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -227,7 +227,7 @@ class SystemInfo {
 
 }
 
-#if os(iOS) || VISION_OS
+#if os(iOS) || os(tvOS) || VISION_OS
 extension SystemInfo {
 
     @available(iOS 13.0, macCatalystApplicationExtension 13.1, *)
@@ -244,7 +244,7 @@ extension SystemInfo {
         }
     }
 
-    @available(iOS 15.0, *)
+    @available(iOS 15.0, tvOS 15.0, *)
     @MainActor
     var currentViewController: UIViewController {
         get throws {

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -244,6 +244,17 @@ extension SystemInfo {
         }
     }
 
+    @available(iOS 15.0, *)
+    @MainActor
+    var currentViewController: UIViewController {
+        get throws {
+            let viewController = self.sharedUIApplication?.currentViewController
+
+            return try viewController
+                .orThrow(ErrorUtils.storeProblemError(withMessage: "Failed to get UIViewController"))
+        }
+    }
+
 }
 #endif
 


### PR DESCRIPTION
There's a bug introduced by Apple in iOS 18.2 which prevents the payment sheet from being displayed if the current scene's key window root view controller is not part of the view hierarchy.

This can happen if it is currently presenting a modal view controller with `modalPresentationStyle = .fullScreen`.

When the issue manifests, there is a log error message printed in the console: `Could not get confirmation scene ID for`

To workaround the issue we traverse the view controller hierarchy until we find the topmost one and present the payment sheet there with the new `purchase()` method introduced in iOS 18.2 which accepts a `UIViewController`.

**IMPORTANT:** The fix requires compiling with Xcode 16.2 to take effect.

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
