### PR TITLE
fix: Use custom label for CompatibilityContentUnavailableView

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/CompatibilityContentUnavailableView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CompatibilityContentUnavailableView.swift
@@ -39,16 +39,38 @@ struct CompatibilityContentUnavailableView: View {
         if #available(iOS 17.0, *) {
             #if swift(>=5.9)
             if let description {
-                ContentUnavailableView(
-                    title,
-                    systemImage: systemImage,
-                    description: description
-                )
+                ContentUnavailableView {
+                    Label {
+                        Text(title)
+                            .font(.title2)
+                            .bold()
+                            .fixedSize(horizontal: false, vertical: true)
+                    } icon: {
+                        Image(systemName: systemImage)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 48, height: 48)
+                            .foregroundStyle(.secondary)
+                            .padding()
+                    }
+                }
+                description: { description }
             } else {
-                ContentUnavailableView(
-                    title,
-                    systemImage: systemImage
-                )
+                ContentUnavailableView {
+                    Label {
+                        Text(title)
+                            .font(.title2)
+                            .bold()
+                            .fixedSize(horizontal: false, vertical: true)
+                    } icon: {
+                        Image(systemName: systemImage)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 48, height: 48)
+                            .foregroundStyle(.secondary)
+                            .padding()
+                    }
+                }
             }
 
             #else

--- a/RevenueCatUI/CustomerCenter/Views/CompatibilityContentUnavailableView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CompatibilityContentUnavailableView.swift
@@ -38,24 +38,11 @@ struct CompatibilityContentUnavailableView: View {
 
         if #available(iOS 17.0, *) {
             #if swift(>=5.9)
-            if let description {
-                ContentUnavailableView {
-                    Label {
-                        titleView
-                    } icon: {
-                        iconView
-                    }
-                }
-                description: { description }
-            } else {
-                ContentUnavailableView {
-                    Label {
-                        titleView
-                    } icon: {
-                        iconView
-                    }
-                }
+            ContentUnavailableView {
+                Label { titleView }
+                icon: { iconView }
             }
+            description: { description }
 
             #else
                 // In Xcode 14, any references to ContentUnavailableView would fail to compile since that entity

--- a/RevenueCatUI/CustomerCenter/Views/CompatibilityContentUnavailableView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CompatibilityContentUnavailableView.swift
@@ -78,14 +78,14 @@ struct CompatibilityContentUnavailableView: View {
         }
 
     }
-    
+
     private var titleView: some View {
         Text(title)
             .font(.title2)
             .bold()
             .fixedSize(horizontal: false, vertical: true)
     }
-    
+
     private var iconView: some View {
         Image(systemName: systemImage)
             .resizable()

--- a/RevenueCatUI/CustomerCenter/Views/CompatibilityContentUnavailableView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CompatibilityContentUnavailableView.swift
@@ -41,34 +41,18 @@ struct CompatibilityContentUnavailableView: View {
             if let description {
                 ContentUnavailableView {
                     Label {
-                        Text(title)
-                            .font(.title2)
-                            .bold()
-                            .fixedSize(horizontal: false, vertical: true)
+                        titleView
                     } icon: {
-                        Image(systemName: systemImage)
-                            .resizable()
-                            .scaledToFill()
-                            .frame(width: 48, height: 48)
-                            .foregroundStyle(.secondary)
-                            .padding()
+                        iconView
                     }
                 }
                 description: { description }
             } else {
                 ContentUnavailableView {
                     Label {
-                        Text(title)
-                            .font(.title2)
-                            .bold()
-                            .fixedSize(horizontal: false, vertical: true)
+                        titleView
                     } icon: {
-                        Image(systemName: systemImage)
-                            .resizable()
-                            .scaledToFill()
-                            .frame(width: 48, height: 48)
-                            .foregroundStyle(.secondary)
-                            .padding()
+                        iconView
                     }
                 }
             }
@@ -82,16 +66,8 @@ struct CompatibilityContentUnavailableView: View {
             #endif
         } else {
             VStack {
-                Image(systemName: systemImage)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: 48, height: 48)
-                    .foregroundStyle(.secondary)
-                    .padding()
-
-                Text(title)
-                    .font(.title2)
-                    .bold()
+                iconView
+                titleView
 
                 if let description {
                     description
@@ -101,6 +77,22 @@ struct CompatibilityContentUnavailableView: View {
             }.frame(maxHeight: .infinity)
         }
 
+    }
+    
+    private var titleView: some View {
+        Text(title)
+            .font(.title2)
+            .bold()
+            .fixedSize(horizontal: false, vertical: true)
+    }
+    
+    private var iconView: some View {
+        Image(systemName: systemImage)
+            .resizable()
+            .scaledToFill()
+            .frame(width: 48, height: 48)
+            .foregroundStyle(.secondary)
+            .padding()
     }
 }
 


### PR DESCRIPTION
### Motivation
This PR tries to address https://github.com/RevenueCat/purchases-ios/issues/4638.

| Before | After |
|--------|--------|
| ![IMG_7180](https://github.com/user-attachments/assets/4c38c0e1-4fec-4c48-9c90-9f2b57823e6d) | ![IMG_7179](https://github.com/user-attachments/assets/2ef54487-3b0d-471b-bcae-84b7509889eb) |

### Description
For some reason, `ContentUnavailableView` truncates the label. I've tried using `lineLimit(nil)` over the `Label`, but that didn't work. This seems to do the trick. 

`fixedSize(vertical:true)` forces the view to grow vertically to the needed height.