### PR TITLE
[Paywalls] Use CALayer-backed shadows and refactor Shape.swift

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -90,13 +90,11 @@ struct StackComponentView: View {
         }
         .padding(style.padding)
         .padding(additionalPadding)
-        .backgroundStyle(style.backgroundStyle, uiConfigProvider: self.viewModel.uiConfigProvider)
         .shape(border: style.border,
-               shape: style.shape)
-        .applyIfLet(style.shadow) { view, shadow in
-            // Without compositingGroup(), the shadow is applied to the stack's children as well.
-            view.compositingGroup().shadow(shadow: shadow)
-        }
+               shape: style.shape,
+               shadow: style.shadow,
+               background: style.backgroundStyle,
+               uiConfigProvider: self.viewModel.uiConfigProvider)
         .padding(style.margin)
     }
 

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -30,10 +30,10 @@ struct BackgroundStyleModifier: ViewModifier {
     var colorScheme
 
     var backgroundStyle: BackgroundStyle?
-    var uiConfigProvider: UIConfigProvider
+    var uiConfigProvider: UIConfigProvider?
 
     func body(content: Content) -> some View {
-        if let backgroundStyle {
+        if let backgroundStyle, let uiConfigProvider {
             content
                 .apply(backgroundStyle: backgroundStyle, colorScheme: colorScheme, uiConfigProvider: uiConfigProvider)
         } else {
@@ -96,7 +96,7 @@ fileprivate extension View {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
-    func backgroundStyle(_ backgroundStyle: BackgroundStyle?, uiConfigProvider: UIConfigProvider) -> some View {
+    func backgroundStyle(_ backgroundStyle: BackgroundStyle?, uiConfigProvider: UIConfigProvider?) -> some View {
         self.modifier(BackgroundStyleModifier(backgroundStyle: backgroundStyle, uiConfigProvider: uiConfigProvider))
     }
 

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 #if PAYWALL_COMPONENTS
 
-enum BackgroundStyle {
+enum BackgroundStyle: Hashable {
 
     case color(PaywallComponent.ColorScheme)
     case image(PaywallComponent.ThemeImageUrls)

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ShadowModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ShadowModifier.swift
@@ -90,13 +90,13 @@ struct LayerShadowModifier: ViewModifier {
     }
 }
 
-// Using the .shadow() modified to add a drop shadow in SwiftUI has multiple downsides:
+// Using the .shadow() modifier to add a drop shadow in SwiftUI has multiple downsides:
 // - The shadow is applied to all children views (can be worked around with .compositingGroup())
 // - The `.compositingGroup()` workaround stops working if the view has less than 100% opacity.
 // - The shadow inherits the opacity of the view, making it impossible to have a translucent
 //   or transparent view with a 100% opacity shadow.
 //
-// ShadowUIView tries to work around these limitations by rendering the shadow in a backing UIView,
+// LayerShadowView tries to work around these limitations by rendering the shadow in a backing UIView,
 // and using a Shape to mask off the inner part of the shadow.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct LayerShadowView: UIViewRepresentable {

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ShadowModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ShadowModifier.swift
@@ -48,10 +48,6 @@ struct ShadowModifier: ViewModifier {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
-    func shadow(shadow: ShadowModifier.ShadowInfo) -> some View {
-        self.modifier(ShadowModifier(shadow: shadow))
-    }
-
     func shadow(
         shadow: ShadowModifier.ShadowInfo,
         shape: some Shape
@@ -185,7 +181,7 @@ struct Shadow_Previews: PreviewProvider {
                 .padding(.horizontal, 20)
                 .background(.yellow)
                 .compositingGroup()
-                .shadow(shadow: .init(color: Color.black, radius: 10, x: 0, y: 0))
+                .shadow(shadow: .init(color: Color.black, radius: 10, x: 0, y: 0), shape: Rectangle())
                 .padding()
         }
         .previewLayout(.sizeThatFits)
@@ -197,7 +193,7 @@ struct Shadow_Previews: PreviewProvider {
                 .padding(.vertical, 10)
                 .padding(.horizontal, 20)
                 .compositingGroup()
-                .shadow(shadow: .init(color: Color.black, radius: 10, x: 0, y: 0))
+                .shadow(shadow: .init(color: Color.black, radius: 10, x: 0, y: 0), shape: Rectangle())
                 .padding()
         }
         .previewLayout(.sizeThatFits)
@@ -210,7 +206,7 @@ struct Shadow_Previews: PreviewProvider {
                 .padding(.horizontal, 20)
                 .background(.yellow)
                 .compositingGroup()
-                .shadow(shadow: .init(color: Color.blue, radius: 10, x: 0, y: 0))
+                .shadow(shadow: .init(color: Color.blue, radius: 10, x: 0, y: 0), shape: Rectangle())
                 .padding()
         }
         .previewLayout(.sizeThatFits)
@@ -223,7 +219,7 @@ struct Shadow_Previews: PreviewProvider {
                 .padding(.horizontal, 20)
                 .background(.yellow)
                 .compositingGroup()
-                .shadow(shadow: .init(color: Color.black, radius: 10, x: 20, y: 0))
+                .shadow(shadow: .init(color: Color.black, radius: 10, x: 20, y: 0), shape: Rectangle())
                 .padding()
         }
         .previewLayout(.sizeThatFits)
@@ -236,7 +232,7 @@ struct Shadow_Previews: PreviewProvider {
                 .padding(.horizontal, 20)
                 .background(.yellow)
                 .compositingGroup()
-                .shadow(shadow: .init(color: Color.black, radius: 10, x: 0, y: 20))
+                .shadow(shadow: .init(color: Color.black, radius: 10, x: 0, y: 20), shape: Rectangle())
                 .padding()
         }
         .previewLayout(.sizeThatFits)
@@ -249,7 +245,7 @@ struct Shadow_Previews: PreviewProvider {
                 .padding(.horizontal, 20)
                 .background(.yellow)
                 .compositingGroup()
-                .shadow(shadow: .init(color: Color.black, radius: 10, x: 20, y: 20))
+                .shadow(shadow: .init(color: Color.black, radius: 10, x: 20, y: 20), shape: Rectangle())
                 .padding()
         }
         .previewLayout(.sizeThatFits)
@@ -262,7 +258,7 @@ struct Shadow_Previews: PreviewProvider {
                 .padding(.horizontal, 20)
                 .background(.yellow)
                 .compositingGroup()
-                .shadow(shadow: .init(color: Color.black, radius: 0, x: 20, y: 20))
+                .shadow(shadow: .init(color: Color.black, radius: 0, x: 20, y: 20), shape: Rectangle())
                 .padding()
         }
         .previewLayout(.sizeThatFits)

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ShadowModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ShadowModifier.swift
@@ -48,9 +48,13 @@ struct ShadowModifier: ViewModifier {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
+    func shadow(shadow: ShadowModifier.ShadowInfo) -> some View {
+        self.modifier(ShadowModifier(shadow: shadow))
+    }
+
     func shadow(
         shadow: ShadowModifier.ShadowInfo,
-        shape: some Shape = Rectangle()
+        shape: some Shape
     ) -> some View {
         self.modifier(LayerShadowModifier(
             shape: shape,

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ShadowModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ShadowModifier.swift
@@ -55,8 +55,8 @@ extension View {
         self.modifier(LayerShadowModifier(
             shape: shape,
             color: shadow.color,
-            x: shadow.x,
-            y: shadow.y,
+            xOffset: shadow.x,
+            yOffset: shadow.y,
             blur: shadow.radius * 2,
             spread: 0
         ))
@@ -68,7 +68,7 @@ struct LayerShadowModifier: ViewModifier {
     let shape: any Shape
     let color: Color
     let xOffset: CGFloat
-    let yLayerShadowModifier: CGFloat
+    let yOffset: CGFloat
     let blur: CGFloat
     let spread: CGFloat
 
@@ -79,8 +79,8 @@ struct LayerShadowModifier: ViewModifier {
                     let rect = geometry.frame(in: .local)
                     LayerShadowView(shape: shape,
                                     color: color,
-                                    xLayerShadowModifier: xLayerShadowModifier,
-                                    yLayerShadowModifier: yLayerShadowModifier,
+                                    xOffset: xOffset,
+                                    yOffset: yOffset,
                                     blur: blur,
                                     spread: spread,
                                     rect: rect)
@@ -113,7 +113,7 @@ private struct LayerShadowView: UIViewRepresentable {
         view.backgroundColor = .clear
         view.layer.shadowColor = UIColor(color).cgColor
         view.layer.shadowOpacity = 1
-        view.layer.shadowOffset = CGSize(width: x, height: y)
+        view.layer.shadowOffset = CGSize(width: xOffset, height: yOffset)
         view.layer.shadowRadius = blur / 2
 
         // Create path for the shape
@@ -143,7 +143,7 @@ private struct LayerShadowView: UIViewRepresentable {
     func updateUIView(_ uiView: UIView, context: Context) {
         uiView.layer.shadowColor = UIColor(color).cgColor
         uiView.layer.shadowOpacity = 1
-        uiView.layer.shadowOffset = CGSize(width: x, height: y)
+        uiView.layer.shadowOffset = CGSize(width: xOffset, height: yOffset)
         uiView.layer.shadowRadius = blur / 2
 
         // Update shadow path

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ShadowModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ShadowModifier.swift
@@ -19,7 +19,7 @@ import SwiftUI
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct ShadowModifier: ViewModifier {
 
-    struct ShadowInfo {
+    struct ShadowInfo: Hashable {
 
         let color: Color
         let radius: CGFloat

--- a/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
@@ -64,14 +64,17 @@ struct ShapeModifier: ViewModifier {
     var background: BackgroundStyle?
     var uiConfigProvider: UIConfigProvider?
 
-    init(border: BorderInfo? = nil,
+    init(border: BorderInfo?,
          shape: Shape?,
-         shadow: ShadowModifier.ShadowInfo? = nil,
-         background: BackgroundStyle? = nil) {
+         shadow: ShadowModifier.ShadowInfo?,
+         background: BackgroundStyle?,
+         uiConfigProvider: UIConfigProvider?
+    ) {
         self.border = border
         self.shape = shape ?? .rectangle(nil)
         self.shadow = shadow
         self.background = background
+        self.uiConfigProvider = uiConfigProvider
     }
 
     func body(content: Content) -> some View {
@@ -249,7 +252,8 @@ extension View {
                 border: border,
                 shape: shape,
                 shadow: shadow,
-                background: background
+                background: background,
+                uiConfigProvider: uiConfigProvider
             )
         )
     }

--- a/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
@@ -338,7 +338,12 @@ struct CornerBorder_Previews: PreviewProvider {
                                     .padding(.vertical, 10)
                                     .padding(.horizontal, 20)
                             }
-                            .shape(border: border, shape: shape, shadow: shadow, background: background)
+                            .shape(border: border,
+                                   shape: shape,
+                                   shadow: shadow,
+                                   background: background,
+                                   uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
+                            )
                             .padding(5)
                         }
                     }

--- a/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
@@ -59,35 +59,51 @@ struct ShapeModifier: ViewModifier {
 
     var border: BorderInfo?
     var shape: Shape
+    var shadow: ShadowModifier.ShadowInfo?
+    var background: BackgroundStyle?
+    var uiConfigProvider: UIConfigProvider?
 
-    init(border: BorderInfo? = nil, shape: Shape?) {
+    init(border: BorderInfo? = nil,
+         shape: Shape?,
+         shadow: ShadowModifier.ShadowInfo? = nil,
+         background: BackgroundStyle? = nil) {
         self.border = border
         self.shape = shape ?? .rectangle(nil)
+        self.shadow = shadow
+        self.background = background
     }
 
     func body(content: Content) -> some View {
         switch self.shape {
-        case .rectangle(let radiuses):
+        case .rectangle(let radiusInfo):
+            let shape = self.effectiveRectangleShape(radiusInfo: radiusInfo)
             content
-                .conditionalClipShape(topLeft: radiuses?.topLeft,
-                                      topRight: radiuses?.topRight,
-                                      bottomLeft: radiuses?.bottomLeft,
-                                      bottomRight: radiuses?.bottomRight)
-                .conditionalOverlay(color: self.border?.color,
-                                    width: self.border?.width,
-                                    topLeft: radiuses?.topLeft,
-                                    topRight: radiuses?.topRight,
-                                    bottomLeft: radiuses?.bottomLeft,
-                                    bottomRight: radiuses?.bottomRight)
+                .backgroundStyle(background, uiConfigProvider: uiConfigProvider)
+                .clipShape(shape)
+                .applyIfLet(border) { view, border in
+                    view.overlay {
+                        shape.strokeBorder(border.color, lineWidth: border.width)
+                    }
+                }
+                .applyIfLet(shadow) { view, shadow in
+                    view.overlay {
+                        view.shadow(shadow: shadow, shape: shape)
+                    }
+                }
         case .pill:
+            let shape = Capsule(style: .circular)
             content
-                .clipShape(Capsule(style: .circular))
-                .applyIfLet(self.border, apply: { view, border in
-                    view.overlay(
-                        Capsule(style: .circular)
-                            .strokeBorder(border.color, lineWidth: border.width)
-                    )
-                })
+                .backgroundStyle(background, uiConfigProvider: uiConfigProvider)
+                .clipShape(shape)
+                .applyIfLet(border) { view, border in
+                    view.overlay {
+                        shape.strokeBorder(border.color, lineWidth: border.width)
+                    }
+                }.applyIfLet(shadow) { view, shadow in
+                    view.overlay {
+                        view.shadow(shadow: shadow, shape: shape)
+                    }
+                }
         case .concave:
             // WIP: Need to implement
             content
@@ -96,117 +112,63 @@ struct ShapeModifier: ViewModifier {
             content
         }
     }
-}
 
-// Helper extensions to conditionally apply clipShape and overlay without AnyView
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-extension View {
-
-    func conditionalClipShape(
-        topLeft: CGFloat?,
-        topRight: CGFloat?,
-        bottomLeft: CGFloat?,
-        bottomRight: CGFloat?
-    ) -> some View {
-        Group {
-            if let topLeft = topLeft,
-                let topRight = topRight,
-                let bottomLeft = bottomLeft,
-                let bottomRight = bottomRight,
-                topLeft > 0 || topRight > 0 || bottomLeft > 0 || bottomRight > 0 {
-                if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
-                    self.clipShape(UnevenRoundedRectangle(
-                        topLeadingRadius: topLeft,
-                        bottomLeadingRadius: bottomLeft,
-                        bottomTrailingRadius: bottomRight,
-                        topTrailingRadius: topRight,
-                        style: .circular
-                    ))
-                } else {
-                    self.applyIf(topLeft > 0) {
-                        $0.clipShape(SingleRoundedCornerShape(radius: topLeft, corners: [.topLeft]))
-                    }
-                    .applyIf(topRight > 0) {
-                        $0.clipShape(SingleRoundedCornerShape(radius: topRight, corners: [.topRight]))
-                    }
-                    .applyIf(bottomLeft > 0) {
-                        $0.clipShape(SingleRoundedCornerShape(radius: bottomLeft, corners: [.bottomLeft]))
-                    }
-                    .applyIf(bottomRight > 0) {
-                        $0.clipShape(SingleRoundedCornerShape(radius: bottomRight, corners: [.bottomRight]))
-                    }
-                }
+    func effectiveRectangleShape(radiusInfo: RadiusInfo?) -> AnyInsettableShape {
+        if let topLeft = radiusInfo?.topLeft,
+           let topRight = radiusInfo?.topRight,
+           let bottomLeft = radiusInfo?.bottomLeft,
+           let bottomRight = radiusInfo?.bottomRight,
+           topLeft > 0 || topRight > 0 || bottomLeft > 0 || bottomRight > 0 {
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                UnevenRoundedRectangle(
+                    topLeadingRadius: topLeft,
+                    bottomLeadingRadius: bottomLeft,
+                    bottomTrailingRadius: bottomRight,
+                    topTrailingRadius: topRight,
+                    style: .circular
+                ).eraseToAnyInsettableShape()
             } else {
-                self
+                BackportedUnevenRoundedRectangle(
+                    topLeft: topLeft,
+                    topRight: topRight,
+                    bottomLeft: bottomLeft,
+                    bottomRight: bottomRight
+                ).eraseToAnyInsettableShape()
             }
-        }
-    }
-
-    // swiftlint:disable:next function_parameter_count
-    func conditionalOverlay(
-        color: Color?,
-        width: CGFloat?,
-        topLeft: CGFloat?,
-        topRight: CGFloat?,
-        bottomLeft: CGFloat?,
-        bottomRight: CGFloat?
-    ) -> some View {
-        Group {
-            if let color = color, let width = width, width > 0 {
-                if let topLeft = topLeft,
-                   let topRight = topRight,
-                   let bottomLeft = bottomLeft,
-                   let bottomRight = bottomRight,
-                   topLeft > 0 || topRight > 0 || bottomLeft > 0 || bottomRight > 0 {
-                    self.overlay {
-                        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
-                            UnevenRoundedRectangle(
-                                topLeadingRadius: topLeft,
-                                bottomLeadingRadius: bottomLeft,
-                                bottomTrailingRadius: bottomRight,
-                                topTrailingRadius: topRight,
-                                style: .circular
-                            )
-                            .strokeBorder(color, lineWidth: width)
-                        } else {
-                            BorderRoundedCornerShape(
-                                topLeft: topLeft,
-                                topRight: topRight,
-                                bottomLeft: bottomLeft,
-                                bottomRight: bottomRight
-                            )
-                            .inset(by: width/2)
-                            .stroke(color, lineWidth: width)
-                        }
-                    }
-                } else {
-                    self
-                        .border(color, width: width)
-                }
-            } else {
-                self
-            }
+        } else {
+            Rectangle().eraseToAnyInsettableShape()
         }
     }
 
 }
 
-private struct SingleRoundedCornerShape: Shape {
-    var radius: CGFloat
-    var corners: UIRectCorner
+// Type-erasing wrapper for InsettableShape protocol
+struct AnyInsettableShape: InsettableShape {
+    private var base: any InsettableShape
+
+    init<S: InsettableShape>(_ shape: S) {
+        self.base = shape
+    }
 
     func path(in rect: CGRect) -> Path {
-        let path = UIBezierPath(
-            roundedRect: rect,
-            byRoundingCorners: corners,
-            cornerRadii: CGSize(width: radius, height: radius)
-        )
-        return Path(path.cgPath)
+        base.path(in: rect)
+    }
+
+    func inset(by amount: CGFloat) -> AnyInsettableShape {
+        var copy = self
+        copy.base = copy.base.inset(by: amount)
+        return copy
     }
 }
 
-private struct BorderRoundedCornerShape: InsettableShape {
+private extension InsettableShape {
+    func eraseToAnyInsettableShape() -> AnyInsettableShape {
+        AnyInsettableShape(self)
+    }
+}
+
+// Substitute for UnevenRoundedRectangle which is only available on iOS 16+
+private struct BackportedUnevenRoundedRectangle: InsettableShape {
     var topLeft: CGFloat
     var topRight: CGFloat
     var bottomLeft: CGFloat
@@ -274,12 +236,17 @@ private struct BorderRoundedCornerShape: InsettableShape {
 extension View {
     func shape(
         border: ShapeModifier.BorderInfo?,
-        shape: ShapeModifier.Shape?
+        shape: ShapeModifier.Shape?,
+        shadow: ShadowModifier.ShadowInfo? = nil,
+        background: BackgroundStyle? = nil,
+        uiConfigProvider: UIConfigProvider? = nil
     ) -> some View {
         self.modifier(
             ShapeModifier(
                 border: border,
-                shape: shape
+                shape: shape,
+                shadow: shadow,
+                background: background
             )
         )
     }


### PR DESCRIPTION
### Motivation

By default shadows in SwiftUI are applied to children views as well, so we implemented a workaround by using `.compositingGroup()`.

However when the background color of a view with a shadow has less than 100% opacity, the `.compositingGroup()` workaround no longer works. Additionally, the shadow inherits the opacity of the view which is less than ideal.

### Description

In this PR, we replace SwiftUI shadows with a CALayer-backed solution. Because this solution requires knowing the shape of the view, I took the opportunity to refactor the Shape modifier code.

I didn't modify any current SwiftUI previews so make sure nothing broke. The only changes were minor rendering differences in the shadows which are not perceptible with your naked eye, and a change in how a shadow applied to a `Text` view renders, as it now applies to its bounding rectangle and not to the text itself. Fortunately, we don't currently support shadows in text.

<img width="786" alt="Screenshot 2025-01-03 at 22 24 46" src="https://github.com/user-attachments/assets/adf2116b-00d2-4828-ad0d-7d36db970791" />