### PR TITLE
Fix Font.TextStyle.caption3 Availabilities on tvOS

### DIFF
--- a/RevenueCatUI/PaywallFontProvider.swift
+++ b/RevenueCatUI/PaywallFontProvider.swift
@@ -49,7 +49,14 @@ open class DefaultPaywallFontProvider: PaywallFontProvider {
         case .caption: return .caption
         case .caption2: return .caption2
 
-        #if compiler(>=6.0) && os(tvOS)
+        // Font.TextStyle.caption3 was introduced with tvOS 18.0/Xcode 16.0, but
+        // was removed without warning in Xcode 16.1/tvOS 18.1 and hasn't been reintroduced
+        // since.
+        // Xcode 16.0 shipped with Swift compiler 6.0, and Xcode 16.1 shipped with Swift compiler 6.0.2,
+        // this allows us to target builds built only with Xcode 16.0.
+        //
+        // We will need to reevaluate this if and when Font.TextStyle.caption3 is reintroduced.
+        #if compiler(>=6.0) && compiler(<6.0.2) && os(tvOS)
         case .caption3: if #available(tvOS 18.0, *) {
             return .system(.caption3)
         } else {
@@ -117,7 +124,14 @@ private extension Font.TextStyle {
         case .caption: return .caption1
         case .caption2: return .caption2
 
-        #if compiler(>=6.0) && os(tvOS)
+        // Font.TextStyle.caption3 was introduced with tvOS 18.0/Xcode 16.0, but
+        // was removed without warning in Xcode 16.1/tvOS 18.1 and hasn't been reintroduced
+        // since.
+        // Xcode 16.0 shipped with Swift compiler 6.0, and Xcode 16.1 shipped with Swift compiler 6.0.2,
+        // this allows us to target builds built only with Xcode 16.0.
+        //
+        // We will need to reevaluate this if and when Font.TextStyle.caption3 is reintroduced.
+        #if compiler(>=6.0) && compiler(<6.0.2) && os(tvOS)
         case .caption3: return .caption2
         #endif
 


### PR DESCRIPTION
## Motiviation
`Font.TextStyle.caption3` was introduced with Xcode 16.0/tvOS 18.0, but was removed with no warning in Xcode 16.1/tvOS 18.1 and hasn’t been reintroduced since.

Thus, if you try to build RevenueCatUI for tvOS on Xcode 16.1-16.2, you’ll get a build failure. This PR addresses these build failures by only compiling the `.caption3` related code when the SDK is built with Xcode 16.0

## Caveats
If `Font.TextStyle.caption3` is reintroduced in a future tvOS/Xcode release, we'll need to update these compilation checks again to avoid warnings.

## Testing
I tested this by building RevenueCatUI with Xcode 15.4, 16.0, 16.1, and 16.2. All builds passed