### PR TITLE
[Paywalls V2] Prefetch low res images

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -26,12 +26,12 @@
 		03C72FC22D349BAE00297FEC /* IconComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C72FC02D349BAE00297FEC /* IconComponentViewModel.swift */; };
 		03C72FC32D349BAE00297FEC /* IconComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C72FBF2D349BAE00297FEC /* IconComponentView.swift */; };
 		03C7305B2D35985900297FEC /* TextComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C7305A2D35985500297FEC /* TextComponentTests.swift */; };
+		03C730F32D35F14600297FEC /* PaywallV2CacheWarming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C730F22D35F13F00297FEC /* PaywallV2CacheWarming.swift */; };
 		03E37BEA2D30B32200CD9678 /* PaywallTabsComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E37BE92D30B32200CD9678 /* PaywallTabsComponent.swift */; };
 		03E37BED2D30B73400CD9678 /* TabsComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E37BEC2D30B72E00CD9678 /* TabsComponentViewModel.swift */; };
 		03E37BEF2D30B73A00CD9678 /* TabsComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E37BEE2D30B73800CD9678 /* TabsComponentView.swift */; };
 		03E37BF12D30B7A100CD9678 /* TabControlComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E37BF02D30B7A100CD9678 /* TabControlComponentView.swift */; };
 		03E37BF32D30B7AB00CD9678 /* TabControlComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E37BF22D30B7AB00CD9678 /* TabControlComponentViewModel.swift */; };
-		03C730F32D35F14600297FEC /* PaywallV2CacheWarming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C730F22D35F13F00297FEC /* PaywallV2CacheWarming.swift */; };
 		03F446212D2F73240046129A /* StackComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446202D2F73210046129A /* StackComponentTests.swift */; };
 		03F446242D2FE0C50046129A /* ShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446232D2FE0C10046129A /* ShapePropertyTests.swift */; };
 		03F446262D2FE1510046129A /* MaskShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */; };
@@ -1280,12 +1280,12 @@
 		03C72FBF2D349BAE00297FEC /* IconComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconComponentView.swift; sourceTree = "<group>"; };
 		03C72FC02D349BAE00297FEC /* IconComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconComponentViewModel.swift; sourceTree = "<group>"; };
 		03C7305A2D35985500297FEC /* TextComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextComponentTests.swift; sourceTree = "<group>"; };
+		03C730F22D35F13F00297FEC /* PaywallV2CacheWarming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallV2CacheWarming.swift; sourceTree = "<group>"; };
 		03E37BE92D30B32200CD9678 /* PaywallTabsComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallTabsComponent.swift; sourceTree = "<group>"; };
 		03E37BEC2D30B72E00CD9678 /* TabsComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsComponentViewModel.swift; sourceTree = "<group>"; };
 		03E37BEE2D30B73800CD9678 /* TabsComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsComponentView.swift; sourceTree = "<group>"; };
 		03E37BF02D30B7A100CD9678 /* TabControlComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabControlComponentView.swift; sourceTree = "<group>"; };
 		03E37BF22D30B7AB00CD9678 /* TabControlComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabControlComponentViewModel.swift; sourceTree = "<group>"; };
-		03C730F22D35F13F00297FEC /* PaywallV2CacheWarming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallV2CacheWarming.swift; sourceTree = "<group>"; };
 		03F446202D2F73210046129A /* StackComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackComponentTests.swift; sourceTree = "<group>"; };
 		03F446232D2FE0C10046129A /* ShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapePropertyTests.swift; sourceTree = "<group>"; };
 		03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskShapePropertyTests.swift; sourceTree = "<group>"; };

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		03E37BEF2D30B73A00CD9678 /* TabsComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E37BEE2D30B73800CD9678 /* TabsComponentView.swift */; };
 		03E37BF12D30B7A100CD9678 /* TabControlComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E37BF02D30B7A100CD9678 /* TabControlComponentView.swift */; };
 		03E37BF32D30B7AB00CD9678 /* TabControlComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E37BF22D30B7AB00CD9678 /* TabControlComponentViewModel.swift */; };
+		03C730F32D35F14600297FEC /* PaywallV2CacheWarming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C730F22D35F13F00297FEC /* PaywallV2CacheWarming.swift */; };
 		03F446212D2F73240046129A /* StackComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446202D2F73210046129A /* StackComponentTests.swift */; };
 		03F446242D2FE0C50046129A /* ShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446232D2FE0C10046129A /* ShapePropertyTests.swift */; };
 		03F446262D2FE1510046129A /* MaskShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */; };
@@ -1284,6 +1285,7 @@
 		03E37BEE2D30B73800CD9678 /* TabsComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsComponentView.swift; sourceTree = "<group>"; };
 		03E37BF02D30B7A100CD9678 /* TabControlComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabControlComponentView.swift; sourceTree = "<group>"; };
 		03E37BF22D30B7AB00CD9678 /* TabControlComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabControlComponentViewModel.swift; sourceTree = "<group>"; };
+		03C730F22D35F13F00297FEC /* PaywallV2CacheWarming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallV2CacheWarming.swift; sourceTree = "<group>"; };
 		03F446202D2F73210046129A /* StackComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackComponentTests.swift; sourceTree = "<group>"; };
 		03F446232D2FE0C10046129A /* ShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapePropertyTests.swift; sourceTree = "<group>"; };
 		03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskShapePropertyTests.swift; sourceTree = "<group>"; };
@@ -4844,6 +4846,7 @@
 		88AD010B2C740CF400AA1F2B /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				03C730F22D35F13F00297FEC /* PaywallV2CacheWarming.swift */,
 				2CC791612CC0493600FBE120 /* Common */,
 				7707A94B2CAD93AC006E0313 /* PaywallButtonComponent.swift */,
 				88AD01032C740CF400AA1F2B /* PaywallImageComponent.swift */,
@@ -5981,6 +5984,7 @@
 				1ED4CA492CC148CF0021AB8F /* PostRedeemWebPurchaseOperation.swift in Sources */,
 				2D00A41D2767C08300FC3DD8 /* ManageSubscriptionsStrings.swift in Sources */,
 				2DD9F4BE274EADC20031AE2C /* Purchases+async.swift in Sources */,
+				03C730F32D35F14600297FEC /* PaywallV2CacheWarming.swift in Sources */,
 				B3C4AAD526B8911300E1B3C8 /* Backend.swift in Sources */,
 				35AAEB452BBB14D000A12548 /* DiagnosticsFileHandler.swift in Sources */,
 				B34D2AA626976FC700D88C3A /* ErrorCode.swift in Sources */,

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -1,0 +1,101 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallV2CacheWarming.swift
+//
+//  Created by Josh Holtz on 1/13/25.
+
+#if PAYWALL_COMPONENTS
+
+extension PaywallComponentsData {
+
+    var allImageURLs: [URL] {
+        var imageUrls = self.componentsConfig.base.allImageURLs
+
+        for (_, localeValues) in self.componentsLocalizations {
+            for (_, value) in localeValues {
+                switch value {
+                case .string:
+                    break
+                case .image(let image):
+                    imageUrls += image.imageUrls
+                }
+            }
+        }
+
+        return imageUrls
+    }
+
+}
+
+extension PaywallComponentsData.PaywallComponentsConfig {
+
+    var allImageURLs: [URL] {
+        let rootStackImageURLs = self.collectAllImageURLs(in: self.stack)
+        let stickFooterImageURLs = self.stickyFooter.flatMap { self.collectAllImageURLs(in: $0.stack) } ?? []
+
+        return rootStackImageURLs + stickFooterImageURLs
+    }
+
+    private func collectAllImageURLs(in stack: PaywallComponent.StackComponent) -> [URL] {
+
+        var urls: [URL] = []
+        for component in stack.components {
+            switch component {
+            case .text:
+                ()
+            case .image(let image):
+                urls += [
+                    image.source.light.heic,
+                    image.source.light.heicLowRes,
+                    image.source.dark?.heic,
+                    image.source.dark?.heicLowRes
+                ].compactMap { $0 }
+
+                if let overides = image.overrides {
+                    urls += [
+                        overides.introOffer?.source?.imageUrls ?? [],
+                        overides.states?.selected?.source?.imageUrls ?? [],
+                        overides.conditions?.compact?.source?.imageUrls ?? [],
+                        overides.conditions?.medium?.source?.imageUrls ?? [],
+                        overides.conditions?.expanded?.source?.imageUrls ?? []
+                    ].flatMap { $0 }
+                }
+            case .stack(let stack):
+                urls += self.collectAllImageURLs(in: stack)
+            case .button(let button):
+                urls += self.collectAllImageURLs(in: button.stack)
+            case .package(let package):
+                urls += self.collectAllImageURLs(in: package.stack)
+            case .purchaseButton(let purchaseButton):
+                urls += self.collectAllImageURLs(in: purchaseButton.stack)
+            case .stickyFooter(let stickyFooter):
+                urls += self.collectAllImageURLs(in: stickyFooter.stack)
+            }
+        }
+
+        return urls
+    }
+
+}
+
+extension PaywallComponent.ThemeImageUrls {
+
+    var imageUrls: [URL] {
+        return [
+            self.light.heic,
+            self.light.heicLowRes,
+            self.dark?.heic,
+            self.dark?.heicLowRes
+        ].compactMap { $0 }
+    }
+
+}
+
+#endif

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -45,6 +45,7 @@ extension PaywallComponentsData.PaywallComponentsConfig {
         return rootStackImageURLs + stickFooterImageURLs
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     private func collectAllImageURLs(in stack: PaywallComponent.StackComponent) -> [URL] {
 
         var urls: [URL] = []
@@ -79,6 +80,16 @@ extension PaywallComponentsData.PaywallComponentsConfig {
                 urls += self.collectAllImageURLs(in: purchaseButton.stack)
             case .stickyFooter(let stickyFooter):
                 urls += self.collectAllImageURLs(in: stickyFooter.stack)
+            case .tabs(let tabs):
+                for tab in tabs.tabs {
+                    urls += self.collectAllImageURLs(in: tab.stack)
+                }
+            case .tabControl:
+                break
+            case .tabControlButton(let controlButton):
+                urls += self.collectAllImageURLs(in: controlButton.stack)
+            case .tabControlToggle:
+                break
             }
         }
 

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -53,6 +53,13 @@ extension PaywallComponentsData.PaywallComponentsConfig {
             switch component {
             case .text:
                 ()
+            case .icon(let icon):
+                guard let baseUrl = URL(string: icon.baseUrl) else {
+                    break
+                }
+
+                urls += icon.formats.imageUrls(base: baseUrl)
+                urls += icon.overrides?.imageUrls(base: baseUrl) ?? []
             case .image(let image):
                 urls += [
                     image.source.light.heicLowRes,
@@ -96,7 +103,31 @@ extension PaywallComponentsData.PaywallComponentsConfig {
 
 }
 
-extension PaywallComponent.ThemeImageUrls {
+extension PaywallComponent.IconComponent.Formats {
+
+    func imageUrls(base: URL) -> [URL] {
+        return [
+            base.appendingPathComponent(heic)
+        ]
+    }
+
+}
+
+extension PaywallComponent.ComponentOverrides where T == PaywallComponent.PartialIconComponent {
+
+    func imageUrls(base: URL) -> [URL] {
+        return [
+            self.introOffer?.formats?.imageUrls(base: base) ?? [],
+            self.states?.selected?.formats?.imageUrls(base: base) ?? [],
+            self.conditions?.compact?.formats?.imageUrls(base: base) ?? [],
+            self.conditions?.medium?.formats?.imageUrls(base: base) ?? [],
+            self.conditions?.expanded?.formats?.imageUrls(base: base) ?? []
+        ].flatMap { $0 }
+    }
+
+}
+
+private extension PaywallComponent.ThemeImageUrls {
 
     var imageUrls: [URL] {
         return [

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -11,6 +11,8 @@
 //
 //  Created by Josh Holtz on 1/13/25.
 
+import Foundation
+
 #if PAYWALL_COMPONENTS
 
 extension PaywallComponentsData {
@@ -52,9 +54,9 @@ extension PaywallComponentsData.PaywallComponentsConfig {
                 ()
             case .image(let image):
                 urls += [
-                    image.source.light.heic,
+//                    image.source.light.heic,
                     image.source.light.heicLowRes,
-                    image.source.dark?.heic,
+//                    image.source.dark?.heic,
                     image.source.dark?.heicLowRes
                 ].compactMap { $0 }
 
@@ -89,9 +91,9 @@ extension PaywallComponent.ThemeImageUrls {
 
     var imageUrls: [URL] {
         return [
-            self.light.heic,
+//            self.light.heic,
             self.light.heicLowRes,
-            self.dark?.heic,
+//            self.dark?.heic,
             self.dark?.heicLowRes
         ].compactMap { $0 }
     }

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -55,9 +55,7 @@ extension PaywallComponentsData.PaywallComponentsConfig {
                 ()
             case .image(let image):
                 urls += [
-//                    image.source.light.heic,
                     image.source.light.heicLowRes,
-//                    image.source.dark?.heic,
                     image.source.dark?.heicLowRes
                 ].compactMap { $0 }
 
@@ -102,9 +100,7 @@ extension PaywallComponent.ThemeImageUrls {
 
     var imageUrls: [URL] {
         return [
-//            self.light.heic,
             self.light.heicLowRes,
-//            self.dark?.heic,
             self.dark?.heicLowRes
         ].compactMap { $0 }
     }

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -74,6 +74,8 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
                 Logger.error(Strings.paywalls.error_prefetching_image(url, error))
             }
         }
+
+
     }
 
 }
@@ -150,7 +152,21 @@ private extension Offerings {
         )
     }
 
+    #if PAYWALL_COMPONENTS
+
     var allImagesInPaywalls: Set<URL> {
+        return self.allImagesInPaywallsV1 + self.allImagesInPaywallsV2
+    }
+
+    #else
+
+    var allImagesInPaywalls: Set<URL> {
+        return self.allImagesInPaywallsV1
+    }
+
+    #endif
+
+    private var allImagesInPaywallsV1: Set<URL> {
         return .init(
             self
                 .offeringsToPreWarm
@@ -159,6 +175,20 @@ private extension Offerings {
                 .flatMap(\.allImageURLs)
         )
     }
+
+    #if PAYWALL_COMPONENTS
+
+    private var allImagesInPaywallsV2: Set<URL> {
+        return .init(
+            self
+                .offeringsToPreWarm
+                .lazy
+                .compactMap(\.paywallComponents)
+                .flatMap(\.data.allImageURLs)
+        )
+    }
+
+    #endif
 
 }
 

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -178,7 +178,7 @@ private extension Offerings {
     #if PAYWALL_COMPONENTS
 
     private var allImagesInPaywallsV2: Set<URL> {
-        // Attempting to warm up all offerings for Paywalls V2.
+        // Attempting to warm up all low res images for all offerings for Paywalls V2.
         // Paywalls V2 paywall are explicitly published so anything that
         // is here is intended to be displayed.
         // Also only prewarming low res urls

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -75,7 +75,6 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
             }
         }
 
-
     }
 
 }
@@ -179,9 +178,14 @@ private extension Offerings {
     #if PAYWALL_COMPONENTS
 
     private var allImagesInPaywallsV2: Set<URL> {
+        // Attempting to warm up all offerings for Paywalls V2.
+        // Paywalls V2 paywall are explicitly published so anything that
+        // is here is intended to be displayed.
+        // Also only prewarming low res urls
         return .init(
             self
-                .offeringsToPreWarm
+                .all
+                .values
                 .lazy
                 .compactMap(\.paywallComponents)
                 .flatMap(\.data.allImageURLs)


### PR DESCRIPTION
### Motivation

Prefetch low res images of all paywalls v2 paywalls

### Description

Collects all the images in v2 paywalls for warming up cache
- Traverses the stack tree to get all of the low res images
- Collects all the images from the localizations
