### PR TITLE
feat: [CustomerCenter] Introduce CustomerCenterNavigationLink

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -757,6 +757,7 @@
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
 		57EAE52B274332830060EB74 /* Obsoletions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52A274332830060EB74 /* Obsoletions.swift */; };
 		57EAE52D274468900060EB74 /* RawDataContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52C274468900060EB74 /* RawDataContainer.swift */; };
+		57ED352D2D37B625007DEA30 /* CustomerCenterNavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED352C2D37B625007DEA30 /* CustomerCenterNavigationLink.swift */; };
 		57EFDC6B27BC1F370057EC39 /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EFDC6A27BC1F370057EC39 /* ProductType.swift */; };
 		57F2C60C29784C11009EE527 /* SwiftVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F2C60B29784C11009EE527 /* SwiftVersionCheck.swift */; };
 		57F3C10529B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F3C10429B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift */; };
@@ -2031,6 +2032,7 @@
 		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		57EAE52A274332830060EB74 /* Obsoletions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Obsoletions.swift; sourceTree = "<group>"; };
 		57EAE52C274468900060EB74 /* RawDataContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataContainer.swift; sourceTree = "<group>"; };
+		57ED352C2D37B625007DEA30 /* CustomerCenterNavigationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterNavigationLink.swift; sourceTree = "<group>"; };
 		57EFDC6A27BC1F370057EC39 /* ProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductType.swift; sourceTree = "<group>"; };
 		57F2C60B29784C11009EE527 /* SwiftVersionCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftVersionCheck.swift; sourceTree = "<group>"; };
 		57F3C10429B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+ActiveDates.swift"; sourceTree = "<group>"; };
@@ -3678,6 +3680,7 @@
 				2D2AFE8E2C6A9D8700D1B0B4 /* CompatibilityContentUnavailableView.swift */,
 				2C4C36122C6FBA8B00AE959B /* CompatibilityTopBarTrailing.swift */,
 				3537565B2C382C2800A1B8D6 /* CustomerCenterView.swift */,
+				57ED352C2D37B625007DEA30 /* CustomerCenterNavigationLink.swift */,
 				35C200B02C39254100B9778B /* FeedbackSurveyView.swift */,
 				3537565C2C382C2800A1B8D6 /* ManageSubscriptionsView.swift */,
 				3537565D2C382C2800A1B8D6 /* NoSubscriptionsView.swift */,
@@ -6619,6 +6622,7 @@
 			files = (
 				03E37BED2D30B73400CD9678 /* TabsComponentViewModel.swift in Sources */,
 				88B1BB132C81479F001B7EE5 /* PaywallComponentTypeTransformers.swift in Sources */,
+				57ED352D2D37B625007DEA30 /* CustomerCenterNavigationLink.swift in Sources */,
 				88B1BB042C813A3C001B7EE5 /* StackComponentViewModel.swift in Sources */,
 				1E5F8F782C46BBD90041EECD /* CustomerCenterAction.swift in Sources */,
 				1ED4CA9F2CC25A5F0021AB8F /* SafariView.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
@@ -48,7 +48,7 @@ public struct CustomerCenterNavigationLink<Label: View>: View {
     /// ```
     ///
     /// - Parameter label: A closure that returns the view to display as the navigation link’s label.
-    public init(label: @escaping () -> Label) {
+    public init(@ViewBuilder label: @escaping () -> Label) {
         self.label = label
     }
 

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
@@ -31,7 +31,7 @@ import SwiftUI
 @available(watchOS, unavailable)
 public struct CustomerCenterNavigationLink<Label: View>: View {
 
-    let label: () -> Label
+    @ViewBuilder let label: () -> Label
 
     /// Initializes the navigation link with a label view provided by a closure.
     ///

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
@@ -8,6 +8,8 @@
 import RevenueCat
 import SwiftUI
 
+#if os(iOS)
+
 /// A view that provides a navigation link to `CustomerCenterView` with a customizable label.
 ///
 /// This is the **preferred way** to integrate `CustomerCenterView` into your `NavigationStack`,
@@ -31,7 +33,8 @@ import SwiftUI
 @available(watchOS, unavailable)
 public struct CustomerCenterNavigationLink<Label: View>: View {
 
-    @ViewBuilder let label: () -> Label
+    private let customerCenterActionHandler: CustomerCenterActionHandler
+    @ViewBuilder private let label: () -> Label
 
     /// Initializes the navigation link with a label view provided by a closure.
     ///
@@ -48,16 +51,23 @@ public struct CustomerCenterNavigationLink<Label: View>: View {
     /// ```
     ///
     /// - Parameter label: A closure that returns the view to display as the navigation link’s label.
-    public init(@ViewBuilder label: @escaping () -> Label) {
-        self.label = label
-    }
+    public init(
+        customerCenterActionHandler: @escaping CustomerCenterActionHandler,
+        @ViewBuilder label: @escaping () -> Label) {
+            self.customerCenterActionHandler = customerCenterActionHandler
+            self.label = label
+        }
 
     /// The content and behavior of the navigation link.
     public var body: some View {
         NavigationLink {
-            CustomerCenterView(isEmbeddedInNavigationStack: true)
+            CustomerCenterView(
+                customerCenterActionHandler: customerCenterActionHandler,
+                isEmbeddedInNavigationStack: true)
         } label: {
             label()
         }
     }
 }
+
+#endif

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
@@ -1,0 +1,75 @@
+//
+//  CustomerCenterNavigationLink.swift
+//  RevenueCat
+//
+//  Created by Facundo Menzella on 14/1/25.
+//
+
+import RevenueCat
+import SwiftUI
+
+/// A view that provides a navigation link to `CustomerCenterView` with a customizable label.
+///
+/// This is the **preferred way** to integrate `CustomerCenterView` into your `NavigationStack`,
+/// ensuring proper navigation behavior by setting `isEmbededInNavigation` to `true`.
+///
+///
+/// Example:
+/// ```swift
+/// CustomerCenterNavigationLink {
+///     HStack {
+///         Image(systemName: "person.circle")
+///         Text("Customer Center")
+///     }
+/// }
+///
+/// CustomerCenterNavigationLink(Text("Customer Center"))
+/// ```
+@available(iOS 15.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+public struct CustomerCenterNavigationLink<Label>: View {
+
+    let label: () -> Label
+
+    /// Initializes the navigation link with a label view provided by a closure.
+    ///
+    /// Use this initializer when the label requires dynamic content or complex logic.
+    ///
+    /// Example:
+    /// ```swift
+    /// CustomerCenterNavigationLink {
+    ///     HStack {
+    ///         Image(systemName: "person.circle")
+    ///         Text("Customer Center")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Parameter label: A closure that returns the view to display as the navigation link’s label.
+    public init(_ label: @escaping () -> Label) {
+        self.label = label
+    }
+
+    /// Initializes the navigation link with a label view provided by an autoclosure.
+    ///
+    /// This initializer offers a more convenient way to pass simple views as labels.
+    ///
+    /// Example:
+    /// ```swift
+    /// CustomerCenterNavigationLink(Text("Customer Center"))
+    /// ```
+    ///
+    /// - Parameter label: An autoclosure that returns the view to display as the navigation link’s label.
+    public init(_ label: @autoclosure @escaping () -> Label) {
+        self.label = label
+    }
+
+    /// The content and behavior of the navigation link.
+    public var body: some View {
+        NavigationLink(value: CustomerCenterView(isEmbededInNavigation: true)) {
+            label()
+        }
+    }
+}

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
@@ -48,7 +48,7 @@ public struct CustomerCenterNavigationLink<Label: View>: View {
     /// ```
     ///
     /// - Parameter label: A closure that returns the view to display as the navigation link’s label.
-    public init(_ label: @escaping () -> Label) {
+    public init(label: @escaping () -> Label) {
         self.label = label
     }
 


### PR DESCRIPTION
### Motivation
This PR aims to reduce ambiguity in how `CustomerCenterView` is used. Together with `presentCustomerCenter`, `CustomerCenterNavigationLink` becomes the recommended approach for navigating to `CustomerCenterView`.

### Description

Following up on [#4622](https://github.com/RevenueCat/purchases-ios/pull/4622) and based on feedback from @hiddevdploeg, we are introducing `CustomerCenterNavigationLink`.

The primary objective is to offer a straightforward method for integrating `CustomerCenterView` into an existing `NavigationView`, without requiring developers to handle the `isEmbeddedInNavigationStack` parameter manually.