### PR TITLE
fix: dismiss alert using binding instead of environment dismiss

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
@@ -34,8 +34,6 @@ struct RestorePurchasesAlert: ViewModifier {
 
     @State
     private var alertType: AlertType = .restorePurchases
-    @Environment(\.dismiss)
-    private var dismiss
     @Environment(\.localization)
     private var localization
     @Environment(\.supportInformation)
@@ -164,7 +162,7 @@ struct RestorePurchasesAlert: ViewModifier {
 
     private func dismissAlert() {
         self.alertType = .restorePurchases
-        dismiss()
+        self.isPresented = false
     }
 }
 


### PR DESCRIPTION
### Motivation
This is a follow-up of https://github.com/RevenueCat/purchases-ios/pull/4622 just to have a cleaner PR.
The environment `dismiss` dismisses the whole thing, whereas using `isPresented` just closes the alert, which is the original intention.

