### PR TITLE
chore: Tweak default copy for dateWhenAppWasPurchased

### DIFF
--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -250,7 +250,7 @@ public struct CustomerCenterConfigData {
                 case .accountDetails:
                     return "Account Details"
                 case .dateWhenAppWasPurchased:
-                    return "Date when app was first purchased"
+                    return "Original Purchase Date"
                 case .userId:
                     return "User ID"
                 case .purchaseHistory:

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -250,7 +250,7 @@ public struct CustomerCenterConfigData {
                 case .accountDetails:
                     return "Account Details"
                 case .dateWhenAppWasPurchased:
-                    return "Original Purchase Date"
+                    return "Original Download Date"
                 case .userId:
                     return "User ID"
                 case .purchaseHistory:


### PR DESCRIPTION
### Motivation
Tweak the default translation for `dateWhenAppWasPurchased`
