### PR TITLE
fix: Fix versions for swift-doc, snapshot-testing & nimble

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,39 @@
+{
+  "pins" : [
+    {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
+        "version" : "2.1.2"
+      }
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "a23ded2c91df9156628a6996ab4f347526f17b6b",
+        "version" : "2.1.2"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "git@github.com:Quick/Nimble.git",
+      "state" : {
+        "revision" : "1f3bde57bde12f5e7b07909848c071e9b73d6edc"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "git@github.com:pointfreeco/swift-snapshot-testing.git",
+      "state" : {
+        "revision" : "26ed3a2b4a2df47917ca9b790a57f91285b923fb"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -37,14 +37,20 @@ let environmentVariables = ProcessInfo.processInfo.environment
 let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "true"
 
 var dependencies: [Package.Dependency] = [
-    .package(url: "git@github.com:Quick/Nimble.git", from: "10.0.0"),
+    .package(url: "git@github.com:Quick/Nimble.git", revision: "1f3bde57bde12f5e7b07909848c071e9b73d6edc"),
     // SST requires iOS 13 starting from version 1.13.0
-    .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", .upToNextMinor(from: "1.12.0"))
+    .package(
+        url: "git@github.com:pointfreeco/swift-snapshot-testing.git",
+        revision: "26ed3a2b4a2df47917ca9b790a57f91285b923fb"
+    )
 ]
 if shouldIncludeDocCPlugin {
     // Versions 1.4.0 and 1.4.1 are failing to compile, so we are pinning it to 1.3.0 for now
     // https://github.com/RevenueCat/purchases-ios/pull/4216
-    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", .exact("1.3.0")))
+    dependencies.append(.package(
+        url: "https://github.com/apple/swift-docc-plugin",
+        revision: "26ac5758409154cc448d7ab82389c520fa8a8247"
+    ))
 }
 
 // See https://github.com/RevenueCat/purchases-ios/pull/2989

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -10,13 +10,20 @@ let environmentVariables = ProcessInfo.processInfo.environment
 let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "true"
 
 var dependencies: [Package.Dependency] = [
-    .package(url: "git@github.com:Quick/Nimble.git", from: "10.0.0"),
-    .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", .upToNextMinor(from: "1.12.0"))
+    .package(url: "git@github.com:Quick/Nimble.git", revision: "1f3bde57bde12f5e7b07909848c071e9b73d6edc"),
+    // SST requires iOS 13 starting from version 1.13.0
+    .package(
+        url: "git@github.com:pointfreeco/swift-snapshot-testing.git",
+        revision: "26ed3a2b4a2df47917ca9b790a57f91285b923fb"
+    )
 ]
 if shouldIncludeDocCPlugin {
     // Versions 1.4.0 and 1.4.1 are failing to compile, so we are pinning it to 1.3.0 for now
     // https://github.com/RevenueCat/purchases-ios/pull/4216
-    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", .exact("1.3.0")))
+    dependencies.append(.package(
+        url: "https://github.com/apple/swift-docc-plugin",
+        revision: "26ac5758409154cc448d7ab82389c520fa8a8247"
+    ))
 }
 
 let package = Package(

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -10,13 +10,20 @@ let environmentVariables = ProcessInfo.processInfo.environment
 let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "true"
 
 var dependencies: [Package.Dependency] = [
-    .package(url: "git@github.com:Quick/Nimble.git", from: "10.0.0"),
-    .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", .upToNextMinor(from: "1.12.0"))
+    .package(url: "git@github.com:Quick/Nimble.git", revision: "1f3bde57bde12f5e7b07909848c071e9b73d6edc"),
+    // SST requires iOS 13 starting from version 1.13.0
+    .package(
+        url: "git@github.com:pointfreeco/swift-snapshot-testing.git",
+        revision: "26ed3a2b4a2df47917ca9b790a57f91285b923fb"
+    )
 ]
 if shouldIncludeDocCPlugin {
     // Versions 1.4.0 and 1.4.1 are failing to compile, so we are pinning it to 1.3.0 for now
     // https://github.com/RevenueCat/purchases-ios/pull/4216
-    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", .exact("1.3.0")))
+    dependencies.append(.package(
+        url: "https://github.com/apple/swift-docc-plugin",
+        revision: "26ac5758409154cc448d7ab82389c520fa8a8247"
+    ))
 }
 
 let package = Package(


### PR DESCRIPTION
### Motivation
While working on the codebase, `Package.resolved` keeps getting modified. This addresses that by fixing the dependency versions to specific commits.

- Nimble (10.0.0) https://github.com/Quick/Nimble/commit/1f3bde57bde12f5e7b07909848c071e9b73d6edc
- swift-snapshot-testing (1.12.0) https://github.com/pointfreeco/swift-snapshot-testing/commit/26ed3a2b4a2df47917ca9b790a57f91285b923fb
- Dooc (1.3.0) https://github.com/swiftlang/swift-docc-plugin/commit/26ac5758409154cc448d7ab82389c520fa8a8247

> This is the fastest, and simple enough till we integrate tuist (or something else)