### PR TITLE
feat: Make CustomerCenterActionHandler optional for CustomerCenterNavigationLink

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
@@ -33,7 +33,7 @@ import SwiftUI
 @available(watchOS, unavailable)
 public struct CustomerCenterNavigationLink<Label: View>: View {
 
-    private let customerCenterActionHandler: CustomerCenterActionHandler
+    private let customerCenterActionHandler: CustomerCenterActionHandler?
     @ViewBuilder private let label: () -> Label
 
     /// Initializes the navigation link with a label view provided by a closure.
@@ -52,7 +52,7 @@ public struct CustomerCenterNavigationLink<Label: View>: View {
     ///
     /// - Parameter label: A closure that returns the view to display as the navigation link’s label.
     public init(
-        customerCenterActionHandler: @escaping CustomerCenterActionHandler,
+        customerCenterActionHandler: CustomerCenterActionHandler? = nil,
         @ViewBuilder label: @escaping () -> Label) {
             self.customerCenterActionHandler = customerCenterActionHandler
             self.label = label


### PR DESCRIPTION
### Motivation
This is a follow-up of https://github.com/RevenueCat/purchases-ios/pull/4664 that makes the action handler optional, matching how `CustomerCenterView` initializer works.