### PR TITLE
[Customer Center] Hack week: add contact support button to customer center

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-22
   x86_64-linux
 

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -764,6 +764,7 @@
 		77BA1AB32CCBB6EE009BF0EA /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BA1AB22CCBB6EE009BF0EA /* RootView.swift */; };
 		805B60C97993B311CEC93EAF /* ProductsFetcherSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628C1F100BB3C1782860D24 /* ProductsFetcherSK2.swift */; };
 		80E80EF226970E04008F245A /* ReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E80EF026970DC3008F245A /* ReceiptFetcher.swift */; };
+		875481962D2F1EB100D5CEAD /* ContactSupportButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875481952D2F1EB100D5CEAD /* ContactSupportButton.swift */; };
 		8834AFA52C2B9375005A72FE /* PresentIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A62222C1D168B00E1A461 /* PresentIfNeededTests.swift */; };
 		887A5FBD2C1D036200E1A461 /* RevenueCatUIDev.h in Headers */ = {isa = PBXBuildFile; fileRef = 887A5FBC2C1D036200E1A461 /* RevenueCatUIDev.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		887A60672C1D037000E1A461 /* PaywallError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A5FC72C1D037000E1A461 /* PaywallError.swift */; };
@@ -2016,6 +2017,7 @@
 		77BA1AB22CCBB6EE009BF0EA /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		80E80EF026970DC3008F245A /* ReceiptFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
 		84C3F1AC1D7E1E64341D3936 /* Pods_RevenueCat_PurchasesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RevenueCat_PurchasesTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		875481952D2F1EB100D5CEAD /* ContactSupportButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactSupportButton.swift; sourceTree = "<group>"; };
 		887A5FB42C1D024300E1A461 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		887A5FBA2C1D036200E1A461 /* RevenueCatUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RevenueCatUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		887A5FBC2C1D036200E1A461 /* RevenueCatUIDev.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RevenueCatUIDev.h; sourceTree = "<group>"; };
@@ -3604,6 +3606,7 @@
 				C3AD12BB2C6EA69D00A4F86F /* SubscriptionDetailsView.swift */,
 				77372D982C6F8C7B008E59D3 /* AppUpdateWarningView.swift */,
 				352304892D0A0F2B003971A4 /* ErrorView.swift */,
+				875481952D2F1EB100D5CEAD /* ContactSupportButton.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -6580,6 +6583,7 @@
 				887A60C02C1D037000E1A461 /* AsyncButton.swift in Sources */,
 				887A60892C1D037000E1A461 /* PaywallPurchasesType.swift in Sources */,
 				2C8EC71B2CCDD43900D6CCF8 /* ComponentViewState.swift in Sources */,
+				875481962D2F1EB100D5CEAD /* ContactSupportButton.swift in Sources */,
 				77089F9E2CD39EC100848CD5 /* ShadowModifier.swift in Sources */,
 				3537566F2C382C2800A1B8D6 /* WrongPlatformView.swift in Sources */,
 				887A60C22C1D037000E1A461 /* ErrorDisplay.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/URLUtilities.swift
+++ b/RevenueCatUI/CustomerCenter/URLUtilities.swift
@@ -65,11 +65,15 @@ enum URLUtilities {
     }
 
     static func canOpenURL(_ url: URL) -> Bool {
+#if DEBUG
+        return true
+#else
         guard !Self.isAppExtension,
               let application = Self.sharedUIApplication else {
             return false
         }
         return application.canOpenURL(url)
+#endif
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -93,7 +93,7 @@ import RevenueCat
     #if DEBUG
 
     convenience init(
-        purchaseInformation: PurchaseInformation,
+        purchaseInformation: PurchaseInformation?,
         configuration: CustomerCenterConfigData
     ) {
         self.init(customerCenterActionHandler: nil)

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
@@ -36,6 +36,8 @@ class ManageSubscriptionsViewModel: ObservableObject {
     @Published
     var loadingPath: CustomerCenterConfigData.HelpPath?
     @Published
+    private(set) var supportInformation: CustomerCenterConfigData.Support?
+    @Published
     var promotionalOfferData: PromotionalOfferData?
     @Published
     var inAppBrowserURL: IdentifiableURL?

--- a/RevenueCatUI/CustomerCenter/Views/ContactSupportButton.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ContactSupportButton.swift
@@ -1,0 +1,52 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ContactSupportButton.swift
+//
+//  Created by Engin Kurutepe on 08.01.25.
+
+import SwiftUI
+import RevenueCat
+
+#if os(iOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct ContactSupportButton: View {
+    @Environment(\.openURL)
+    private var openURL
+    @Environment(\.localization)
+    private var localization: CustomerCenterConfigData.Localization
+    let support: CustomerCenterConfigData.Support?
+    
+    var body: some View {
+        if let supportURL {
+            Button(localization.commonLocalizedString(for: .contactSupport)) {
+                Task {
+                    openURL(supportURL)
+                }
+            }
+        } else {
+            EmptyView()
+        }
+    }
+    
+    private var supportURL: URL? {
+        guard let support else { return nil }
+        let subject = self.localization.commonLocalizedString(for: .defaultSubject)
+        let body = support.calculateBody(self.localization)
+        return URLUtilities.createMailURLIfPossible(email: support.email,
+                                                    subject: subject,
+                                                    body: body)
+    }
+}
+
+#endif

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -30,6 +30,8 @@ struct ManageSubscriptionsView: View {
     private var localization: CustomerCenterConfigData.Localization
     @Environment(\.colorScheme)
     private var colorScheme
+    @Environment(\.supportInformation)
+    private var supportInformation
 
     @StateObject
     private var viewModel: ManageSubscriptionsViewModel
@@ -81,7 +83,6 @@ struct ManageSubscriptionsView: View {
     var content: some View {
         ZStack {
             List {
-
                 if let purchaseInformation = self.viewModel.purchaseInformation {
                     Section {
                         SubscriptionDetailsView(
@@ -91,6 +92,8 @@ struct ManageSubscriptionsView: View {
                     Section {
                         ManageSubscriptionsButtonsView(viewModel: self.viewModel,
                                                        loadingPath: self.$viewModel.loadingPath)
+                        
+                        ContactSupportButton(support: supportInformation)
                     } header: {
                         if let subtitle = self.viewModel.screen.subtitle {
                             Text(subtitle)
@@ -170,6 +173,7 @@ struct ManageSubscriptionsView_Previews: PreviewProvider {
                                         customerCenterActionHandler: nil)
                 .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
                 .environment(\.appearance, CustomerCenterConfigTestData.customerCenterData.appearance)
+                .environment(\.supportInformation, CustomerCenterConfigTestData.customerCenterData.support)
             }.preferredColorScheme(colorScheme)
             .previewDisplayName("Monthly renewing - \(colorScheme)")
 
@@ -182,6 +186,7 @@ struct ManageSubscriptionsView_Previews: PreviewProvider {
                                         customerCenterActionHandler: nil)
                 .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
                 .environment(\.appearance, CustomerCenterConfigTestData.customerCenterData.appearance)
+                .environment(\.supportInformation, CustomerCenterConfigTestData.customerCenterData.support)
             }.preferredColorScheme(colorScheme)
             .previewDisplayName("Yearly expiring - \(colorScheme)")
         }

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -32,6 +32,8 @@ struct NoSubscriptionsView: View {
     private var appearance: CustomerCenterConfigData.Appearance
     @Environment(\.colorScheme)
     private var colorScheme
+    @Environment(\.openURL)
+    var openURL
     @State
     private var showRestoreAlert: Bool = false
 
@@ -58,6 +60,8 @@ struct NoSubscriptionsView: View {
                     showRestoreAlert = true
                 }
                 .restorePurchasesAlert(isPresented: $showRestoreAlert)
+                
+                ContactSupportButton(support: configuration.support)
             }
 
         }

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -32,8 +32,6 @@ struct NoSubscriptionsView: View {
     private var appearance: CustomerCenterConfigData.Appearance
     @Environment(\.colorScheme)
     private var colorScheme
-    @Environment(\.openURL)
-    var openURL
     @State
     private var showRestoreAlert: Bool = false
 

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -48,15 +48,6 @@ struct WrongPlatformView: View {
     @Environment(\.openURL)
     private var openURL
 
-    private var supportURL: URL? {
-        guard let supportInformation = self.supportInformation else { return nil }
-        let subject = self.localization.commonLocalizedString(for: .defaultSubject)
-        let body = supportInformation.calculateBody(self.localization)
-        return URLUtilities.createMailURLIfPossible(email: supportInformation.email,
-                                                    subject: subject,
-                                                    body: body)
-    }
-
     init(screen: CustomerCenterConfigData.Screen? = nil,
          purchaseInformation: PurchaseInformation) {
         self.screen = screen
@@ -88,14 +79,9 @@ struct WrongPlatformView: View {
                     }
                 }
             }
-            if let url = supportURL {
-                Section {
-                    AsyncButton {
-                        openURL(url)
-                    } label: {
-                        Text(localization.commonLocalizedString(for: .contactSupport))
-                    }
-                }
+
+            Section {
+                ContactSupportButton(support: supportInformation)
             }
         }
         .toolbar {


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
It seems like we have the ability to open system email client to contact support but we were not surfacing this for the users. See the discussion: https://revenuecat.slack.com/archives/C072SLPSTQS/p1736178563670389

### Description
Adds a user tappable ContactSupportButton to customer center at the top level for all purchase states.