### PR TITLE
[Paywalls V2] Updating UIConfig aliased colors to contain both light and dark

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		03A98D322D2441B8009BCA61 /* PaywallDataDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98D312D2441B2009BCA61 /* PaywallDataDecodingTests.swift */; };
 		03A98D362D244329009BCA61 /* UIConfigDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98D352D244321009BCA61 /* UIConfigDecodingTests.swift */; };
 		03A98D382D2AC63B009BCA61 /* UIConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98D372D2AC637009BCA61 /* UIConfigProvider.swift */; };
+		03C72F8D2D3311E300297FEC /* DisplayableColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C72F8C2D3311D500297FEC /* DisplayableColor.swift */; };
 		03F446212D2F73240046129A /* StackComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446202D2F73210046129A /* StackComponentTests.swift */; };
 		03F446242D2FE0C50046129A /* ShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446232D2FE0C10046129A /* ShapePropertyTests.swift */; };
 		03F446262D2FE1510046129A /* MaskShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */; };
@@ -1253,6 +1254,7 @@
 		03A98D312D2441B2009BCA61 /* PaywallDataDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallDataDecodingTests.swift; sourceTree = "<group>"; };
 		03A98D352D244321009BCA61 /* UIConfigDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfigDecodingTests.swift; sourceTree = "<group>"; };
 		03A98D372D2AC637009BCA61 /* UIConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfigProvider.swift; sourceTree = "<group>"; };
+		03C72F8C2D3311D500297FEC /* DisplayableColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayableColor.swift; sourceTree = "<group>"; };
 		03F446202D2F73210046129A /* StackComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackComponentTests.swift; sourceTree = "<group>"; };
 		03F446232D2FE0C10046129A /* ShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapePropertyTests.swift; sourceTree = "<group>"; };
 		03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskShapePropertyTests.swift; sourceTree = "<group>"; };
@@ -2561,6 +2563,7 @@
 				4D6F4BCF2CF69DE300353AF6 /* ForegroundColorScheme.swift */,
 				2C91068D2CE2481800189565 /* SizeModifier.swift */,
 				2CAB87F62CAAB13200247013 /* Shape.swift */,
+				03C72F8C2D3311D500297FEC /* DisplayableColor.swift */,
 			);
 			path = ViewHelpers;
 			sourceTree = "<group>";
@@ -6648,6 +6651,7 @@
 				3537566C2C382C2800A1B8D6 /* ManageSubscriptionsView.swift in Sources */,
 				887A60C82C1D037000E1A461 /* ProgressView.swift in Sources */,
 				887A60D02C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift in Sources */,
+				03C72F8D2D3311E300297FEC /* DisplayableColor.swift in Sources */,
 				887A60CD2C1D037000E1A461 /* PaywallView.swift in Sources */,
 				1E2F910B2CC8FE5600BDB016 /* ContactSupportUtilities.swift in Sources */,
 				1E5F8F6E2C4515430041EECD /* View+PresentCustomerCenter.swift in Sources */,

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
@@ -127,7 +127,7 @@ struct StackComponentStyle {
         self.dimension = dimension
         self.size = size
         self.spacing = spacing
-        self.backgroundStyle = backgroundColor?.backgroundStyle
+        self.backgroundStyle = backgroundColor?.asDisplayable(uiConfigProvider: uiConfigProvider).backgroundStyle
         self.padding = padding.edgeInsets
         self.margin = margin.edgeInsets
         self.shape = shape?.shape
@@ -192,7 +192,7 @@ private extension PaywallComponent.Border {
 
     func border(uiConfigProvider: UIConfigProvider) -> ShapeModifier.BorderInfo? {
         return ShapeModifier.BorderInfo(
-            color: self.color.toDynamicColor(uiConfigProvider: uiConfigProvider),
+            color: self.color.asDisplayable(uiConfigProvider: uiConfigProvider).toDynamicColor(),
             width: self.width
         )
     }
@@ -204,7 +204,7 @@ private extension PaywallComponent.Shadow {
 
     func shadow(uiConfigProvider: UIConfigProvider) -> ShadowModifier.ShadowInfo? {
         return ShadowModifier.ShadowInfo(
-            color: self.color.toDynamicColor(uiConfigProvider: uiConfigProvider),
+            color: self.color.asDisplayable(uiConfigProvider: uiConfigProvider).toDynamicColor(),
             radius: self.radius,
             x: self.x,
             y: self.y

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -56,11 +56,11 @@ struct TextComponentView: View {
                         .fontWeight(style.fontWeight)
                         .fixedSize(horizontal: false, vertical: true)
                         .multilineTextAlignment(style.textAlignment)
-                        .foregroundColorScheme(style.color, uiConfigProvider: self.viewModel.uiConfigProvider)
+                        .foregroundColorScheme(style.color)
                         .padding(style.padding)
                         .size(style.size,
                               horizontalAlignment: style.horizontalAlignment)
-                        .backgroundStyle(style.backgroundStyle, uiConfigProvider: self.viewModel.uiConfigProvider)
+                        .backgroundStyle(style.backgroundStyle)
                         .padding(style.margin)
                 } else {
                     EmptyView()
@@ -205,8 +205,8 @@ struct TextComponentView_Previews: PreviewProvider {
                     ),
                     uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
                         colors: [
-                            "primary": .hex("#ff0000"),
-                            "secondary": .hex("#ffcc00")
+                            "primary": .init(light: .hex("#ff0000")),
+                            "secondary": .init(light: .hex("#ffcc00"))
                         ]
                     )),
                     component: .init(
@@ -229,8 +229,8 @@ struct TextComponentView_Previews: PreviewProvider {
                     ),
                     uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
                         colors: [
-                            "primary": .hex("#ff0000"),
-                            "secondary": .hex("#ffcc00")
+                            "primary": .init(light: .hex("#ff0000")),
+                            "secondary": .init(light: .hex("#ffcc00"))
                         ]
                     )),
                     component: .init(

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -62,6 +62,7 @@ class TextComponentViewModel {
         let fontFamily = self.uiConfigProvider.getFontFamily(for: partial?.fontName ?? self.component.fontName)
 
         let style = TextComponentStyle(
+            uiConfigProvider: self.uiConfigProvider,
             visible: partial?.visible ?? true,
             text: Self.processText(
                 text,
@@ -211,7 +212,7 @@ struct TextComponentStyle {
     let visible: Bool
     let text: String
     let fontWeight: Font.Weight
-    let color: PaywallComponent.ColorScheme
+    let color: DisplayableColorScheme
     let font: Font
     let horizontalAlignment: Alignment
     let textAlignment: TextAlignment
@@ -221,6 +222,7 @@ struct TextComponentStyle {
     let margin: EdgeInsets
 
     init(
+        uiConfigProvider: UIConfigProvider,
         visible: Bool,
         text: String,
         fontFamily: String?,
@@ -236,14 +238,14 @@ struct TextComponentStyle {
         self.visible = visible
         self.text = text
         self.fontWeight = fontWeight.fontWeight
-        self.color = color
+        self.color = color.asDisplayable(uiConfigProvider: uiConfigProvider)
 
         // WIP: Take into account the fontFamily mapping
         self.font = fontSize.makeFont(familyName: fontFamily)
 
         self.textAlignment = horizontalAlignment.textAlignment
         self.horizontalAlignment = horizontalAlignment.frameAlignment
-        self.backgroundStyle = backgroundColor?.backgroundStyle
+        self.backgroundStyle = backgroundColor?.asDisplayable(uiConfigProvider: uiConfigProvider).backgroundStyle
         self.size = size
         self.padding = padding.edgeInsets
         self.margin = margin.edgeInsets

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -170,8 +170,7 @@ private struct LoadedPaywallsV2View: View {
         .environmentObject(self.selectedPackageContext)
         .frame(maxHeight: .infinity, alignment: .topLeading)
         .backgroundStyle(
-            self.paywallState.componentsConfig.background.backgroundStyle,
-            uiConfigProvider: self.uiConfigProvider
+            self.paywallState.componentsConfig.background.asDisplayable(uiConfigProvider: uiConfigProvider).backgroundStyle
         )
         .edgesIgnoringSafeArea(.top)
     }

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -170,7 +170,8 @@ private struct LoadedPaywallsV2View: View {
         .environmentObject(self.selectedPackageContext)
         .frame(maxHeight: .infinity, alignment: .topLeading)
         .backgroundStyle(
-            self.paywallState.componentsConfig.background.asDisplayable(uiConfigProvider: uiConfigProvider).backgroundStyle
+            self.paywallState.componentsConfig.background
+                .asDisplayable(uiConfigProvider: uiConfigProvider).backgroundStyle
         )
         .edgesIgnoringSafeArea(.top)
     }

--- a/RevenueCatUI/Templates/V2/Previews/PreviewMock.swift
+++ b/RevenueCatUI/Templates/V2/Previews/PreviewMock.swift
@@ -24,7 +24,7 @@ import SwiftUI
 enum PreviewUIConfig {
 
     static func make(
-        colors: [String: PaywallComponent.ColorInfo] = [:],
+        colors: [String: PaywallComponent.ColorScheme] = [:],
         fonts: [String: UIConfig.FontsConfig] = [:]
     ) -> UIConfig {
         return .init(

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -18,10 +18,10 @@ import SwiftUI
 
 enum BackgroundStyle: Hashable {
 
-    case color(PaywallComponent.ColorScheme)
+    case color(DisplayableColorScheme)
     case image(PaywallComponent.ThemeImageUrls)
 
-}
+} 
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct BackgroundStyleModifier: ViewModifier {
@@ -30,12 +30,11 @@ struct BackgroundStyleModifier: ViewModifier {
     var colorScheme
 
     var backgroundStyle: BackgroundStyle?
-    var uiConfigProvider: UIConfigProvider?
 
     func body(content: Content) -> some View {
-        if let backgroundStyle, let uiConfigProvider {
+        if let backgroundStyle {
             content
-                .apply(backgroundStyle: backgroundStyle, colorScheme: colorScheme, uiConfigProvider: uiConfigProvider)
+                .apply(backgroundStyle: backgroundStyle, colorScheme: colorScheme)
         } else {
             content
         }
@@ -49,14 +48,13 @@ fileprivate extension View {
     @ViewBuilder
     func apply(
         backgroundStyle: BackgroundStyle,
-        colorScheme: ColorScheme,
-        uiConfigProvider: UIConfigProvider
+        colorScheme: ColorScheme
     ) -> some View {
         switch backgroundStyle {
         case .color(let color):
             switch color.effectiveColor(for: colorScheme) {
-            case .hex, .alias:
-                self.background(color.toDynamicColor(uiConfigProvider: uiConfigProvider))
+            case .hex:
+                self.background(color.toDynamicColor())
             case .linear(let degrees, _):
                 self.background {
                     GradientView(
@@ -96,13 +94,13 @@ fileprivate extension View {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
-    func backgroundStyle(_ backgroundStyle: BackgroundStyle?, uiConfigProvider: UIConfigProvider?) -> some View {
-        self.modifier(BackgroundStyleModifier(backgroundStyle: backgroundStyle, uiConfigProvider: uiConfigProvider))
+    func backgroundStyle(_ backgroundStyle: BackgroundStyle?) -> some View {
+        self.modifier(BackgroundStyleModifier(backgroundStyle: backgroundStyle))
     }
 
 }
 
-extension PaywallComponent.Background {
+extension BackgroundStyle {
 
     var backgroundStyle: BackgroundStyle? {
         switch self {
@@ -115,7 +113,7 @@ extension PaywallComponent.Background {
 
 }
 
-extension PaywallComponent.ColorScheme {
+extension DisplayableColorScheme {
 
     var backgroundStyle: BackgroundStyle {
         return .color(self)
@@ -148,7 +146,7 @@ struct BackgrounDStyle_Previews: PreviewProvider {
             .backgroundStyle(.color(.init(
                 light: .hex("#ff0000"),
                 dark: .hex("#ffcc00")
-            )), uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
+            )))
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Color - Light (should be red)")
 
@@ -157,7 +155,7 @@ struct BackgrounDStyle_Previews: PreviewProvider {
             .backgroundStyle(.color(.init(
                 light: .hex("#ff0000"),
                 dark: .hex("#ffcc00")
-            )), uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
+            )))
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Color - Dark (should be yellow)")
@@ -166,7 +164,7 @@ struct BackgrounDStyle_Previews: PreviewProvider {
         testContent
             .backgroundStyle(.color(.init(
                 light: .hex("#ff0000")
-            )), uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
+            )))
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Color - Dark (should be red because fallback)")
@@ -188,7 +186,7 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                     heic: darkUrl,
                     heicLowRes: darkUrl
                 )
-            )), uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
+            )))
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Image - Light (should be pink cat)")
 
@@ -209,7 +207,7 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                     heic: darkUrl,
                     heicLowRes: darkUrl
                 )
-            )), uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
+            )))
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Image - Dark (should be japan cats)")
@@ -226,9 +224,8 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                             .init(color: "#ff0000", percent: 0),
                             .init(color: "#E58984", percent: 100)
                         ])
-                      )
-                ),
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
+                    ).asDisplayable(uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
+                ))
             )
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
@@ -246,9 +243,8 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                             .init(color: "#00E519", percent: 0),
                             .init(color: "#9DEAD3", percent: 100)
                         ])
-                      )
-                ),
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
+                    ).asDisplayable(uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
+                )
             )
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Linear Gradient - Light (should be green")
@@ -265,9 +261,8 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                             .init(color: "#ff0000", percent: 0),
                             .init(color: "#E58984", percent: 100)
                         ])
-                      )
-                ),
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
+                      ).asDisplayable(uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
+                )
             )
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
@@ -286,9 +281,8 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                             .init(color: "#000000", percent: 0),
                             .init(color: "#ffffff", percent: 100)
                         ])
-                      )
-                ),
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
+                      ).asDisplayable(uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
+                )
             )
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Radial Gradient - Light (should be green")

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -21,7 +21,7 @@ enum BackgroundStyle: Hashable {
     case color(DisplayableColorScheme)
     case image(PaywallComponent.ThemeImageUrls)
 
-} 
+}
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct BackgroundStyleModifier: ViewModifier {

--- a/RevenueCatUI/Templates/V2/ViewHelpers/DisplayableColor.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/DisplayableColor.swift
@@ -30,7 +30,6 @@ extension PaywallComponent.Background {
 
 }
 
-
 struct DisplayableColorScheme: Equatable, Hashable {
 
     init(light: DisplayableColorInfo, dark: DisplayableColorInfo? = nil) {
@@ -44,19 +43,20 @@ struct DisplayableColorScheme: Equatable, Hashable {
 }
 
 enum DisplayableColorInfo: Codable, Sendable, Hashable {
-    
+
     case hex(PaywallComponent.ColorHex)
     case linear(Int, [PaywallComponent.GradientPoint])
     case radial([PaywallComponent.GradientPoint])
-    
+
 }
 
 extension DisplayableColorScheme {
 
-    static func from(colorScheme: PaywallComponent.ColorScheme, uiConfigProvider: UIConfigProvider) throws -> DisplayableColorScheme {
+    static func from(colorScheme: PaywallComponent.ColorScheme,
+                     uiConfigProvider: UIConfigProvider) throws -> DisplayableColorScheme {
         let light = try colorScheme.light.asDisplayable(forLight: true, uiConfigProvider: uiConfigProvider)
         let dark = try colorScheme.dark?.asDisplayable(forLight: false, uiConfigProvider: uiConfigProvider)
-        
+
         return DisplayableColorScheme(light: light, dark: dark)
     }
 
@@ -82,19 +82,19 @@ extension PaywallComponent.ColorInfo {
         case .hex(let hex):
             return .hex(hex)
         case .alias(let name):
-            
+
             let aliasedColorScheme = uiConfigProvider.getColor(for: name)
             let aliasedColorInfo = forLight ? aliasedColorScheme?.light : aliasedColorScheme?.dark
-            
+
             guard let aliasedColorInfo else {
                 Logger.warning("Aliased color '\(name)' does not exist.")
                 fatalError()
             }
-            
+
             switch aliasedColorInfo {
             case .hex(let hex):
                 return .hex(hex)
-            case .alias(_):
+            case .alias(let name):
                 Logger.warning("Aliased color '\(name)' has an aliased value which is not allowed.")
                 fatalError()
             case .linear(let degree, let points):
@@ -108,7 +108,7 @@ extension PaywallComponent.ColorInfo {
             return .radial(points)
         }
     }
-    
+
 }
 
 #endif

--- a/RevenueCatUI/Templates/V2/ViewHelpers/DisplayableColor.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/DisplayableColor.swift
@@ -1,0 +1,114 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DisplayColor.swift
+//
+//  Created by Josh Holtz on 1/11/25.
+
+import Foundation
+import RevenueCat
+import SwiftUI
+
+#if PAYWALL_COMPONENTS
+
+extension PaywallComponent.Background {
+
+    func asDisplayable(uiConfigProvider: UIConfigProvider) -> BackgroundStyle {
+        switch self {
+        case .color(let color):
+            return .color(color.asDisplayable(uiConfigProvider: uiConfigProvider))
+        case .image(let image):
+            return .image(image)
+        }
+    }
+
+}
+
+
+struct DisplayableColorScheme: Equatable, Hashable {
+
+    init(light: DisplayableColorInfo, dark: DisplayableColorInfo? = nil) {
+        self.light = light
+        self.dark = dark
+    }
+
+    let light: DisplayableColorInfo
+    let dark: DisplayableColorInfo?
+
+}
+
+enum DisplayableColorInfo: Codable, Sendable, Hashable {
+    
+    case hex(PaywallComponent.ColorHex)
+    case linear(Int, [PaywallComponent.GradientPoint])
+    case radial([PaywallComponent.GradientPoint])
+    
+}
+
+extension DisplayableColorScheme {
+
+    static func from(colorScheme: PaywallComponent.ColorScheme, uiConfigProvider: UIConfigProvider) throws -> DisplayableColorScheme {
+        let light = try colorScheme.light.asDisplayable(forLight: true, uiConfigProvider: uiConfigProvider)
+        let dark = try colorScheme.dark?.asDisplayable(forLight: false, uiConfigProvider: uiConfigProvider)
+        
+        return DisplayableColorScheme(light: light, dark: dark)
+    }
+
+}
+
+extension PaywallComponent.ColorScheme {
+
+    func asDisplayable(uiConfigProvider: UIConfigProvider) -> DisplayableColorScheme {
+        do {
+            return try DisplayableColorScheme.from(colorScheme: self, uiConfigProvider: uiConfigProvider)
+        } catch {
+            // WIP: Fallback clear (FOR NOW)
+            return DisplayableColorScheme(light: .hex("#ffffff00"))
+        }
+    }
+
+}
+
+extension PaywallComponent.ColorInfo {
+
+    func asDisplayable(forLight: Bool, uiConfigProvider: UIConfigProvider) throws -> DisplayableColorInfo {
+        switch self {
+        case .hex(let hex):
+            return .hex(hex)
+        case .alias(let name):
+            
+            let aliasedColorScheme = uiConfigProvider.getColor(for: name)
+            let aliasedColorInfo = forLight ? aliasedColorScheme?.light : aliasedColorScheme?.dark
+            
+            guard let aliasedColorInfo else {
+                Logger.warning("Aliased color '\(name)' does not exist.")
+                fatalError()
+            }
+            
+            switch aliasedColorInfo {
+            case .hex(let hex):
+                return .hex(hex)
+            case .alias(_):
+                Logger.warning("Aliased color '\(name)' has an aliased value which is not allowed.")
+                fatalError()
+            case .linear(let degree, let points):
+                return .linear(degree, points)
+            case .radial(let points):
+                return .radial(points)
+            }
+        case .linear(let degree, let points):
+            return .linear(degree, points)
+        case .radial(let points):
+            return .radial(points)
+        }
+    }
+    
+}
+
+#endif

--- a/RevenueCatUI/Templates/V2/ViewHelpers/DisplayableColor.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/DisplayableColor.swift
@@ -32,13 +32,24 @@ extension PaywallComponent.Background {
 
 struct DisplayableColorScheme: Equatable, Hashable {
 
-    init(light: DisplayableColorInfo, dark: DisplayableColorInfo? = nil) {
-        self.light = light
-        self.dark = dark
-    }
+    static let error = DisplayableColorScheme(hasError: true)
 
     let light: DisplayableColorInfo
     let dark: DisplayableColorInfo?
+
+    let hasError: Bool
+
+    init(light: DisplayableColorInfo, dark: DisplayableColorInfo? = nil) {
+        self.light = light
+        self.dark = dark
+        self.hasError = false
+    }
+
+    private init(hasError: Bool) {
+        self.light = .hex("#ffffff00")
+        self.dark = nil
+        self.hasError = true
+    }
 
 }
 
@@ -54,7 +65,6 @@ extension DisplayableColorScheme {
 
     static func from(colorScheme: PaywallComponent.ColorScheme,
                      uiConfigProvider: UIConfigProvider) throws -> DisplayableColorScheme {
-        //
         let light = try colorScheme.light.asDisplayable(forLight: true, uiConfigProvider: uiConfigProvider)
         let dark = try colorScheme.dark?.asDisplayable(forLight: false, uiConfigProvider: uiConfigProvider)
 
@@ -70,7 +80,7 @@ extension PaywallComponent.ColorScheme {
             return try DisplayableColorScheme.from(colorScheme: self, uiConfigProvider: uiConfigProvider)
         } catch {
             // WIP: Falling back to clear color until move validation into view model initialization
-            return DisplayableColorScheme(light: .hex("#ffffff00"))
+            return DisplayableColorScheme.error
         }
     }
 

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ForegroundColorScheme.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ForegroundColorScheme.swift
@@ -51,14 +51,12 @@ fileprivate extension View {
     ) -> some View {
         switch color.effectiveColor(for: colorScheme) {
         case .hex:
-            let color = color.toDynamicColor()
-
             // Do not apply a clear text color
             // Use the default color
             if color.hasError {
                 self
             } else {
-                self.foregroundColor(color)
+                self.foregroundColor(color.toDynamicColor())
             }
         case .linear(let degrees, _):
             self.overlay {

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ForegroundColorScheme.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ForegroundColorScheme.swift
@@ -55,10 +55,10 @@ fileprivate extension View {
 
             // Do not apply a clear text color
             // Use the default color
-            if color != Color.clear {
-                self.foregroundColor(color)
-            } else {
+            if color.hasError {
                 self
+            } else {
+                self.foregroundColor(color)
             }
         case .linear(let degrees, _):
             self.overlay {

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ForegroundColorScheme.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ForegroundColorScheme.swift
@@ -22,14 +22,12 @@ struct ForegroundColorSchemeModifier: ViewModifier {
     @Environment(\.colorScheme)
     var colorScheme
 
-    var foregroundColorScheme: PaywallComponent.ColorScheme
-    var uiConfigProvider: UIConfigProvider
+    var foregroundColorScheme: DisplayableColorScheme
 
     func body(content: Content) -> some View {
         content.foregroundColorScheme(
             self.foregroundColorScheme,
-            colorScheme: self.colorScheme,
-            uiConfigProvider: self.uiConfigProvider
+            colorScheme: self.colorScheme
         )
     }
 
@@ -38,11 +36,9 @@ struct ForegroundColorSchemeModifier: ViewModifier {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
     func foregroundColorScheme(
-        _ colorScheme: PaywallComponent.ColorScheme,
-        uiConfigProvider: UIConfigProvider
+        _ colorScheme: DisplayableColorScheme
     ) -> some View {
-        self.modifier(ForegroundColorSchemeModifier(foregroundColorScheme: colorScheme,
-                                                    uiConfigProvider: uiConfigProvider))
+        self.modifier(ForegroundColorSchemeModifier(foregroundColorScheme: colorScheme))
     }
 }
 
@@ -50,13 +46,12 @@ extension View {
 fileprivate extension View {
     @ViewBuilder
     func foregroundColorScheme(
-        _ color: PaywallComponent.ColorScheme,
-        colorScheme: ColorScheme,
-        uiConfigProvider: UIConfigProvider
+        _ color: DisplayableColorScheme,
+        colorScheme: ColorScheme
     ) -> some View {
         switch color.effectiveColor(for: colorScheme) {
-        case .hex, .alias:
-            let color = color.toDynamicColor(uiConfigProvider: uiConfigProvider)
+        case .hex:
+            let color = color.toDynamicColor()
 
             // Do not apply a clear text color
             // Use the default color

--- a/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
@@ -83,7 +83,7 @@ struct ShapeModifier: ViewModifier {
             let shape = self.effectiveRectangleShape(radiusInfo: radiusInfo)
             let effectiveShape = shape ?? Rectangle().eraseToAnyInsettableShape()
             content
-                .backgroundStyle(background, uiConfigProvider: uiConfigProvider)
+                .backgroundStyle(background)
                 // We want to clip only in case there is a non-Rectangle shape
                 // or if there's a border, otherwise we let the background color
                 // extend behind the safe areas
@@ -101,7 +101,7 @@ struct ShapeModifier: ViewModifier {
         case .pill:
             let shape = Capsule(style: .circular)
             content
-                .backgroundStyle(background, uiConfigProvider: uiConfigProvider)
+                .backgroundStyle(background)
                 .clipShape(shape)
                 .applyIfLet(border) { view, border in
                     view.overlay {

--- a/RevenueCatUI/Templates/V2/ViewHelpers/SizeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/SizeModifier.swift
@@ -64,13 +64,6 @@ fileprivate extension View {
 
 extension View {
 
-//    func size(_ size: PaywallComponent.Size,
-//              alignment: Alignment = .center) -> some View {
-//        self.modifier(SizeModifier(size: size,
-//                                   hortizontalAlignment: alignment,
-//                                   verticalAlignment: alignment))
-//    }
-
     func size(_ size: PaywallComponent.Size,
               horizontalAlignment: Alignment = .center,
               verticalAlignment: Alignment = .center) -> some View {

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -24,7 +24,7 @@ struct UIConfigProvider {
         self.uiConfig = uiConfig
     }
 
-    func getColor(for name: String) -> PaywallComponent.ColorInfo? {
+    func getColor(for name: String) -> PaywallComponent.ColorScheme? {
         return self.uiConfig.app.colors[name]
     }
 

--- a/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
@@ -20,10 +20,10 @@ public struct UIConfig: Codable, Equatable, Sendable {
 
     public struct AppConfig: Codable, Equatable, Sendable {
 
-        public var colors: [String: PaywallComponent.ColorInfo]
+        public var colors: [String: PaywallComponent.ColorScheme]
         public var fonts: [String: FontsConfig]
 
-        public init(colors: [String: PaywallComponent.ColorInfo],
+        public init(colors: [String: PaywallComponent.ColorScheme],
                     fonts: [String: FontsConfig]) {
             self.colors = colors
             self.fonts = fonts


### PR DESCRIPTION
## Motivation

Aliased color will be both light and dark

## Description

This ended up being a whole thing...

TL;DR - Added a new `DisplayableColorScheme` object that has types of `hex`, `linear`, and `radial`... 

`PaywallComponent.ColorScheme -> `DisplayableColorScheme` -> `Color`/`Gradient`

### Issue

We have `.alias` as a value on `ColorInfo` but we need to alias an entire set of light/dark colors (aka `ColorScheme`).

Our logic right now directly converts `ColorInfo` into a SwiftUI/UI color (for foreground, background, etc). This works fine for `hex`, `linear`, and `radial` but will not work well for alias. We need to perform the alias lookup at the `ColorScheme` level (near the view model layer instead of at the render layer)

### Solution

Create a new `DisplayableColorScheme` and `DisplayableColorInfo` struct. These new data structures only have values for `hex`, `linear`, and `radial`. 

`ColorScheme` (and `ColorInfo`) get mapped to `DisplayableColorScheme` (and `DisplayableColorInfo`) and in this mapping is where the `alias` look up happens. This makes it safer/cleaner at the render level because everything has a specific color now.

The converting to `DisplayableColorScheme` currently will fallback to a clear color if there is an error and log an error. We will EVENTUALLY AND SOON (in a follow up PR) add this validation that the alias exists in the creation of the view models so that we can error out early if needed.

NOTE: We will also add big backend validation that the alias colors exist so the SDKs will never (🤞) have to encounter an alias color not existing.
