### PR TITLE
fix: Show close button in ErrorView

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -107,27 +107,30 @@ public struct CustomerCenterView: View {
         }
     }
 
-    // swiftlint:disable:next missing_docs
-    public var body: some View {
-        Group {
-            if navigationOptions.usesExistingNavigation {
+    @ViewBuilder
+    var navigationContent: some View {
+        if navigationOptions.usesExistingNavigation {
+            content
+        } else {
+            CompatibilityNavigationStack {
                 content
-            } else {
-                CompatibilityNavigationStack {
-                    content
-                }
             }
         }
-        .task {
-            await loadInformationIfNeeded()
-        }
-        .task {
+    }
+
+    // swiftlint:disable:next missing_docs
+    public var body: some View {
+        navigationContent
+            .task {
+                await loadInformationIfNeeded()
+            }
+            .task {
 #if DEBUG
-            guard ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else { return }
+                guard ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else { return }
 #endif
-            self.trackImpression()
-        }
-        .environmentObject(self.viewModel)
+                self.trackImpression()
+            }
+            .environmentObject(self.viewModel)
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -85,24 +85,36 @@ public struct CustomerCenterView: View {
         self.navigationOptions = navigationOptions
     }
 
+    @ViewBuilder
+    var content: some View {
+        switch self.viewModel.state {
+        case .error:
+            ErrorView()
+                .dismissCircleButtonToolbar()
+        case .notLoaded:
+            TintedProgressView()
+        case .success:
+            if let configuration = self.viewModel.configuration {
+                destinationView(configuration: configuration)
+                    .environment(\.localization, configuration.localization)
+                    .environment(\.appearance, configuration.appearance)
+                    .environment(\.supportInformation, configuration.support)
+                    .environment(\.customerCenterPresentationMode, self.mode)
+                    .environment(\.navigationOptions, self.navigationOptions)
+            } else {
+                TintedProgressView()
+            }
+        }
+    }
+
     // swiftlint:disable:next missing_docs
     public var body: some View {
         Group {
-            switch self.viewModel.state {
-            case .error:
-                ErrorView()
-            case .notLoaded:
-                TintedProgressView()
-            case .success:
-                if let configuration = self.viewModel.configuration {
-                    destinationView(configuration: configuration)
-                        .environment(\.localization, configuration.localization)
-                        .environment(\.appearance, configuration.appearance)
-                        .environment(\.supportInformation, configuration.support)
-                        .environment(\.customerCenterPresentationMode, self.mode)
-                        .environment(\.navigationOptions, self.navigationOptions)
-                } else {
-                    TintedProgressView()
+            if navigationOptions.usesExistingNavigation {
+                content
+            } else {
+                CompatibilityNavigationStack {
+                    content
                 }
             }
         }
@@ -175,16 +187,8 @@ private extension CustomerCenterView {
         let accentColor = Color.from(colorInformation: configuration.appearance.accentColor,
                                      for: self.colorScheme)
 
-        Group {
-            if navigationOptions.usesExistingNavigation {
-                destinationContent(configuration: configuration)
-            } else {
-                CompatibilityNavigationStack {
-                    destinationContent(configuration: configuration)
-                }
-            }
-        }
-        .applyIf(accentColor != nil, apply: { $0.tint(accentColor) })
+        destinationContent(configuration: configuration)
+            .applyIf(accentColor != nil, apply: { $0.tint(accentColor) })
     }
 
     func trackImpression() {

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -85,6 +85,29 @@ public struct CustomerCenterView: View {
         self.navigationOptions = navigationOptions
     }
 
+    // swiftlint:disable:next missing_docs
+    public var body: some View {
+        navigationContent
+            .task {
+                await loadInformationIfNeeded()
+            }
+            .task {
+#if DEBUG
+                guard ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else { return }
+#endif
+                self.trackImpression()
+            }
+            .environmentObject(self.viewModel)
+    }
+
+}
+
+@available(iOS 15.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private extension CustomerCenterView {
+
     @ViewBuilder
     var content: some View {
         switch self.viewModel.state {
@@ -117,29 +140,6 @@ public struct CustomerCenterView: View {
             }
         }
     }
-
-    // swiftlint:disable:next missing_docs
-    public var body: some View {
-        navigationContent
-            .task {
-                await loadInformationIfNeeded()
-            }
-            .task {
-#if DEBUG
-                guard ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else { return }
-#endif
-                self.trackImpression()
-            }
-            .environmentObject(self.viewModel)
-    }
-
-}
-
-@available(iOS 15.0, *)
-@available(macOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
-private extension CustomerCenterView {
 
     func loadInformationIfNeeded() async {
         if viewModel.state == .notLoaded {


### PR DESCRIPTION
### Motivation
I noticed the error view was not showing the close button. The navigation is not applied to all views, so there's nowhere to place the button.

This wraps all the views to the navigation stack if not provided
