### PR TITLE
[EXTERNAL] Lock RateLimiter.shouldProceed() entirely to avoid race conditions (#4635) via @nguyenhuy

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -57,7 +57,7 @@
 		2C7457882CEDF7C0004ACE52 /* BackgroundStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7457872CEDF7AC004ACE52 /* BackgroundStyle.swift */; };
 		2C74578A2CEE314F004ACE52 /* Background.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7457892CEE314C004ACE52 /* Background.swift */; };
 		2C7F0AD32B8EEB4600381179 /* RateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */; };
-		2C7F0AD62B8EEF7B00381179 /* RateLimiterRests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */; };
+		2C7F0AD62B8EEF7B00381179 /* RateLimiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7F0AD42B8EEF0B00381179 /* RateLimiterTests.swift */; };
 		2C8EC6DB2CCC23B700D6CCF8 /* Template5Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8EC6DA2CCC23B700D6CCF8 /* Template5Preview.swift */; };
 		2C8EC6DD2CCC7C5B00D6CCF8 /* PackageValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8EC6DC2CCC7C5500D6CCF8 /* PackageValidator.swift */; };
 		2C8EC6DF2CCD27A500D6CCF8 /* PartialComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8EC6DE2CCD27A100D6CCF8 /* PartialComponentTests.swift */; };
@@ -1289,7 +1289,7 @@
 		2C7457872CEDF7AC004ACE52 /* BackgroundStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundStyle.swift; sourceTree = "<group>"; };
 		2C7457892CEE314C004ACE52 /* Background.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Background.swift; sourceTree = "<group>"; };
 		2C7F0AD22B8EEB4600381179 /* RateLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiter.swift; sourceTree = "<group>"; };
-		2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiterRests.swift; sourceTree = "<group>"; };
+		2C7F0AD42B8EEF0B00381179 /* RateLimiterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiterTests.swift; sourceTree = "<group>"; };
 		2C8EC6AE2CCBD33E00D6CCF8 /* ButtonComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentTests.swift; sourceTree = "<group>"; };
 		2C8EC6DA2CCC23B700D6CCF8 /* Template5Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Template5Preview.swift; sourceTree = "<group>"; };
 		2C8EC6DC2CCC7C5500D6CCF8 /* PackageValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageValidator.swift; sourceTree = "<group>"; };
@@ -3514,7 +3514,7 @@
 				5712BE9129241F7900A83F15 /* TimingUtilTests.swift */,
 				4F8DDB682AAA9189000188F2 /* OperationDispatcherTests.swift */,
 				4FEF41AC2B4F301800CD699F /* MacAppStoreDetectorTests.swift */,
-				2C7F0AD42B8EEF0B00381179 /* RateLimiterRests.swift */,
+				2C7F0AD42B8EEF0B00381179 /* RateLimiterTests.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -6326,7 +6326,7 @@
 				1EFA950D2CDB6B6500CA5951 /* BackendPostRedeemWebPurchaseTests.swift in Sources */,
 				35C05DC82BC8510000109308 /* DiagnosticsTrackerTests.swift in Sources */,
 				35C272A12BC4084C005A0CE8 /* MockDiagnosticsTracker.swift in Sources */,
-				2C7F0AD62B8EEF7B00381179 /* RateLimiterRests.swift in Sources */,
+				2C7F0AD62B8EEF7B00381179 /* RateLimiterTests.swift in Sources */,
 				FDAADFCB2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift in Sources */,
 				356E2DE82CD3CF930055AABB /* StoredEventTests.swift in Sources */,
 				351B513F26D4496000BD2BD7 /* MockIdentityManager.swift in Sources */,

--- a/Sources/Misc/RateLimiter.swift
+++ b/Sources/Misc/RateLimiter.swift
@@ -17,7 +17,6 @@ internal final class RateLimiter: @unchecked Sendable {
     private let lock = Lock()
     private var timestamps: [Date?]
     private var index: Int = 0
-    
     private let maxCallsInclusive: Int
 
     let maxCalls: Int

--- a/Sources/Misc/RateLimiter.swift
+++ b/Sources/Misc/RateLimiter.swift
@@ -13,9 +13,11 @@
 
 import Foundation
 
-internal class RateLimiter {
+internal final class RateLimiter: @unchecked Sendable {
+    private let lock = Lock()
     private var timestamps: [Date?]
     private var index: Int = 0
+    
     private let maxCallsInclusive: Int
 
     let maxCalls: Int
@@ -30,17 +32,19 @@ internal class RateLimiter {
     }
 
     func shouldProceed() -> Bool {
-        let now = Date()
-        let oldestIndex = (index + 1) % maxCallsInclusive
-        let oldestTimestamp = timestamps[oldestIndex]
+        return self.lock.perform {
+            let now = Date()
+            let oldestIndex = (index + 1) % maxCallsInclusive
+            let oldestTimestamp = timestamps[oldestIndex]
 
-        // Check if the oldest timestamp is outside the rate limiting period or if it's nil
-        if let oldestTimestamp = oldestTimestamp, now.timeIntervalSince(oldestTimestamp) <= period {
-            return false
-        } else {
-            timestamps[index] = now
-            index = oldestIndex
-            return true
+            // Check if the oldest timestamp is outside the rate limiting period or if it's nil
+            if let oldestTimestamp = oldestTimestamp, now.timeIntervalSince(oldestTimestamp) <= period {
+                return false
+            } else {
+                timestamps[index] = now
+                index = oldestIndex
+                return true
+            }
         }
     }
 }

--- a/Tests/UnitTests/Misc/RateLimiterTests.swift
+++ b/Tests/UnitTests/Misc/RateLimiterTests.swift
@@ -7,7 +7,7 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  RateLimiterRests.swift
+//  RateLimiterTests.swift
 //
 //  Created by Josh Holtz on 2/27/24.
 


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Introduced in #3709, `RateLimiter` is used exclusively by `Purchases.syncAttributesAndOfferingsIfNeeded(completion:)`. The [documentation of this method](https://www.revenuecat.com/docs/tools/targeting/custom-attributes#the-syncattributesandofferingsifneeded-method) doesn't mention any threading requirement, so it's reasonable to assume that it can be called on any thread. This means `RateLimiter` needs to be thread safe, otherwise clients will run into race conditions as reported in #4440.

### Description
Fortunately the `RateLimiter` class is quite simple.

Its contants don't need to be atomic/locked since they are thread safe by definition. Turning `timestamps` and `index` vars into atomics doesn't help much in this case because `shouldProceed()` needs multiple reads and writes in a "transaction".

Using a `Lock` to wrap the whole method is the simplest and self-contained approach so I picked it.  Android is doing the same thing ([here](https://github.com/RevenueCat/purchases-android/blob/eb3c8f4aa1a6993f12d6e2f93cc82d26063101a6/purchases/src/main/kotlin/com/revenuecat/purchases/utils/RateLimiter.kt#L10)).

The lock is a non-recursive lock because there is no need for reentrant. And in principle I avoid recursive locks as much as possible since one can easily lose control over the locks, especially in more complicated use cases/codebases. This is a big problem that we have had for a long time in AsyncDisplayKit/Texture.

Unit tests remain the same because testing for race conditions is rather difficult and unpredictable. Texture has a bunch of thrash tests that kind of work but not 100%. Since the subject under test in this case is rather simple and the fix is straightforward it should work. Otherwise, we can have follow up PRs for both iOS and [Android](https://github.com/RevenueCat/purchases-android/blob/eb3c8f4aa1a6993f12d6e2f93cc82d26063101a6/purchases/src/test/java/com/revenuecat/purchases/utils/RateLimiterTest.kt).

This should resolve #4440.

This PR also renames `RateLimiterRests.swift` to `RateLimiterTests.swift`.

### Contribution
Original PR #4635 by @nguyenhuy