### PR TITLE
[Paywalls V2] Fix current offering and sticky footer

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
@@ -30,68 +30,27 @@ struct RootView: View {
     }
 
     var body: some View {
-        ScrollView {
-            StackComponentView(viewModel: viewModel.stackViewModel, onDismiss: onDismiss)
-        }.applyIfLet(viewModel.stickyFooterViewModel) { stackView, stickyFooterViewModel in
-            stackView
-                // Using overlay because safeAreaInsert with fixedSize
-                .overlay(
-                    StackComponentView(
-                        viewModel: stickyFooterViewModel.stackViewModel,
-                        onDismiss: onDismiss,
-                        additionalPadding: EdgeInsets(
-                            top: 0,
-                            leading: 0,
-                            bottom: additionalFooterPaddingBottom,
-                            trailing: 0
-                        )
-                    )
-                    .fixedSize(horizontal: false, vertical: true)
-                    .edgesIgnoringSafeArea(.bottom),
-                    alignment: .bottom
-                )
-                // First we ensure our footer draws in the bottom safe area. Then we add additional padding, so its
-                // background shows in that same bottom safe area.
-                .ignoresSafeArea(edges: .bottom)
-                .onBottomSafeAreaPaddingChange { bottomPadding in
-                    self.additionalFooterPaddingBottom = bottomPadding
-                }
+        VStack(alignment: .center, spacing: 0) {
+            ScrollView {
+                StackComponentView(viewModel: viewModel.stackViewModel, onDismiss: onDismiss)
+            }
 
+            if let stickyFooterViewModel = viewModel.stickyFooterViewModel {
+                StackComponentView(
+                    viewModel: stickyFooterViewModel.stackViewModel,
+                    onDismiss: onDismiss,
+                    additionalPadding: EdgeInsets(
+                        top: 0,
+                        leading: 0,
+                        bottom: additionalFooterPaddingBottom,
+                        trailing: 0
+                    )
+                )
+                .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private struct OnBottomSafeAreaPaddingChangeModifier: ViewModifier {
-    private let callback: (CGFloat) -> Void
-
-    init(_ callback: @escaping (CGFloat) -> Void) {
-        self.callback = callback
-    }
-
-    func body(content: Content) -> some View {
-        content
-            .background(
-                GeometryReader { geometry in
-                    Color.clear
-                        .onAppear {
-                            callback(geometry.safeAreaInsets.bottom)
-                        }
-                        .onChange(of: geometry.safeAreaInsets.bottom) { newValue in
-                            callback(newValue)
-                        }
-                }
-            )
-    }
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-fileprivate extension View {
-    /// Sort-of backported safeAreaPadding (iOS 17+), for as much as we need.
-    func onBottomSafeAreaPaddingChange(_ callback: @escaping (CGFloat) -> Void) -> some View {
-        self.modifier(OnBottomSafeAreaPaddingChangeModifier(callback))
-    }
 }
 
 #endif

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -162,11 +162,21 @@ private extension Offering {
             )
         }
 
+        #if PAYWALL_COMPONENTS
+        return Offering(identifier: self.identifier,
+                        serverDescription: self.serverDescription,
+                        metadata: self.metadata,
+                        paywall: self.paywall,
+                        paywallComponentsData: self.paywallComponentsData,
+                        availablePackages: updatedPackages
+        )
+        #else
         return Offering(identifier: self.identifier,
                         serverDescription: self.serverDescription,
                         metadata: self.metadata,
                         paywall: self.paywall,
                         availablePackages: updatedPackages
         )
+        #endif
     }
 }


### PR DESCRIPTION
### Motivation

Some fixes while testing

### Description

- Current offering didn't have paywall component data
- Sticky footer wasn't showing content behind
  - `safeAreaInsets` breaks with complex layouts
  - `overlay` kept scroll content behind it
  - Just putting a vstack unedr the scrollview
