### PR TITLE
Do not warn when using mac API keys

### DIFF
--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -335,7 +335,7 @@ extension Configuration {
     }
 
     static func validate(apiKey: String) -> APIKeyValidationResult {
-        if apiKey.hasPrefix(Self.applePlatformKeyPrefix) {
+        if applePlatformKeyPrefixes.contains(where: { prefix in apiKey.hasPrefix(prefix) }) {
             // Apple key format: "apple_CtDdmbdWBySmqJeeQUTyrNxETUVkajsJ"
             return .validApplePlatform
         } else if apiKey.contains("_") {
@@ -355,7 +355,7 @@ extension Configuration {
         }
     }
 
-    private static let applePlatformKeyPrefix: String = "appl_"
+    private static let applePlatformKeyPrefixes: Set<String> = ["appl_", "mac_"]
 
 }
 

--- a/Tests/UnitTests/Purchasing/ConfigurationTests.swift
+++ b/Tests/UnitTests/Purchasing/ConfigurationTests.swift
@@ -19,8 +19,12 @@ import XCTest
 
 class ConfigurationTests: TestCase {
 
-    func testValidateAPIKeyWithPlatformSpecificKey() {
+    func testValidateAPIKeyWithApplPlatformSpecificKey() {
         expect(Configuration.validate(apiKey: "appl_1a2b3c4d5e6f7h")) == .validApplePlatform
+    }
+
+    func testValidateAPIKeyWithMacPlatformSpecificKey() {
+        expect(Configuration.validate(apiKey: "mac_1a2b3c4d5e6f7h")) == .validApplePlatform
     }
 
     func testValidateAPIKeyWithInvalidPlatformKey() {


### PR DESCRIPTION
### Description
`mac_` prefixed API keys are still valid and we shouldn't warn when using them.