### PR TITLE
[Paywalls V2] New overrides structure

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		03A98D322D2441B8009BCA61 /* PaywallDataDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98D312D2441B2009BCA61 /* PaywallDataDecodingTests.swift */; };
 		03A98D362D244329009BCA61 /* UIConfigDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98D352D244321009BCA61 /* UIConfigDecodingTests.swift */; };
 		03A98D382D2AC63B009BCA61 /* UIConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98D372D2AC637009BCA61 /* UIConfigProvider.swift */; };
+		03C06FC52D4553C000600693 /* PresentedPartialsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C06FC42D4553BB00600693 /* PresentedPartialsTests.swift */; };
 		03C72F6D2D32CDFB00297FEC /* FamilySharingTogglePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C72F6C2D32CDFB00297FEC /* FamilySharingTogglePreview.swift */; };
 		03C72F8D2D3311E300297FEC /* DisplayableColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C72F8C2D3311D500297FEC /* DisplayableColor.swift */; };
 		03C72FBE2D34949600297FEC /* PaywallIconComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C72FBD2D34949600297FEC /* PaywallIconComponent.swift */; };
@@ -1290,6 +1291,7 @@
 		03A98D312D2441B2009BCA61 /* PaywallDataDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallDataDecodingTests.swift; sourceTree = "<group>"; };
 		03A98D352D244321009BCA61 /* UIConfigDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfigDecodingTests.swift; sourceTree = "<group>"; };
 		03A98D372D2AC637009BCA61 /* UIConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfigProvider.swift; sourceTree = "<group>"; };
+		03C06FC42D4553BB00600693 /* PresentedPartialsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentedPartialsTests.swift; sourceTree = "<group>"; };
 		03C72F6C2D32CDFB00297FEC /* FamilySharingTogglePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilySharingTogglePreview.swift; sourceTree = "<group>"; };
 		03C72F8C2D3311D500297FEC /* DisplayableColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayableColor.swift; sourceTree = "<group>"; };
 		03C72FBD2D34949600297FEC /* PaywallIconComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallIconComponent.swift; sourceTree = "<group>"; };
@@ -2525,6 +2527,7 @@
 		030890822D2B77DD0069677B /* PaywallsV2 */ = {
 			isa = PBXGroup;
 			children = (
+				03C06FC42D4553BB00600693 /* PresentedPartialsTests.swift */,
 				030890832D2B77E20069677B /* VariableHandlerV2Tests.swift */,
 			);
 			path = PaywallsV2;
@@ -6908,6 +6911,7 @@
 				887A63432C1D177800E1A461 /* LocalizationTests.swift in Sources */,
 				030890842D2B77E70069677B /* VariableHandlerV2Tests.swift in Sources */,
 				FD6186542D1393FA007843DA /* MockCustomerCenterStoreKitUtilities.swift in Sources */,
+				03C06FC52D4553C000600693 /* PresentedPartialsTests.swift in Sources */,
 				887A63442C1D177800E1A461 /* PaywallFooterTests.swift in Sources */,
 				887A63452C1D177800E1A461 /* PaywallViewEventsTests.swift in Sources */,
 				887A63472C1D177800E1A461 /* PurchaseCompletedHandlerTests.swift in Sources */,

--- a/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
@@ -98,13 +98,13 @@ struct PackageComponentView_Previews: PreviewProvider {
                     color: .init(light: .hex("#000000")),
                     padding: .zero,
                     margin: .zero,
-                    overrides: .init(
-                        states: .init(
-                            selected: .init(
-                                color: .init(light: .hex("#ff0000"))
-                            )
-                        )
-                    )
+                    overrides: [
+                        .init(conditions: [
+                            .selected
+                        ], properties: .init(
+                            color: .init(light: .hex("#ff0000"))
+                        ))
+                    ]
                 )),
                 .text(.init(
                     text: "detail",
@@ -125,13 +125,13 @@ struct PackageComponentView_Previews: PreviewProvider {
                           leading: 10,
                           trailing: 10),
             border: .init(color: .init(light: .hex("#cccccc")), width: 2),
-            overrides: .init(
-                states: .init(
-                    selected: .init(
-                        border: .init(color: .init(light: .hex("#ff0000")), width: 2)
-                    )
-                )
-            )
+            overrides: [
+                .init(conditions: [
+                    .selected
+                ], properties: .init(
+                    border: .init(color: .init(light: .hex("#ff0000")), width: 2)
+                ))
+            ]
         )
     }
 

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 #if PAYWALL_COMPONENTS
 
-private typealias PresentedStackPartial = PaywallComponent.PartialStackComponent
+typealias PresentedStackPartial = PaywallComponent.PartialStackComponent
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class StackComponentViewModel {

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
@@ -182,25 +182,25 @@ struct TabsComponentView_Previews: PreviewProvider {
                                             text: "tab_1_button",
                                             color: .init(light: .hex("#000000")),
                                             size: .init(width: .fit, height: .fit),
-                                            overrides: .init(
-                                                states: .init(
-                                                    selected: .init(
-                                                        color: .init(light: .hex("#ffffff"))
-                                                    )
-                                                )
-                                            )
+                                            overrides: [
+                                                .init(conditions: [
+                                                    .selected
+                                                ], properties: .init(
+                                                    color: .init(light: .hex("#ffffff"))
+                                                ))
+                                            ]
                                         ))
                                     ],
                                     size: .init(width: .fit, height: .fit),
                                     padding: .init(top: 4, bottom: 4, leading: 16, trailing: 16),
                                     shape: .pill,
-                                    overrides: .init(
-                                        states: .init(
-                                            selected: .init(
-                                                backgroundColor: .init(light: .hex("#3d6787"))
-                                            )
-                                        )
-                                    )
+                                    overrides: [
+                                        .init(conditions: [
+                                            .selected
+                                        ], properties: .init(
+                                            backgroundColor: .init(light: .hex("#3d6787"))
+                                        ))
+                                    ]
                                 )
                             )
                         ),
@@ -220,25 +220,25 @@ struct TabsComponentView_Previews: PreviewProvider {
                                             text: "tab_2_button",
                                             color: .init(light: .hex("#000000")),
                                             size: .init(width: .fit, height: .fit),
-                                            overrides: .init(
-                                                states: .init(
-                                                    selected: .init(
-                                                        color: .init(light: .hex("#ffffff"))
-                                                    )
-                                                )
-                                            )
+                                            overrides: [
+                                                .init(conditions: [
+                                                    .selected
+                                                ], properties: .init(
+                                                    color: .init(light: .hex("#ffffff"))
+                                                ))
+                                            ]
                                         ))
                                     ],
                                     size: .init(width: .fit, height: .fit),
                                     padding: .init(top: 4, bottom: 4, leading: 16, trailing: 16),
                                     shape: .pill,
-                                    overrides: .init(
-                                        states: .init(
-                                            selected: .init(
-                                                backgroundColor: .init(light: .hex("#3d6787"))
-                                            )
-                                        )
-                                    )
+                                    overrides: [
+                                        .init(conditions: [
+                                            .selected
+                                        ], properties: .init(
+                                            backgroundColor: .init(light: .hex("#3d6787"))
+                                        ))
+                                    ]
                                 )
                             )
                         ),
@@ -258,25 +258,25 @@ struct TabsComponentView_Previews: PreviewProvider {
                                             text: "tab_3_button",
                                             color: .init(light: .hex("#000000")),
                                             size: .init(width: .fit, height: .fit),
-                                            overrides: .init(
-                                                states: .init(
-                                                    selected: .init(
-                                                        color: .init(light: .hex("#ffffff"))
-                                                    )
-                                                )
-                                            )
+                                            overrides: [
+                                                .init(conditions: [
+                                                    .selected
+                                                ], properties: .init(
+                                                    color: .init(light: .hex("#ffffff"))
+                                                ))
+                                            ]
                                         ))
                                     ],
                                     size: .init(width: .fit, height: .fit),
                                     padding: .init(top: 4, bottom: 4, leading: 16, trailing: 16),
                                     shape: .pill,
-                                    overrides: .init(
-                                        states: .init(
-                                            selected: .init(
-                                                backgroundColor: .init(light: .hex("#3d6787"))
-                                            )
-                                        )
-                                    )
+                                    overrides: [
+                                        .init(conditions: [
+                                            .selected
+                                        ], properties: .init(
+                                            backgroundColor: .init(light: .hex("#3d6787"))
+                                        ))
+                                    ]
                                 )
                             )
                         )
@@ -357,13 +357,13 @@ struct TabsComponentView_Previews: PreviewProvider {
                                             text: "tab_1_button",
                                             color: .init(light: .hex("#000000")),
                                             size: .init(width: .fit, height: .fit),
-                                            overrides: .init(
-                                                states: .init(
-                                                    selected: .init(
-                                                        color: .init(light: .hex("#ffffff"))
-                                                    )
-                                                )
-                                            )
+                                            overrides: [
+                                                .init(conditions: [
+                                                    .selected
+                                                ], properties: .init(
+                                                    color: .init(light: .hex("#ffffff"))
+                                                ))
+                                            ]
                                         ))
                                     ],
                                     size: .init(width: .fit, height: .fit),
@@ -372,13 +372,13 @@ struct TabsComponentView_Previews: PreviewProvider {
                                                             topTrailing: 8,
                                                             bottomLeading: 8,
                                                             bottomTrailing: 8)),
-                                    overrides: .init(
-                                        states: .init(
-                                            selected: .init(
-                                                backgroundColor: .init(light: .hex("#3d6787"))
-                                            )
-                                        )
-                                    )
+                                    overrides: [
+                                        .init(conditions: [
+                                            .selected
+                                        ], properties: .init(
+                                            backgroundColor: .init(light: .hex("#3d6787"))
+                                        ))
+                                    ]
                                 )
                             )
                         ),
@@ -392,13 +392,13 @@ struct TabsComponentView_Previews: PreviewProvider {
                                             text: "tab_2_button",
                                             color: .init(light: .hex("#000000")),
                                             size: .init(width: .fit, height: .fit),
-                                            overrides: .init(
-                                                states: .init(
-                                                    selected: .init(
-                                                        color: .init(light: .hex("#ffffff"))
-                                                    )
-                                                )
-                                            )
+                                            overrides: [
+                                                .init(conditions: [
+                                                    .selected
+                                                ], properties: .init(
+                                                    color: .init(light: .hex("#ffffff"))
+                                                ))
+                                            ]
                                         ))
                                     ],
                                     size: .init(width: .fit, height: .fit),
@@ -407,13 +407,13 @@ struct TabsComponentView_Previews: PreviewProvider {
                                                             topTrailing: 8,
                                                             bottomLeading: 8,
                                                             bottomTrailing: 8)),
-                                    overrides: .init(
-                                        states: .init(
-                                            selected: .init(
-                                                backgroundColor: .init(light: .hex("#3d6787"))
-                                            )
-                                        )
-                                    )
+                                    overrides: [
+                                        .init(conditions: [
+                                            .selected
+                                        ], properties: .init(
+                                            backgroundColor: .init(light: .hex("#3d6787"))
+                                        ))
+                                    ]
                                 )
                             )
                         ),
@@ -427,13 +427,13 @@ struct TabsComponentView_Previews: PreviewProvider {
                                             text: "tab_3_button",
                                             color: .init(light: .hex("#000000")),
                                             size: .init(width: .fit, height: .fit),
-                                            overrides: .init(
-                                                states: .init(
-                                                    selected: .init(
-                                                        color: .init(light: .hex("#ffffff"))
-                                                    )
-                                                )
-                                            )
+                                            overrides: [
+                                                .init(conditions: [
+                                                    .selected
+                                                ], properties: .init(
+                                                    color: .init(light: .hex("#ffffff"))
+                                                ))
+                                            ]
                                         ))
                                     ],
                                     size: .init(width: .fit, height: .fit),
@@ -442,13 +442,13 @@ struct TabsComponentView_Previews: PreviewProvider {
                                                             topTrailing: 8,
                                                             bottomLeading: 8,
                                                             bottomTrailing: 8)),
-                                    overrides: .init(
-                                        states: .init(
-                                            selected: .init(
-                                                backgroundColor: .init(light: .hex("#3d6787"))
-                                            )
-                                        )
-                                    )
+                                    overrides: [
+                                        .init(conditions: [
+                                            .selected
+                                        ], properties: .init(
+                                            backgroundColor: .init(light: .hex("#3d6787"))
+                                        ))
+                                    ]
                                 )
                             )
                         )

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -327,24 +327,24 @@ struct TextComponentView_Previews: PreviewProvider {
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000")),
-                    overrides: .init(
-                        states: .init(
-                            selected: .init(
-                                fontWeight: .black,
-                                color: .init(light: .hex("#ff0000")),
-                                backgroundColor: .init(light: .hex("#0000ff")),
-                                padding: .init(top: 10,
-                                               bottom: 10,
-                                               leading: 10,
-                                               trailing: 10),
-                                margin: .init(top: 10,
-                                              bottom: 10,
-                                              leading: 10,
-                                              trailing: 10),
-                                fontSize: 34
-                            )
-                        )
-                    )
+                    overrides: [
+                        .init(conditions: [
+                            .selected
+                        ], properties: .init(
+                            fontWeight: .black,
+                            color: .init(light: .hex("#ff0000")),
+                            backgroundColor: .init(light: .hex("#0000ff")),
+                            padding: .init(top: 10,
+                                           bottom: 10,
+                                           leading: 10,
+                                           trailing: 10),
+                            margin: .init(top: 10,
+                                          bottom: 10,
+                                          leading: 10,
+                                          trailing: 10),
+                            fontSize: 34
+                        ))
+                    ]
                 )
             )
         )
@@ -369,13 +369,13 @@ struct TextComponentView_Previews: PreviewProvider {
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000")),
-                    overrides: .init(
-                        conditions: .init(
-                            medium: .init(
-                                text: "id_2"
-                            )
-                        )
-                    )
+                    overrides: [
+                        .init(conditions: [
+                            .medium
+                        ], properties: .init(
+                            text: "id_2"
+                        ))
+                    ]
                 )
             )
         )
@@ -400,13 +400,13 @@ struct TextComponentView_Previews: PreviewProvider {
                 component: .init(
                     text: "id_1",
                     color: .init(light: .hex("#000000")),
-                    overrides: .init(
-                        conditions: .init(
-                            medium: .init(
-                                text: "id_2"
-                            )
-                        )
-                    )
+                    overrides: [
+                        .init(conditions: [
+                            .medium
+                        ], properties: .init(
+                            text: "id_2"
+                        ))
+                    ]
                 )
             )
         )

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
@@ -141,14 +141,14 @@ private enum FamilySharingTogglePreview {
                                     bottomLeading: 16,
                                     bottomTrailing: 20)),
             border: .init(color: .init(light: .hex("#cccccc")), width: 1),
-            overrides: .init(
-                states: .init(
-                    selected: .init(
-                        backgroundColor: .init(light: .hex("#ffdfdd")),
-                        border: .init(color: .init(light: .hex("#e89d89")), width: 1)
-                    )
-                )
-            )
+            overrides: [
+                .init(conditions: [
+                    .selected
+                ], properties: .init(
+                    backgroundColor: .init(light: .hex("#ffdfdd")),
+                    border: .init(color: .init(light: .hex("#e89d89")), width: 1)
+                ))
+            ]
         )
 
         return PaywallComponent.PackageComponent(
@@ -202,13 +202,13 @@ private enum FamilySharingTogglePreview {
                             text: "toggle_text",
                             color: .init(light: .hex("#000000")),
                             size: .init(width: .fit, height: .fit),
-                            overrides: .init(
-                                states: .init(
-                                    selected: .init(
-                                        color: .init(light: .hex("#ffffff"))
-                                    )
-                                )
-                            )
+                            overrides: [
+                                .init(conditions: [
+                                    .selected
+                                ], properties: .init(
+                                    color: .init(light: .hex("#ffffff"))
+                                ))
+                            ]
                         )),
                         .tabControlToggle(.init(
                             defaultValue: false,

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
@@ -111,14 +111,14 @@ private enum MultiTierPreview {
                                     bottomLeading: 16,
                                     bottomTrailing: 20)),
             border: .init(color: .init(light: .hex("#cccccc")), width: 1),
-            overrides: .init(
-                states: .init(
-                    selected: .init(
-                        backgroundColor: .init(light: .hex("#ffdfdd")),
-                        border: .init(color: .init(light: .hex("#e89d89")), width: 1)
-                    )
-                )
-            )
+            overrides: [
+                .init(conditions: [
+                    .selected
+                ], properties: .init(
+                    backgroundColor: .init(light: .hex("#ffdfdd")),
+                    border: .init(color: .init(light: .hex("#e89d89")), width: 1)
+                ))
+            ]
         )
 
         return PaywallComponent.PackageComponent(
@@ -178,25 +178,25 @@ private enum MultiTierPreview {
                                             text: "tab_1_button",
                                             color: .init(light: .hex("#000000")),
                                             size: .init(width: .fit, height: .fit),
-                                            overrides: .init(
-                                                states: .init(
-                                                    selected: .init(
-                                                        color: .init(light: .hex("#ffffff"))
-                                                    )
-                                                )
-                                            )
+                                            overrides: [
+                                                .init(conditions: [
+                                                    .selected
+                                                ], properties: .init(
+                                                    color: .init(light: .hex("#ffffff"))
+                                                ))
+                                            ]
                                         ))
                                     ],
                                     size: .init(width: .fit, height: .fit),
                                     padding: .init(top: 4, bottom: 4, leading: 16, trailing: 16),
                                     shape: .pill,
-                                    overrides: .init(
-                                        states: .init(
-                                            selected: .init(
-                                                backgroundColor: .init(light: .hex("#e89d89"))
-                                            )
-                                        )
-                                    )
+                                    overrides: [
+                                        .init(conditions: [
+                                            .selected
+                                        ], properties: .init(
+                                            backgroundColor: .init(light: .hex("#e89d89"))
+                                        ))
+                                    ]
                                 )
                             )
                         ),
@@ -210,25 +210,25 @@ private enum MultiTierPreview {
                                             text: "tab_2_button",
                                             color: .init(light: .hex("#000000")),
                                             size: .init(width: .fit, height: .fit),
-                                            overrides: .init(
-                                                states: .init(
-                                                    selected: .init(
-                                                        color: .init(light: .hex("#ffffff"))
-                                                    )
-                                                )
-                                            )
+                                            overrides: [
+                                                .init(conditions: [
+                                                    .selected
+                                                ], properties: .init(
+                                                    color: .init(light: .hex("#ffffff"))
+                                                ))
+                                            ]
                                         ))
                                     ],
                                     size: .init(width: .fit, height: .fit),
                                     padding: .init(top: 4, bottom: 4, leading: 16, trailing: 16),
                                     shape: .pill,
-                                    overrides: .init(
-                                        states: .init(
-                                            selected: .init(
-                                                backgroundColor: .init(light: .hex("#e89d89"))
-                                            )
-                                        )
-                                    )
+                                    overrides: [
+                                        .init(conditions: [
+                                            .selected
+                                        ], properties: .init(
+                                            backgroundColor: .init(light: .hex("#e89d89"))
+                                        ))
+                                    ]
                                 )
                             )
                         )

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -29,35 +29,14 @@ protocol PresentedPartial {
 
 }
 
-/// Structure holding override configurations for different presentation states
-struct PresentedOverrides<T: PresentedPartial> {
+/// Array holding override configurations for different presentation states
+typealias PresentedOverrides<T: PresentedPartial> = [PresentedOverride<T>]
 
-    /// Override for intro offer state
-    public let introOffer: T?
-    /// Override for different selection states
-    public let states: PresentedStates<T>?
-    /// Override for different screen size conditions
-    public let conditions: PresentedConditions<T>?
+/// Structure holding override configurations for a presentation state
+struct PresentedOverride<T: PresentedPartial> {
 
-}
-
-/// Structure defining states for selected/unselected components
-struct PresentedStates<T: PresentedPartial> {
-
-    /// Override for selected state
-    let selected: T?
-
-}
-
-/// Structure defining overrides for different screen size conditions
-struct PresentedConditions<T: PresentedPartial> {
-
-    /// Override for compact size
-    let compact: T?
-    /// Override for medium size
-    let medium: T?
-    /// Override for expanded size
-    let expanded: T?
+    let conditions: [PaywallComponent.Condition]
+    let properties: T?
 
 }
 
@@ -75,44 +54,50 @@ extension PresentedPartial {
         isEligibleForIntroOffer: Bool,
         with presentedOverrides: PresentedOverrides<Self>?
     ) -> Self? {
-        var conditionPartial = buildConditionPartial(for: condition, with: presentedOverrides)
-
-        if isEligibleForIntroOffer {
-            conditionPartial = Self.combine(conditionPartial, with: presentedOverrides?.introOffer)
+        guard let presentedOverrides else {
+            return nil
         }
 
-        switch state {
-        case .default:
-            break
-        case .selected:
-            conditionPartial = Self.combine(conditionPartial, with: presentedOverrides?.states?.selected)
+        var presentedPartial: Self?
+
+        for presentedOverride in presentedOverrides where self.shouldApply(
+            for: presentedOverride.conditions,
+            state: state,
+            activeCondition: condition,
+            isEligibleForIntroOffer: isEligibleForIntroOffer) {
+            presentedPartial = Self.combine(presentedPartial, with: presentedOverride.properties)
         }
 
-        return conditionPartial
+        return presentedPartial
     }
 
-    /// Builds a partial component based on screen conditions
-    /// - Parameters:
-    ///   - conditionType: Screen size condition
-    ///   - presentedOverrides: Override configurations to apply
-    /// - Returns: Configured partial component for the given condition
-    private static func buildConditionPartial(
-        for conditionType: ScreenCondition,
-        with presentedOverrides: PresentedOverrides<Self>?
-    ) -> Self? {
-        let conditions = presentedOverrides?.conditions
-        let applicableConditions = conditionType.applicableConditions
-            .compactMap { type -> Self? in
-                switch type {
-                case .compact: return conditions?.compact
-                case .medium: return conditions?.medium
-                case .expanded: return conditions?.expanded
+    private static func shouldApply(
+        for conditions: [PaywallComponent.Condition],
+        state: ComponentViewState,
+        activeCondition: ScreenCondition,
+        isEligibleForIntroOffer: Bool
+    ) -> Bool {
+        // Early return when any condition evaluates to false
+        for condition in conditions {
+            switch condition {
+            case .compact, .medium, .expanded:
+                if !activeCondition.applicableConditions.contains(condition) {
+                    return false
                 }
+            case .introOffer:
+                if !isEligibleForIntroOffer {
+                    return false
+                }
+            case .selected:
+                if state != .selected {
+                    return false
+                }
+            case .unsupported:
+                return false
             }
-
-        return applicableConditions.reduce(nil) { partial, next in
-            Self.combine(partial, with: next)
         }
+
+        return true
     }
 
 }
@@ -120,7 +105,7 @@ extension PresentedPartial {
 private extension ScreenCondition {
 
     /// Returns applicable condition types based on current screen condition
-    var applicableConditions: [PaywallComponent.ComponentConditionsType] {
+    var applicableConditions: [PaywallComponent.Condition] {
         switch self {
         case .compact: return [.compact]
         case .medium: return [.compact, .medium]
@@ -130,39 +115,26 @@ private extension ScreenCondition {
 
 }
 
-extension PaywallComponent.ComponentOverrides {
-
-    /// Maps a partial component using a conversion function
-    /// - Parameters:
-    ///   - partial: Source partial component
-    ///   - convert: Conversion function to apply
-    /// - Returns: Converted partial component
-    private func mapPartial<P: PresentedPartial>(
-        _ partial: T?,
-        using convert: (T) throws -> P
-    ) throws -> P? {
-        try partial.flatMap(convert)
-    }
+extension Array {
 
     /// Converts component overrides to presented overrides
     /// - Parameter convert: Conversion function to apply
     /// - Returns: Presented overrides with converted components
-    func toPresentedOverrides<P: PresentedPartial>(convert: (T) throws -> P) throws -> PresentedOverrides<P> {
-        PresentedOverrides(
-            introOffer: try mapPartial(self.introOffer, using: convert),
-            states: try self.states.flatMap { states in
-                PresentedStates(
-                    selected: try mapPartial(states.selected, using: convert)
-                )
-            },
-            conditions: try self.conditions.flatMap { condition in
-                PresentedConditions(
-                    compact: try mapPartial(condition.compact, using: convert),
-                    medium: try mapPartial(condition.medium, using: convert),
-                    expanded: try mapPartial(condition.expanded, using: convert)
-                )
-            }
-        )
+    func toPresentedOverrides<
+        T: PaywallComponent.PartialComponent,
+        P: PresentedPartial
+    >(
+        convert: (T) throws -> P
+    ) throws -> PresentedOverrides<P>
+    where Element == PaywallComponent.ComponentOverride<T> {
+        return try self.compactMap { partial in
+            let presentedPartial = try convert(partial.properties)
+
+            return PresentedOverride(
+                conditions: partial.conditions,
+                properties: presentedPartial
+            )
+        }
     }
 
 }

--- a/Sources/Paywalls/Components/Common/ComponentOverrides.swift
+++ b/Sources/Paywalls/Components/Common/ComponentOverrides.swift
@@ -25,16 +25,21 @@ public extension PaywallComponent {
 
     struct ComponentOverride<T: PartialComponent>: PaywallComponentBase {
 
-        let conditions: [Condition]
-        let properties: T?
+        public let conditions: [Condition]
+        public let properties: T
+
+        public init(conditions: [Condition], properties: T) {
+            self.conditions = conditions
+            self.properties = properties
+        }
 
     }
 
     enum Condition: String, Codable, Sendable, Hashable, Equatable {
 
-        case compact = "compact"
-        case medium = "medium"
-        case expanded = "expanded"
+        case compact
+        case medium
+        case expanded
         case introOffer = "intro_offer"
         case selected
 
@@ -96,7 +101,7 @@ public extension PaywallComponent {
             case compact
             case medium
             case expanded
-            case introOffer
+            case introOffer = "intro_offer"
             case selected
 
         }

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -108,7 +108,7 @@ extension Array where Element == PaywallComponent.ComponentOverride<PaywallCompo
 
     func imageUrls(base: URL) -> [URL] {
         return self.compactMap { iconOverrides in
-            iconOverrides.properties?.formats?.imageUrls(base: base) ?? []
+            iconOverrides.properties.formats?.imageUrls(base: base) ?? []
         }.flatMap { $0 }
     }
 
@@ -118,7 +118,7 @@ extension Array where Element == PaywallComponent.ComponentOverride<PaywallCompo
 
     var imageUrls: [URL] {
         return self.compactMap { iconOverrides in
-            iconOverrides.properties?.source?.imageUrls ?? []
+            iconOverrides.properties.source?.imageUrls ?? []
         }.flatMap { $0 }
     }
 

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -61,19 +61,10 @@ extension PaywallComponentsData.PaywallComponentsConfig {
                 urls += icon.formats.imageUrls(base: baseUrl)
                 urls += icon.overrides?.imageUrls(base: baseUrl) ?? []
             case .image(let image):
-                urls += [
-                    image.source.light.heicLowRes,
-                    image.source.dark?.heicLowRes
-                ].compactMap { $0 }
+                urls += image.source.imageUrls
 
-                if let overides = image.overrides {
-                    urls += [
-                        overides.introOffer?.source?.imageUrls ?? [],
-                        overides.states?.selected?.source?.imageUrls ?? [],
-                        overides.conditions?.compact?.source?.imageUrls ?? [],
-                        overides.conditions?.medium?.source?.imageUrls ?? [],
-                        overides.conditions?.expanded?.source?.imageUrls ?? []
-                    ].flatMap { $0 }
+                if let overrides = image.overrides {
+                    urls += overrides.imageUrls
                 }
             case .stack(let stack):
                 urls += self.collectAllImageURLs(in: stack)
@@ -113,16 +104,22 @@ extension PaywallComponent.IconComponent.Formats {
 
 }
 
-extension PaywallComponent.ComponentOverrides where T == PaywallComponent.PartialIconComponent {
+extension Array where Element == PaywallComponent.ComponentOverride<PaywallComponent.PartialIconComponent> {
 
     func imageUrls(base: URL) -> [URL] {
-        return [
-            self.introOffer?.formats?.imageUrls(base: base) ?? [],
-            self.states?.selected?.formats?.imageUrls(base: base) ?? [],
-            self.conditions?.compact?.formats?.imageUrls(base: base) ?? [],
-            self.conditions?.medium?.formats?.imageUrls(base: base) ?? [],
-            self.conditions?.expanded?.formats?.imageUrls(base: base) ?? []
-        ].flatMap { $0 }
+        return self.compactMap { iconOverrides in
+            iconOverrides.properties?.formats?.imageUrls(base: base) ?? []
+        }.flatMap { $0 }
+    }
+
+}
+
+extension Array where Element == PaywallComponent.ComponentOverride<PaywallComponent.PartialImageComponent> {
+
+    var imageUrls: [URL] {
+        return self.compactMap { iconOverrides in
+            iconOverrides.properties?.source?.imageUrls ?? []
+        }.flatMap { $0 }
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
@@ -1,0 +1,229 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PresentedPartialsTests.swift
+//
+//  Created by Josh Holtz on 1/25/25.
+
+import Nimble
+import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if PAYWALL_COMPONENTS
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+class PresentedPartialsTest: TestCase {
+
+    func testNoPresentedPartials() {
+        let state = ComponentViewState.default
+        let condition = ScreenCondition.compact
+        let isEligibleForIntroOffer = false
+
+        let presentedOverrides: PresentedOverrides<PresentedStackPartial> = []
+
+        let result = PresentedStackPartial.buildPartial(
+            state: state,
+            condition: condition,
+            isEligibleForIntroOffer: isEligibleForIntroOffer,
+            with: presentedOverrides
+        )
+
+        expect(result).to(beNil())
+    }
+
+    func testPresentedPartialsCompactAppliedForCompact() {
+        let state = ComponentViewState.default
+        let condition = ScreenCondition.compact
+        let isEligibleForIntroOffer = false
+
+        let presentedOverrides: PresentedOverrides<PresentedStackPartial> = [
+            .init(conditions: [
+                .compact
+            ], properties: .init(
+                margin: .zero
+            ))
+        ]
+
+        let result = PresentedStackPartial.buildPartial(
+            state: state,
+            condition: condition,
+            isEligibleForIntroOffer: isEligibleForIntroOffer,
+            with: presentedOverrides
+        )
+
+        let expected: PresentedStackPartial = .init(
+            margin: .zero
+        )
+
+        expect(result).to(equal(expected))
+    }
+
+    func testPresentedPartialsMediumNotAppliedForCompact() {
+        let state = ComponentViewState.default
+        let condition = ScreenCondition.compact
+        let isEligibleForIntroOffer = false
+
+        let presentedOverrides: PresentedOverrides<PresentedStackPartial> = [
+            .init(conditions: [
+                .medium
+            ], properties: .init(
+                margin: .zero
+            ))
+        ]
+
+        let result = PresentedStackPartial.buildPartial(
+            state: state,
+            condition: condition,
+            isEligibleForIntroOffer: isEligibleForIntroOffer,
+            with: presentedOverrides
+        )
+
+        expect(result).to(beNil())
+    }
+
+    func testPresentedPartialsCompactAndMediumAppliedForMedium() {
+        let state = ComponentViewState.default
+        let condition = ScreenCondition.medium
+        let isEligibleForIntroOffer = false
+
+        let presentedOverrides: PresentedOverrides<PresentedStackPartial> = [
+            .init(conditions: [
+                .compact
+            ], properties: .init(
+                padding: .zero,
+                margin: .zero
+            )),
+            .init(conditions: [
+                .medium
+            ], properties: .init(
+                spacing: 8,
+                margin: .init(top: 2, bottom: 2, leading: 2, trailing: 2)
+            ))
+        ]
+
+        let result = PresentedStackPartial.buildPartial(
+            state: state,
+            condition: condition,
+            isEligibleForIntroOffer: isEligibleForIntroOffer,
+            with: presentedOverrides
+        )
+
+        let expected: PresentedStackPartial = .init(
+            spacing: 8,
+            padding: .zero,
+            margin: .init(top: 2, bottom: 2, leading: 2, trailing: 2)
+        )
+
+        expect(result).to(equal(expected))
+    }
+
+    func testPresentedPartialsSelectedAppliedWhenSelected() {
+        let state = ComponentViewState.selected
+        let condition = ScreenCondition.medium
+        let isEligibleForIntroOffer = false
+
+        let presentedOverrides: PresentedOverrides<PresentedStackPartial> = [
+            .init(conditions: [
+                .selected
+            ], properties: .init(
+                padding: .zero
+            ))
+        ]
+
+        let result = PresentedStackPartial.buildPartial(
+            state: state,
+            condition: condition,
+            isEligibleForIntroOffer: isEligibleForIntroOffer,
+            with: presentedOverrides
+        )
+
+        let expected: PresentedStackPartial = .init(
+            padding: .zero
+        )
+
+        expect(result).to(equal(expected))
+    }
+
+    func testPresentedPartialsSelectedNotAppliedWhenNotSelected() {
+        let state = ComponentViewState.default
+        let condition = ScreenCondition.medium
+        let isEligibleForIntroOffer = false
+
+        let presentedOverrides: PresentedOverrides<PresentedStackPartial> = [
+            .init(conditions: [
+                .selected
+            ], properties: .init(
+                padding: .zero
+            ))
+        ]
+
+        let result = PresentedStackPartial.buildPartial(
+            state: state,
+            condition: condition,
+            isEligibleForIntroOffer: isEligibleForIntroOffer,
+            with: presentedOverrides
+        )
+
+        expect(result).to(beNil())
+    }
+
+    func testPresentedPartialsIntroOfferAppliedWhenIntroOffer() {
+        let state = ComponentViewState.default
+        let condition = ScreenCondition.medium
+        let isEligibleForIntroOffer = true
+
+        let presentedOverrides: PresentedOverrides<PresentedStackPartial> = [
+            .init(conditions: [
+                .introOffer
+            ], properties: .init(
+                padding: .zero
+            ))
+        ]
+
+        let result = PresentedStackPartial.buildPartial(
+            state: state,
+            condition: condition,
+            isEligibleForIntroOffer: isEligibleForIntroOffer,
+            with: presentedOverrides
+        )
+
+        let expected: PresentedStackPartial = .init(
+            padding: .zero
+        )
+
+        expect(result).to(equal(expected))
+    }
+
+    func testPresentedPartialsIntroOfferNotAppliedWhenNotIntroOffer() {
+        let state = ComponentViewState.default
+        let condition = ScreenCondition.medium
+        let isEligibleForIntroOffer = false
+
+        let presentedOverrides: PresentedOverrides<PresentedStackPartial> = [
+            .init(conditions: [
+                .introOffer
+            ], properties: .init(
+                padding: .zero
+            ))
+        ]
+
+        let result = PresentedStackPartial.buildPartial(
+            state: state,
+            condition: condition,
+            isEligibleForIntroOffer: isEligibleForIntroOffer,
+            with: presentedOverrides
+        )
+
+        expect(result).to(beNil())
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
@@ -17,6 +17,8 @@ import RevenueCat
 @testable import RevenueCatUI
 import XCTest
 
+#if PAYWALL_COMPONENTS
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class VariableHandlerV2Test: TestCase {
 
@@ -515,3 +517,5 @@ class VariableHandlerV2Test: TestCase {
     }
 
 }
+
+#endif

--- a/Tests/UnitTests/Paywalls/Components/PartialComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/PartialComponentTests.swift
@@ -49,6 +49,18 @@ final class PartialComponentTests: TestCase {
                          heicLowRes: sampleURL))
         ), PaywallComponent.PartialImageComponent()),
 
+        // IconComponent
+        (PaywallComponent.IconComponent(
+            baseUrl: "",
+            iconName: "",
+            formats: .init(svg: "", png: "", heic: "", webp: ""),
+            size: .init(width: .fit, height: .fit),
+            padding: .zero,
+            margin: .zero,
+            color: .init(light: .hex("#000000")),
+            iconBackground: nil
+        ), PaywallComponent.PartialIconComponent()),
+
         // StackComponent
         (PaywallComponent.StackComponent(components: []), PaywallComponent.PartialStackComponent())
     ]


### PR DESCRIPTION
## Motivation

Migrating `overrides` from a structured object to an array of override objects

## Description

### Previously

Overrides were a very structure object that had all of the different types of states/conditions that allowed base properties of a component to be overridden. However, this was not flexible when it came to multiple being activated as it was missing for cases when multiples types of conditions were being evaluated.

### Now

Overrides is an array that has an array of `conditions` and `properties`. It will get applied in order from first to last IF all of the `conditions` are true.

This allows the FE/BE to determine the orders of overrides from lowest to higher priority so all of the SDKs/renderers don't need to duplicate that logic.
