### PR TITLE
v4: Fix crash in iOS 11-12 when using MainActor

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -33,10 +33,10 @@ public typealias PurchaseResultData = (transaction: StoreTransaction?,
 /**
  Completion block for ``Purchases/purchase(product:completion:)``
  */
-public typealias PurchaseCompletedBlock =  @MainActor @Sendable (StoreTransaction?,
-                                                      CustomerInfo?,
-                                                      PublicError?,
-                                                      Bool) -> Void
+public typealias PurchaseCompletedBlock = @MainActor @Sendable (StoreTransaction?,
+                                                                CustomerInfo?,
+                                                                PublicError?,
+                                                                Bool) -> Void
 
 /**
  Block for starting purchases in ``PurchasesDelegate/purchases(_:readyForPromotedProduct:purchase:)``

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -33,10 +33,10 @@ public typealias PurchaseResultData = (transaction: StoreTransaction?,
 /**
  Completion block for ``Purchases/purchase(product:completion:)``
  */
-public typealias PurchaseCompletedBlock = @MainActor @Sendable (StoreTransaction?,
-                                                                CustomerInfo?,
-                                                                PublicError?,
-                                                                Bool) -> Void
+public typealias PurchaseCompletedBlock =  @Sendable (StoreTransaction?,
+                                                      CustomerInfo?,
+                                                      PublicError?,
+                                                      Bool) -> Void
 
 /**
  Block for starting purchases in ``PurchasesDelegate/purchases(_:readyForPromotedProduct:purchase:)``

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -33,7 +33,7 @@ public typealias PurchaseResultData = (transaction: StoreTransaction?,
 /**
  Completion block for ``Purchases/purchase(product:completion:)``
  */
-public typealias PurchaseCompletedBlock =  @Sendable (StoreTransaction?,
+public typealias PurchaseCompletedBlock =  @MainActor @Sendable (StoreTransaction?,
                                                       CustomerInfo?,
                                                       PublicError?,
                                                       Bool) -> Void

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -984,14 +984,11 @@ private extension PurchasesOrchestrator {
     func getAndRemovePurchaseCompletedCallback(
         forTransaction transaction: StoreTransaction
     ) -> (@Sendable (StoreTransaction?,
-                    CustomerInfo?,
-                    PublicError?,
-                    Bool) -> Void)? {
+                     CustomerInfo?,
+                     PublicError?,
+                     Bool) -> Void)? {
         return self.purchaseCompleteCallbacksByProductID.modify {
-            let block = $0.removeValue(forKey: transaction.productIdentifier)
-            return { transaction, customerInfo, error, cancelled in
-                block?(transaction, customerInfo, error, cancelled)
-            }
+            return $0.removeValue(forKey: transaction.productIdentifier)
         }
     }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -972,8 +972,8 @@ private extension PurchasesOrchestrator {
                 return false
             }
 
-            callbacks[productIdentifier] = { transaction, customerInfo, error, cancelled in
-                self.operationDispatcher.dispatchOnMainActor {
+            callbacks[productIdentifier] = { [weak self] transaction, customerInfo, error, cancelled in
+                self?.operationDispatcher.dispatchOnMainActor {
                     completion(transaction, customerInfo, error, cancelled)
                 }
             }

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -983,7 +983,10 @@ private extension PurchasesOrchestrator {
 
     func getAndRemovePurchaseCompletedCallback(
         forTransaction transaction: StoreTransaction
-    ) -> PurchaseCompletedBlock? {
+    ) -> (@Sendable (StoreTransaction?,
+                    CustomerInfo?,
+                    PublicError?,
+                    Bool) -> Void)? {
         return self.purchaseCompleteCallbacksByProductID.modify {
             let block = $0.removeValue(forKey: transaction.productIdentifier)
             return { transaction, customerInfo, error, cancelled in

--- a/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
@@ -27,7 +27,7 @@ class StoreKitRequestFetcher: NSObject {
 
     private let requestFactory: ReceiptRefreshRequestFactory
     private var receiptRefreshRequest: SKRequest?
-    private var receiptRefreshCompletionHandlers: [@MainActor @Sendable () -> Void]
+    private var receiptRefreshCompletionHandlers: [@Sendable () -> Void]
     private let operationDispatcher: OperationDispatcher
 
     init(requestFactory: ReceiptRefreshRequestFactory = ReceiptRefreshRequestFactory(),
@@ -38,7 +38,7 @@ class StoreKitRequestFetcher: NSObject {
         self.receiptRefreshCompletionHandlers = []
     }
 
-    func fetchReceiptData(_ completion: @MainActor @Sendable @escaping () -> Void) {
+    func fetchReceiptData(_ completion: @Sendable @escaping () -> Void) {
         self.operationDispatcher.dispatchOnWorkerThread {
             self.receiptRefreshCompletionHandlers.append(completion)
 
@@ -94,7 +94,7 @@ private extension StoreKitRequestFetcher {
             self.receiptRefreshCompletionHandlers = []
 
             for handler in completionHandlers {
-                self.operationDispatcher.dispatchOnMainActor {
+                self.operationDispatcher.dispatchOnMainThread {
                     handler()
                 }
             }

--- a/Tests/UnitTests/Mocks/MockRequestFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockRequestFetcher.swift
@@ -9,7 +9,7 @@ class MockRequestFetcher: StoreKitRequestFetcher {
     var refreshReceiptCalledCount = 0
     var refreshReceiptCalled = false
 
-    override func fetchReceiptData(_ completion: @MainActor @Sendable @escaping () -> Void) {
+    override func fetchReceiptData(_ completion: @Sendable @escaping () -> Void) {
         self.refreshReceiptCalledCount += 1
         self.refreshReceiptCalled = true
 


### PR DESCRIPTION
Fix crash on iOS 11 and 12 when compiling with Xcode 16 and instantiating an array with type @MainActor lambda

`var foo: [@MainActor @Sendable () -> Void] = []`
