### PR TITLE
fix: Set environment values for every child view in CustomerCenter

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
@@ -29,10 +29,13 @@ struct FeedbackSurveyView: View {
 
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
+
     @Environment(\.appearance)
     private var appearance: CustomerCenterConfigData.Appearance
+
     @Environment(\.colorScheme)
     private var colorScheme
+
     @Environment(\.customerCenterPresentationMode)
     private var mode: CustomerCenterPresentationMode
 

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -29,6 +29,7 @@ struct ManageSubscriptionsView: View {
 
     @Environment(\.colorScheme)
     private var colorScheme
+
     @Environment(\.supportInformation)
     private var support
 
@@ -68,6 +69,8 @@ struct ManageSubscriptionsView: View {
                 feedbackSurveyData: feedbackSurveyData,
                 customerCenterActionHandler: self.customerCenterActionHandler,
                 isPresented: .isNotNil(self.$viewModel.feedbackSurveyData))
+            .environment(\.localization, localization)
+            .environment(\.navigationOptions, navigationOptions)
         }
     }
 
@@ -124,6 +127,7 @@ struct ManageSubscriptionsView: View {
         ) {
             PurchaseHistoryView(viewModel: PurchaseHistoryViewModel())
                 .environment(\.localization, localization)
+                .environment(\.navigationOptions, navigationOptions)
         }
         .dismissCircleButtonToolbar()
         .restorePurchasesAlert(isPresented: self.$viewModel.showRestoreAlert)

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -123,6 +123,7 @@ struct ManageSubscriptionsView: View {
             usesNavigationStack: navigationOptions.usesNavigationStack
         ) {
             PurchaseHistoryView(viewModel: PurchaseHistoryViewModel())
+                .environment(\.localization, localization)
         }
         .dismissCircleButtonToolbar()
         .restorePurchasesAlert(isPresented: self.$viewModel.showRestoreAlert)

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
@@ -107,6 +107,7 @@ struct PurchaseHistoryView: View {
         ) {
             PurchaseDetailView(
                 viewModel: PurchaseDetailViewModel(purchaseInfo: $0))
+            .environment(\.localization, localization)
         }
         .navigationTitle(localization[.purchaseHistory])
         .listStyle(.insetGrouped)

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
@@ -108,6 +108,7 @@ struct PurchaseHistoryView: View {
             PurchaseDetailView(
                 viewModel: PurchaseDetailViewModel(purchaseInfo: $0))
             .environment(\.localization, localization)
+            .environment(\.navigationOptions, navigationOptions)
         }
         .navigationTitle(localization[.purchaseHistory])
         .listStyle(.insetGrouped)


### PR DESCRIPTION
### Motivation
This PR addresses a bug where environment values, such as localizations, were not propagating to child views. 

The bug occurs when the navigation stack or navigation view is provided by the client app instead of the one managed by the customer center. To resolve this, the environment must be applied directly to the container view, allowing it to cascade properly to all child views.

