### PR TITLE
Deprecate misnamed purchase(params) function in Obj-C

### DIFF
--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -259,6 +259,15 @@ public extension Purchases {
         self.attribution.setCreative(creative)
     }
 
+    @available(iOS, deprecated, renamed: "purchase(_:completion:)")
+    @available(tvOS, deprecated, renamed: "purchase(_:completion:)")
+    @available(watchOS, deprecated, renamed: "purchase(_:completion:)")
+    @available(macOS, deprecated, renamed: "purchase(_:completion:)")
+    @available(macCatalyst, deprecated, renamed: "purchase(_:completion:)")
+    @objc(params:withCompletion:)
+    func purchaseWithParams(_ params: PurchaseParams, completion: @escaping PurchaseCompletedBlock) {
+        self.purchase(params, completion: completion)
+    }
 }
 
 public extension StoreProduct {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1028,7 +1028,7 @@ public extension Purchases {
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
-    @objc(params:withCompletion:)
+    @objc(purchaseWithParams:completion:)
     func purchase(_ params: PurchaseParams, completion: @escaping PurchaseCompletedBlock) {
         purchasesOrchestrator.purchase(params: params, completion: completion)
     }

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -373,7 +373,7 @@ public protocol PurchasesType: AnyObject {
      *
      * If the user cancelled, `userCancelled` will be `true`.
      */
-    @objc(params:withCompletion:)
+    @objc(purchaseWithParams:completion:)
     func purchase(_ params: PurchaseParams, completion: @escaping PurchaseCompletedBlock)
 
     /**

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
@@ -125,10 +125,8 @@ NSURL *url;
     [p setCreative: nil];
     [p setCreative: @""];
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-    if (@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)) {
-        RCPurchaseParams *packageParams;
-        [p params:packageParams withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
-    }
+    RCPurchaseParams *purchaseParams;
+    [p params:purchaseParams withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
     #endif
 
     [p getCustomerInfoWithFetchPolicy:RCCacheFetchPolicyFetchCurrent completion:^(RCCustomerInfo *customerInfo,

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
@@ -124,6 +124,12 @@ NSURL *url;
     [p setKeyword: @""];
     [p setCreative: nil];
     [p setCreative: @""];
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    if (@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)) {
+        RCPurchaseParams *packageParams;
+        [p params:packageParams withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
+    }
+    #endif
 
     [p getCustomerInfoWithFetchPolicy:RCCacheFetchPolicyFetchCurrent completion:^(RCCustomerInfo *customerInfo,
                                                                                   NSError *error) {}];
@@ -165,7 +171,8 @@ NSURL *url;
         }];
     }
 
-    [p params:packageParams withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
+    [p purchaseWithParams:productParams completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
+    [p purchaseWithParams:packageParams completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
     #endif
 
     [p getProductsWithIdentifiers:@[@""] completion:^(NSArray<RCStoreProduct *> *products) { }];


### PR DESCRIPTION
### Motivation
The `purchase(_ params: PurchaseParams, completion: @escaping PurchaseCompletedBlock)` was mistakenly exposed to Objective-C with the name `params` in https://github.com/RevenueCat/purchases-ios/pull/4485.

### Description
This PR deprecates that existing `params` name in Objective-C (`@objc(params:withCompletion:)`) and replaces it with `purchaseWithParams` (`@objc(purchaseWithParams:completion:)`).

### Implementation Details
Swift doesn't support deprecating only an Objective-C selector. You need to create a second Swift function with the correct `@objc` selector and ensure that the Swift function names don't conflict. This isn't ideal because it adds an extra deprecated function to the Swift API, but it gets the job done. 

So to accomplish this, this PR renames the existing Swift function with the incorrect `@objc` selector to `purchaseWithParams` and marks it as deprecated. 

#### Old Obj-C API
```objc
[p params:purchaseParams withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
```

#### New Obj-C API
```objc
[p purchaseWithParams:purchaseParams completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
```
