### PR TITLE
fix: Add paywall tester examples for simpler testing

### DIFF
--- a/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
+++ b/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
@@ -106,8 +106,10 @@ private struct PresentingCustomerCenterModifier: ViewModifier {
     }
 
     private func customerCenterView() -> some View {
-        CustomerCenterView(customerCenterActionHandler: self.customerCenterActionHandler)
-            .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
+        CustomerCenterView(
+            customerCenterActionHandler: self.customerCenterActionHandler,
+            navigationOptions: .init(shouldShowCloseButton: presentationMode == .fullScreen))
+        .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -17,7 +17,10 @@ struct SamplePaywallsList: View {
     private var display: Display?
 
     @State
-    private var presentingCustomerCenter: Bool = false
+    private var presentingCustomerCenterSheet: Bool = false
+
+    @State
+    private var presentingCustomerCenterFullScreen: Bool = false
 
     var body: some View {
         NavigationView {
@@ -87,8 +90,10 @@ struct SamplePaywallsList: View {
                     introEligibility: Self.introEligibility
                 )
             )
-        case .customerCenter:
+        case .customerCenterSheet:
             CustomerCenterView(customerCenterActionHandler: self.handleCustomerCenterAction)
+        case .customerCenterFullScreen, .customerCenterNavigaitonView:
+            EmptyView()
         case .uiKitCustomerCenter:
             CustomerCenterUIKitView(
                 customerCenterActionHandler: self.handleCustomerCenterAction
@@ -160,10 +165,16 @@ struct SamplePaywallsList: View {
 
             #if os(iOS)
             Section("Customer Center") {
-                Button {
-                    self.display = .customerCenter
+                NavigationLink {
+                    CustomerCenterView(
+                        customerCenterActionHandler: handleCustomerCenterAction,
+                        navigationOptions: CustomerCenterNavigationOptions(
+                            usesNavigationStack: false,
+                            usesExistingNavigation: true,
+                            shouldShowCloseButton: false
+                        ))
                 } label: {
-                    TemplateLabel(name: "SwiftUI", icon: "person.fill.questionmark")
+                    Text("Inside NavigationView")
                 }
 
                 Button {
@@ -173,7 +184,13 @@ struct SamplePaywallsList: View {
                 }
 
                 Button {
-                    self.presentingCustomerCenter = true
+                    self.presentingCustomerCenterFullScreen = true
+                } label: {
+                    TemplateLabel(name: "Fullscreen", icon: "person.fill")
+                }
+
+                Button {
+                    self.presentingCustomerCenterSheet = true
                 } label: {
                     TemplateLabel(name: "Sheet", icon: "person.fill")
                 }
@@ -191,8 +208,18 @@ struct SamplePaywallsList: View {
         .frame(maxWidth: .infinity)
         .buttonStyle(.plain)
         #if os(iOS)
-        .presentCustomerCenter(isPresented: self.$presentingCustomerCenter, customerCenterActionHandler: self.handleCustomerCenterAction) {
-            self.presentingCustomerCenter = false
+        .presentCustomerCenter(
+            isPresented: self.$presentingCustomerCenterSheet,
+            customerCenterActionHandler: self.handleCustomerCenterAction
+        ) {
+            self.presentingCustomerCenterSheet = false
+        }
+        .presentCustomerCenter(
+            isPresented: self.$presentingCustomerCenterFullScreen,
+            customerCenterActionHandler: self.handleCustomerCenterAction,
+            presentationMode: .fullScreen
+        ) {
+            self.presentingCustomerCenterFullScreen = false
         }
         #endif
     }
@@ -272,7 +299,9 @@ private extension SamplePaywallsList {
         case customPaywall(PaywallViewMode)
         case missingPaywall
         case unrecognizedPaywall
-        case customerCenter
+        case customerCenterSheet
+        case customerCenterFullScreen
+        case customerCenterNavigaitonView
         case uiKitCustomerCenter
         #if PAYWALL_COMPONENTS
         case componentPaywall(PaywallComponentsData)
@@ -301,8 +330,15 @@ extension SamplePaywallsList.Display: Identifiable {
         case .unrecognizedPaywall:
             return "unrecognized"
 
-        case .customerCenter:
-            return "customer-center"
+        case .customerCenterSheet:
+            return "customer-center-sheet"
+
+        case .customerCenterFullScreen:
+            return "customer-center-sheet"
+
+        case .customerCenterNavigaitonView:
+            return "customer-center-sheet"
+
         #if PAYWALL_COMPONENTS
         case .componentPaywall:
             return "component-paywall"


### PR DESCRIPTION
### Motivation
This PR extends the testing cases for CC in the PaywallTester app:
- NavigationView
- Sheet
- Fullscreen
- UIKit
