### PR TITLE
fix: [CustomerCenter] Introduce NavigationOptions for custom navigation

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -527,6 +527,7 @@
 		57069A5428E3918400B86355 /* AsyncExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57069A5328E3918400B86355 /* AsyncExtensions.swift */; };
 		57069A5E28E398E100B86355 /* AsyncExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57069A5D28E398E100B86355 /* AsyncExtensionsTests.swift */; };
 		570FAF4B2864EC2300D3C769 /* NonSubscriptionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */; };
+		571197642D3AE403000BC39E /* CustomerCenterNavigationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571197632D3AE3F5000BC39E /* CustomerCenterNavigationOptions.swift */; };
 		5712BE9029241EB500A83F15 /* TimingUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5712BE8F29241EB500A83F15 /* TimingUtil.swift */; };
 		5712BE9229241F7900A83F15 /* TimingUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5712BE9129241F7900A83F15 /* TimingUtilTests.swift */; };
 		571E7AD4279F2D0C003B3606 /* StoreKitTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */; };
@@ -1842,6 +1843,7 @@
 		570896B427595C8100296F1C /* Coverage.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = Coverage.xctestplan; path = Tests/TestPlans/Coverage.xctestplan; sourceTree = "<group>"; };
 		570896B527595C8100296F1C /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = Tests/TestPlans/UnitTests.xctestplan; sourceTree = "<group>"; };
 		570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonSubscriptionTransaction.swift; sourceTree = "<group>"; };
+		571197632D3AE3F5000BC39E /* CustomerCenterNavigationOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterNavigationOptions.swift; sourceTree = "<group>"; };
 		5712BE8F29241EB500A83F15 /* TimingUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingUtil.swift; sourceTree = "<group>"; };
 		5712BE9129241F7900A83F15 /* TimingUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingUtilTests.swift; sourceTree = "<group>"; };
 		571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitTestHelpers.swift; sourceTree = "<group>"; };
@@ -3677,6 +3679,7 @@
 		353756602C382C2800A1B8D6 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				571197632D3AE3F5000BC39E /* CustomerCenterNavigationOptions.swift */,
 				FD33CD4B2D034CA6000D13A4 /* UIKit Compatibility */,
 				3531DF872CFE138800D454BF /* ManageSubscriptionsButtonsView.swift */,
 				2D2AFE8E2C6A9D8700D1B0B4 /* CompatibilityContentUnavailableView.swift */,
@@ -6757,6 +6760,7 @@
 				887A60832C1D037000E1A461 /* VersionDetector.swift in Sources */,
 				88B1BAFC2C813A3C001B7EE5 /* ImageComponentView.swift in Sources */,
 				2C91068A2CE22D3500189565 /* FlexVStack.swift in Sources */,
+				571197642D3AE403000BC39E /* CustomerCenterNavigationOptions.swift in Sources */,
 				03C72FC22D349BAE00297FEC /* IconComponentViewModel.swift in Sources */,
 				887A60872C1D037000E1A461 /* ViewExtensions.swift in Sources */,
 				2C8EC6DB2CCC23B700D6CCF8 /* MultiTierPreview.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/ButtonStyles.swift
+++ b/RevenueCatUI/CustomerCenter/ButtonStyles.swift
@@ -78,6 +78,41 @@ struct DismissCircleButton: View {
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
+struct DismissCircleButtonToolbarModifier: ViewModifier {
+
+    @Environment(\.navigationOptions)
+    var navigationOptions
+
+    func body(content: Content) -> some View {
+        if navigationOptions.shouldShowCloseButton {
+            content
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        DismissCircleButton()
+                    }
+                }
+        } else {
+            content
+        }
+
+    }
+}
+
+@available(iOS 15.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension View {
+    /// Adds a toolbar with a dismiss button if `navigationOptions.shouldShowCloseButton` is true.
+    func dismissCircleButtonToolbar() -> some View {
+        modifier(DismissCircleButtonToolbarModifier())
+    }
+}
+
+@available(iOS 15.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
 struct ButtonStyles_Previews: PreviewProvider {
 
     static var previews: some View {

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterEnvironment.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterEnvironment.swift
@@ -59,6 +59,11 @@ extension CustomerCenterConfigData.Appearance {
 
 }
 
+struct CustomerCenterNavigationOptionsKey: EnvironmentKey {
+
+    static let defaultValue: CustomerCenterNavigationOptions = .default
+}
+
 extension EnvironmentValues {
 
     var localization: CustomerCenterConfigData.Localization {
@@ -79,6 +84,11 @@ extension EnvironmentValues {
     var customerCenterPresentationMode: CustomerCenterPresentationMode {
         get { self[CustomerCenterPresentationModeKey.self] }
         set { self[CustomerCenterPresentationModeKey.self] = newValue }
+    }
+
+    var navigationOptions: CustomerCenterNavigationOptions {
+        get { self[CustomerCenterNavigationOptionsKey.self] }
+        set { self[CustomerCenterNavigationOptionsKey.self] = newValue }
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
@@ -21,6 +21,16 @@ import SwiftUI
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 struct AppUpdateWarningView: View {
+
+    @Environment(\.appearance)
+    private var appearance: CustomerCenterConfigData.Appearance
+
+    @Environment(\.colorScheme)
+    private var colorScheme
+
+    @Environment(\.localization)
+    private var localization: CustomerCenterConfigData.Localization
+
     let onUpdateAppClick: () -> Void
     let onContinueAnywayClick: () -> Void
 
@@ -28,13 +38,6 @@ struct AppUpdateWarningView: View {
         self.onUpdateAppClick = onUpdateAppClick
         self.onContinueAnywayClick = onContinueAnywayClick
     }
-
-    @Environment(\.localization)
-    private var localization: CustomerCenterConfigData.Localization
-    @Environment(\.appearance)
-    private var appearance: CustomerCenterConfigData.Appearance
-    @Environment(\.colorScheme)
-    private var colorScheme
 
     @ViewBuilder
     var content: some View {
@@ -63,11 +66,7 @@ struct AppUpdateWarningView: View {
                 .listRowSeparator(.hidden)
             }
         }
-        .toolbar {
-            ToolbarItem(placement: .compatibleTopBarTrailing) {
-                DismissCircleButton()
-            }
-        }
+        .dismissCircleButtonToolbar()
     }
 
     var body: some View {

--- a/RevenueCatUI/CustomerCenter/Views/CompatibilityNavigationStack.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CompatibilityNavigationStack.swift
@@ -52,10 +52,13 @@ extension View {
         isPresented: Binding<Bool>,
         @ViewBuilder destination: @escaping () -> Destination
     ) -> some View {
-        if #available(iOS 16.0, *) {
+        @Environment(\.navigationOptions)
+        var navigationOptions
+
+        if #available(iOS 16.0, *), navigationOptions.usesNavigationStack {
             self.navigationDestination(isPresented: isPresented, destination: destination)
         } else {
-            self.overlay(
+            self.background(
                 NavigationLink(
                     destination: destination(),
                     isActive: isPresented

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationLink.swift
@@ -12,11 +12,10 @@ import SwiftUI
 
 /// A view that provides a navigation link to `CustomerCenterView` with a customizable label.
 ///
-/// This is the **preferred way** to integrate `CustomerCenterView` into your `NavigationStack`,
-/// ensuring proper navigation behavior by setting `isEmbededInNavigation` to `true`.
+/// This is the **preferred way** to integrate `CustomerCenterView` into your `NavigationView`,
+/// ensuring proper navigation behavior by pre-setting navigation options.
 ///
-///
-/// Example:
+/// ## Example Usage
 /// ```swift
 /// CustomerCenterNavigationLink {
 ///     HStack {
@@ -63,7 +62,11 @@ public struct CustomerCenterNavigationLink<Label: View>: View {
         NavigationLink {
             CustomerCenterView(
                 customerCenterActionHandler: customerCenterActionHandler,
-                isEmbeddedInNavigationStack: true)
+                navigationOptions: CustomerCenterNavigationOptions(
+                    usesNavigationStack: false,
+                    usesExistingNavigation: true,
+                    shouldShowCloseButton: false
+                ))
         } label: {
             label()
         }

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationOptions.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationOptions.swift
@@ -1,0 +1,59 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerCenterNavigationOptions.swift
+//
+//  Created by Facundo Menzella on 17/1/25.
+
+/// Options for configuring the navigation behavior in the Customer Center.
+///
+/// This struct allows customization of navigation behavior, including the use of modern or legacy navigation systems,
+/// whether to push onto an existing navigation stack, and whether to display a close button in the toolbar.
+public struct CustomerCenterNavigationOptions {
+
+    /// Indicates whether the modern iOS 16+ navigation system (`NavigationStack` with `.navigationDestination`)
+    /// should be used instead of the legacy navigation system (`NavigationLink` with `NavigationView`).
+    /// - `true` (default): Use `NavigationStack` for navigation.
+    /// - `false`: Fall back to using `NavigationLink` for compatibility with older iOS versions.
+    public let usesNavigationStack: Bool
+
+    /// Specifies whether the current view should push its destination onto an existing navigation stack or
+    /// wrap the destination content in its own navigation stack.
+    /// - `true`: The destination is pushed onto the existing navigation stack, preserving navigation context.
+    /// - `false` (default): The destination content is wrapped in a new `NavigationStack`.
+    public let usesExistingNavigation: Bool
+
+    /// Controls whether a close button should be displayed in the toolbar.
+    /// - `true` (default): Displays a close button in the toolbar.
+    /// - `false`: Does not display a close button, avoiding redundancy with the back button in a stacked navigation.
+    public let shouldShowCloseButton: Bool
+
+    /// The default configuration for `CustomerCenterNavigationOptions`.
+    ///
+    /// - `usesNavigationStack`: `true` (default to modern navigation).
+    /// - `usesExistingNavigation`: `false` (wraps content in a new navigation stack by default).
+    /// - `shouldShowCloseButton`: `true` (displays a close button by default).
+    public static let `default` = CustomerCenterNavigationOptions()
+
+    /// Initializes a new instance of `CustomerCenterNavigationOptions`.
+    ///
+    /// - Parameters:
+    ///   - usesNavigationStack: Whether to use the modern iOS 16+ `NavigationStack` system. Defaults to `true`.
+    ///   - usesExistingNavigation: Whether to push onto an existing navigation stack. Defaults to `false`.
+    ///   - shouldShowCloseButton: Whether to display a close button in the toolbar. Defaults to `true`.
+    public init(
+        usesNavigationStack: Bool = true,
+        usesExistingNavigation: Bool = false,
+        shouldShowCloseButton: Bool = true
+    ) {
+        self.usesNavigationStack = usesNavigationStack
+        self.usesExistingNavigation = usesExistingNavigation
+        self.shouldShowCloseButton = shouldShowCloseButton
+    }
+}

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -43,25 +43,20 @@ public struct CustomerCenterView: View {
 
     private let mode: CustomerCenterPresentationMode
 
-    /// A flag indicating whether the view is already embedded in a navigation stack.
-    ///
-    /// - When set to `true`, the view must be part of an existing `NavigationStack` / `NavigationView`.
-    /// - When set to `false`, the view is not part of an external `NavigationStack` / `NavigationView`
-    /// and uses one internally.
-    private let isEmbeddedInNavigationStack: Bool
+    private let navigationOptions: CustomerCenterNavigationOptions
 
     /// Create a view to handle common customer support tasks
     /// - Parameters:
     ///   - customerCenterActionHandler: An optional `CustomerCenterActionHandler` to handle actions
     ///   from the Customer Center.
-    ///   - isEmbeddedInNavigationStack: Whether this view is already inside a `NavigationStack` / `NavigationView`
+    ///   - navigationOptions: Options to control the navigation behavior
     public init(
         customerCenterActionHandler: CustomerCenterActionHandler? = nil,
-        isEmbeddedInNavigationStack: Bool = false) {
+        navigationOptions: CustomerCenterNavigationOptions = .default) {
         self.init(
             customerCenterActionHandler: customerCenterActionHandler,
             mode: .default,
-            isEmbeddedInNavigationStack: isEmbeddedInNavigationStack
+            navigationOptions: navigationOptions
         )
     }
 
@@ -70,23 +65,24 @@ public struct CustomerCenterView: View {
     ///   - customerCenterActionHandler: An optional `CustomerCenterActionHandler` to handle actions
     ///   from the Customer Center.
     ///   - mode: The presentation mode for the Customer Center
-    ///   - isEmbeddedInNavigationStack: Whether this view is already inside a navigation stack
+    ///   - navigationOptions: Options to control the navigation behavior
     init(
         customerCenterActionHandler: CustomerCenterActionHandler? = nil,
         mode: CustomerCenterPresentationMode,
-        isEmbeddedInNavigationStack: Bool = false) {
+        navigationOptions: CustomerCenterNavigationOptions) {
         self._viewModel = .init(wrappedValue:
                                     CustomerCenterViewModel(customerCenterActionHandler: customerCenterActionHandler))
         self.mode = mode
-        self.isEmbeddedInNavigationStack = isEmbeddedInNavigationStack
+        self.navigationOptions = navigationOptions
     }
 
     fileprivate init(
         viewModel: CustomerCenterViewModel,
-        mode: CustomerCenterPresentationMode = CustomerCenterPresentationMode.default) {
+        mode: CustomerCenterPresentationMode =  .default,
+        navigationOptions: CustomerCenterNavigationOptions = .default) {
         self._viewModel = .init(wrappedValue: viewModel)
         self.mode = mode
-        self.isEmbeddedInNavigationStack = false
+        self.navigationOptions = navigationOptions
     }
 
     // swiftlint:disable:next missing_docs
@@ -103,7 +99,8 @@ public struct CustomerCenterView: View {
                         .environment(\.localization, configuration.localization)
                         .environment(\.appearance, configuration.appearance)
                         .environment(\.supportInformation, configuration.support)
-                        .environment(\.customerCenterPresentationMode, self.mode)
+//                        .environment(\.customerCenterPresentationMode, self.mode)
+                        .environment(\.navigationOptions, self.navigationOptions)
                 } else {
                     TintedProgressView()
                 }
@@ -179,7 +176,7 @@ private extension CustomerCenterView {
                                      for: self.colorScheme)
 
         Group {
-            if isEmbeddedInNavigationStack {
+            if navigationOptions.usesExistingNavigation {
                 destinationContent(configuration: configuration)
             } else {
                 CompatibilityNavigationStack {

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -26,10 +26,12 @@ struct ManageSubscriptionsView: View {
 
     @Environment(\.appearance)
     private var appearance: CustomerCenterConfigData.Appearance
-    @Environment(\.localization)
-    private var localization: CustomerCenterConfigData.Localization
+
     @Environment(\.colorScheme)
     private var colorScheme
+
+    @Environment(\.localization)
+    private var localization: CustomerCenterConfigData.Localization
 
     @StateObject
     private var viewModel: ManageSubscriptionsViewModel
@@ -53,27 +55,10 @@ struct ManageSubscriptionsView: View {
     }
 
     var body: some View {
-        if #available(iOS 16.0, *) {
-            content
-                .navigationDestination(isPresented: .isNotNil(self.$viewModel.feedbackSurveyData)) {
-                    if let feedbackSurveyData = self.viewModel.feedbackSurveyData {
-                        FeedbackSurveyView(feedbackSurveyData: feedbackSurveyData,
-                                           customerCenterActionHandler: self.customerCenterActionHandler,
-                                           isPresented: .isNotNil(self.$viewModel.feedbackSurveyData))
-                    }
-                }
-        } else {
-            content
-                .background(NavigationLink(
-                    destination: self.viewModel.feedbackSurveyData.map { data in
-                        FeedbackSurveyView(feedbackSurveyData: data,
-                                           customerCenterActionHandler: self.customerCenterActionHandler,
-                                           isPresented: .isNotNil(self.$viewModel.feedbackSurveyData))
-                    },
-                    isActive: .isNotNil(self.$viewModel.feedbackSurveyData)
-                ) {
-                    EmptyView()
-                })
+        content.compatibleNavigation(item: $viewModel.feedbackSurveyData) { feedbackSurveyData in
+            FeedbackSurveyView(feedbackSurveyData: feedbackSurveyData,
+                               customerCenterActionHandler: self.customerCenterActionHandler,
+                               isPresented: .isNotNil(self.$viewModel.feedbackSurveyData))
         }
     }
 
@@ -116,11 +101,7 @@ struct ManageSubscriptionsView: View {
 
             }
         }
-        .toolbar {
-            ToolbarItem(placement: .compatibleTopBarTrailing) {
-                DismissCircleButton()
-            }
-        }
+        .dismissCircleButtonToolbar()
         .restorePurchasesAlert(isPresented: self.$viewModel.showRestoreAlert)
         .sheet(
             item: self.$viewModel.promotionalOfferData,
@@ -143,10 +124,7 @@ struct ManageSubscriptionsView: View {
         }, content: { inAppBrowserURL in
             SafariView(url: inAppBrowserURL.url)
         })
-        .applyIf(self.viewModel.screen.type == .management, apply: {
-            $0.navigationTitle(self.viewModel.screen.title).navigationBarTitleDisplayMode(.inline)
-        })
-
+        .dismissCircleButtonToolbar()
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -26,12 +26,15 @@ struct NoSubscriptionsView: View {
 
     let configuration: CustomerCenterConfigData
 
-    @Environment(\.localization)
-    private var localization: CustomerCenterConfigData.Localization
     @Environment(\.appearance)
     private var appearance: CustomerCenterConfigData.Appearance
+
+    @Environment(\.localization)
+    private var localization: CustomerCenterConfigData.Localization
+
     @Environment(\.colorScheme)
     private var colorScheme
+
     @State
     private var showRestoreAlert: Bool = false
 
@@ -61,11 +64,7 @@ struct NoSubscriptionsView: View {
             }
 
         }
-        .toolbar {
-            ToolbarItem(placement: .compatibleTopBarTrailing) {
-                DismissCircleButton()
-            }
-        }
+        .dismissCircleButtonToolbar()
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -37,14 +37,18 @@ struct WrongPlatformView: View {
 
     private let screen: CustomerCenterConfigData.Screen?
 
-    @Environment(\.localization)
-    private var localization: CustomerCenterConfigData.Localization
     @Environment(\.appearance)
     private var appearance: CustomerCenterConfigData.Appearance
+
     @Environment(\.colorScheme)
     private var colorScheme
+
+    @Environment(\.localization)
+    private var localization: CustomerCenterConfigData.Localization
+
     @Environment(\.supportInformation)
     private var supportInformation: CustomerCenterConfigData.Support?
+
     @Environment(\.openURL)
     private var openURL
 
@@ -98,11 +102,7 @@ struct WrongPlatformView: View {
                 }
             }
         }
-        .toolbar {
-            ToolbarItem(placement: .compatibleTopBarTrailing) {
-                DismissCircleButton()
-            }
-        }
+        .dismissCircleButtonToolbar()
         .applyIf(self.screen?.title != nil, apply: {
             $0.navigationTitle(self.screen!.title).navigationBarTitleDisplayMode(.inline)
         })


### PR DESCRIPTION
### Motivation
This PR tackles https://github.com/RevenueCat/purchases-ios/issues/4311#issuecomment-2380571212, introducing `CustomerCenterNavigationOptions` to customize how navigation is handle within the `CustomerCenter`.

### Description
Instead of three separate variables I went for a struct, winning in future flexibility. New variables can be added without breaking the API.

It adds some view modifiers to simplify the use of it internally as well.