### PR TITLE
Fix `@MainActor` reference in unsupported OS versions

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -33,11 +33,18 @@ public typealias PurchaseResultData = (transaction: StoreTransaction?,
 /**
  Completion block for ``Purchases/purchase(product:completion:)``
  */
+#if swift(>=5.5) && canImport(_Concurrency)
 public typealias PurchaseCompletedBlock = @MainActor @Sendable (StoreTransaction?,
                                                                 CustomerInfo?,
                                                                 PublicError?,
                                                                 Bool) -> Void
-
+#else
+// OS versions that don't support Swift Concurrency can't have references to Swift Concurrency types like @MainActor
+public typealias PurchaseCompletedBlock = (StoreTransaction?,
+                                           CustomerInfo?,
+                                           PublicError?,
+                                           Bool) -> Void
+#endif
 /**
  Block for starting purchases in ``PurchasesDelegate/purchases(_:readyForPromotedProduct:purchase:)``
  */


### PR DESCRIPTION
https://github.com/RevenueCat/purchases-ios/pull/1826 introduced references to `@MainActor` that are utilized in OS versions that don't support Swift Concurrency - namely, iOS 11-12 and macOS 10.12-10.14. 

This PR addresses it by using a compilation flag. 