### PR TITLE
[Paywalls V2] Allow overriding of font size on paywall

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -155,7 +155,10 @@ fileprivate extension ButtonComponentViewModel {
         let stackViewModel = try factory.toStackViewModel(
             component: component.stack,
             localizationProvider: localizationProvider,
-            uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+            uiConfigProvider: .init(
+                uiConfig: PreviewUIConfig.make(),
+                fontSizeOverride: nil
+            ),
             offering: offering
         )
 

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -117,7 +117,10 @@ struct ImageComponentView_Previews: PreviewProvider {
                         locale: Locale.current,
                         localizedStrings: [:]
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                    uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(),
+                        fontSizeOverride: nil
+                    ),
                     component: .init(
                         source: .init(
                             light: .init(
@@ -146,7 +149,10 @@ struct ImageComponentView_Previews: PreviewProvider {
                         locale: Locale.current,
                         localizedStrings: [:]
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                    uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(),
+                        fontSizeOverride: nil
+                    ),
                     component: .init(
                         source: .init(
                             light: .init(
@@ -175,7 +181,10 @@ struct ImageComponentView_Previews: PreviewProvider {
                         locale: Locale.current,
                         localizedStrings: [:]
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                    uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(),
+                        fontSizeOverride: nil
+                    ),
                     component: .init(
                         source: .init(
                             light: .init(
@@ -207,7 +216,10 @@ struct ImageComponentView_Previews: PreviewProvider {
                         locale: Locale.current,
                         localizedStrings: [:]
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                    uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(),
+                        fontSizeOverride: nil
+                    ),
                     component: .init(
                         source: .init(
                             light: .init(

--- a/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
@@ -204,7 +204,10 @@ fileprivate extension PackageComponentViewModel {
         let stackViewModel = try factory.toStackViewModel(
             component: component.stack,
             localizationProvider: localizationProvider,
-            uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+            uiConfigProvider: .init(
+                uiConfig: PreviewUIConfig.make(),
+                fontSizeOverride: nil
+            ),
             offering: offering
         )
 

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -152,7 +152,10 @@ fileprivate extension PurchaseButtonComponentViewModel {
         let stackViewModel = try factory.toStackViewModel(
             component: component.stack,
             localizationProvider: localizationProvider,
-            uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+            uiConfigProvider: .init(
+                uiConfig: PreviewUIConfig.make(),
+                fontSizeOverride: nil
+            ),
             offering: offering
         )
 

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -521,14 +521,20 @@ fileprivate extension StackComponentViewModel {
                 packageValidator: validator,
                 offering: offering,
                 localizationProvider: localizationProvider,
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
+                uiConfigProvider: .init(
+                    uiConfig: PreviewUIConfig.make(),
+                    fontSizeOverride: nil
+                )
             )
         }
 
         try self.init(
             component: component,
             viewModels: viewModels,
-            uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
+            uiConfigProvider: .init(
+                uiConfig: PreviewUIConfig.make(),
+                fontSizeOverride: nil
+            )
         )
     }
 

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -88,7 +88,10 @@ struct TextComponentView_Previews: PreviewProvider {
                         "id_1": .string("Hello, world")
                     ]
                 ),
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                uiConfigProvider: .init(
+                    uiConfig: PreviewUIConfig.make(),
+                    fontSizeOverride: nil
+                ),
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000"))
@@ -110,7 +113,10 @@ struct TextComponentView_Previews: PreviewProvider {
                             "id_1": .string("Hello, world")
                         ]
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                    uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(),
+                        fontSizeOverride: nil
+                    ),
                     component: .init(
                         text: "id_1",
                         color: .init(light: .hex("#000000")),
@@ -128,11 +134,13 @@ struct TextComponentView_Previews: PreviewProvider {
                             "id_1": .string("Hello, world")
                         ]
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
-                        fonts: [
-                            "primary": .init(ios: .name("Chalkduster"))
-                        ]
-                    )),
+                    uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(
+                            fonts: [
+                                "primary": .init(ios: .name("Chalkduster"))
+                            ]
+                        ), fontSizeOverride: nil
+                    ),
                     component: .init(
                         text: "id_1",
                         fontName: "primary",
@@ -151,11 +159,14 @@ struct TextComponentView_Previews: PreviewProvider {
                             "id_1": .string("Hello, world")
                         ]
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
-                        fonts: [
-                            "primary": .init(ios: .name("Chalkduster"))
-                        ]
-                    )),
+                    uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(
+                            fonts: [
+                                "primary": .init(ios: .name("Chalkduster"))
+                            ]
+                        ),
+                        fontSizeOverride: nil
+                    ),
                     component: .init(
                         text: "id_1",
                         fontName: "This font name is not configured",
@@ -174,11 +185,14 @@ struct TextComponentView_Previews: PreviewProvider {
                             "id_1": .string("Hello, world")
                         ]
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
-                        fonts: [
-                            "primary": .init(ios: .name("This Font Does Not Exist"))
-                        ]
-                    )),
+                    uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(
+                            fonts: [
+                                "primary": .init(ios: .name("This Font Does Not Exist"))
+                            ]
+                        ),
+                        fontSizeOverride: nil
+                    ),
                     component: .init(
                         text: "id_1",
                         fontName: "primary",
@@ -203,12 +217,15 @@ struct TextComponentView_Previews: PreviewProvider {
                             "id_1": .string("Red bg, yellow fg")
                         ]
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
-                        colors: [
-                            "primary": .init(light: .hex("#ff0000")),
-                            "secondary": .init(light: .hex("#ffcc00"))
-                        ]
-                    )),
+                    uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(
+                            colors: [
+                                "primary": .init(light: .hex("#ff0000")),
+                                "secondary": .init(light: .hex("#ffcc00"))
+                            ]
+                        ),
+                        fontSizeOverride: nil
+                    ),
                     component: .init(
                         text: "id_1",
                         color: .init(light: .alias("secondary")),
@@ -227,12 +244,15 @@ struct TextComponentView_Previews: PreviewProvider {
                             "id_1": .string("Clear bg and default fg")
                         ]
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
-                        colors: [
-                            "primary": .init(light: .hex("#ff0000")),
-                            "secondary": .init(light: .hex("#ffcc00"))
-                        ]
-                    )),
+                    uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(
+                            colors: [
+                                "primary": .init(light: .hex("#ff0000")),
+                                "secondary": .init(light: .hex("#ffcc00"))
+                            ]
+                        ),
+                        fontSizeOverride: nil
+                    ),
                     component: .init(
                         text: "id_1",
                         color: .init(light: .alias("not a thing")),
@@ -256,7 +276,10 @@ struct TextComponentView_Previews: PreviewProvider {
                         "id_1": .string("Hello, world")
                     ]
                 ),
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                uiConfigProvider: .init(
+                    uiConfig: PreviewUIConfig.make(),
+                    fontSizeOverride: nil
+                ),
                 component: .init(
                     text: "id_1",
                     color: PaywallComponent.ColorScheme(
@@ -289,7 +312,10 @@ struct TextComponentView_Previews: PreviewProvider {
                         "id_1": .string("Hello, world")
                     ]
                 ),
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                uiConfigProvider: .init(
+                    uiConfig: PreviewUIConfig.make(),
+                    fontSizeOverride: nil
+                ),
                 component: .init(
                     text: "id_1",
                     fontName: nil,
@@ -323,7 +349,10 @@ struct TextComponentView_Previews: PreviewProvider {
                         "id_1": .string("Hello, world")
                     ]
                 ),
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                uiConfigProvider: .init(
+                    uiConfig: PreviewUIConfig.make(),
+                    fontSizeOverride: nil
+                ),
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000")),
@@ -365,7 +394,10 @@ struct TextComponentView_Previews: PreviewProvider {
                         "id_2": .string("Showing medium condition")
                     ]
                 ),
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                uiConfigProvider: .init(
+                    uiConfig: PreviewUIConfig.make(),
+                    fontSizeOverride: nil
+                ),
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000")),
@@ -396,7 +428,10 @@ struct TextComponentView_Previews: PreviewProvider {
                         "id_2": .string("SHOULDN'T SHOW MEDIUM")
                     ]
                 ),
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                uiConfigProvider: .init(
+                    uiConfig: PreviewUIConfig.make(),
+                    fontSizeOverride: nil
+                ),
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000")),
@@ -428,7 +463,10 @@ struct TextComponentView_Previews: PreviewProvider {
                         )
                     ]
                 ),
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                uiConfigProvider: .init(
+                    uiConfig: PreviewUIConfig.make(),
+                    fontSizeOverride: nil
+                ),
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000"))
@@ -458,7 +496,10 @@ struct TextComponentView_Previews: PreviewProvider {
                         )
                     ]
                 ),
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                uiConfigProvider: .init(
+                    uiConfig: PreviewUIConfig.make(),
+                    fontSizeOverride: nil
+                ),
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000"))

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -77,6 +77,22 @@ struct TextComponentView: View {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct TextComponentView_Previews: PreviewProvider {
 
+    static let fontSizeOverridesUIConfigProvider = UIConfigProvider(
+        uiConfig: PreviewUIConfig.make(),
+        fontSizeOverride: .init(
+            headingXXL: 10,
+            headingXL: 12,
+            headingL: 14,
+            headingM: 16,
+            headingS: 18,
+            headingXS: 20,
+            bodyXL: 22,
+            bodyL: 24,
+            bodyM: 26,
+            bodyS: 28
+        )
+    )
+
     static var previews: some View {
         // Default
         TextComponentView(
@@ -265,6 +281,44 @@ struct TextComponentView_Previews: PreviewProvider {
         .previewRequiredEnvironmentProperties()
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Custom Color")
+
+        // Font Size Override
+        VStack {
+            let data: [(String, PaywallComponent.FontSize)] = [
+                ("Heading XXL - Size 10", .headingXXL),
+                ("Heading XL - Size 12", .headingXL),
+                ("Heading L - Size 14", .headingL),
+                ("Heading M - Size 16", .headingM),
+                ("Heading S - Size 18", .headingS),
+                ("Heading XS - Size 20", .headingXS),
+                ("Body XL - Size 22", .bodyXL),
+                ("Body L - Size 24", .bodyL),
+                ("Body M - Size 26", .bodyM),
+                ("Body S - Size 28", .bodyS)
+            ]
+            ForEach(data, id: \.self.0) { (string, size) in
+                TextComponentView(
+                    // swiftlint:disable:next force_try
+                    viewModel: try! .init(
+                        localizationProvider: .init(
+                            locale: Locale.current,
+                            localizedStrings: [
+                                "id_1": .string(string)
+                            ]
+                        ),
+                        uiConfigProvider: self.fontSizeOverridesUIConfigProvider,
+                        component: .init(
+                            text: "id_1",
+                            color: .init(light: .hex("#000000")),
+                            fontSize: size
+                        )
+                    )
+                )
+            }
+        }
+        .previewRequiredEnvironmentProperties()
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Font Size Overrides")
 
         // Gradient
         TextComponentView(

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -241,7 +241,10 @@ struct TextComponentStyle {
         self.color = color.asDisplayable(uiConfigProvider: uiConfigProvider)
 
         // WIP: Take into account the fontFamily mapping
-        self.font = fontSize.makeFont(familyName: fontFamily)
+        self.font = fontSize.makeFont(
+            familyName: fontFamily,
+            fontSizeOverrides: uiConfigProvider.fontSizeOverride
+        )
 
         self.textAlignment = horizontalAlignment.textAlignment
         self.horizontalAlignment = horizontalAlignment.frameAlignment

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -61,7 +61,10 @@ struct PaywallsV2View: View {
         showZeroDecimalPlacePrices: Bool,
         onDismiss: @escaping () -> Void
     ) {
-        let uiConfigProvider = UIConfigProvider(uiConfig: paywallComponents.uiConfig)
+        let uiConfigProvider = UIConfigProvider(
+            uiConfig: paywallComponents.uiConfig,
+            fontSizeOverride: paywallComponents.data.componentsConfig.fontSizeOverrides
+        )
 
         self.paywallComponentsData = paywallComponents.data
         self.uiConfigProvider = uiConfigProvider

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FallbackComponentPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FallbackComponentPreview.swift
@@ -122,7 +122,10 @@ struct FallbackComponentPreview_Previews: PreviewProvider {
             packageValidator: packageValidator,
             offering: offering,
             localizationProvider: localizationProvider,
-            uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
+            uiConfigProvider: .init(
+                uiConfig: PreviewUIConfig.make(),
+                fontSizeOverride: nil
+            )
         )
     }
 

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -224,7 +224,10 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                             .init(color: "#ff0000", percent: 0),
                             .init(color: "#E58984", percent: 100)
                         ])
-                    ).asDisplayable(uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
+                    ).asDisplayable(uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(),
+                        fontSizeOverride: nil
+                    )
                 ))
             )
             .preferredColorScheme(.dark)
@@ -243,7 +246,10 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                             .init(color: "#00E519", percent: 0),
                             .init(color: "#9DEAD3", percent: 100)
                         ])
-                    ).asDisplayable(uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
+                    ).asDisplayable(uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(),
+                        fontSizeOverride: nil
+                    ))
                 )
             )
             .previewLayout(.sizeThatFits)
@@ -261,7 +267,10 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                             .init(color: "#ff0000", percent: 0),
                             .init(color: "#E58984", percent: 100)
                         ])
-                      ).asDisplayable(uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
+                      ).asDisplayable(uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(),
+                        fontSizeOverride: nil
+                      ))
                 )
             )
             .preferredColorScheme(.dark)
@@ -281,7 +290,10 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                             .init(color: "#000000", percent: 0),
                             .init(color: "#ffffff", percent: 100)
                         ])
-                      ).asDisplayable(uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()))
+                      ).asDisplayable(uiConfigProvider: .init(
+                        uiConfig: PreviewUIConfig.make(),
+                        fontSizeOverride: nil
+                      ))
                 )
             )
             .previewLayout(.sizeThatFits)

--- a/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
@@ -338,11 +338,15 @@ struct CornerBorder_Previews: PreviewProvider {
                                     .padding(.vertical, 10)
                                     .padding(.horizontal, 20)
                             }
-                            .shape(border: border,
-                                   shape: shape,
-                                   shadow: shadow,
-                                   background: background,
-                                   uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
+                            .shape(
+                                border: border,
+                                shape: shape,
+                                shadow: shadow,
+                                background: background,
+                                uiConfigProvider: .init(
+                                    uiConfig: PreviewUIConfig.make(),
+                                    fontSizeOverride: nil
+                                )
                             )
                             .padding(5)
                         }
@@ -378,9 +382,12 @@ struct CornerBorder_Previews: PreviewProvider {
                 .padding(.horizontal, 20)
                 .background(.yellow)
                 .shape(
-                    border: .init(color: .blue,
-                                  width: 4),
-                    shape: nil)
+                    border: .init(
+                        color: .blue,
+                        width: 4
+                    ),
+                    shape: nil
+                )
                 .padding()
         }
         .previewLayout(.sizeThatFits)
@@ -394,10 +401,15 @@ struct CornerBorder_Previews: PreviewProvider {
                 .background(.yellow)
                 .shape(
                     border: nil,
-                    shape: .rectangle(.init(topLeft: 8,
-                                            topRight: 0,
-                                            bottomLeft: 0,
-                                            bottomRight: 8)))
+                    shape: .rectangle(
+                        .init(
+                            topLeft: 8,
+                            topRight: 0,
+                            bottomLeft: 0,
+                            bottomRight: 8
+                        )
+                    )
+                )
                 .padding()
         }
         .previewLayout(.sizeThatFits)
@@ -410,12 +422,19 @@ struct CornerBorder_Previews: PreviewProvider {
                 .padding(.horizontal, 20)
                 .background(.yellow)
                 .shape(
-                    border: .init(color: .blue,
-                                  width: 6),
-                    shape: .rectangle(.init(topLeft: 8,
-                                            topRight: 8,
-                                            bottomLeft: 8,
-                                            bottomRight: 8)))
+                    border: .init(
+                        color: .blue,
+                        width: 6
+                    ),
+                    shape: .rectangle(
+                        .init(
+                            topLeft: 8,
+                            topRight: 8,
+                            bottomLeft: 8,
+                            bottomRight: 8
+                        )
+                    )
+                )
                 .padding()
         }
         .previewLayout(.sizeThatFits)
@@ -428,12 +447,19 @@ struct CornerBorder_Previews: PreviewProvider {
                 .padding(.horizontal, 20)
                 .background(.yellow)
                 .shape(
-                    border: .init(color: .blue,
-                                  width: 6),
-                    shape: .rectangle(.init(topLeft: 8,
-                                            topRight: 0,
-                                            bottomLeft: 0,
-                                            bottomRight: 8)))
+                    border: .init(
+                        color: .blue,
+                        width: 6
+                    ),
+                    shape: .rectangle(
+                        .init(
+                            topLeft: 8,
+                            topRight: 0,
+                            bottomLeft: 0,
+                            bottomRight: 8
+                        )
+                    )
+                )
                 .padding()
         }
         .previewLayout(.sizeThatFits)

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
@@ -16,10 +16,22 @@ import SwiftUI
 
 #if PAYWALL_COMPONENTS
 
+private extension Int {
+    var asCGFloat: CGFloat {
+        return CGFloat(self)
+    }
+}
+
 extension PaywallComponent.FontSize {
 
-    func makeFont(familyName: String?) -> Font {
-        return Font(self.makeUIFont(familyName: familyName))
+    func makeFont(
+        familyName: String?,
+        fontSizeOverrides: PaywallComponentsData.FontSizeOverrides?
+    ) -> Font {
+        return Font(self.makeUIFont(
+            familyName: familyName,
+            fontSizeOverrides: fontSizeOverrides
+        ))
     }
 
     private var textStyle: UIFont.TextStyle {
@@ -37,19 +49,22 @@ extension PaywallComponent.FontSize {
     }
 
     // swiftlint:disable cyclomatic_complexity
-    private func makeUIFont(familyName: String?) -> UIFont {
+    private func makeUIFont(
+        familyName: String?,
+        fontSizeOverrides: PaywallComponentsData.FontSizeOverrides?
+    ) -> UIFont {
         let fontSize: CGFloat
         switch self {
-        case .headingXXL: fontSize = 40
-        case .headingXL: fontSize = 34
-        case .headingL: fontSize = 28
-        case .headingM: fontSize = 24
-        case .headingS: fontSize = 20
-        case .headingXS: fontSize = 16
-        case .bodyXL: fontSize = 18
-        case .bodyL: fontSize = 17
-        case .bodyM: fontSize = 15
-        case .bodyS: fontSize = 13
+        case .headingXXL: fontSize = fontSizeOverrides?.headingXXL.asCGFloat ?? 40
+        case .headingXL: fontSize = fontSizeOverrides?.headingXL.asCGFloat ?? 34
+        case .headingL: fontSize = fontSizeOverrides?.headingL.asCGFloat ?? 28
+        case .headingM: fontSize = fontSizeOverrides?.headingM.asCGFloat ?? 24
+        case .headingS: fontSize = fontSizeOverrides?.headingS.asCGFloat ?? 20
+        case .headingXS: fontSize = fontSizeOverrides?.headingXS.asCGFloat ?? 16
+        case .bodyXL: fontSize = fontSizeOverrides?.bodyXL.asCGFloat ?? 18
+        case .bodyL: fontSize = fontSizeOverrides?.bodyL.asCGFloat ?? 17
+        case .bodyM: fontSize = fontSizeOverrides?.bodyM.asCGFloat ?? 15
+        case .bodyS: fontSize = fontSizeOverrides?.bodyS.asCGFloat ?? 13
         }
 
         // Create the base font, with fallback to the system font

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -19,9 +19,11 @@ import RevenueCat
 struct UIConfigProvider {
 
     private let uiConfig: UIConfig
+    let fontSizeOverride: PaywallComponentsData.FontSizeOverrides?
 
-    init(uiConfig: UIConfig) {
+    init(uiConfig: UIConfig, fontSizeOverride: PaywallComponentsData.FontSizeOverrides?) {
         self.uiConfig = uiConfig
+        self.fontSizeOverride = fontSizeOverride
     }
 
     func getColor(for name: String) -> PaywallComponent.ColorScheme? {

--- a/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
@@ -42,6 +42,28 @@ public struct PaywallComponentsData: Codable, Equatable, Sendable {
         public let bodyM: Int
         public let bodyS: Int
 
+        public init(headingXXL: Int,
+                    headingXL: Int,
+                    headingL: Int,
+                    headingM: Int,
+                    headingS: Int,
+                    headingXS: Int,
+                    bodyXL: Int,
+                    bodyL: Int,
+                    bodyM: Int,
+                    bodyS: Int) {
+            self.headingXXL = headingXXL
+            self.headingXL = headingXL
+            self.headingL = headingL
+            self.headingM = headingM
+            self.headingS = headingS
+            self.headingXS = headingXS
+            self.bodyXL = bodyXL
+            self.bodyL = bodyL
+            self.bodyM = bodyM
+            self.bodyS = bodyS
+        }
+
         // swiftlint:disable:next nesting
         private enum CodingKeys: String, CodingKey {
             case headingXXL = "heading_xxl"

--- a/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
@@ -21,9 +21,39 @@ public struct PaywallComponentsData: Codable, Equatable, Sendable {
     public struct ComponentsConfig: Codable, Equatable, Sendable {
 
         public var base: PaywallComponentsConfig
+        public var fontSizeOverrides: FontSizeOverrides?
 
         public init(base: PaywallComponentsConfig) {
             self.base = base
+        }
+
+    }
+
+    public struct FontSizeOverrides: Codable, Equatable, Sendable {
+
+        public let headingXXL: Int
+        public let headingXL: Int
+        public let headingL: Int
+        public let headingM: Int
+        public let headingS: Int
+        public let headingXS: Int
+        public let bodyXL: Int
+        public let bodyL: Int
+        public let bodyM: Int
+        public let bodyS: Int
+
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: String, CodingKey {
+            case headingXXL = "heading_xxl"
+            case headingXL = "heading_xl"
+            case headingL = "heading_l"
+            case headingM = "heading_m"
+            case headingS = "heading_s"
+            case headingXS = "heading_xs"
+            case bodyXL = "body_xl"
+            case bodyL = "body_l"
+            case bodyM = "body_m"
+            case bodyS = "body_s"
         }
 
     }


### PR DESCRIPTION
### Motivation

Allow overriding of font sizes per paywall

### Description

New `fontSizeOverride` on `PaywallComopnentsData`

- This is the same level the `base` paywall is on
- Allows overriding of all font size names (`heading_xxl`, `heading_xl`, `body_l`, etc)

<img width="1535" alt="Screenshot 2025-01-12 at 6 21 05 AM" src="https://github.com/user-attachments/assets/76175e8c-2637-4c1c-bd76-ff190eefb6ca" />

