### PR TITLE
[Paywalls V2] Fix analytics and dismiss

### DIFF
--- a/RevenueCatUI/Templates/V2/Previews/PreviewMock.swift
+++ b/RevenueCatUI/Templates/V2/Previews/PreviewMock.swift
@@ -29,13 +29,16 @@ struct PreviewRequiredEnvironmentProperties: ViewModifier {
     let screenCondition: ScreenCondition
     let componentViewState: ComponentViewState
     let packageContext: PackageContext?
+    let colorScheme: ColorScheme
 
     func body(content: Content) -> some View {
         content
             .environmentObject(IntroOfferEligibilityContext(introEligibilityChecker: .default()))
+            .environmentObject(PurchaseHandler.default())
             .environmentObject(self.packageContext ?? Self.defaultPackageContext)
             .environment(\.screenCondition, screenCondition)
             .environment(\.componentViewState, componentViewState)
+            .environment(\.colorScheme, colorScheme)
     }
 
 }
@@ -45,12 +48,14 @@ extension View {
     func previewRequiredEnvironmentProperties(
         screenCondition: ScreenCondition = .compact,
         componentViewState: ComponentViewState = .default,
-        packageContext: PackageContext? = nil
+        packageContext: PackageContext? = nil,
+        colorScheme: ColorScheme = .light
     ) -> some View {
         self.modifier(PreviewRequiredEnvironmentProperties(
             screenCondition: screenCondition,
             componentViewState: componentViewState,
-            packageContext: packageContext
+            packageContext: packageContext,
+            colorScheme: colorScheme
         ))
     }
 }

--- a/Sources/Paywalls/Events/PaywallEvent.swift
+++ b/Sources/Paywalls/Events/PaywallEvent.swift
@@ -80,6 +80,27 @@ extension PaywallEvent {
         public var localeIdentifier: String
         public var darkMode: Bool
 
+        #if PAYWALL_COMPONENTS
+        @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+        public init(
+            offering: Offering,
+            paywallComponentsData: PaywallComponentsData,
+            sessionID: SessionID,
+            displayMode: PaywallViewMode,
+            locale: Locale,
+            darkMode: Bool
+        ) {
+            self.init(
+                offeringIdentifier: offering.identifier,
+                paywallRevision: paywallComponentsData.revision,
+                sessionID: sessionID,
+                displayMode: displayMode,
+                localeIdentifier: locale.identifier,
+                darkMode: darkMode
+            )
+        }
+        #endif
+
         @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
         public init(
             offering: Offering,


### PR DESCRIPTION
### Motivation

Paywalls V2 view was not tracking impression/close event, disabling while purchase, dismissing after purchase.

### Description

Brought in code that was being used in Paywalls V1 for this