### PR TITLE
[Paywalls V2] Allow for app specific component overrides

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		03A98D322D2441B8009BCA61 /* PaywallDataDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98D312D2441B2009BCA61 /* PaywallDataDecodingTests.swift */; };
 		03A98D362D244329009BCA61 /* UIConfigDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98D352D244321009BCA61 /* UIConfigDecodingTests.swift */; };
 		03A98D382D2AC63B009BCA61 /* UIConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98D372D2AC637009BCA61 /* UIConfigProvider.swift */; };
+		03C72FAD2D33F73C00297FEC /* PresentedPartialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C72FAC2D33F73900297FEC /* PresentedPartialTests.swift */; };
 		03F446212D2F73240046129A /* StackComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446202D2F73210046129A /* StackComponentTests.swift */; };
 		03F446242D2FE0C50046129A /* ShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446232D2FE0C10046129A /* ShapePropertyTests.swift */; };
 		03F446262D2FE1510046129A /* MaskShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */; };
@@ -1253,6 +1254,7 @@
 		03A98D312D2441B2009BCA61 /* PaywallDataDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallDataDecodingTests.swift; sourceTree = "<group>"; };
 		03A98D352D244321009BCA61 /* UIConfigDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfigDecodingTests.swift; sourceTree = "<group>"; };
 		03A98D372D2AC637009BCA61 /* UIConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfigProvider.swift; sourceTree = "<group>"; };
+		03C72FAC2D33F73900297FEC /* PresentedPartialTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentedPartialTests.swift; sourceTree = "<group>"; };
 		03F446202D2F73210046129A /* StackComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackComponentTests.swift; sourceTree = "<group>"; };
 		03F446232D2FE0C10046129A /* ShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapePropertyTests.swift; sourceTree = "<group>"; };
 		03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskShapePropertyTests.swift; sourceTree = "<group>"; };
@@ -2467,6 +2469,7 @@
 		030890822D2B77DD0069677B /* PaywallsV2 */ = {
 			isa = PBXGroup;
 			children = (
+				03C72FAC2D33F73900297FEC /* PresentedPartialTests.swift */,
 				030890832D2B77E20069677B /* VariableHandlerV2Tests.swift */,
 			);
 			path = PaywallsV2;
@@ -6742,6 +6745,7 @@
 				887A633C2C1D177800E1A461 /* Template1ViewTests.swift in Sources */,
 				35A99C842CCB95A70074AB41 /* PurchaseInformationTests.swift in Sources */,
 				777FB4882C661C0600CD4749 /* SemanticVersionTests.swift in Sources */,
+				03C72FAD2D33F73C00297FEC /* PresentedPartialTests.swift in Sources */,
 				88AD4C482C24E8EA00943C3E /* ExternalPurchaseAndRestoreTests.swift in Sources */,
 				887A633D2C1D177800E1A461 /* Template2ViewTests.swift in Sources */,
 				887A633E2C1D177800E1A461 /* Template3ViewTests.swift in Sources */,

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -312,6 +312,33 @@ struct TextComponentView_Previews: PreviewProvider {
         .previewRequiredEnvironmentProperties()
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Customizations")
+        
+        // State - App Specific
+        TextComponentView(
+            // swiftlint:disable:next force_try
+            viewModel: try! .init(
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("Hello, world"),
+                        "id_2": .string("Hello, world on iOS app")
+                    ]
+                ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                component: .init(
+                    text: "id_1",
+                    color: .init(light: .hex("#000000")),
+                    overrides: .init(
+                        app: .init(
+                            text: "id_2"
+                        )
+                    )
+                )
+            )
+        )
+        .previewRequiredEnvironmentProperties()
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("State - App Specific")
 
         // State - Selected
         TextComponentView(
@@ -320,7 +347,8 @@ struct TextComponentView_Previews: PreviewProvider {
                 localizationProvider: .init(
                     locale: Locale.current,
                     localizedStrings: [
-                        "id_1": .string("Hello, world")
+                        "id_1": .string("Hello, world"),
+                        "id_2": .string("THIS SHOULDN'T SHOW")
                     ]
                 ),
                 uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
@@ -328,8 +356,15 @@ struct TextComponentView_Previews: PreviewProvider {
                     text: "id_1",
                     color: .init(light: .hex("#000000")),
                     overrides: .init(
+                        // None of this should be displayed
+                        app: .init(
+                            text: "id_2",
+                            color: .init(light: .hex("#ffcc00"))
+                        ),
+                        // Selected should override app
                         states: .init(
                             selected: .init(
+                                text: "id_1",
                                 fontWeight: .black,
                                 color: .init(light: .hex("#ff0000")),
                                 backgroundColor: .init(light: .hex("#0000ff")),

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -312,7 +312,7 @@ struct TextComponentView_Previews: PreviewProvider {
         .previewRequiredEnvironmentProperties()
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Customizations")
-        
+
         // State - App Specific
         TextComponentView(
             // swiftlint:disable:next force_try

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -18,7 +18,7 @@ import RevenueCat
 #if PAYWALL_COMPONENTS
 
 /// Protocol defining how partial components can be combined
-protocol PresentedPartial {
+protocol PresentedPartial: Equatable {
 
     /// Combines two partial components, allowing for override behavior
     /// - Parameters:

--- a/Sources/Paywalls/Components/Common/ComponentOverrides.swift
+++ b/Sources/Paywalls/Components/Common/ComponentOverrides.swift
@@ -24,15 +24,18 @@ public extension PaywallComponent {
     struct ComponentOverrides<T: PartialComponent>: PaywallComponentBase {
 
         public init(
+            app: T? = nil,
             introOffer: T? = nil,
             states: PaywallComponent.ComponentStates<T>? = nil,
             conditions: PaywallComponent.ComponentConditions<T>? = nil
         ) {
+            self.app = app
             self.introOffer = introOffer
             self.states = states
             self.conditions = conditions
         }
 
+        public let app: T?
         public let introOffer: T?
         public let states: ComponentStates<T>?
         public let conditions: ComponentConditions<T>?

--- a/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialTests.swift
@@ -1,0 +1,181 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Untitled.swift
+//
+//  Created by Josh Holtz on 1/12/25.
+
+import Nimble
+import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if PAYWALL_COMPONENTS
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+class PresentedPartialTest: TestCase {
+
+    func testNothing() {
+        let presentedOverrides: PresentedOverrides<LocalizedTextPartial>? = nil
+
+        let localizedPartial = LocalizedTextPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            with: presentedOverrides
+        )
+
+        let expectedResult = LocalizedTextPartial(
+            text: nil,
+            partial: .init(
+                visible: nil
+            )
+        )
+
+        expect(localizedPartial).to(equal(expectedResult))
+    }
+
+    func testApp() {
+        let presentedOverrides: PresentedOverrides<LocalizedTextPartial> = .init(
+            app: .init(
+                text: "override_id_app",
+                partial: .init(
+                    visible: nil,
+                    fontSize: .bodyL
+                )
+            ),
+            introOffer: nil,
+            states: nil,
+            conditions: nil
+        )
+
+        let localizedPartial = LocalizedTextPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            with: presentedOverrides
+        )
+
+        let expectedResult = LocalizedTextPartial(
+            text: "override_id_app",
+            partial: .init(
+                visible: nil,
+                fontSize: .bodyL
+            )
+        )
+
+        expect(localizedPartial).to(equal(expectedResult))
+    }
+
+    func testConditionCompactOverridesApp() {
+        let presentedOverrides: PresentedOverrides<LocalizedTextPartial> = .init(
+            app: .init(
+                text: "override_id_app",
+                partial: .init(
+                    visible: nil,
+                    fontWeight: .light,
+                    fontSize: .bodyL
+                )
+            ),
+            introOffer: nil,
+            states: nil,
+            conditions: .init(
+                compact: .init(
+                    text: "override_id_compact",
+                    partial: .init(
+                        visible: nil,
+                        fontSize: .bodyM
+                    )
+                ),
+                // This won't get used because `buildPartial` since its using `compact
+                medium: .init(
+                    text: "override_id_medium",
+                    partial: .init(
+                        visible: nil,
+                        horizontalAlignment: .trailing
+                    )
+                ),
+                expanded: nil
+            )
+        )
+
+        let localizedPartial = LocalizedTextPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            with: presentedOverrides
+        )
+
+        let expectedResult = LocalizedTextPartial(
+            text: "override_id_compact", // From compact
+            partial: .init(
+                visible: nil,
+                fontWeight: .light, // From app
+                fontSize: .bodyM // From compact
+            )
+        )
+
+        expect(localizedPartial).to(equal(expectedResult))
+    }
+
+    func testConditionMediumOverridesConditionCompactOverridesApp() {
+        let presentedOverrides: PresentedOverrides<LocalizedTextPartial> = .init(
+            app: .init(
+                text: "override_id_app",
+                partial: .init(
+                    visible: nil,
+                    fontWeight: .light,
+                    fontSize: .bodyL
+                )
+            ),
+            introOffer: nil,
+            states: nil,
+            conditions: .init(
+                compact: .init(
+                    text: "override_id_compact",
+                    partial: .init(
+                        visible: nil,
+                        fontSize: .bodyM,
+                        horizontalAlignment: .leading
+                    )
+                ),
+                medium: .init(
+                    text: "override_id_medium",
+                    partial: .init(
+                        visible: nil,
+                        horizontalAlignment: .trailing
+                    )
+                ),
+                expanded: nil
+            )
+        )
+
+        let localizedPartial = LocalizedTextPartial.buildPartial(
+            state: .default,
+            condition: .medium,
+            isEligibleForIntroOffer: false,
+            with: presentedOverrides
+        )
+
+        let expectedResult = LocalizedTextPartial(
+            text: "override_id_medium", // From medium
+            partial: .init(
+                visible: nil,
+                fontWeight: .light, // From app
+                fontSize: .bodyM, // From compact
+                horizontalAlignment: .trailing // From medium
+            )
+        )
+
+        expect(localizedPartial).to(equal(expectedResult))
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
@@ -17,6 +17,8 @@ import RevenueCat
 @testable import RevenueCatUI
 import XCTest
 
+#if PAYWALL_COMPONENTS
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class VariableHandlerV2Test: TestCase {
 
@@ -515,3 +517,5 @@ class VariableHandlerV2Test: TestCase {
     }
 
 }
+
+#endif


### PR DESCRIPTION
### Motivation

There are occasions where we will want components to have overridden values PER app

Example:
- Different deep link schemes/urls
- Different terms/privacy policies (iOS vs Android)

### Description

Added a new optional `app` override property that will get dynamically set by the offferings response API for the app that requested it

⚠️  THE BACKEND IS NOT IMPLEMENTED YET
