### PR TITLE
fix: Use usesNavigationStack instead of usesExistingNavigation

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -62,7 +62,7 @@ struct ManageSubscriptionsView: View {
     var body: some View {
         content.compatibleNavigation(
             item: $viewModel.feedbackSurveyData,
-            usesNavigationStack: navigationOptions.usesExistingNavigation
+            usesNavigationStack: navigationOptions.usesNavigationStack
         ) { feedbackSurveyData in
             FeedbackSurveyView(
                 feedbackSurveyData: feedbackSurveyData,


### PR DESCRIPTION
### Motivation
Use `. usesNavigationStack` instead of `.usesExistingNavigation` for the custom modifier.
 