### PR TITLE
Add `uiPreviewMode` to `DangerousSettings`

### DIFF
--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -59,6 +59,12 @@ import Foundation
     @objc public let autoSyncPurchases: Bool
 
     /**
+     * if `true`, the SDK will return a set of mock products instead of the
+     * products obtained from StoreKit. This is useful for testing or preview purposes. 
+     */
+    @_spi(Internal) public let uiPreviewMode: Bool
+
+    /**
      * A property meant for apps that do their own entitlements computation, separated from RevenueCat.
      * It:
      *   - disables automatic CustomerInfo cache updates
@@ -101,13 +107,24 @@ import Foundation
 
     }
 
-    /// Designated initializer
+    /**
+     * Only use a Dangerous Setting if suggested by RevenueCat support team.
+     *
+     * - Parameter uiPreviewMode: if `true`, the SDK will return a set of mock products instead of the
+     * products obtained from StoreKit. This is useful for testing or preview purposes. 
+     */
+    @_spi(Internal) public init(uiPreviewMode: Bool) {
+        self.init(autoSyncPurchases: false, internalSettings: Internal.default, uiPreviewMode: uiPreviewMode)
+    }
+
     internal init(autoSyncPurchases: Bool,
                   customEntitlementComputation: Bool = false,
-                  internalSettings: InternalDangerousSettingsType) {
+                  internalSettings: InternalDangerousSettingsType,
+                  uiPreviewMode: Bool = false) {
         self.autoSyncPurchases = autoSyncPurchases
         self.internalSettings = internalSettings
         self.customEntitlementComputation = customEntitlementComputation
+        self.uiPreviewMode = uiPreviewMode
     }
 
 }

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -108,7 +108,7 @@ import Foundation
     }
 
     /**
-     * Only use a Dangerous Setting if suggested by RevenueCat support team.
+     * Used to initialize the SDK in UI preview mode.
      *
      * - Parameter uiPreviewMode: if `true`, the SDK will return a set of mock products instead of the
      * products obtained from StoreKit. This is useful for testing or preview purposes. 
@@ -117,6 +117,7 @@ import Foundation
         self.init(autoSyncPurchases: false, internalSettings: Internal.default, uiPreviewMode: uiPreviewMode)
     }
 
+    /// Designated initializer
     internal init(autoSyncPurchases: Bool,
                   customEntitlementComputation: Bool = false,
                   internalSettings: InternalDangerousSettingsType,

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -113,7 +113,7 @@ import Foundation
      * - Parameter uiPreviewMode: if `true`, the SDK will return a set of mock products instead of the
      * products obtained from StoreKit. This is useful for testing or preview purposes. 
      */
-    @_spi(Internal) public init(uiPreviewMode: Bool) {
+    @_spi(Internal) public convenience init(uiPreviewMode: Bool) {
         self.init(autoSyncPurchases: false, internalSettings: Internal.default, uiPreviewMode: uiPreviewMode)
     }
 

--- a/Tests/APITesters/AllAPITests/AllAPITests.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/AllAPITests/AllAPITests.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		3502630E2CF61E9F00894270 /* SubscriptionInfoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3502630D2CF61E9A00894270 /* SubscriptionInfoAPI.swift */; };
 		35370AC52CFF8304004F0A64 /* RCSubscriptionInfoAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 35370AC42CFF82F8004F0A64 /* RCSubscriptionInfoAPI.h */; };
 		35370AC82CFF8317004F0A64 /* RCSubscriptionInfoAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 35370AC72CFF8312004F0A64 /* RCSubscriptionInfoAPI.m */; };
+		75C1B6AD2D48D4550011512D /* DangerousSettingsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C1B6AC2D48D4550011512D /* DangerousSettingsAPI.swift */; };
 		FD33CD732D03587E000D13A4 /* CustomerCenterViewControllerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD33CD722D035876000D13A4 /* CustomerCenterViewControllerAPI.swift */; };
 		FDCC983A2D0A0FD500F5854B /* CustomerCenterViewAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCC98392D0A0FD500F5854B /* CustomerCenterViewAPI.swift */; };
 /* End PBXBuildFile section */
@@ -354,6 +355,8 @@
 		3502630D2CF61E9A00894270 /* SubscriptionInfoAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionInfoAPI.swift; sourceTree = "<group>"; };
 		35370AC42CFF82F8004F0A64 /* RCSubscriptionInfoAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCSubscriptionInfoAPI.h; sourceTree = "<group>"; };
 		35370AC72CFF8312004F0A64 /* RCSubscriptionInfoAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCSubscriptionInfoAPI.m; sourceTree = "<group>"; };
+		75C1B6AC2D48D4550011512D /* DangerousSettingsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DangerousSettingsAPI.swift; sourceTree = "<group>"; };
+		75C1B6AE2D48D4DB0011512D /* RevenueCat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RevenueCat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD33CD722D035876000D13A4 /* CustomerCenterViewControllerAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterViewControllerAPI.swift; sourceTree = "<group>"; };
 		FDCC98392D0A0FD500F5854B /* CustomerCenterViewAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterViewAPI.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -533,6 +536,7 @@
 		2D4C61942C5AD34900A29FD2 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				75C1B6AE2D48D4DB0011512D /* RevenueCat.framework */,
 				2D4C62D82C5D41EC00A29FD2 /* RevenueCat.framework */,
 				2D4C62D42C5D41E200A29FD2 /* RevenueCat.framework */,
 				2D4C62D02C5D41D400A29FD2 /* ReceiptParser.framework */,
@@ -551,6 +555,7 @@
 				2D4C61D42C5AD62900A29FD2 /* ConfigurationAPI.swift */,
 				1E37C7812C6518410009D546 /* CustomerCenterConfigDataAPI.swift */,
 				2D4C61C92C5AD62800A29FD2 /* CustomerInfoAPI.swift */,
+				75C1B6AC2D48D4550011512D /* DangerousSettingsAPI.swift */,
 				2D4C61CA2C5AD62900A29FD2 /* EntitlementInfoAPI.swift */,
 				2D4C61C12C5AD62800A29FD2 /* EntitlementInfosAPI.swift */,
 				2D4C61D52C5AD62900A29FD2 /* ErrorCodesAPI.swift */,
@@ -1021,6 +1026,7 @@
 				2D4C61E32C5AD62A00A29FD2 /* PurchasesDiagnosticsAPI.swift in Sources */,
 				2D4C61E22C5AD62A00A29FD2 /* CustomerInfoAPI.swift in Sources */,
 				2D4C61DC2C5AD62A00A29FD2 /* StoreTransactionAPI.swift in Sources */,
+				75C1B6AD2D48D4550011512D /* DangerousSettingsAPI.swift in Sources */,
 				2D4C61EC2C5AD62A00A29FD2 /* AttributionAPI.swift in Sources */,
 				2D4C61EB2C5AD62A00A29FD2 /* AttributionNetworkAPI.swift in Sources */,
 				2D4C61ED2C5AD62A00A29FD2 /* PackageAPI.swift in Sources */,

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DangerousSettingsAPI.swift
+//
+//  Created by Antonio Pallares on 28/1/25.
+
+@_spi(Internal) import RevenueCat
+
+func checkDangerousSettingsAPI() {
+    let _: DangerousSettings = DangerousSettings(uiPreviewMode: true)
+}

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/main.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/main.swift
@@ -70,5 +70,7 @@ func main() -> Int {
 
     checkVerificationResultAPI()
 
+    checkDangerousSettingsAPI()
+
     return 0
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
We need a way to activate the UI Preview mode in the SDK to enable the Paywall Previews functionality in the RC app without actually adding any new public APIs to the SDK

### Description
This PR adds a new property to `DangerousSettings`: `uiPreviewMode`. 
* This new public API is opt-in only, thanks to the [`@_spi` attribute](https://swiftpackageindex.com/swiftlang/swift-syntax/600.0.1/documentation/swiftsyntax/spi).
* The UI Preview Mode of the SDK will limit all the functionality of the SDK to only enable implementing the Paywall Previews functionality (and similar) in the RevenueCat app, so that developers can properly test their paywalls on their own devices.
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
