### PR TITLE
feat: Add debug section for purchase detail

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseDetailViewModel.swift
@@ -30,6 +30,7 @@ final class PurchaseDetailViewModel: ObservableObject {
     private var localization: CustomerCenterConfigData.Localization
 
     @Published var items: [PurchaseDetailItem] = []
+    var debugItems: [PurchaseDetailItem] = []
 
     var localizedOwnership: String? {
         switch purchaseInfo {
@@ -70,10 +71,11 @@ private extension PurchaseDetailViewModel {
 
         await MainActor.run {
             var items: [PurchaseDetailItem] = [
-            .productName(product.localizedTitle)
-        ]
+                .productName(product.localizedTitle)
+            ]
 
-        items.append(contentsOf: purchaseInfo.purchaseDetailItems)
+            items.append(contentsOf: purchaseInfo.purchaseDetailItems)
+            self.debugItems = purchaseInfo.purchaseDetailDebugItems
             self.items = items
         }
     }

--- a/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseInfo.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseInfo.swift
@@ -85,7 +85,11 @@ enum PurchaseInfo: Identifiable {
     }
 
     var purchaseDetailDebugItems: [PurchaseDetailItem] {
+#if DEBUG
         debugItems
+#else
+        []
+#endif
     }
 
     var purchaseDetailItems: [PurchaseDetailItem] {

--- a/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseInfo.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseInfo.swift
@@ -84,6 +84,10 @@ enum PurchaseInfo: Identifiable {
         }
     }
 
+    var purchaseDetailDebugItems: [PurchaseDetailItem] {
+        debugItems
+    }
+
     var purchaseDetailItems: [PurchaseDetailItem] {
         var items: [PurchaseDetailItem] = []
         switch self {
@@ -129,10 +133,6 @@ enum PurchaseInfo: Identifiable {
             items.append(.purchaseDate(formattedDate(transaction.purchaseDate)))
 
         }
-
-#if DEBUG
-        items.append(contentsOf: debugItems)
-#endif
 
         return items
     }

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -86,6 +86,7 @@ struct ManageSubscriptionsView: View {
                     } label: {
                         Text(localization[.seeAllPurchases])
                             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                 }

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseDetailView.swift
@@ -38,6 +38,17 @@ struct PurchaseDetailView: View {
                     Text(ownership)
                 }
             }
+
+            if !viewModel.debugItems.isEmpty {
+                Section(localization[.debugHeaderTitle]) {
+                    ForEach(viewModel.debugItems) { detailItem in
+                        CompatibilityLabeledContent(
+                            localization[detailItem.label],
+                            content: content(detailItem: detailItem)
+                        )
+                    }
+                }
+            }
         }
         .listStyle(.insetGrouped)
         .navigationBarTitleDisplayMode(.inline)

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseLinkView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseLinkView.swift
@@ -46,6 +46,7 @@ struct PurchaseLinkView: View {
             Image(systemName: "chevron.forward")
                 .foregroundStyle(.secondary)
         }
+        .contentShape(Rectangle())
         .onAppear {
             Task {
                 guard

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -138,6 +138,7 @@ public struct CustomerCenterConfigData {
             case storeRCBilling = "store_web"
             case storeExternal = "store_external"
             case storeUnknownStore = "store_unknown"
+            case debugHeaderTitle = "Debug"
 
             var defaultValue: String {
                 switch self {
@@ -315,6 +316,8 @@ public struct CustomerCenterConfigData {
                     return "External Purchases"
                 case .storeUnknownStore:
                     return "Unknown Store"
+                case .debugHeaderTitle:
+                    return "Debug"
                 }
             }
         }


### PR DESCRIPTION
### Motivation
This PR splits the purchase detail into two different sections to be explicit on what's only in debug mode

> it also sets the content shape to a few views to improve "tappabitliy" of the button

![Screenshot 2025-01-24 at 16 40 14](https://github.com/user-attachments/assets/92bad5eb-399e-4dc8-82e3-7e2813846420)
