### PR TITLE
refactor: [CustomerCenter] Improve syntax for CommonLocalizedString

### DIFF
--- a/RevenueCatUI/CustomerCenter/ButtonStyles.swift
+++ b/RevenueCatUI/CustomerCenter/ButtonStyles.swift
@@ -69,7 +69,7 @@ struct DismissCircleButton: View {
                 )
             }
         .buttonStyle(.plain)
-        .accessibilityLabel(Text(localization.commonLocalizedString(for: .dismiss)))
+        .accessibilityLabel(Text(localization[.dismiss]))
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/ContactSupportUtilities.swift
+++ b/RevenueCatUI/CustomerCenter/ContactSupportUtilities.swift
@@ -29,7 +29,7 @@ extension CustomerCenterConfigData.Support {
         }
         let defaultBody =
             """
-            \(localization.commonLocalizedString(for: .defaultBody))
+            \(localization[.defaultBody])
 
             ---------------------------
             \(infoToInclude.map { (key, value) in
@@ -40,7 +40,7 @@ extension CustomerCenterConfigData.Support {
     }
 
     private static func defaultData(_ localization: CustomerCenterConfigData.Localization) -> [(String, String)] {
-        let unknown = localization.commonLocalizedString(for: .unknown)
+        let unknown = localization[.unknown]
         var osVersion = unknown
         var deviceModel = unknown
         #if canImport(UIKit) && !os(watchOS)

--- a/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseDetailViewModel.swift
@@ -1,0 +1,83 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchaseHistoryViewModel.swift
+//
+//
+//  Created by Facundo Menzella on 14/1/25.
+//
+
+import Foundation
+import SwiftUI
+
+import RevenueCat
+
+#if os(iOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+final class PurchaseDetailViewModel: ObservableObject {
+
+    @Environment(\.localization)
+    private var localization: CustomerCenterConfigData.Localization
+
+    @Published var items: [PurchaseDetailItem] = []
+
+    var localizedOwnership: String? {
+        switch purchaseInfo {
+        case .subscription(let subscriptionInfo):
+            subscriptionInfo.ownershipType == .familyShared
+            ? localization[.sharedThroughFamilyMember]
+            : nil
+        case .nonSubscription(let nonSubscriptionTransaction):
+            nil
+        }
+    }
+
+    init(purchaseInfo: PurchaseInfo) {
+        self.purchaseInfo = purchaseInfo
+    }
+
+    func didAppear() async {
+        await fetchProduct()
+    }
+
+    // MARK: - Private
+
+    private let purchaseInfo: PurchaseInfo
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private extension PurchaseDetailViewModel {
+
+    func fetchProduct() async {
+        guard
+            let product = await Purchases.shared.products([purchaseInfo.productIdentifier]).first
+        else {
+            return
+        }
+
+        var items: [PurchaseDetailItem] = [
+            .productName(product.localizedTitle ?? product.productIdentifier)
+        ]
+
+        items.append(contentsOf: purchaseInfo.purchaseDetailItems)
+
+        await MainActor.run {
+            self.items = items
+        }
+    }
+}
+
+#endif

--- a/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseDetailViewModel.swift
@@ -37,7 +37,7 @@ final class PurchaseDetailViewModel: ObservableObject {
             subscriptionInfo.ownershipType == .familyShared
             ? localization[.sharedThroughFamilyMember]
             : nil
-        case .nonSubscription(let nonSubscriptionTransaction):
+        case .nonSubscription:
             nil
         }
     }

--- a/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
@@ -42,20 +42,20 @@ struct AppUpdateWarningView: View {
             List {
                 Section {
                     CompatibilityContentUnavailableView(
-                        localization.commonLocalizedString(for: .updateWarningTitle),
+                        localization[.updateWarningTitle],
                         systemImage: "arrow.up.circle.fill",
-                        description: Text(localization.commonLocalizedString(for: .updateWarningDescription))
+                        description: Text(localization[.updateWarningDescription])
                     )
                 }
 
                 Section {
-                    Button(localization.commonLocalizedString(for: .updateWarningUpdate)) {
+                    Button(localization[.updateWarningUpdate]) {
                         onUpdateAppClick()
                     }
                     .buttonStyle(ProminentButtonStyle())
                     .padding(.top, 4)
 
-                    Button(localization.commonLocalizedString(for: .updateWarningIgnore)) {
+                    Button(localization[.updateWarningIgnore]) {
                         onContinueAnywayClick()
                     }
                     .buttonStyle(TextButtonStyle())

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -82,11 +82,20 @@ struct ManageSubscriptionsView: View {
         ZStack {
             List {
 
+<<<<<<< Updated upstream
                 if let purchaseInformation = self.viewModel.purchaseInformation {
                     Section {
                         SubscriptionDetailsView(
                             purchaseInformation: purchaseInformation,
                             refundRequestStatus: self.viewModel.refundRequestStatus)
+=======
+                if support?.displayPurchaseHistoryLink == true {
+                    Button {
+                        viewModel.showPurchases = true
+                    } label: {
+                        Text(localization[.seeAllPurchases])
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+>>>>>>> Stashed changes
                     }
                     Section {
                         ManageSubscriptionsButtonsView(viewModel: self.viewModel,
@@ -113,6 +122,11 @@ struct ManageSubscriptionsView: View {
                                                        loadingPath: self.$viewModel.loadingPath)
                     }
                 }
+<<<<<<< Updated upstream
+=======
+            } else {
+                let fallbackDescription = localization[.tryCheckRestore]
+>>>>>>> Stashed changes
 
             }
         }

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -40,8 +40,8 @@ struct NoSubscriptionsView: View {
     }
 
     var body: some View {
-        let fallbackDescription = localization.commonLocalizedString(for: .tryCheckRestore)
-        let fallbackTitle = localization.commonLocalizedString(for: .noSubscriptionsFound)
+        let fallbackDescription = localization[.tryCheckRestore]
+        let fallbackTitle = localization[.noSubscriptionsFound]
 
         List {
             Section {
@@ -54,7 +54,7 @@ struct NoSubscriptionsView: View {
             }
 
             Section {
-                Button(localization.commonLocalizedString(for: .restorePurchases)) {
+                Button(localization[.restorePurchases]) {
                     showRestoreAlert = true
                 }
                 .restorePurchasesAlert(isPresented: $showRestoreAlert)

--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -82,7 +82,7 @@ struct PromotionalOfferView: View {
                     Button {
                         self.dismissPromotionalOfferView(.declinePromotionalOffer)
                     } label: {
-                        Text(self.localization.commonLocalizedString(for: .noThanks))
+                        Text(self.localization[.noThanks])
                     }
                     .padding()
                     .frame(maxWidth: .infinity)

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseDetailView.swift
@@ -1,0 +1,83 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchaseHistoryView.swift
+//
+//  Created by Facundo Menzella on 14/1/25.
+//
+
+#if os(iOS)
+import RevenueCat
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct PurchaseDetailView: View {
+
+    @Environment(\.localization)
+    private var localization: CustomerCenterConfigData.Localization
+
+    @StateObject var viewModel: PurchaseDetailViewModel
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(viewModel.items) { detailItem in
+                    CompatibilityLabeledContent(
+                        localization[detailItem.label],
+                        content: content(detailItem: detailItem)
+                    )
+                }
+            } footer: {
+                if let ownership = viewModel.localizedOwnership {
+                    Text(ownership)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            Task {
+                await viewModel.didAppear()
+            }
+        }
+    }
+
+    func content(detailItem: PurchaseDetailItem) -> String {
+        switch detailItem {
+        case let .productName(name):
+            return name
+
+        case let .paidPrice(price):
+            return price ?? "-"
+
+        case .status(let value),
+                .periodType(let value),
+                .store(let value):
+            return localization[value]
+
+        case .purchaseDate(let value),
+                .expiresDate(let value),
+                .nextRenewalDate(let value),
+                .unsubscribeDetectedAt(let value),
+                .billingIssuesDetectedAt(let value),
+                .gracePeriodExpiresDate(let value),
+                .refundedAtDate(let value),
+                .productID(let value),
+                .transactionID(let value):
+            return value
+
+        case .sandbox(let value):
+            return value
+            ? localization[.answerYes]
+            : localization[.answerNo]
+        }
+    }
+}
+
+#endif

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
@@ -1,0 +1,133 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchaseHistoryView.swift
+//
+//  Created by RevenueCat on 3/7/24.
+//
+
+#if os(iOS)
+import RevenueCat
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct PurchaseHistoryView: View {
+    @Environment(\.localization)
+    private var localization: CustomerCenterConfigData.Localization
+
+    @StateObject var viewModel: PurchaseHistoryViewModel
+
+    var body: some View {
+        List {
+            if viewModel.isLoading {
+                ProgressView()
+            } else if viewModel.errorMessage != nil {
+                ErrorView()
+            } else if let info = viewModel.customerInfo {
+                if !info.activeSubscriptions.isEmpty {
+                    Section(header: Text(
+                        localization[.activeSubscriptions]
+                    )) {
+                        ForEach(viewModel.activeSubscriptions) { activeSubscription in
+                            Button {
+                                viewModel.selectedPurchase = activeSubscription
+                            } label: {
+                                PurchaseLinkView(purchaseInfo: activeSubscription)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+
+                    Section(header: Text(
+                        localization[.expiredSubscriptions]
+                    )) {
+                        ForEach(viewModel.inactiveSubscriptions) { inactiveSubscription in
+                            Button {
+                                viewModel.selectedPurchase = inactiveSubscription
+                            } label: {
+                                PurchaseLinkView(purchaseInfo: inactiveSubscription)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+
+                // Non-Subscription Purchases Section
+                if !viewModel.nonSubscriptions.isEmpty {
+                    Section(header: Text(
+                        localization[.otherPurchases]
+                    )) {
+                        ForEach(viewModel.nonSubscriptions) { inactiveSubscription in
+                            Button {
+                                viewModel.selectedPurchase = inactiveSubscription
+                            } label: {
+                                PurchaseLinkView(purchaseInfo: inactiveSubscription)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+
+                // Account Details Section
+                Section(header: Text(
+                    localization[.accountDetails]
+                )) {
+                    CompatibilityLabeledContent(
+                        localization[.dateWhenAppWasPurchased],
+                        content: dateFormatter.string(from: info.originalPurchaseDate!)
+                    )
+
+                    CompatibilityLabeledContent(
+                        localization[.userId],
+                        content: info.originalAppUserId
+                    )
+                    .contextMenu {
+                        Button {
+                            UIPasteboard.general.string = info.originalAppUserId
+                        } label: {
+                            Text(localization[.copy])
+                            Image(systemName: "doc.on.clipboard")
+                        }
+                    }
+                }
+            }
+        }
+        .compatibleNavigation(item: $viewModel.selectedPurchase) {
+            PurchaseDetailView(
+                viewModel: PurchaseDetailViewModel(purchaseInfo: $0))
+        }
+        .navigationTitle(localization[.purchaseHistory])
+        .listStyle(.insetGrouped)
+        .onAppear {
+            Task {
+                await viewModel.didAppear()
+            }
+        }
+    }
+
+    private var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }
+}
+
+#if DEBUG
+@available(iOS 15.0, *)
+struct PurchaseHistoryView_Previews: PreviewProvider {
+    static var previews: some View {
+        CompatibilityNavigationStack {
+            PurchaseHistoryView(viewModel: PurchaseHistoryViewModel())
+        }
+    }
+}
+#endif
+
+#endif

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseLinkView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseLinkView.swift
@@ -1,0 +1,96 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchaseHistoryView.swift
+//
+//  Created by Facundo Menzella on 14/1/25.
+//
+
+#if os(iOS)
+import RevenueCat
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct PurchaseLinkView: View {
+    @Environment(\.localization)
+    private var localization: CustomerCenterConfigData.Localization
+
+    @State var productName: String?
+    let purchaseInfo: PurchaseInfo
+
+    var body: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(productName ?? purchaseInfo.productIdentifier)
+                    .font(.headline)
+
+                Text(dateString)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if let price = purchaseInfo.paidPrice {
+                Text(price)
+                    .font(.subheadline)
+                    .foregroundStyle(.tertiary)
+            }
+
+            Image(systemName: "chevron.forward")
+                .foregroundStyle(.secondary)
+        }
+        .onAppear {
+            Task {
+                guard
+                    let product = await Purchases.shared.products([purchaseInfo.productIdentifier]).first
+                else {
+                    return
+                }
+
+                productName = product.localizedTitle
+            }
+        }
+    }
+
+    private var purchasedOnLocalized: String {
+        localization[.purchaseInfoPurchasedOnDate]
+            .replacingOccurrences(of: L10n.date, with: formattedDate(purchaseInfo.purchaseDate))
+    }
+
+    private var dateString: String {
+        guard let expiresDate = purchaseInfo.expiresDate else {
+            return purchasedOnLocalized
+        }
+
+        guard purchaseInfo.isActive else {
+            return localization[.purchaseInfoExpiredOnDate]
+                .replacingOccurrences(of: L10n.date, with: formattedDate(expiresDate))
+        }
+
+        return purchaseInfo.willRenew
+        ? localization[.purchaseInfoRenewsOnDate]
+            .replacingOccurrences(of: L10n.date, with: formattedDate(expiresDate))
+        : localization[.purchaseInfoExpiresOnDate]
+            .replacingOccurrences(of: L10n.date, with: formattedDate(expiresDate))
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter.string(from: date)
+    }
+}
+
+private enum L10n {
+    static let date = "{{ date }}"
+}
+
+#endif

--- a/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
@@ -41,7 +41,7 @@ struct RestorePurchasesAlert: ViewModifier {
 
     private var supportURL: URL? {
         guard let supportInformation = self.supportInformation else { return nil }
-        let subject = self.localization.commonLocalizedString(for: .defaultSubject)
+        let subject = self.localization[.defaultSubject]
         let body = supportInformation.calculateBody(self.localization)
         return URLUtilities.createMailURLIfPossible(email: supportInformation.email,
                                                     subject: subject,
@@ -72,7 +72,7 @@ struct RestorePurchasesAlert: ViewModifier {
         case .purchasesRecovered:
             return [
                 AlertOrConfirmationDialog.AlertAction(
-                    title: localization.commonLocalizedString(for: .dismiss),
+                    title: localization[.dismiss],
                     role: .cancel,
                     action: dismissAlert
                 )
@@ -85,7 +85,7 @@ struct RestorePurchasesAlert: ViewModifier {
                customerCenterViewModel.shouldShowAppUpdateWarnings {
                 actions.append(
                     AlertOrConfirmationDialog.AlertAction(
-                        title: localization.commonLocalizedString(for: .updateWarningUpdate),
+                        title: localization[.updateWarningUpdate],
                         role: nil,
                         action: onUpdateAppClick
                     )
@@ -95,7 +95,7 @@ struct RestorePurchasesAlert: ViewModifier {
             if let url = supportURL {
                 actions.append(
                     AlertOrConfirmationDialog.AlertAction(
-                        title: localization.commonLocalizedString(for: .contactSupport),
+                        title: localization[.contactSupport],
                         role: nil,
                         action: { Task { openURL(url) } }
                     )
@@ -104,7 +104,7 @@ struct RestorePurchasesAlert: ViewModifier {
 
             actions.append(
                 AlertOrConfirmationDialog.AlertAction(
-                    title: localization.commonLocalizedString(for: .dismiss),
+                    title: localization[.dismiss],
                     role: .cancel,
                     action: dismissAlert
                 )
@@ -115,7 +115,7 @@ struct RestorePurchasesAlert: ViewModifier {
         case .restorePurchases:
             return [
                 AlertOrConfirmationDialog.AlertAction(
-                    title: localization.commonLocalizedString(for: .checkPastPurchases),
+                    title: localization[.checkPastPurchases],
                     role: nil,
                     action: {
                         Task {
@@ -125,7 +125,7 @@ struct RestorePurchasesAlert: ViewModifier {
                     }
                 ),
                 AlertOrConfirmationDialog.AlertAction(
-                    title: localization.commonLocalizedString(for: .cancel),
+                    title: localization[.cancel],
                     role: .cancel,
                     action: dismissAlert
                 )
@@ -137,26 +137,26 @@ struct RestorePurchasesAlert: ViewModifier {
     private func alertTitle() -> String {
         switch self.alertType {
         case .purchasesRecovered:
-            return localization.commonLocalizedString(for: .purchasesRecovered)
+            return localization[.purchasesRecovered]
         case .purchasesNotFound:
             return ""
         case .restorePurchases:
-            return localization.commonLocalizedString(for: .restorePurchases)
+            return localization[.restorePurchases]
         }
     }
 
     private func alertMessage() -> String {
         switch self.alertType {
         case .purchasesRecovered:
-            return localization.commonLocalizedString(for: .purchasesRecoveredExplanation)
+            return localization[.purchasesRecoveredExplanation]
         case .purchasesNotFound:
-            var message = localization.commonLocalizedString(for: .purchasesNotRecovered)
+            var message = localization[.purchasesNotRecovered]
             if customerCenterViewModel.shouldShowAppUpdateWarnings {
-                message += "\n\n" + localization.commonLocalizedString(for: .updateWarningDescription)
+                message += "\n\n" + localization[.updateWarningDescription]
             }
             return message
         case .restorePurchases:
-            return localization.commonLocalizedString(for: .goingToCheckPurchases)
+            return localization[.goingToCheckPurchases]
         }
     }
 

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailsView.swift
@@ -41,7 +41,7 @@ struct SubscriptionDetailsView: View {
                 if let durationTitle = purchaseInformation.durationTitle {
                     IconLabelView(
                         iconName: "coloncurrencysign.arrow.circlepath",
-                        label: localization.commonLocalizedString(for: .billingCycle),
+                        label: localization[.billingCycle],
                         value: durationTitle
                     )
                 }
@@ -49,7 +49,7 @@ struct SubscriptionDetailsView: View {
                 let priceValue: String? = {
                     switch purchaseInformation.price {
                     case .free:
-                        return localization.commonLocalizedString(for: .free)
+                        return localization[.free]
                     case .paid(let localizedPrice):
                         return localizedPrice
                     case .unknown:
@@ -60,7 +60,7 @@ struct SubscriptionDetailsView: View {
                 if let price = priceValue {
                     IconLabelView(
                         iconName: "coloncurrencysign",
-                        label: localization.commonLocalizedString(for: .currentPrice),
+                        label: localization[.currentPrice],
                         value: price
                     )
                 }
@@ -71,7 +71,7 @@ struct SubscriptionDetailsView: View {
                         IconLabelView(
                             iconName: "calendar",
                             label: label(for: expirationOrRenewal),
-                            value: localization.commonLocalizedString(for: .never)
+                            value: localization[.never]
                         )
                     case .date(let value):
                         IconLabelView(
@@ -86,7 +86,7 @@ struct SubscriptionDetailsView: View {
                    let refundStatusMessage = refundStatusMessage(for: refundRequestStatus) {
                     IconLabelView(
                         iconName: "arrowshape.turn.up.backward",
-                        label: localization.commonLocalizedString(for: .refundStatus),
+                        label: localization[.refundStatus],
                         value: refundStatusMessage
                     )
                 }
@@ -98,9 +98,9 @@ struct SubscriptionDetailsView: View {
     private func refundStatusMessage(for status: RefundRequestStatus) -> String? {
         switch status {
         case .error:
-            return localization.commonLocalizedString(for: .refundErrorGeneric)
+            return localization[.refundErrorGeneric]
         case .success:
-            return localization.commonLocalizedString(for: .refundGranted)
+            return localization[.refundGranted]
         case .userCancelled:
             return nil
         @unknown default:
@@ -111,11 +111,11 @@ struct SubscriptionDetailsView: View {
     private func label(for expirationOrRenewal: PurchaseInformation.ExpirationOrRenewal) -> String {
         switch expirationOrRenewal.label {
         case .nextBillingDate:
-            return localization.commonLocalizedString(for: .nextBillingDate)
+            return localization[.nextBillingDate]
         case .expires:
-            return localization.commonLocalizedString(for: .expires)
+            return localization[.expires]
         case .expired:
-            return localization.commonLocalizedString(for: .expired)
+            return localization[.expired]
         }
     }
 }
@@ -148,23 +148,23 @@ struct SubscriptionDetailsHeader: View {
                                             localization: CustomerCenterConfigData.Localization) -> String {
         switch purchaseInformation.explanation {
         case .promotional:
-            return localization.commonLocalizedString(for: .youHavePromo)
+            return localization[.youHavePromo]
         case .earliestRenewal:
-            return localization.commonLocalizedString(for: .subEarliestRenewal)
+            return localization[.subEarliestRenewal]
         case .earliestExpiration:
-            return localization.commonLocalizedString(for: .subEarliestExpiration)
+            return localization[.subEarliestExpiration]
         case .expired:
-            return localization.commonLocalizedString(for: .subExpired)
+            return localization[.subExpired]
         case .lifetime:
-            return localization.commonLocalizedString(for: .youHaveLifetime)
+            return localization[.youHaveLifetime]
         case .google:
-            return localization.commonLocalizedString(for: .googleSubscriptionManage)
+            return localization[.googleSubscriptionManage]
         case .web:
-            return localization.commonLocalizedString(for: .webSubscriptionManage)
+            return localization[.webSubscriptionManage]
         case .otherStorePurchase:
-            return localization.commonLocalizedString(for: .pleaseContactSupportToManage)
+            return localization[.pleaseContactSupportToManage]
         case .amazon:
-            return localization.commonLocalizedString(for: .amazonSubscriptionManage)
+            return localization[.amazonSubscriptionManage]
         }
     }
 }

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -50,7 +50,7 @@ struct WrongPlatformView: View {
 
     private var supportURL: URL? {
         guard let supportInformation = self.supportInformation else { return nil }
-        let subject = self.localization.commonLocalizedString(for: .defaultSubject)
+        let subject = self.localization[.defaultSubject]
         let body = supportInformation.calculateBody(self.localization)
         return URLUtilities.createMailURLIfPossible(email: supportInformation.email,
                                                     subject: subject,
@@ -84,7 +84,7 @@ struct WrongPlatformView: View {
                     AsyncButton {
                         openURL(managementURL)
                     } label: {
-                        Text(localization.commonLocalizedString(for: .manageSubscription))
+                        Text(localization[.manageSubscription])
                     }
                 }
             }
@@ -93,7 +93,7 @@ struct WrongPlatformView: View {
                     AsyncButton {
                         openURL(url)
                     } label: {
-                        Text(localization.commonLocalizedString(for: .contactSupport))
+                        Text(localization[.contactSupport])
                     }
                 }
             }

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -188,13 +188,15 @@ public struct CustomerCenterConfigData {
                     return "Never"
                 }
             }
+        }
 
+        public subscript(_ key: CommonLocalizedString) -> String {
+            localizedStrings[key.rawValue] ?? key.defaultValue
         }
 
         public func commonLocalizedString(for key: CommonLocalizedString) -> String {
             return self.localizedStrings[key.rawValue] ?? key.defaultValue
         }
-
     }
 
     public struct HelpPath {


### PR DESCRIPTION
### Motivation
The previous syntax made the whole dance too verbose:

```diff
- .navigationTitle(localization.commonLocalizedString(for: .purchaseHistory))
+ .navigationTitle(localization[.purchaseHistory])
```

This simplifies it 💅 

> This only affects `CustomerCenter`