### PR TITLE
fixed navigation with new param

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/CompatibilityNavigationStack.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CompatibilityNavigationStack.swift
@@ -24,9 +24,18 @@ import SwiftUI
 struct CompatibilityNavigationStack<Content: View>: View {
 
     @ViewBuilder var content: Content
+    let isInNavigationStack: Bool
+
+    init(isInNavigationStack: Bool = false,
+         @ViewBuilder content: () -> Content) {
+        self.isInNavigationStack = isInNavigationStack
+        self.content = content()
+    }
 
     var body: some View {
-        if #available(iOS 16.0, *) {
+        if isInNavigationStack {
+            content
+        } else if #available(iOS 16.0, *) {
             NavigationStack {
                 content
             }

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -42,30 +42,40 @@ public struct CustomerCenterView: View {
     private var colorScheme
 
     private let mode: CustomerCenterPresentationMode
+    private let isInNavigationStack: Bool
 
     /// Create a view to handle common customer support tasks
     /// - Parameters:
     ///   - customerCenterActionHandler: An optional `CustomerCenterActionHandler` to handle actions
     ///   from the Customer Center.
-    public init(customerCenterActionHandler: CustomerCenterActionHandler? = nil) {
-        self.init(customerCenterActionHandler: customerCenterActionHandler, mode: .default)
+    ///   - isInNavigationStack: Whether this view is already inside a navigation stack
+    public init(customerCenterActionHandler: CustomerCenterActionHandler? = nil,
+                isInNavigationStack: Bool = false) {
+        self.init(customerCenterActionHandler: customerCenterActionHandler,
+                  mode: .default,
+                  isInNavigationStack: isInNavigationStack)
     }
 
     /// Create a view to handle common customer support tasks
     /// - Parameters:
     ///   - customerCenterActionHandler: An optional `CustomerCenterActionHandler` to handle actions
     ///   from the Customer Center.
+    ///   - mode: The presentation mode for the Customer Center
+    ///   - isInNavigationStack: Whether this view is already inside a navigation stack
     init(customerCenterActionHandler: CustomerCenterActionHandler? = nil,
-         mode: CustomerCenterPresentationMode) {
+         mode: CustomerCenterPresentationMode,
+         isInNavigationStack: Bool = false) {
         self._viewModel = .init(wrappedValue:
                                     CustomerCenterViewModel(customerCenterActionHandler: customerCenterActionHandler))
         self.mode = mode
+        self.isInNavigationStack = isInNavigationStack
     }
 
     fileprivate init(viewModel: CustomerCenterViewModel,
                      mode: CustomerCenterPresentationMode = CustomerCenterPresentationMode.default) {
         self._viewModel = .init(wrappedValue: viewModel)
         self.mode = mode
+        self.isInNavigationStack = false
     }
 
     // swiftlint:disable:next missing_docs
@@ -157,7 +167,7 @@ private extension CustomerCenterView {
         let accentColor = Color.from(colorInformation: configuration.appearance.accentColor,
                                      for: self.colorScheme)
 
-        CompatibilityNavigationStack {
+        CompatibilityNavigationStack(isInNavigationStack: isInNavigationStack) {
             destinationContent(configuration: configuration)
         }
         .applyIf(accentColor != nil, apply: { $0.tint(accentColor) })


### PR DESCRIPTION
Fixes the navigation issues for Customer Center when presented through a NavigationStack. 

Solves the issue by adding an extra optional parameter that you use when showing `CustomerCenterView` in a `NavigationStack`: 

```swift
    CustomerCenterView(isInNavigationStack: true)
```


| Before | After |
| :-: | :-: |
| https://github.com/user-attachments/assets/68154d11-8a82-43e0-95ec-482c0c40446d | https://github.com/user-attachments/assets/034b1b88-a0ef-4e90-9d4c-cec4cddaa72b |

## The problem: 

When presenting the Customer Center in a navigation stack, if we add another one, we kinda break navigation. I reproduced this in a very, very simple SwiftUI app: 
<img width="562" alt="image" src="https://github.com/user-attachments/assets/3f7affa0-3ab6-4870-bb48-e18951c7fd4b" />

What happens is that you go into customer center, it flashes but then automatically dismisses as soon as it loads, because the internal navigation stack and the external one kinda fight each other. If you try to tap again, it errors out. 

The solution is actually dead simple - if we're already in a `NavigationStack`, we don't create a new one. 

What I don't love about this solution is that we do kind of give the consumer the responsibility of passing in this parameter correctly, but I tried my best to find ways around it to auto-detect and couldn't come up with something reliable. 

And it doesn't feel that complicated of a thing to pass in. 

Still to be done: 

- API Tests
- Do we need to update the presentation modes? Do we want to reuse presentation modes? I kinda tried but it didn't fit all that well since it's meant for sheets, but maybe it can be fitted better. 
- Do we need to update events / metrics for this? 
