### PR TITLE
Add convenience method for setting PostHog User ID

### DIFF
--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -331,6 +331,16 @@ public extension Attribution {
     }
 
     /**
+     * Subscriber attribute associated with the PostHog User ID for the user.
+     * Optional for the RevenueCat PostHog integration.
+     *
+     *- Parameter postHogUserID: Empty String or `nil` will delete the subscriber attribute.
+     */
+    @objc func setPostHogUserID(_ postHogUserID: String?) {
+        self.subscriberAttributesManager.setPostHogUserID(postHogUserID, appUserID: appUserID)
+    }
+
+    /**
      * Subscriber attribute associated with the install media source for the user.
      *
      * #### Related Articles

--- a/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -44,6 +44,7 @@ enum ReservedSubscriberAttribute: String {
     case mixpanelDistinctID = "$mixpanelDistinctId"
     case firebaseAppInstanceID = "$firebaseAppInstanceId"
     case tenjinAnalyticsInstallationID = "$tenjinId"
+    case postHogUserID = "$posthogUserId"
 
     case mediaSource = "$mediaSource"
     case campaign = "$campaign"

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -112,6 +112,10 @@ class SubscriberAttributesManager {
         setReservedAttribute(.tenjinAnalyticsInstallationID, value: tenjinAnalyticsInstallationID, appUserID: appUserID)
     }
 
+    func setPostHogUserID(_ postHogUserID: String?, appUserID: String) {
+        setReservedAttribute(.postHogUserID, value: postHogUserID, appUserID: appUserID)
+    }
+
     func setMediaSource(_ mediaSource: String?, appUserID: String) {
         setReservedAttribute(.mediaSource, value: mediaSource, appUserID: appUserID)
     }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAttributionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAttributionAPI.m
@@ -46,6 +46,8 @@
     [a setFirebaseAppInstanceID: @""];
     [a setTenjinAnalyticsInstallationID: nil];
     [a setTenjinAnalyticsInstallationID: @""];
+    [a setPostHogUserID:nil];
+    [a setPostHogUserID:@""];
     [a setMediaSource: nil];
     [a setMediaSource: @""];
     [a setCampaign: nil];

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AttributionAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AttributionAPI.swift
@@ -61,6 +61,9 @@ func checkAttributionAPI() {
     attribution.setTenjinAnalyticsInstallationID("")
     attribution.setTenjinAnalyticsInstallationID(nil)
 
+    attribution.setPostHogUserID("")
+    attribution.setPostHogUserID(nil)
+
     attribution.setMediaSource("")
     attribution.setMediaSource(nil)
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriberAttributesView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriberAttributesView.swift
@@ -45,6 +45,7 @@ struct SubscriberAttributesView: View {
         case setMixpanelDistinctID
         case setFirebaseAppInstanceID
         case setTenjinAnalyticsInstallationID
+        case setPostHogUserID
     }
     
     let customerInfo: RevenueCat.CustomerInfo
@@ -158,6 +159,8 @@ struct SubscriberAttributesView: View {
                     Purchases.shared.attribution.setFirebaseAppInstanceID(self.otherValue)
                 case .setTenjinAnalyticsInstallationID:
                     Purchases.shared.attribution.setTenjinAnalyticsInstallationID(self.otherValue)
+                case .setPostHogUserID:
+                    Purchases.shared.attribution.setPostHogUserID(self.otherValue)
                 }
             }
         }

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -431,6 +431,10 @@ extension MockPurchases: PurchasesType {
         self.unimplemented()
     }
 
+    func setPostHogUserID(_ postHogUserID: String?) {
+        self.unimplemented()
+    }
+
     func collectDeviceIdentifiers() {
         self.unimplemented()
     }

--- a/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
@@ -225,6 +225,18 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
         invokedSetTenjinAnalyticsInstallationIDParametersList.append((tenjinAnalyticsInstallationID, appUserID))
     }
 
+    var invokedSetPostHogUserID = false
+    var invokedSetPostHogUserIDCount = 0
+    var invokedSetPostHogUserIDParameters: (postHogUserID: String?, appUserID: String?)?
+    var invokedSetPostHogUserIDParametersList = [(postHogUserID: String?, appUserID: String?)]()
+
+    override func setPostHogUserID(_ postHogUserID: String?, appUserID: String) {
+        invokedSetPostHogUserID = true
+        invokedSetPostHogUserIDCount += 1
+        invokedSetPostHogUserIDParameters = (postHogUserID, appUserID)
+        invokedSetPostHogUserIDParametersList.append((postHogUserID, appUserID))
+    }
+
     var invokedSetMediaSource = false
     var invokedSetMediaSourceCount = 0
     var invokedSetMediaSourceParameters: (mediaSource: String?, appUserID: String?)?

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -489,6 +489,16 @@ class PurchasesSubscriberAttributesTests: TestCase {
         (nil, purchases.appUserID)
     }
 
+    func testSetAndClearPostHogUserID() {
+        setupPurchases()
+        purchases.attribution.setPostHogUserID("posthog")
+        purchases.attribution.setPostHogUserID(nil)
+        expect(self.mockSubscriberAttributesManager.invokedSetPostHogUserIDParametersList[0]) ==
+        ("posthog", purchases.appUserID)
+        expect(self.mockSubscriberAttributesManager.invokedSetPostHogUserIDParametersList[1]) ==
+        (nil, purchases.appUserID)
+    }
+
     func testSetAndClearMediaSource() {
         setupPurchases()
         purchases.attribution.setMediaSource("media")
@@ -690,6 +700,17 @@ class PurchasesSubscriberAttributesTests: TestCase {
         expect(self.mockSubscriberAttributesManager.invokedSetTenjinAnalyticsInstallationIDParameters?.tenjinID) ==
         "123abc"
         expect(self.mockSubscriberAttributesManager.invokedSetTenjinAnalyticsInstallationIDParameters?.appUserID) ==
+        mockIdentityManager.currentAppUserID
+    }
+
+    func testSetPostHogUserIDMakesRightCalls() {
+        setupPurchases()
+
+        Purchases.shared.attribution.setPostHogUserID("123abc")
+        expect(self.mockSubscriberAttributesManager.invokedSetPostHogUserIDCount) == 1
+        expect(self.mockSubscriberAttributesManager.invokedSetPostHogUserIDParameters?.postHogUserID) ==
+        "123abc"
+        expect(self.mockSubscriberAttributesManager.invokedSetPostHogUserIDParameters?.appUserID) ==
         mockIdentityManager.currentAppUserID
     }
 


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
#4656 

### Description
- Adds a convenience method to set the PostHog User ID (`$posthogUserId`)