### PR TITLE
v4: Fix main actor references in iOS 11-12

### DIFF
--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -17,7 +17,7 @@ import Foundation
 
 class CustomerInfoManager {
 
-    // todo: remove main actor here
+    // todo: confirm removal of mainActor here
     typealias CustomerInfoCompletion = @Sendable (Result<CustomerInfo, BackendError>) -> Void
 
     private let offlineEntitlementsManager: OfflineEntitlementsManager

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -17,6 +17,7 @@ import Foundation
 
 class CustomerInfoManager {
 
+    // todo: remove main actor here
     typealias CustomerInfoCompletion = @MainActor @Sendable (Result<CustomerInfo, BackendError>) -> Void
 
     private let offlineEntitlementsManager: OfflineEntitlementsManager

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -18,7 +18,7 @@ import Foundation
 class CustomerInfoManager {
 
     // todo: remove main actor here
-    typealias CustomerInfoCompletion = @MainActor @Sendable (Result<CustomerInfo, BackendError>) -> Void
+    typealias CustomerInfoCompletion = @Sendable (Result<CustomerInfo, BackendError>) -> Void
 
     private let offlineEntitlementsManager: OfflineEntitlementsManager
     private let operationDispatcher: OperationDispatcher
@@ -90,7 +90,7 @@ class CustomerInfoManager {
             }
 
             if let completion = completion {
-                self.operationDispatcher.dispatchOnMainActor {
+                self.operationDispatcher.dispatchAsyncOnMainThread {
                     completion(result)
                 }
             }
@@ -115,7 +115,7 @@ class CustomerInfoManager {
         }
 
         if let completion = completion {
-            self.operationDispatcher.dispatchOnMainActor {
+            self.operationDispatcher.dispatchAsyncOnMainThread {
                 completion(.success(customerInfo))
             }
         }
@@ -129,7 +129,7 @@ class CustomerInfoManager {
     ) {
         switch fetchPolicy {
         case .fromCacheOnly:
-            self.operationDispatcher.dispatchOnMainActor {
+            self.operationDispatcher.dispatchAsyncOnMainThread {
                 completion?(
                     Result(self.cachedCustomerInfo(appUserID: appUserID), .missingCachedCustomerInfo())
                 )
@@ -150,7 +150,7 @@ class CustomerInfoManager {
                 Logger.debug(Strings.customerInfo.vending_cache)
                 if let completion = completion {
                     completionCalled = true
-                    self.operationDispatcher.dispatchOnMainActor {
+                    self.operationDispatcher.dispatchAsyncOnMainThread {
                         completion(.success(infoFromCache))
                     }
                 }
@@ -176,7 +176,7 @@ class CustomerInfoManager {
                 if let infoFromCache = infoFromCache, !isCacheStale {
                     Logger.debug(Strings.customerInfo.vending_cache)
                     if let completion = completion {
-                        self.operationDispatcher.dispatchOnMainActor {
+                        self.operationDispatcher.dispatchAsyncOnMainThread {
                             completion(.success(infoFromCache))
                         }
                     }

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -52,6 +52,7 @@ class OperationDispatcher {
         self.mainQueue.async(execute: block)
     }
 
+    // todo: main actor references need OS check
     func dispatchOnMainActor(_ block: @MainActor @escaping @Sendable () -> Void) {
         Self.dispatchOnMainActor(block)
     }
@@ -79,6 +80,7 @@ class OperationDispatcher {
 
 extension OperationDispatcher {
 
+    // todo: main actor needs OS check
     static func dispatchOnMainActor(_ block: @MainActor @escaping @Sendable () -> Void) {
         if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
             Task<Void, Never> { @MainActor in

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -52,7 +52,7 @@ class OperationDispatcher {
         self.mainQueue.async(execute: block)
     }
 
-    // todo: main actor references need OS check
+    // todo: confirm all references to this have OS checks
     func dispatchOnMainActor(_ block: @MainActor @escaping @Sendable () -> Void) {
         Self.dispatchOnMainActor(block)
     }

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -149,7 +149,7 @@ class SystemInfo {
     /// Asynchronous API if caller can't ensure that it's invoked in the `@MainActor`
     /// - Seealso: `isApplicationBackgrounded`
     func isApplicationBackgrounded(completion: @escaping @Sendable (Bool) -> Void) {
-        self.operationDispatcher.dispatchOnMainActor {
+        self.operationDispatcher.dispatchOnMainThread {
             completion(self.isApplicationBackgrounded)
         }
     }
@@ -157,8 +157,7 @@ class SystemInfo {
     /// Synchronous API for callers in `@MainActor`.
     /// - Seealso: `isApplicationBackgrounded(completion:)`
     // todo: main actor here
-    @MainActor
-    var isApplicationBackgrounded: Bool {
+    private var isApplicationBackgrounded: Bool {
     #if os(iOS) || os(tvOS) || VISION_OS
         return self.isApplicationBackgroundedIOSAndTVOS
     #elseif os(macOS)
@@ -276,7 +275,6 @@ private extension SystemInfo {
     // it are made. There are no pre-processor macros available to check if the code is running in an app extension,
     // so we check if we're running in an app extension at runtime, and if not, we use KVC to call sharedApplication.
     // todo: main actor here
-    @MainActor
     var isApplicationBackgroundedIOSAndTVOS: Bool {
         if self.isAppExtension {
             return true
@@ -288,7 +286,6 @@ private extension SystemInfo {
 
     #elseif os(watchOS)
 
-    @MainActor
     // todo: main actor here
     var isApplicationBackgroundedWatchOS: Bool {
         var isSingleTargetApplication: Bool {

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -156,6 +156,7 @@ class SystemInfo {
 
     /// Synchronous API for callers in `@MainActor`.
     /// - Seealso: `isApplicationBackgrounded(completion:)`
+    // todo: main actor here
     @MainActor
     var isApplicationBackgrounded: Bool {
     #if os(iOS) || os(tvOS) || VISION_OS
@@ -274,6 +275,7 @@ private extension SystemInfo {
     // iOS/tvOS App extensions can't access UIApplication.sharedApplication, and will fail to compile if any calls to
     // it are made. There are no pre-processor macros available to check if the code is running in an app extension,
     // so we check if we're running in an app extension at runtime, and if not, we use KVC to call sharedApplication.
+    // todo: main actor here
     @MainActor
     var isApplicationBackgroundedIOSAndTVOS: Bool {
         if self.isAppExtension {
@@ -287,6 +289,7 @@ private extension SystemInfo {
     #elseif os(watchOS)
 
     @MainActor
+    // todo: main actor here
     var isApplicationBackgroundedWatchOS: Bool {
         var isSingleTargetApplication: Bool {
             return Bundle.main.infoDictionary?.keys.contains("WKApplication") == true

--- a/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
+++ b/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
@@ -33,7 +33,7 @@ class OfflineEntitlementsManager {
     // todo: main actor here
     func updateProductsEntitlementsCacheIfStale(
         isAppBackgrounded: Bool,
-        completion: (@MainActor @Sendable (Result<(), Error>) -> Void)?
+        completion: (@Sendable (Result<(), Error>) -> Void)?
     ) {
         guard #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
               !self.systemInfo.observerMode,
@@ -106,11 +106,11 @@ private extension OfflineEntitlementsManager {
 
     // todo: main actor here
     func dispatchCompletionOnMainThreadIfPossible<Value, Error: Swift.Error>(
-        _ completion: (@MainActor @Sendable (Result<Value, Error>) -> Void)?,
+        _ completion: (@Sendable (Result<Value, Error>) -> Void)?,
         result: Result<Value, Error>
     ) {
         if let completion = completion {
-            self.operationDispatcher.dispatchOnMainActor {
+            self.operationDispatcher.dispatchOnMainThread {
                 completion(result)
             }
         }

--- a/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
+++ b/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
@@ -30,6 +30,7 @@ class OfflineEntitlementsManager {
         self.systemInfo = systemInfo
     }
 
+    // todo: main actor here
     func updateProductsEntitlementsCacheIfStale(
         isAppBackgrounded: Bool,
         completion: (@MainActor @Sendable (Result<(), Error>) -> Void)?
@@ -103,6 +104,7 @@ private extension OfflineEntitlementsManager {
 
 private extension OfflineEntitlementsManager {
 
+    // todo: main actor here
     func dispatchCompletionOnMainThreadIfPossible<Value, Error: Swift.Error>(
         _ completion: (@MainActor @Sendable (Result<Value, Error>) -> Void)?,
         result: Result<Value, Error>

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -39,6 +39,7 @@ class OfferingsManager {
         self.productsManager = productsManager
     }
 
+    // todo: main actor here
     func offerings(
         appUserID: String,
         fetchPolicy: FetchPolicy = .default,
@@ -72,6 +73,7 @@ class OfferingsManager {
         return self.deviceCache.cachedOfferings
     }
 
+    // todo: main actor here
     func updateOfferingsCache(
         appUserID: String,
         isAppBackgrounded: Bool,
@@ -132,6 +134,7 @@ class OfferingsManager {
 
 private extension OfferingsManager {
 
+    // todo: main actor here
     func fetchFromNetwork(
         appUserID: String,
         fetchPolicy: FetchPolicy = .default,
@@ -225,6 +228,7 @@ private extension OfferingsManager {
         }
     }
 
+    // todo: main actor here
     func handleOfferingsBackendResult(
         with response: OfferingsResponse,
         appUserID: String,
@@ -255,6 +259,7 @@ private extension OfferingsManager {
         }
     }
 
+    // todo: main actor here
     func handleOfferingsUpdateError(
         _ error: Error,
         completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
@@ -264,6 +269,7 @@ private extension OfferingsManager {
         self.dispatchCompletionOnMainThreadIfPossible(completion, value: .failure(error))
     }
 
+    // todo: main actor here
     func dispatchCompletionOnMainThreadIfPossible<T>(
         _ completion: (@MainActor @Sendable (T) -> Void)?,
         value: T

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -44,7 +44,7 @@ class OfferingsManager {
         appUserID: String,
         fetchPolicy: FetchPolicy = .default,
         fetchCurrent: Bool = false,
-        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
+        completion: (@Sendable (Result<Offerings, Error>) -> Void)?
     ) {
         guard !fetchCurrent else {
             self.fetchFromNetwork(appUserID: appUserID, fetchPolicy: fetchPolicy, completion: completion)
@@ -78,7 +78,7 @@ class OfferingsManager {
         appUserID: String,
         isAppBackgrounded: Bool,
         fetchPolicy: FetchPolicy = .default,
-        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
+        completion: (@Sendable (Result<Offerings, Error>) -> Void)?
     ) {
         self.backend.offerings.getOfferings(appUserID: appUserID, isAppBackgrounded: isAppBackgrounded) { result in
             switch result {
@@ -138,7 +138,7 @@ private extension OfferingsManager {
     func fetchFromNetwork(
         appUserID: String,
         fetchPolicy: FetchPolicy = .default,
-        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
+        completion: (@Sendable (Result<Offerings, Error>) -> Void)?
     ) {
         Logger.debug(Strings.offering.no_cached_offerings_fetching_from_network)
 
@@ -233,7 +233,7 @@ private extension OfferingsManager {
         with response: OfferingsResponse,
         appUserID: String,
         fetchPolicy: FetchPolicy,
-        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
+        completion: (@Sendable (Result<Offerings, Error>) -> Void)?
     ) {
         self.createOfferings(from: response, fetchPolicy: fetchPolicy) { result in
             switch result {
@@ -262,20 +262,20 @@ private extension OfferingsManager {
     // todo: main actor here
     func handleOfferingsUpdateError(
         _ error: Error,
-        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
+        completion: (@Sendable (Result<Offerings, Error>) -> Void)?
     ) {
         Logger.appleError(Strings.offering.fetching_offerings_error(error: error,
                                                                     underlyingError: error.underlyingError))
         self.dispatchCompletionOnMainThreadIfPossible(completion, value: .failure(error))
     }
 
-    // todo: main actor here
+    // todo: verify main actor replacement here
     func dispatchCompletionOnMainThreadIfPossible<T>(
-        _ completion: (@MainActor @Sendable (T) -> Void)?,
+        _ completion: (@Sendable (T) -> Void)?,
         value: T
     ) {
         if let completion = completion {
-            self.operationDispatcher.dispatchOnMainActor {
+            self.operationDispatcher.dispatchOnMainThread {
                 completion(value)
             }
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -33,6 +33,7 @@ public typealias PurchaseResultData = (transaction: StoreTransaction?,
 /**
  Completion block for ``Purchases/purchase(product:completion:)``
  */
+// todo: main actor here
 public typealias PurchaseCompletedBlock = @MainActor @Sendable (StoreTransaction?,
                                                                 CustomerInfo?,
                                                                 PublicError?,

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -34,10 +34,10 @@ public typealias PurchaseResultData = (transaction: StoreTransaction?,
  Completion block for ``Purchases/purchase(product:completion:)``
  */
 // todo: main actor here
-public typealias PurchaseCompletedBlock = @MainActor @Sendable (StoreTransaction?,
-                                                                CustomerInfo?,
-                                                                PublicError?,
-                                                                Bool) -> Void
+public typealias PurchaseCompletedBlock = @Sendable (StoreTransaction?,
+                                                     CustomerInfo?,
+                                                     PublicError?,
+                                                     Bool) -> Void
 
 /**
  Block for starting purchases in ``PurchasesDelegate/purchases(_:readyForPromotedProduct:purchase:)``

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -374,8 +374,9 @@ final class PurchasesOrchestrator {
          * we wouldn't be able to notify of the purchase result.
          */
 
+        // todo: verify actor replacement here
         guard let productIdentifier = payment.extractProductIdentifier() else {
-            self.operationDispatcher.dispatchOnMainActor {
+            self.operationDispatcher.dispatchOnMainThread {
                 completion(
                     nil,
                     nil,
@@ -1291,8 +1292,9 @@ private extension PurchasesOrchestrator {
         }
     }
 
+    // todo: verify actor replacement here
     func handleTestProduct(_ completion: @escaping PurchaseCompletedBlock) {
-        self.operationDispatcher.dispatchOnMainActor {
+        self.operationDispatcher.dispatchOnMainThread {
             completion(
                 nil,
                 nil,

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -47,6 +47,7 @@ protocol TransactionPosterType: AnyObject, Sendable {
     /// Finishes the transaction if not in observer mode.
     /// - Note: `handlePurchasedTransaction` calls this automatically,
     /// this is only required for failed transactions.
+    // todo: main actor here
     func finishTransactionIfNeeded(
         _ transaction: StoreTransactionType,
         completion: @escaping @Sendable @MainActor () -> Void
@@ -121,6 +122,7 @@ final class TransactionPoster: TransactionPosterType {
         }
     }
 
+    // todo: main actor here
     func finishTransactionIfNeeded(
         _ transaction: StoreTransactionType,
         completion: @escaping @Sendable @MainActor () -> Void

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -50,7 +50,7 @@ protocol TransactionPosterType: AnyObject, Sendable {
     // todo: main actor here
     func finishTransactionIfNeeded(
         _ transaction: StoreTransactionType,
-        completion: @escaping @Sendable @MainActor () -> Void
+        completion: @escaping @Sendable () -> Void
     )
 
 }
@@ -125,11 +125,11 @@ final class TransactionPoster: TransactionPosterType {
     // todo: main actor here
     func finishTransactionIfNeeded(
         _ transaction: StoreTransactionType,
-        completion: @escaping @Sendable @MainActor () -> Void
+        completion: @escaping @Sendable () -> Void
     ) {
         @Sendable
         func complete() {
-            self.operationDispatcher.dispatchOnMainActor(completion)
+            self.operationDispatcher.dispatchOnMainThread(completion)
         }
 
         guard self.finishTransactions else {
@@ -332,6 +332,7 @@ extension TransactionPoster {
 
 private extension TransactionPoster {
 
+    // todo: verify actor replacement ehre
     func product(with identifier: String, completion: @escaping (StoreProduct?) -> Void) {
         self.productsManager.products(withIdentifiers: [identifier]) { products in
             self.operationDispatcher.dispatchOnMainThread {

--- a/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
@@ -41,7 +41,7 @@ class StoreKitRequestFetcher: NSObject {
     }
 
     // todo: main actor here
-    func fetchReceiptData(_ completion: @MainActor @Sendable @escaping () -> Void) {
+    func fetchReceiptData(_ completion: @Sendable @escaping () -> Void) {
         self.operationDispatcher.dispatchOnWorkerThread {
             self.receiptRefreshCompletionHandlers.append(completion)
 

--- a/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
@@ -29,6 +29,7 @@ class StoreKitRequestFetcher: NSObject {
     private var receiptRefreshRequest: SKRequest?
     // todo: main actor here
     private var receiptRefreshCompletionHandlers: [@Sendable () -> Void]
+
     private let operationDispatcher: OperationDispatcher
 
     init(requestFactory: ReceiptRefreshRequestFactory = ReceiptRefreshRequestFactory(),
@@ -95,8 +96,9 @@ private extension StoreKitRequestFetcher {
             let completionHandlers = self.receiptRefreshCompletionHandlers
             self.receiptRefreshCompletionHandlers = []
 
+            // todo: verify main actor replacement here
             for handler in completionHandlers {
-                self.operationDispatcher.dispatchOnMainActor {
+                self.operationDispatcher.dispatchOnMainThread {
                     handler()
                 }
             }

--- a/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
@@ -27,7 +27,8 @@ class StoreKitRequestFetcher: NSObject {
 
     private let requestFactory: ReceiptRefreshRequestFactory
     private var receiptRefreshRequest: SKRequest?
-    private var receiptRefreshCompletionHandlers: [@MainActor @Sendable () -> Void]
+    // todo: main actor here
+    private var receiptRefreshCompletionHandlers: [@Sendable () -> Void]
     private let operationDispatcher: OperationDispatcher
 
     init(requestFactory: ReceiptRefreshRequestFactory = ReceiptRefreshRequestFactory(),
@@ -38,6 +39,7 @@ class StoreKitRequestFetcher: NSObject {
         self.receiptRefreshCompletionHandlers = []
     }
 
+    // todo: main actor here
     func fetchReceiptData(_ completion: @MainActor @Sendable @escaping () -> Void) {
         self.operationDispatcher.dispatchOnWorkerThread {
             self.receiptRefreshCompletionHandlers.append(completion)


### PR DESCRIPTION
Having references to `@MainActor` crashes the SDK in runtime in iOS 11 and 12 in our SDK v4 when compiling with Xcode 16 (it's not an issue in Xcode 15). 

We've reported this to Apple as `FB16345033`. 

To solve this, we need to remove all references to `@MainActor` for iOS 11 and 12. Conceptually this makes sense - that should never have compiled in the first place, since iOS 11 and 12 do not support Swift Concurrency. 

But this is a fairly delicate open heart surgery, so we need to test it out thoroughly. 