### PR TITLE
Expose parse as web purchase redemption APIs for hybrids

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -154,6 +154,21 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
      */
     @objc public static func canMakePayments() -> Bool { StoreKit1Wrapper.canMakePayments() }
 
+    /// Parses a deep link URL to verify it's a RevenueCat web purchase redemption link
+    /// - Seealso: ``Purchases/redeemWebPurchase(_:)``
+    @objc public static func parseAsWebPurchaseRedemption(_ url: URL) -> WebPurchaseRedemption? {
+        return DeepLinkParser.parseAsWebPurchaseRedemption(url)
+    }
+
+    /// Parses a deep link URL string to verify it's a RevenueCat web purchase redemption link
+    /// - Seealso: ``Purchases/redeemWebPurchase(_:)``
+    @objc public static func parseUrlStringAsWebPurchaseRedemption(_ urlString: String) -> WebPurchaseRedemption? {
+        guard let url = URL(string: urlString) else {
+            return nil
+        }
+        return DeepLinkParser.parseAsWebPurchaseRedemption(url)
+    }
+
     /**
      * Set a custom log handler for redirecting logs to your own logging system.
      *
@@ -758,12 +773,6 @@ extension Purchases {
 // MARK: Identity
 
 public extension Purchases {
-
-    /// Parses a deep link URL to verify it's a RevenueCat web purchase redemption link
-    /// - Seealso: ``Purchases/redeemWebPurchase(_:)``
-    @objc internal static func parseAsWebPurchaseRedemption(_ url: URL) -> WebPurchaseRedemption? {
-        return DeepLinkParser.parseAsWebPurchaseRedemption(url)
-    }
 
     @objc var appUserID: String { self.identityManager.currentAppUserID }
 

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
@@ -124,6 +124,8 @@ NSURL *url;
     [p setKeyword: @""];
     [p setCreative: nil];
     [p setCreative: @""];
+    RCWebPurchaseRedemption *webPurchaseRedemption2 = [RCPurchases parseAsWebPurchaseRedemption:url];
+    RCWebPurchaseRedemption *webPurchaseRedemption3 = [RCPurchases parseUrlStringAsWebPurchaseRedemption:@""];
 
     [p getCustomerInfoWithFetchPolicy:RCCacheFetchPolicyFetchCurrent completion:^(RCCustomerInfo *customerInfo,
                                                                                   NSError *error) {}];

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
@@ -99,9 +99,11 @@ private func checkStaticMethods() {
     let simulatesAskToBuyInSandbox: Bool = Purchases.simulatesAskToBuyInSandbox
     let sharedPurchases: Purchases = Purchases.shared
     let isPurchasesConfigured: Bool = Purchases.isConfigured
+    let webPurchaseRedemption: WebPurchaseRedemption? = Purchases.parseAsWebPurchaseRedemption(url)
+    let webPurchaseRedemption2: WebPurchaseRedemption? = Purchases.parseUrlStringAsWebPurchaseRedemption("")
 
     print(canI, version, logLevel, proxyUrl!, forceUniversalAppStore, simulatesAskToBuyInSandbox,
-          sharedPurchases, isPurchasesConfigured)
+          sharedPurchases, isPurchasesConfigured, webPurchaseRedemption!, webPurchaseRedemption2!)
 }
 
 private func checkExtensions() {


### PR DESCRIPTION
### Description
While working on supporting web2app flows in our KMP SDK, I noticed we're mostly not using PHC for many of the functionalities, but using the native SDKs directly. The problem with using the PHC `redeemWebPurchase` method was that that method returns a map for the `CustomerInfo` that needs to be mapped back to a `CustomerInfo` object in KMP. For existing methods, we are instead performing that step using the native types, and performing the mapping from there (which is much more type safe). If I wanted to use the PHC methods, I would have need to write a new mapper from a Map to a `CustomerInfo` object in KMP. I felt it was better to follow what we have and continue using the native types here.

However, I wasn't able to access the `parseAsWebPurchaseRedemption` nor the extension function for `URL` from KMP. I believe in order to access these, I need to make these functions public in the type, and not in a non-objc extension. Additionally, I added a method that takes a urlString instead of a `URL` for convenience.