### PR TITLE
Add text in default language to `feedbackSurveyCompleted` callback

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterAction.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterAction.swift
@@ -23,7 +23,13 @@ public enum CustomerCenterAction {
     /// - Parameter refundRequestStatus: The status of the refund request
     case refundRequestCompleted(_ refundRequestStatus: RefundRequestStatus)
     /// An option of the feedback survey has been selected
-    /// - Parameter feedbackSurveyOptionId: The id of the feedback survey option selected
+    /// - Parameter feedbackSurveyOptionId: The id of the selected feedback survey option
     case feedbackSurveyCompleted(_ feedbackSurveyOptionId: String)
+    /// An option of the feedback survey has been selected
+    /// - Parameter feedbackSurveyOptionId: The id of the selected feedback survey option
+    /// - Parameter titleInDefaultLocale: The displayed text of the selected feedback survey
+    /// option in the default locale (English by default)
+    case feedbackSurveyCompletedWithTitleInDefaultLocale(_ feedbackSurveyOptionId: String,
+                                                         _ titleInDefaultLocale: String)
 
 }

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterAction.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterAction.swift
@@ -26,10 +26,7 @@ public enum CustomerCenterAction {
     /// - Parameter feedbackSurveyOptionId: The id of the selected feedback survey option
     case feedbackSurveyCompleted(_ feedbackSurveyOptionId: String)
     /// An option of the feedback survey has been selected
-    /// - Parameter feedbackSurveyOptionId: The id of the selected feedback survey option
-    /// - Parameter titleInDefaultLocale: The displayed text of the selected feedback survey
-    /// option in the default locale (English by default)
-    case feedbackSurveyCompletedWithTitleInDefaultLocale(_ feedbackSurveyOptionId: String,
-                                                         _ titleInDefaultLocale: String)
+    /// - Parameter option: The ``CustomerCenterConfigData.HelpPath.FeedbackSurvey.Option`` that was selected
+    case feedbackSurveyCompletedWithOption(_ option: CustomerCenterConfigData.HelpPath.FeedbackSurvey.Option)
 
 }

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -73,16 +73,19 @@ enum CustomerCenterConfigTestData {
                                         .init(
                                             id: "1",
                                             title: "Too expensive",
+                                            titleInDefaultLocale: "Too expensive",
                                             promotionalOffer: nil
                                         ),
                                         .init(
                                             id: "2",
                                             title: "Don't use the app",
+                                            titleInDefaultLocale: "Don't use the app",
                                             promotionalOffer: nil
                                         ),
                                         .init(
                                             id: "3",
                                             title: "Bought by mistake",
+                                            titleInDefaultLocale: "Bought by mistake",
                                             promotionalOffer: nil
                                         )
                                     ]

--- a/RevenueCatUI/CustomerCenter/ViewModels/FeedbackSurveyViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/FeedbackSurveyViewModel.swift
@@ -64,6 +64,8 @@ class FeedbackSurveyViewModel: ObservableObject {
         if let customerCenterActionHandler = self.customerCenterActionHandler {
             trackSurveyAnswerSubmitted(option: option, darkMode: darkMode, displayMode: displayMode)
             customerCenterActionHandler(.feedbackSurveyCompleted(option.id))
+            customerCenterActionHandler(.feedbackSurveyCompletedWithTitleInDefaultLocale(option.id,
+                                                                                         option.titleInDefaultLocale))
         }
 
         if let promotionalOffer = option.promotionalOffer,

--- a/RevenueCatUI/CustomerCenter/ViewModels/FeedbackSurveyViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/FeedbackSurveyViewModel.swift
@@ -64,8 +64,7 @@ class FeedbackSurveyViewModel: ObservableObject {
         if let customerCenterActionHandler = self.customerCenterActionHandler {
             trackSurveyAnswerSubmitted(option: option, darkMode: darkMode, displayMode: displayMode)
             customerCenterActionHandler(.feedbackSurveyCompleted(option.id))
-            customerCenterActionHandler(.feedbackSurveyCompletedWithTitleInDefaultLocale(option.id,
-                                                                                         option.titleInDefaultLocale))
+            customerCenterActionHandler(.feedbackSurveyCompletedWithOption(option))
         }
 
         if let promotionalOffer = option.promotionalOffer,

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -309,11 +309,16 @@ public struct CustomerCenterConfigData {
 
                 public let id: String
                 public let title: String
+                public let titleInDefaultLocale: String
                 public let promotionalOffer: PromotionalOffer?
 
-                public init(id: String, title: String, promotionalOffer: PromotionalOffer?) {
+                public init(id: String,
+                            title: String,
+                            titleInDefaultLocale: String,
+                            promotionalOffer: PromotionalOffer?) {
                     self.id = id
                     self.title = title
+                    self.titleInDefaultLocale = titleInDefaultLocale
                     self.promotionalOffer = promotionalOffer
                 }
 
@@ -541,12 +546,12 @@ extension CustomerCenterConfigData.HelpPath.FeedbackSurvey.Option {
     init(from response: CustomerCenterConfigResponse.HelpPath.FeedbackSurvey.Option) {
         self.id = response.id
         self.title = response.title
+        self.titleInDefaultLocale = response.titleInDefaultLocale
         if let promotionalOffer = response.promotionalOffer {
             self.promotionalOffer = CustomerCenterConfigData.HelpPath.PromotionalOffer(from: promotionalOffer)
         } else {
             self.promotionalOffer = nil
         }
-
     }
 
 }

--- a/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
+++ b/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
@@ -87,6 +87,7 @@ struct CustomerCenterConfigResponse {
 
                 let id: String
                 let title: String
+                let titleInDefaultLocale: String
                 let promotionalOffer: PromotionalOffer?
 
             }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -256,6 +256,8 @@ extension SamplePaywallsList {
             print("CustomerCenter: refundRequestCompleted. Result: \(status)")
         case .feedbackSurveyCompleted(let surveyOptionID):
             print("CustomerCenter: feedbackSurveyCompleted. Result: \(surveyOptionID)")
+        case .feedbackSurveyCompletedWithTitleInDefaultLocale(let surveyOptionID, let titleInDefaultLocale):
+            print("CustomerCenter: feedbackSurveyCompleted. Result: \(surveyOptionID); \(titleInDefaultLocale)")
         }
     }
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -256,8 +256,8 @@ extension SamplePaywallsList {
             print("CustomerCenter: refundRequestCompleted. Result: \(status)")
         case .feedbackSurveyCompleted(let surveyOptionID):
             print("CustomerCenter: feedbackSurveyCompleted. Result: \(surveyOptionID)")
-        case .feedbackSurveyCompletedWithTitleInDefaultLocale(let surveyOptionID, let titleInDefaultLocale):
-            print("CustomerCenter: feedbackSurveyCompleted. Result: \(surveyOptionID); \(titleInDefaultLocale)")
+        case .feedbackSurveyCompletedWithOption(let option):
+            print("CustomerCenter: feedbackSurveyCompleted. Result: \(option)")
         }
     }
 }


### PR DESCRIPTION
With the changes we did to the localization UI, this callback is kinda broken since the ids are auto-generated, and mean nothing to the developer.

After this PR we'll be sending the English translation of the option as well so it's easier to understand what each option represent. It requires backend changes to send the English/default language translation to the callback as well.