### PR TITLE
[Paywalls V2] Add masking (concave, convex, circle) and padding/margin to image

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -288,7 +288,7 @@ struct ImageComponentView_Previews: PreviewProvider {
         }
         .previewRequiredEnvironmentProperties()
         .previewLayout(.fixed(width: 400, height: 400))
-        .previewDisplayName("Light - Fill with Convex")
+        .previewDisplayName("Light - Fit with Convex")
 
         // Light - Fit with Concave
         VStack {

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -229,6 +229,96 @@ struct ImageComponentView_Previews: PreviewProvider {
         .previewRequiredEnvironmentProperties()
         .previewLayout(.fixed(width: 400, height: 400))
         .previewDisplayName("Light - Rounded Corner")
+
+        // Light - Fit with Circle
+        VStack {
+            ImageComponentView(
+                // swiftlint:disable:next force_try
+                viewModel: try! .init(
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [:]
+                    ),
+                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                    component: .init(
+                        source: .init(
+                            light: .init(
+                                width: 750,
+                                height: 530,
+                                original: catUrl,
+                                heic: catUrl,
+                                heicLowRes: catUrl
+                            )
+                        ),
+                        fitMode: .fit,
+                        maskShape: .circle
+                    )
+                )
+            )
+        }
+        .previewRequiredEnvironmentProperties()
+        .previewLayout(.fixed(width: 400, height: 400))
+        .previewDisplayName("Light - Circle")
+
+        // Light - Fit with Convex
+        VStack {
+            ImageComponentView(
+                // swiftlint:disable:next force_try
+                viewModel: try! .init(
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [:]
+                    ),
+                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                    component: .init(
+                        source: .init(
+                            light: .init(
+                                width: 750,
+                                height: 530,
+                                original: catUrl,
+                                heic: catUrl,
+                                heicLowRes: catUrl
+                            )
+                        ),
+                        fitMode: .fit,
+                        maskShape: .convex
+                    )
+                )
+            )
+        }
+        .previewRequiredEnvironmentProperties()
+        .previewLayout(.fixed(width: 400, height: 400))
+        .previewDisplayName("Light - Fill with Convex")
+
+        // Light - Fit with Concave
+        VStack {
+            ImageComponentView(
+                // swiftlint:disable:next force_try
+                viewModel: try! .init(
+                    localizationProvider: .init(
+                        locale: Locale.current,
+                        localizedStrings: [:]
+                    ),
+                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                    component: .init(
+                        source: .init(
+                            light: .init(
+                                width: 750,
+                                height: 530,
+                                original: catUrl,
+                                heic: catUrl,
+                                heicLowRes: catUrl
+                            )
+                        ),
+                        fitMode: .fit,
+                        maskShape: .concave
+                    )
+                )
+            )
+        }
+        .previewRequiredEnvironmentProperties()
+        .previewLayout(.fixed(width: 400, height: 400))
+        .previewDisplayName("Light - Fit with Concave")
     }
 }
 

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -84,16 +84,16 @@ struct ImageComponentView: View {
             .frame(maxWidth: .infinity)
             // WIP: Fix this later when accessibility info is available
             .accessibilityHidden(true)
-            // WIP: Need to replace this gradient with the better one
             .applyIfLet(style.colorOverlay, apply: { view, colorOverlay in
                 view.overlay(
                     Color.clear.backgroundStyle(.color(colorOverlay))
                 )
             })
-            // WIP: this needs more shapes and borders
-            // WIP: this might also need dropshadow
             .shape(border: nil,
                    shape: style.shape)
+            .padding(style.padding)
+            // WIP: Add border still
+            .padding(style.margin)
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
@@ -141,8 +141,8 @@ struct ImageComponentStyle {
     let size: PaywallComponent.Size
     let shape: ShapeModifier.Shape?
     let colorOverlay: DisplayableColorScheme?
-    let padding: PaywallComponent.Padding?
-    let margin: PaywallComponent.Padding?
+    let padding: EdgeInsets
+    let margin: EdgeInsets
     let border: PaywallComponent.Border?
     let shadow: PaywallComponent.Shadow?
     let contentMode: ContentMode
@@ -172,8 +172,8 @@ struct ImageComponentStyle {
         self.size = size
         self.shape = maskShape?.shape
         self.colorOverlay = colorOverlay?.asDisplayable(uiConfigProvider: uiConfigProvider)
-        self.padding = padding
-        self.margin = margin
+        self.padding = (padding ?? .zero).edgeInsets
+        self.margin = (margin ?? .zero).edgeInsets
         self.border = border
         self.shadow = shadow
         self.contentMode = fitMode.contentMode

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
@@ -196,8 +196,8 @@ private extension PaywallComponent.MaskShape {
                 )
             }
             return .rectangle(corners)
-        case .pill:
-            return .pill
+        case .circle:
+            return .circle
         case .concave:
             return .concave
         case .convex:

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -34,7 +34,7 @@ private enum Template1Preview {
             )
         ),
         fitMode: .fit,
-        maskShape: .concave
+        maskShape: .convex
     )
 
     static let title = PaywallComponent.TextComponent(

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -34,10 +34,7 @@ private enum Template1Preview {
             )
         ),
         fitMode: .fit,
-        colorOverlay: .init(light: .linear(0, [
-            .init(color: "#ffffff", percent: 0),
-            .init(color: "#ffffff00", percent: 40)
-        ]))
+        maskShape: .concave
     )
 
     static let title = PaywallComponent.TextComponent(

--- a/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
@@ -193,7 +193,7 @@ private struct ConcaveShape: Shape {
         // Create the upward-facing concave curve
         path.addQuadCurve(
             to: CGPoint(x: rect.minX, y: rect.maxY),
-            control: CGPoint(x: rect.midX, y: rect.maxY - proportionalCurveHeight)
+            control: CGPoint(x: rect.midX, y: rect.maxY - self.curveHeight)
         )
 
         // Bottom-left corner
@@ -204,11 +204,9 @@ private struct ConcaveShape: Shape {
         return path
     }
 
-    private var proportionalCurveHeight: CGFloat {
-        // Calculate the curve height as a proportion of both width and height
-        let baseHeight = size.height * curveHeightPercentage
-        let widthFactor = size.width / size.height
-        return baseHeight * widthFactor
+    private var curveHeight: CGFloat {
+        // Calculate the curve height as a percentage of the view's height
+        max(0, size.height * curveHeightPercentage)
     }
 
 }

--- a/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
@@ -240,7 +240,7 @@ public extension PaywallComponent {
     enum MaskShape: Codable, Sendable, Hashable, Equatable {
 
         case rectangle(CornerRadiuses?)
-        case pill
+        case circle
         case concave
         case convex
 
@@ -251,8 +251,8 @@ public extension PaywallComponent {
             case .rectangle(let corners):
                 try container.encodeIfPresent(MaskShapeType.rectangle.rawValue, forKey: .type)
                 try container.encode(corners, forKey: .corners)
-            case .pill:
-                try container.encode(MaskShapeType.pill.rawValue, forKey: .type)
+            case .circle:
+                try container.encode(MaskShapeType.circle.rawValue, forKey: .type)
             case .concave:
                 try container.encode(MaskShapeType.concave.rawValue, forKey: .type)
             case .convex:
@@ -268,8 +268,8 @@ public extension PaywallComponent {
             case .rectangle:
                 let value: CornerRadiuses? = try container.decodeIfPresent(CornerRadiuses.self, forKey: .corners)
                 self = .rectangle(value)
-            case .pill:
-                self = .pill
+            case .circle:
+                self = .circle
             case .concave:
                 self = .concave
             case .convex:
@@ -289,7 +289,7 @@ public extension PaywallComponent {
         private enum MaskShapeType: String, Decodable {
 
             case rectangle
-            case pill
+            case circle
             case concave
             case convex
 


### PR DESCRIPTION
### Motivation

Image was missing a bunch of properties in its rendering

### Description

- Mask
  - Replaced `pill` with `circle`
  - Added `concave` and `convex`
- Add `padding` and `margin`

| Circle | Convex | Concave |
|--------|--------|--------|
| <img width="479" alt="Screenshot 2025-01-15 at 12 07 25 PM" src="https://github.com/user-attachments/assets/9f3d97f6-0b8a-4dbf-ab9b-7780f55bbd08" /> | <img width="490" alt="Screenshot 2025-01-15 at 11 57 30 AM" src="https://github.com/user-attachments/assets/7e9f4538-e39e-4cac-8a92-501fa90cfad4" /> | <img width="543" alt="Screenshot 2025-01-15 at 11 57 42 AM" src="https://github.com/user-attachments/assets/cd527fc4-2159-4947-b8c3-9cd83a9c491c" /> | 

