### PR TITLE
[Paywalls V2] Accept number as font size for text

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		03A98D362D244329009BCA61 /* UIConfigDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98D352D244321009BCA61 /* UIConfigDecodingTests.swift */; };
 		03A98D382D2AC63B009BCA61 /* UIConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98D372D2AC637009BCA61 /* UIConfigProvider.swift */; };
 		03C72F8D2D3311E300297FEC /* DisplayableColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C72F8C2D3311D500297FEC /* DisplayableColor.swift */; };
+		03C7305B2D35985900297FEC /* TextComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C7305A2D35985500297FEC /* TextComponentTests.swift */; };
 		03F446212D2F73240046129A /* StackComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446202D2F73210046129A /* StackComponentTests.swift */; };
 		03F446242D2FE0C50046129A /* ShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446232D2FE0C10046129A /* ShapePropertyTests.swift */; };
 		03F446262D2FE1510046129A /* MaskShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */; };
@@ -1255,6 +1256,7 @@
 		03A98D352D244321009BCA61 /* UIConfigDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfigDecodingTests.swift; sourceTree = "<group>"; };
 		03A98D372D2AC637009BCA61 /* UIConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfigProvider.swift; sourceTree = "<group>"; };
 		03C72F8C2D3311D500297FEC /* DisplayableColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayableColor.swift; sourceTree = "<group>"; };
+		03C7305A2D35985500297FEC /* TextComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextComponentTests.swift; sourceTree = "<group>"; };
 		03F446202D2F73210046129A /* StackComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackComponentTests.swift; sourceTree = "<group>"; };
 		03F446232D2FE0C10046129A /* ShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapePropertyTests.swift; sourceTree = "<group>"; };
 		03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskShapePropertyTests.swift; sourceTree = "<group>"; };
@@ -2597,6 +2599,7 @@
 			children = (
 				03F446222D2FE0B90046129A /* Properties */,
 				03F446202D2F73210046129A /* StackComponentTests.swift */,
+				03C7305A2D35985500297FEC /* TextComponentTests.swift */,
 				03A98CEE2D1EE040009BCA61 /* FallbackComponentTests.swift */,
 				2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */,
 				2C8EC6DE2CCD27A100D6CCF8 /* PartialComponentTests.swift */,
@@ -6174,6 +6177,7 @@
 				35272E2226D0048D00F22C3B /* HTTPClientTests.swift in Sources */,
 				2DDF41CB24F6F4C3005BC22D /* ASN1ObjectIdentifierBuilderTests.swift in Sources */,
 				5766AA5A283D4CAB00FA6091 /* IgnoreHashableTests.swift in Sources */,
+				03C7305B2D35985900297FEC /* TextComponentTests.swift in Sources */,
 				B36824BF268FBC8700957E4C /* SubscriberAttributeTests.swift in Sources */,
 				351B51BC26D450E800BD2BD7 /* OfferingsTests.swift in Sources */,
 				5796A38827D6B85900653165 /* BackendPostReceiptDataTests.swift in Sources */,

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -114,7 +114,7 @@ struct TextComponentView_Previews: PreviewProvider {
                     component: .init(
                         text: "id_1",
                         color: .init(light: .hex("#000000")),
-                        fontSize: .headingXXL
+                        fontSize: 40
                     )
                 )
             )
@@ -137,7 +137,7 @@ struct TextComponentView_Previews: PreviewProvider {
                         text: "id_1",
                         fontName: "primary",
                         color: .init(light: .hex("#000000")),
-                        fontSize: .headingXXL
+                        fontSize: 40
                     )
                 )
             )
@@ -160,7 +160,7 @@ struct TextComponentView_Previews: PreviewProvider {
                         text: "id_1",
                         fontName: "This font name is not configured",
                         color: .init(light: .hex("#000000")),
-                        fontSize: .headingXXL
+                        fontSize: 40
                     )
                 )
             )
@@ -183,7 +183,7 @@ struct TextComponentView_Previews: PreviewProvider {
                         text: "id_1",
                         fontName: "primary",
                         color: .init(light: .hex("#000000")),
-                        fontSize: .headingXXL
+                        fontSize: 40
                     )
                 )
             )
@@ -213,7 +213,7 @@ struct TextComponentView_Previews: PreviewProvider {
                         text: "id_1",
                         color: .init(light: .alias("secondary")),
                         backgroundColor: .init(light: .alias("primary")),
-                        fontSize: .headingXXL
+                        fontSize: 40
                     )
                 )
             )
@@ -237,7 +237,7 @@ struct TextComponentView_Previews: PreviewProvider {
                         text: "id_1",
                         color: .init(light: .alias("not a thing")),
                         backgroundColor: .init(light: .alias("also not a thing")),
-                        fontSize: .headingXXL
+                        fontSize: 40
                     )
                 )
             )
@@ -271,7 +271,7 @@ struct TextComponentView_Previews: PreviewProvider {
                             .init(color: "#00FDFF", percent: 100)
                         ])
                       ),
-                    fontSize: .headingXXL
+                    fontSize: 40
                 )
             )
         )
@@ -304,7 +304,7 @@ struct TextComponentView_Previews: PreviewProvider {
                                   bottom: 20,
                                   leading: 10,
                                   trailing: 10),
-                    fontSize: .bodyS,
+                    fontSize: 13,
                     horizontalAlignment: .leading
                 )
             )
@@ -341,7 +341,7 @@ struct TextComponentView_Previews: PreviewProvider {
                                               bottom: 10,
                                               leading: 10,
                                               trailing: 10),
-                                fontSize: .headingXL
+                                fontSize: 34
                             )
                         )
                     )

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -232,7 +232,7 @@ struct TextComponentStyle {
         size: PaywallComponent.Size,
         padding: PaywallComponent.Padding,
         margin: PaywallComponent.Padding,
-        fontSize: PaywallComponent.FontSize,
+        fontSize: CGFloat,
         horizontalAlignment: PaywallComponent.HorizontalAlignment
     ) {
         self.visible = visible
@@ -241,7 +241,7 @@ struct TextComponentStyle {
         self.color = color.asDisplayable(uiConfigProvider: uiConfigProvider)
 
         // WIP: Take into account the fontFamily mapping
-        self.font = fontSize.makeFont(familyName: fontFamily)
+        self.font = Self.makeFont(size: fontSize, familyName: fontFamily)
 
         self.textAlignment = horizontalAlignment.textAlignment
         self.horizontalAlignment = horizontalAlignment.frameAlignment
@@ -249,6 +249,30 @@ struct TextComponentStyle {
         self.size = size
         self.padding = padding.edgeInsets
         self.margin = margin.edgeInsets
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension TextComponentStyle {
+
+    static func makeFont(size fontSize: CGFloat, familyName: String?) -> Font {
+        // Create the base font, with fallback to the system font
+        let baseFont: UIFont
+        if let familyName = familyName {
+            if let customFont = UIFont(name: familyName, size: fontSize) {
+                baseFont = customFont
+            } else {
+                Logger.warning("Custom font '\(familyName)' could not be loaded. Falling back to system font.")
+                baseFont = UIFont.systemFont(ofSize: fontSize, weight: .regular)
+            }
+        } else {
+            baseFont = UIFont.systemFont(ofSize: fontSize, weight: .regular)
+        }
+
+        // Apply dynamic type scaling
+        let uiFont = UIFontMetrics.default.scaledFont(for: baseFont)
+        return Font(uiFont)
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -48,7 +48,7 @@ private enum Template1Preview {
         backgroundColor: nil,
         padding: .zero,
         margin: .zero,
-        fontSize: .headingL,
+        fontSize: 28,
         horizontalAlignment: .center
     )
 
@@ -60,7 +60,7 @@ private enum Template1Preview {
         backgroundColor: nil,
         padding: .zero,
         margin: .zero,
-        fontSize: .bodyM,
+        fontSize: 15,
         horizontalAlignment: .center
     )
 

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template5Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template5Preview.swift
@@ -54,7 +54,7 @@ private enum Template5Preview {
         backgroundColor: nil,
         padding: .zero,
         margin: .zero,
-        fontSize: .headingL,
+        fontSize: 28,
         horizontalAlignment: .leading
     )
 
@@ -66,7 +66,7 @@ private enum Template5Preview {
         backgroundColor: nil,
         padding: .zero,
         margin: .zero,
-        fontSize: .bodyM,
+        fontSize: 15,
         horizontalAlignment: .leading
     )
 
@@ -146,7 +146,7 @@ private enum Template5Preview {
             .text(.init(
                 text: "package_terms",
                 color: .init(light: .hex("#999999")),
-                fontSize: .bodyS
+                fontSize: 13
             ))
         ],
         dimension: .vertical(.center, .start),

--- a/Sources/Paywalls/Components/PaywallTextComponent.swift
+++ b/Sources/Paywalls/Components/PaywallTextComponent.swift
@@ -36,7 +36,7 @@ public extension PaywallComponent {
             size: Size = .init(width: .fill, height: .fit),
             padding: Padding = .zero,
             margin: Padding = .zero,
-            fontSize: CGFloat = 16, // TODO: Change
+            fontSize: CGFloat = 16,
             horizontalAlignment: HorizontalAlignment = .center,
             overrides: ComponentOverrides<PartialTextComponent>? = nil
         ) {

--- a/Sources/Paywalls/Components/PaywallTextComponent.swift
+++ b/Sources/Paywalls/Components/PaywallTextComponent.swift
@@ -71,6 +71,7 @@ public extension PaywallComponent {
                                                            forKey: .overrides)
 
             // Decode fontSize as CGFloat or fallback to FontSize
+            // This can be removed after 2025-03-01 when we are sure no more paywalls are using this
             if let rawFontSize = try? container.decode(CGFloat.self, forKey: .fontSize) {
                 self.fontSize = rawFontSize
             } else if let fontSizeEnum = try? container.decode(FontSize.self, forKey: .fontSize) {

--- a/Sources/Paywalls/Components/PaywallTextComponent.swift
+++ b/Sources/Paywalls/Components/PaywallTextComponent.swift
@@ -13,13 +13,12 @@ import Foundation
 public extension PaywallComponent {
 
     struct TextComponent: PaywallComponentBase {
-
         let type: ComponentType
         public let text: LocalizationKey
         public let fontName: String?
         public let fontWeight: FontWeight
         public let color: ColorScheme
-        public let fontSize: FontSize
+        public let fontSize: CGFloat
         public let horizontalAlignment: HorizontalAlignment
         public let backgroundColor: ColorScheme?
         public let size: Size
@@ -37,7 +36,7 @@ public extension PaywallComponent {
             size: Size = .init(width: .fill, height: .fit),
             padding: Padding = .zero,
             margin: Padding = .zero,
-            fontSize: FontSize = .bodyM,
+            fontSize: CGFloat = 16, // TODO: Change
             horizontalAlignment: HorizontalAlignment = .center,
             overrides: ComponentOverrides<PartialTextComponent>? = nil
         ) {
@@ -54,6 +53,54 @@ public extension PaywallComponent {
             self.horizontalAlignment = horizontalAlignment
             self.overrides = overrides
         }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.type = try container.decode(ComponentType.self, forKey: .type)
+            self.text = try container.decode(LocalizationKey.self, forKey: .text)
+            self.fontName = try container.decodeIfPresent(String.self, forKey: .fontName)
+            self.fontWeight = try container.decode(FontWeight.self, forKey: .fontWeight)
+            self.color = try container.decode(ColorScheme.self, forKey: .color)
+            self.horizontalAlignment = try container.decode(HorizontalAlignment.self, forKey: .horizontalAlignment)
+            self.backgroundColor = try container.decodeIfPresent(ColorScheme.self, forKey: .backgroundColor)
+            self.size = try container.decode(Size.self, forKey: .size)
+            self.padding = try container.decode(Padding.self, forKey: .padding)
+            self.margin = try container.decode(Padding.self, forKey: .margin)
+            self.overrides = try container.decodeIfPresent(ComponentOverrides<PartialTextComponent>.self,
+                                                           forKey: .overrides)
+
+            // Decode fontSize as CGFloat or fallback to FontSize
+            if let rawFontSize = try? container.decode(CGFloat.self, forKey: .fontSize) {
+                self.fontSize = rawFontSize
+            } else if let fontSizeEnum = try? container.decode(FontSize.self, forKey: .fontSize) {
+                self.fontSize = fontSizeEnum.size
+            } else {
+                throw DecodingError.dataCorruptedError(forKey: .fontSize,
+                                                       in: container,
+                                                       debugDescription: "Invalid fontSize format")
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(type, forKey: .type)
+            try container.encode(text, forKey: .text)
+            try container.encodeIfPresent(fontName, forKey: .fontName)
+            try container.encode(fontWeight, forKey: .fontWeight)
+            try container.encode(color, forKey: .color)
+            try container.encode(horizontalAlignment, forKey: .horizontalAlignment)
+            try container.encodeIfPresent(backgroundColor, forKey: .backgroundColor)
+            try container.encode(size, forKey: .size)
+            try container.encode(padding, forKey: .padding)
+            try container.encode(margin, forKey: .margin)
+            try container.encodeIfPresent(overrides, forKey: .overrides)
+
+            // Encode fontSize as CGFloat
+            try container.encode(fontSize, forKey: .fontSize)
+        }
+
     }
 
     struct PartialTextComponent: PartialComponent {
@@ -63,7 +110,7 @@ public extension PaywallComponent {
         public let fontName: String?
         public let fontWeight: FontWeight?
         public let color: ColorScheme?
-        public let fontSize: FontSize?
+        public let fontSize: CGFloat?
         public let horizontalAlignment: HorizontalAlignment?
         public let backgroundColor: ColorScheme?
         public let size: Size?
@@ -80,7 +127,7 @@ public extension PaywallComponent {
             size: Size? = nil,
             padding: Padding? = nil,
             margin: Padding? = nil,
-            fontSize: FontSize? = nil,
+            fontSize: CGFloat? = nil,
             horizontalAlignment: HorizontalAlignment? = nil
         ) {
             self.visible = visible
@@ -102,6 +149,7 @@ public extension PaywallComponent {
 extension PaywallComponent.TextComponent {
 
     enum CodingKeys: String, CodingKey {
+
         case type
         case text = "textLid"
         case fontName
@@ -115,6 +163,7 @@ extension PaywallComponent.TextComponent {
         case margin
 
         case overrides
+
     }
 
 }
@@ -133,6 +182,25 @@ extension PaywallComponent.PartialTextComponent {
         case size
         case padding
         case margin
+    }
+
+}
+
+private extension PaywallComponent.FontSize {
+
+    var size: CGFloat {
+        switch self {
+        case .headingXXL: return 40
+        case .headingXL: return 34
+        case .headingL: return 28
+        case .headingM: return 24
+        case .headingS: return 20
+        case .headingXS: return 16
+        case .bodyXL: return 18
+        case .bodyL: return 17
+        case .bodyM: return 15
+        case .bodyS: return 13
+        }
     }
 
 }

--- a/Tests/UnitTests/Networking/Responses/Fixtures/UIConfig.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/UIConfig.json
@@ -1,77 +1,83 @@
 {
-    "app": {
-        "colors": {
-            "primary": {
-                "type": "hex",
-                "value": "#ffcc00"
+  "app": {
+    "colors": {
+      "primary": {
+        "light": {
+          "type": "hex",
+          "value": "#ffcc00"
+        }
+      },
+      "secondary": {
+        "light": {
+          "type": "linear",
+          "degrees": 45,
+          "points": [
+            {
+              "color": "#032400ff",
+              "percent": 0
             },
-            "secondary": {
-                "type": "linear",
-                "degrees": 45,
-                "points": [
-                    {
-                        "color": "#032400ff",
-                        "percent": 0
-                    },
-                    {
-                        "color": "#090979ff",
-                        "percent": 35
-                    },
-                    {
-                        "color": "#216c32ff",
-                        "percent": 100
-                    }
-                ]
+            {
+              "color": "#090979ff",
+              "percent": 35
             },
-            "tertiary": {
-                "type": "radial",
-                "points": [
-                    {
-                        "color": "#032400ff",
-                        "percent": 0
-                    },
-                    {
-                        "color": "#090979ff",
-                        "percent": 35
-                    },
-                    {
-                        "color": "#216c32ff",
-                        "percent": 100
-                    }
-                ]
+            {
+              "color": "#216c32ff",
+              "percent": 100
             }
-        },
-        "fonts": {
-            "primary": {
-                "ios": {
-                    "type": "name",
-                    "value": "SF Pro"
-                },
-                "android": {
-                    "type": "name",
-                    "value": "Roboto"
-                },
-                "web": {
-                    "type": "google_fonts",
-                    "value": "Gothic"
-                }
+          ]
+        }
+      },
+      "tertiary": {
+        "light": {
+          "type": "radial",
+          "points": [
+            {
+              "color": "#032400ff",
+              "percent": 0
+            },
+            {
+              "color": "#090979ff",
+              "percent": 35
+            },
+            {
+              "color": "#216c32ff",
+              "percent": 100
             }
+          ]
         }
+      }
     },
-    "localizations": {
-        "en_US": {
-            "monthly": "monthly"
+    "fonts": {
+      "primary": {
+        "ios": {
+          "type": "name",
+          "value": "SF Pro"
         },
-        "es_ES": {
-            "monthly": "mensual"
-        }
-    },
-    "variable_config": {
-        "variable_compatibility_map": {
-            "new var": "guaranteed var"
+        "android": {
+          "type": "name",
+          "value": "Roboto"
         },
-        "function_compatibility_map": {
-            "new fun": "guaranteed fun"
+        "web": {
+          "type": "google_fonts",
+          "value": "Gothic"
         }
+      }
     }
+  },
+  "localizations": {
+    "en_US": {
+      "monthly": "monthly"
+    },
+    "es_ES": {
+      "monthly": "mensual"
+    }
+  },
+  "variable_config": {
+    "variable_compatibility_map": {
+      "new var": "guaranteed var"
+    },
+    "function_compatibility_map": {
+      "new fun": "guaranteed fun"
+    }
+  }
 }

--- a/Tests/UnitTests/Networking/Responses/UIConfigDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/UIConfigDecodingTests.swift
@@ -23,17 +23,17 @@ class UIConfigDecodingTests: BaseHTTPResponseTest {
         let uiConfig: UIConfig = try self.decodeFixture("UIConfig")
 
         expect(uiConfig.app.colors).to(equal([
-            "primary": .hex("#ffcc00"),
-            "secondary": .linear(45, [
+            "primary": .init(light: .hex("#ffcc00")),
+            "secondary": .init(light: .linear(45, [
                 .init(color: "#032400ff", percent: 0),
                 .init(color: "#090979ff", percent: 35),
                 .init(color: "#216c32ff", percent: 100)
-            ]),
-            "tertiary": .radial([
+            ])),
+            "tertiary": .init(light: .radial([
                 .init(color: "#032400ff", percent: 0),
                 .init(color: "#090979ff", percent: 35),
                 .init(color: "#216c32ff", percent: 100)
-            ])
+            ]))
         ]))
         expect(uiConfig.app.fonts).to(equal([
             "primary": .init(ios: .name("SF Pro"))

--- a/Tests/UnitTests/Paywalls/Components/PartialComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/PartialComponentTests.swift
@@ -36,7 +36,7 @@ final class PartialComponentTests: TestCase {
             backgroundColor: .init(light: .hex("#FFFFFF")),
             padding: .init(top: 10, bottom: 10, leading: 10, trailing: 10),
             margin: .init(top: 5, bottom: 5, leading: 5, trailing: 5),
-            fontSize: .bodyM,
+            fontSize: 16,
             horizontalAlignment: .leading
         ), PaywallComponent.PartialTextComponent()),
 

--- a/Tests/UnitTests/Paywalls/Components/TextComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/TextComponentTests.swift
@@ -1,0 +1,83 @@
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+#if PAYWALL_COMPONENTS
+
+class TextComponentTests: TestCase {
+
+    func testFontSizeWithString() throws {
+        let jsonStack = """
+        {
+            "type": "text",
+            "text_lid": "123",
+            "font_weight": "regular",
+            "color": { "light": { "type": "hex", "value": "#ffffff" } },
+            "font_size": "body_m",
+            "horizontal_alignment": "center",
+            "size": {
+                "width": { "type": "fill" },
+                "height": { "type": "fill" }
+            },
+            "padding": {
+                "top": 0,
+                "bottom": 0,
+                "leading": 0,
+                "trailing": 0
+            },
+            "margin": {
+                "top": 0,
+                "bottom": 0,
+                "leading": 0,
+                "trailing": 0
+            }
+        }
+        """
+
+        let textComponent = try JSONDecoder.default.decode(
+            PaywallComponent.TextComponent.self,
+            from: jsonStack.data(using: .utf8)!
+        )
+
+        expect(textComponent.fontSize).to(equal(15))
+    }
+
+    func testFontSizeWithNummber() throws {
+        let jsonStack = """
+        {
+            "type": "text",
+            "text_lid": "123",
+            "font_weight": "regular",
+            "color": { "light": { "type": "hex", "value": "#ffffff" } },
+            "font_size": 123,
+            "horizontal_alignment": "center",
+            "size": {
+                "width": { "type": "fill" },
+                "height": { "type": "fill" }
+            },
+            "padding": {
+                "top": 0,
+                "bottom": 0,
+                "leading": 0,
+                "trailing": 0
+            },
+            "margin": {
+                "top": 0,
+                "bottom": 0,
+                "leading": 0,
+                "trailing": 0
+            }
+        }
+        """
+
+        let textComponent = try JSONDecoder.default.decode(
+            PaywallComponent.TextComponent.self,
+            from: jsonStack.data(using: .utf8)!
+        )
+
+        expect(textComponent.fontSize).to(equal(123))
+    }
+
+}
+
+#endif


### PR DESCRIPTION
### Motivation

More flexability in font size

### Description

Use `CGFloat` as `fontSize` on `TextComponent` but also back support `FontSize` for a while
