### PR TITLE
Use config response for `displayPurchaseHistoryLink`

### DIFF
--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -686,7 +686,7 @@ extension CustomerCenterConfigData.Support {
     init(from response: CustomerCenterConfigResponse.Support) {
         self.email = response.email
         self.shouldWarnCustomerToUpdate = response.shouldWarnCustomerToUpdate ?? true
-        self.displayPurchaseHistoryLink = false
+        self.displayPurchaseHistoryLink = response.displayPurchaseHistoryLink ?? false
     }
 
 }

--- a/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
+++ b/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
@@ -133,7 +133,7 @@ struct CustomerCenterConfigResponse {
 
         let email: String
         let shouldWarnCustomerToUpdate: Bool?
-
+        let displayPurchaseHistoryLink: Bool?
     }
 
 }

--- a/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
+++ b/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
@@ -108,7 +108,8 @@ class CustomerCenterConfigDataTests: TestCase {
                 localization: .init(locale: "en_US", localizedStrings: ["key": "value"]),
                 support: .init(
                     email: "support@example.com",
-                    shouldWarnCustomerToUpdate: false
+                    shouldWarnCustomerToUpdate: false,
+                    displayPurchaseHistoryLink: false
                 )
             ),
             lastPublishedAppVersion: "1.2.3",


### PR DESCRIPTION
### Motivation
Currently this is false by default. This will leave it ready for the feature flag, enabling purchase history


