### PR TITLE
[Paywalls V2] Add support for alias solid hex colors (not gradients)

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -90,7 +90,7 @@ struct StackComponentView: View {
         }
         .padding(style.padding)
         .padding(additionalPadding)
-        .backgroundStyle(style.backgroundStyle)
+        .backgroundStyle(style.backgroundStyle, uiConfigProvider: self.viewModel.uiConfigProvider)
         .shape(border: style.border,
                shape: style.shape)
         .applyIfLet(style.shadow) { view, shadow in
@@ -456,7 +456,8 @@ fileprivate extension StackComponentViewModel {
 
         try self.init(
             component: component,
-            viewModels: viewModels
+            viewModels: viewModels,
+            uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
         )
     }
 

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
@@ -22,16 +22,19 @@ private typealias PresentedStackPartial = PaywallComponent.PartialStackComponent
 class StackComponentViewModel {
 
     private let component: PaywallComponent.StackComponent
+    let uiConfigProvider: UIConfigProvider
     private let presentedOverrides: PresentedOverrides<PresentedStackPartial>?
 
     let viewModels: [PaywallComponentViewModel]
 
     init(
         component: PaywallComponent.StackComponent,
-        viewModels: [PaywallComponentViewModel]
+        viewModels: [PaywallComponentViewModel],
+        uiConfigProvider: UIConfigProvider
     ) throws {
         self.component = component
         self.viewModels = viewModels
+        self.uiConfigProvider = uiConfigProvider
 
         self.presentedOverrides = try self.component.overrides?.toPresentedOverrides { $0 }
     }
@@ -51,6 +54,7 @@ class StackComponentViewModel {
         )
 
         let style = StackComponentStyle(
+            uiConfigProvider: self.uiConfigProvider,
             visible: partial?.visible ?? true,
             dimension: partial?.dimension ?? self.component.dimension,
             size: partial?.size ?? self.component.size,
@@ -107,6 +111,7 @@ struct StackComponentStyle {
     let shadow: ShadowModifier.ShadowInfo?
 
     init(
+        uiConfigProvider: UIConfigProvider,
         visible: Bool,
         dimension: PaywallComponent.Dimension,
         size: PaywallComponent.Size,
@@ -126,8 +131,8 @@ struct StackComponentStyle {
         self.padding = padding.edgeInsets
         self.margin = margin.edgeInsets
         self.shape = shape?.shape
-        self.border = border?.border
-        self.shadow = shadow?.shadow
+        self.border = border?.border(uiConfigProvider: uiConfigProvider)
+        self.shadow = shadow?.shadow(uiConfigProvider: uiConfigProvider)
     }
 
     var vstackStrategy: StackStrategy {
@@ -185,9 +190,9 @@ private extension PaywallComponent.Shape {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension PaywallComponent.Border {
 
-    var border: ShapeModifier.BorderInfo? {
-        ShapeModifier.BorderInfo(
-            color: self.color.toDynamicColor(),
+    func border(uiConfigProvider: UIConfigProvider) -> ShapeModifier.BorderInfo? {
+        return ShapeModifier.BorderInfo(
+            color: self.color.toDynamicColor(uiConfigProvider: uiConfigProvider),
             width: self.width
         )
     }
@@ -197,9 +202,9 @@ private extension PaywallComponent.Border {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension PaywallComponent.Shadow {
 
-    var shadow: ShadowModifier.ShadowInfo? {
-        ShadowModifier.ShadowInfo(
-            color: self.color.toDynamicColor(),
+    func shadow(uiConfigProvider: UIConfigProvider) -> ShadowModifier.ShadowInfo? {
+        return ShadowModifier.ShadowInfo(
+            color: self.color.toDynamicColor(uiConfigProvider: uiConfigProvider),
             radius: self.radius,
             x: self.x,
             y: self.y

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -11,6 +11,8 @@
 //
 //  Created by Josh Holtz on 6/11/24.
 
+// swiftlint:disable file_length
+
 import Foundation
 import RevenueCat
 import SwiftUI
@@ -54,10 +56,10 @@ struct TextComponentView: View {
                         .fontWeight(style.fontWeight)
                         .fixedSize(horizontal: false, vertical: true)
                         .multilineTextAlignment(style.textAlignment)
-                        .foregroundColorScheme(style.color)
+                        .foregroundColorScheme(style.color, uiConfigProvider: self.viewModel.uiConfigProvider)
                         .padding(style.padding)
                         .size(style.size, alignment: style.horizontalAlignment)
-                        .backgroundStyle(style.backgroundStyle)
+                        .backgroundStyle(style.backgroundStyle, uiConfigProvider: self.viewModel.uiConfigProvider)
                         .padding(style.margin)
                 } else {
                     EmptyView()
@@ -188,6 +190,60 @@ struct TextComponentView_Previews: PreviewProvider {
         .previewRequiredEnvironmentProperties()
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Custom Font")
+
+        // Custom Color
+        VStack {
+            TextComponentView(
+                // swiftlint:disable:next force_try
+                viewModel: try! .init(
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [
+                            "id_1": .string("Red bg, yellow fg")
+                        ]
+                    ),
+                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
+                        colors: [
+                            "primary": .hex("#ff0000"),
+                            "secondary": .hex("#ffcc00")
+                        ]
+                    )),
+                    component: .init(
+                        text: "id_1",
+                        color: .init(light: .alias("secondary")),
+                        backgroundColor: .init(light: .alias("primary")),
+                        fontSize: .headingXXL
+                    )
+                )
+            )
+
+            TextComponentView(
+                // swiftlint:disable:next force_try
+                viewModel: try! .init(
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [
+                            "id_1": .string("Clear bg and default fg")
+                        ]
+                    ),
+                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
+                        colors: [
+                            "primary": .hex("#ff0000"),
+                            "secondary": .hex("#ffcc00")
+                        ]
+                    )),
+                    component: .init(
+                        text: "id_1",
+                        color: .init(light: .alias("not a thing")),
+                        backgroundColor: .init(light: .alias("also not a thing")),
+                        fontSize: .headingXXL
+                    )
+                )
+            )
+        }
+        .previewRequiredEnvironmentProperties()
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Custom Color")
 
         // Gradient
         TextComponentView(

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -20,7 +20,7 @@ import SwiftUI
 class TextComponentViewModel {
 
     private let localizationProvider: LocalizationProvider
-    private let uiConfigProvider: UIConfigProvider
+    let uiConfigProvider: UIConfigProvider
     private let component: PaywallComponent.TextComponent
 
     private let text: String

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -30,11 +30,12 @@ struct BackgroundStyleModifier: ViewModifier {
     var colorScheme
 
     var backgroundStyle: BackgroundStyle?
+    var uiConfigProvider: UIConfigProvider
 
     func body(content: Content) -> some View {
         if let backgroundStyle {
             content
-                .apply(backgroundStyle: backgroundStyle, colorScheme: colorScheme)
+                .apply(backgroundStyle: backgroundStyle, colorScheme: colorScheme, uiConfigProvider: uiConfigProvider)
         } else {
             content
         }
@@ -46,12 +47,16 @@ struct BackgroundStyleModifier: ViewModifier {
 fileprivate extension View {
 
     @ViewBuilder
-    func apply(backgroundStyle: BackgroundStyle, colorScheme: ColorScheme) -> some View {
+    func apply(
+        backgroundStyle: BackgroundStyle,
+        colorScheme: ColorScheme,
+        uiConfigProvider: UIConfigProvider
+    ) -> some View {
         switch backgroundStyle {
         case .color(let color):
             switch color.effectiveColor(for: colorScheme) {
             case .hex, .alias:
-                self.background(color.toDynamicColor())
+                self.background(color.toDynamicColor(uiConfigProvider: uiConfigProvider))
             case .linear(let degrees, _):
                 self.background {
                     GradientView(
@@ -91,8 +96,8 @@ fileprivate extension View {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
-    func backgroundStyle(_ backgroundStyle: BackgroundStyle?) -> some View {
-        self.modifier(BackgroundStyleModifier(backgroundStyle: backgroundStyle))
+    func backgroundStyle(_ backgroundStyle: BackgroundStyle?, uiConfigProvider: UIConfigProvider) -> some View {
+        self.modifier(BackgroundStyleModifier(backgroundStyle: backgroundStyle, uiConfigProvider: uiConfigProvider))
     }
 
 }
@@ -143,7 +148,7 @@ struct BackgrounDStyle_Previews: PreviewProvider {
             .backgroundStyle(.color(.init(
                 light: .hex("#ff0000"),
                 dark: .hex("#ffcc00")
-            )))
+            )), uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Color - Light (should be red)")
 
@@ -152,7 +157,7 @@ struct BackgrounDStyle_Previews: PreviewProvider {
             .backgroundStyle(.color(.init(
                 light: .hex("#ff0000"),
                 dark: .hex("#ffcc00")
-            )))
+            )), uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Color - Dark (should be yellow)")
@@ -161,7 +166,7 @@ struct BackgrounDStyle_Previews: PreviewProvider {
         testContent
             .backgroundStyle(.color(.init(
                 light: .hex("#ff0000")
-            )))
+            )), uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Color - Dark (should be red because fallback)")
@@ -183,7 +188,7 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                     heic: darkUrl,
                     heicLowRes: darkUrl
                 )
-            )))
+            )), uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Image - Light (should be pink cat)")
 
@@ -204,7 +209,7 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                     heic: darkUrl,
                     heicLowRes: darkUrl
                 )
-            )))
+            )), uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Image - Dark (should be japan cats)")
@@ -222,7 +227,8 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                             .init(color: "#E58984", percent: 100)
                         ])
                       )
-                 )
+                ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
             )
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
@@ -241,7 +247,8 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                             .init(color: "#9DEAD3", percent: 100)
                         ])
                       )
-                 )
+                ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
             )
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Linear Gradient - Light (should be green")
@@ -259,7 +266,8 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                             .init(color: "#E58984", percent: 100)
                         ])
                       )
-                 )
+                ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
             )
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
@@ -279,7 +287,8 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                             .init(color: "#ffffff", percent: 100)
                         ])
                       )
-                 )
+                ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
             )
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Radial Gradient - Light (should be green")

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ForegroundColorScheme.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ForegroundColorScheme.swift
@@ -58,8 +58,8 @@ fileprivate extension View {
         case .hex, .alias:
             let color = color.toDynamicColor(uiConfigProvider: uiConfigProvider)
 
-            // Only apply foreground color if not clear
-            // This is a way to
+            // Do not apply a clear text color
+            // Use the default color
             if color != Color.clear {
                 self.foregroundColor(color)
             } else {

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
@@ -251,6 +251,7 @@ extension PaywallComponent.ColorInfo {
             // Alias should never have an alias
             // Using fallback so recursion doesn't happen
             if case .alias = aliasColor {
+                Logger.warning("Aliased color '\(alias)' has an aliased value which is not allowed.")
                 return fallback
             }
 

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -24,6 +24,14 @@ struct UIConfigProvider {
         self.uiConfig = uiConfig
     }
 
+    func getColor(for name: String?) -> PaywallComponent.ColorInfo? {
+        guard let name else {
+            return nil
+        }
+
+        return self.uiConfig.app.colors[name]
+    }
+
     func getFontFamily(for name: String?) -> String? {
         guard let name, let fontInfo = self.uiConfig.app.fonts[name]?.ios else {
             return nil

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -24,11 +24,7 @@ struct UIConfigProvider {
         self.uiConfig = uiConfig
     }
 
-    func getColor(for name: String?) -> PaywallComponent.ColorInfo? {
-        guard let name else {
-            return nil
-        }
-
+    func getColor(for name: String) -> PaywallComponent.ColorInfo? {
         return self.uiConfig.app.colors[name]
     }
 

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -92,7 +92,8 @@ struct ViewModelFactory {
 
             return .stack(
                 try StackComponentViewModel(component: component,
-                                            viewModels: viewModels)
+                                            viewModels: viewModels,
+                                            uiConfigProvider: uiConfigProvider)
             )
         case .button(let component):
             let stackViewModel = try toStackViewModel(
@@ -175,7 +176,8 @@ struct ViewModelFactory {
 
         return try StackComponentViewModel(
             component: component,
-            viewModels: viewModels
+            viewModels: viewModels,
+            uiConfigProvider: uiConfigProvider
         )
     }
 


### PR DESCRIPTION
### Motivation

Add support for aliased `hex` colors (for when dashboard supports them)

⚠️ Gradients will required a bigger rework (a Linear ticket has been added for this)

### Description

Passes a `UIConfigProvider` into the `toColor()` method which does the alias lookup
