### PR TITLE
fix: Show expired subscriptions if nonEmpty

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
@@ -46,7 +46,9 @@ struct PurchaseHistoryView: View {
                             .buttonStyle(.plain)
                         }
                     }
+                }
 
+                if !viewModel.inactiveSubscriptions.isEmpty {
                     Section(header: Text(
                         localization[.expiredSubscriptions]
                     )) {


### PR DESCRIPTION
### Motivation
Show expired subscriptions if non-empty in `PurchaseHistory`
