### PR TITLE
fix: Set https urls for packages

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "accessibilitysnapshot",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/EmergeTools/AccessibilitySnapshot.git",
+      "state" : {
+        "revision" : "54046d8fa44b9fa9f0e2229526f6ed89cb5e0ec2",
+        "version" : "1.0.2"
+      }
+    },
+    {
       "identity" : "cwlcatchexception",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlCatchException.git",
@@ -19,17 +28,44 @@
       }
     },
     {
+      "identity" : "flyingfox",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swhitty/FlyingFox.git",
+      "state" : {
+        "revision" : "f7829d4aca8cbfecb410a1cce872b1b045224aa1",
+        "version" : "0.16.0"
+      }
+    },
+    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
-      "location" : "git@github.com:Quick/Nimble.git",
+      "location" : "https://github.com/quick/nimble",
       "state" : {
         "revision" : "1f3bde57bde12f5e7b07909848c071e9b73d6edc"
       }
     },
     {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
+      "state" : {
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
+      }
+    },
+    {
+      "identity" : "snapshotpreviews",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/EmergeTools/SnapshotPreviews.git",
+      "state" : {
+        "revision" : "e29969072e600518867af25d4d2acd0d1d2ffd5f",
+        "version" : "0.10.20"
+      }
+    },
+    {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
-      "location" : "git@github.com:pointfreeco/swift-snapshot-testing.git",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
         "revision" : "26ed3a2b4a2df47917ca9b790a57f91285b923fb"
       }

--- a/Package.swift
+++ b/Package.swift
@@ -37,10 +37,10 @@ let environmentVariables = ProcessInfo.processInfo.environment
 let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "true"
 
 var dependencies: [Package.Dependency] = [
-    .package(url: "git@github.com:Quick/Nimble.git", revision: "1f3bde57bde12f5e7b07909848c071e9b73d6edc"),
+    .package(url: "https://github.com/quick/nimble", revision: "1f3bde57bde12f5e7b07909848c071e9b73d6edc"),
     // SST requires iOS 13 starting from version 1.13.0
     .package(
-        url: "git@github.com:pointfreeco/swift-snapshot-testing.git",
+        url: "https://github.com/pointfreeco/swift-snapshot-testing",
         revision: "26ed3a2b4a2df47917ca9b790a57f91285b923fb"
     )
 ]
@@ -100,7 +100,10 @@ let package = Package(
         .target(name: "ReceiptParser",
                 path: "LocalReceiptParsing"),
         .testTarget(name: "ReceiptParserTests",
-                    dependencies: ["ReceiptParser", "Nimble"],
+                    dependencies: [
+                        "ReceiptParser",
+                        .product(name: "Nimble", package: "nimble")
+                    ],
                     exclude: ["ReceiptParserTests-Info.plist"]),
         // RevenueCatUI
         .target(name: "RevenueCatUI",
@@ -115,7 +118,7 @@ let package = Package(
         .testTarget(name: "RevenueCatUITests",
                     dependencies: [
                         "RevenueCatUI",
-                        "Nimble",
+                        .product(name: "Nimble", package: "nimble"),
                         .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
                     ],
                     exclude: ["Templates/__Snapshots__", "Data/__Snapshots__", "TestPlans"],

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -10,10 +10,10 @@ let environmentVariables = ProcessInfo.processInfo.environment
 let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "true"
 
 var dependencies: [Package.Dependency] = [
-    .package(url: "git@github.com:Quick/Nimble.git", revision: "1f3bde57bde12f5e7b07909848c071e9b73d6edc"),
+    .package(url: "https://github.com/quick/nimble", revision: "1f3bde57bde12f5e7b07909848c071e9b73d6edc"),
     // SST requires iOS 13 starting from version 1.13.0
     .package(
-        url: "git@github.com:pointfreeco/swift-snapshot-testing.git",
+        url: "https://github.com/pointfreeco/swift-snapshot-testing",
         revision: "26ed3a2b4a2df47917ca9b790a57f91285b923fb"
     )
 ]
@@ -64,7 +64,10 @@ let package = Package(
         .target(name: "ReceiptParser",
                 path: "LocalReceiptParsing"),
         .testTarget(name: "ReceiptParserTests",
-                    dependencies: ["ReceiptParser", "Nimble"],
+                    dependencies: [
+                        "ReceiptParser",
+                        .product(name: "Nimble", package: "nimble")
+                    ],
                     exclude: ["ReceiptParserTests-Info.plist"]),
         // RevenueCatUI
         .target(name: "RevenueCatUI",
@@ -77,7 +80,7 @@ let package = Package(
         .testTarget(name: "RevenueCatUITests",
                     dependencies: [
                         "RevenueCatUI",
-                        "Nimble",
+                        .product(name: "Nimble", package: "nimble"),
                         .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
                     ],
                     exclude: ["Templates/__Snapshots__", "Data/__Snapshots__", "TestPlans"],

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -10,10 +10,10 @@ let environmentVariables = ProcessInfo.processInfo.environment
 let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "true"
 
 var dependencies: [Package.Dependency] = [
-    .package(url: "git@github.com:Quick/Nimble.git", revision: "1f3bde57bde12f5e7b07909848c071e9b73d6edc"),
+    .package(url: "https://github.com/quick/nimble", revision: "1f3bde57bde12f5e7b07909848c071e9b73d6edc"),
     // SST requires iOS 13 starting from version 1.13.0
     .package(
-        url: "git@github.com:pointfreeco/swift-snapshot-testing.git",
+        url: "https://github.com/pointfreeco/swift-snapshot-testing",
         revision: "26ed3a2b4a2df47917ca9b790a57f91285b923fb"
     )
 ]
@@ -64,7 +64,10 @@ let package = Package(
         .target(name: "ReceiptParser",
                 path: "LocalReceiptParsing"),
         .testTarget(name: "ReceiptParserTests",
-                    dependencies: ["ReceiptParser", "Nimble"],
+                    dependencies: [
+                        "ReceiptParser",
+                        .product(name: "Nimble", package: "nimble")
+                    ],
                     exclude: ["ReceiptParserTests-Info.plist"]),
         // RevenueCatUI
         .target(name: "RevenueCatUI",
@@ -77,7 +80,7 @@ let package = Package(
         .testTarget(name: "RevenueCatUITests",
                     dependencies: [
                         "RevenueCatUI",
-                        "Nimble",
+                        .product(name: "Nimble", package: "nimble")
                         .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
                     ],
                     exclude: ["Templates/__Snapshots__", "Data/__Snapshots__", "TestPlans"],


### PR DESCRIPTION
### Motivation
This is a follow-up of https://github.com/RevenueCat/purchases-ios/pull/4661
- The url keeps changing from ssh to https. 
- Tweak how nimble is declared as a dependency
