### PR TITLE
[Trusted Entitlements] Do not clear CustomerInfo upon enabling Trusted Entitlements

### DIFF
--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -183,8 +183,7 @@ private extension IdentityManager {
 
     func invalidateCachesIfNeeded(appUserID: String) {
         if self.shouldInvalidateCaches(for: appUserID) {
-            Logger.info(Strings.identity.invalidating_cached_customer_info)
-            self.deviceCache.clearCustomerInfoCache(appUserID: appUserID)
+            Logger.info(Strings.identity.invalidating_http_cache)
             self.backend.clearHTTPClientCaches()
         }
     }

--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -34,7 +34,7 @@ enum IdentityStrings {
 
     case deleting_attributes_none_found
 
-    case invalidating_cached_customer_info
+    case invalidating_http_cache
 
     case switching_user(newUserID: String)
 
@@ -70,8 +70,8 @@ extension IdentityStrings: LogMessage {
             return "currentAppUserID is nil. This might happen if the cache in UserDefaults is unintentionally cleared."
         case .deleting_attributes_none_found:
             return "Attempt to delete attributes for user, but there were none to delete"
-        case .invalidating_cached_customer_info:
-            return "Detected unverified cached CustomerInfo but verification is enabled. Invalidating cache."
+        case .invalidating_http_cache:
+            return "Detected unverified cached CustomerInfo but verification is enabled. Invalidating HTTP cache."
         case let .switching_user(newUserID):
             return "Switching to user '\(newUserID)'."
         case let .switching_user_same_app_user_id(newUserID):

--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -71,7 +71,7 @@ extension IdentityStrings: LogMessage {
         case .deleting_attributes_none_found:
             return "Attempt to delete attributes for user, but there were none to delete"
         case .invalidating_http_cache:
-            return "Detected unverified cached CustomerInfo but verification is enabled. Invalidating HTTP cache."
+            return "Detected unverified cached CustomerInfo but verification is enabled. Invalidating ETag cache."
         case let .switching_user(newUserID):
             return "Switching to user '\(newUserID)'."
         case let .switching_user_same_app_user_id(newUserID):

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -116,10 +116,8 @@ class IdentityManagerTests: TestCase {
         expect(self.mockDeviceCache.invokedClearCachesForAppUserID) == false
         expect(self.mockBackend.invokedClearHTTPClientCaches) == true
         expect(self.mockBackend.invokedClearHTTPClientCachesCount) == 1
-        expect(self.mockDeviceCache.invokedClearCustomerInfoCache) == true
-        expect(self.mockDeviceCache.invokedClearCustomerInfoCacheParameters?.appUserID) == "nacho"
 
-        self.logger.verifyMessageWasLogged(Strings.identity.invalidating_cached_customer_info, level: .info)
+        self.logger.verifyMessageWasLogged(Strings.identity.invalidating_http_cache, level: .info)
     }
 
     func testIdentifyingCorrectlyIdentifies() {

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -116,6 +116,7 @@ class IdentityManagerTests: TestCase {
         expect(self.mockDeviceCache.invokedClearCachesForAppUserID) == false
         expect(self.mockBackend.invokedClearHTTPClientCaches) == true
         expect(self.mockBackend.invokedClearHTTPClientCachesCount) == 1
+        expect(self.mockDeviceCache.invokedClearCustomerInfoCache) == false
 
         self.logger.verifyMessageWasLogged(Strings.identity.invalidating_http_cache, level: .info)
     }


### PR DESCRIPTION
### Description
Until now, when devs enabled Trusted Entitlements, we would clear the cached `CustomerInfo` and customers would need to refetch the latest value from the server, which could potentially cause delays and/or losing access temporarily.

With this PR, we won't be clearing the cached CustomerInfo anymore. Instead, we would return the cached customer info, which will have a `VerificationResult` of `NOT_REQUESTED`. 

iOS equivalent of https://github.com/RevenueCat/purchases-android/pull/2049

- [ ] Update docs