### PR TITLE
[Paywalls V2] Fix paywalls badge rendering

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
@@ -26,13 +26,13 @@ struct BadgeModifier: ViewModifier {
     struct BadgeInfo {
         let style: PaywallComponent.BadgeStyle
         let alignment: PaywallComponent.TwoDimensionAlignment
-        let stack: PaywallComponent.CodableBox<PaywallComponent.StackComponent>
+        let stack: PaywallComponent.StackComponent
         let badgeViewModels: [PaywallComponentViewModel]
         let stackShape: ShapeModifier.Shape?
         let uiConfigProvider: UIConfigProvider
 
         var backgroundStyle: BackgroundStyle? {
-            stack.value.backgroundColor?.asDisplayable(uiConfigProvider: uiConfigProvider).backgroundStyle
+            stack.backgroundColor?.asDisplayable(uiConfigProvider: uiConfigProvider).backgroundStyle
         }
     }
 
@@ -77,7 +77,6 @@ fileprivate extension View {
                             .backgroundStyle(badge.backgroundStyle)
                             .shape(border: nil, shape: effectiveShape(badge: badge))
                     }
-
                     .fixedSize()
                     .padding(effectiveMargin(badge: badge).edgeInsets)
                 }
@@ -178,30 +177,30 @@ fileprivate extension View {
             case .top, .bottom, .center:
                 return .zero
             case .leading, .topLeading, .bottomLeading:
-                return .init(top: 0, bottom: 0, leading: badge.stack.value.margin.leading, trailing: 0)
+                return .init(top: 0, bottom: 0, leading: badge.stack.margin.leading, trailing: 0)
             case .trailing, .topTrailing, .bottomTrailing:
-                return .init(top: 0, bottom: 0, leading: 0, trailing: badge.stack.value.margin.trailing)
+                return .init(top: 0, bottom: 0, leading: 0, trailing: badge.stack.margin.trailing)
             }
         case .nested:
             switch badge.alignment {
             case .center, .leading, .trailing:
                 return .zero
             case .top:
-                return .init(top: badge.stack.value.margin.top, bottom: 0, leading: 0, trailing: 0)
+                return .init(top: badge.stack.margin.top, bottom: 0, leading: 0, trailing: 0)
             case .bottom:
-                return .init(top: 0, bottom: badge.stack.value.margin.bottom, leading: 0, trailing: 0)
+                return .init(top: 0, bottom: badge.stack.margin.bottom, leading: 0, trailing: 0)
             case .topLeading:
-                return .init(top: badge.stack.value.margin.top, bottom: 0,
-                             leading: badge.stack.value.margin.leading, trailing: 0)
+                return .init(top: badge.stack.margin.top, bottom: 0,
+                             leading: badge.stack.margin.leading, trailing: 0)
             case .topTrailing:
-                return .init(top: badge.stack.value.margin.top, bottom: 0,
-                             leading: 0, trailing: badge.stack.value.margin.trailing)
+                return .init(top: badge.stack.margin.top, bottom: 0,
+                             leading: 0, trailing: badge.stack.margin.trailing)
             case .bottomLeading:
-                return .init(top: 0, bottom: badge.stack.value.margin.bottom,
-                             leading: badge.stack.value.margin.leading, trailing: 0)
+                return .init(top: 0, bottom: badge.stack.margin.bottom,
+                             leading: badge.stack.margin.leading, trailing: 0)
             case .bottomTrailing:
-                return .init(top: 0, bottom: badge.stack.value.margin.bottom,
-                             leading: 0, trailing: badge.stack.value.margin.trailing)
+                return .init(top: 0, bottom: badge.stack.margin.bottom,
+                             leading: 0, trailing: badge.stack.margin.trailing)
             }
         }
     }
@@ -211,7 +210,7 @@ fileprivate extension View {
     private func effectiveShape(badge: BadgeModifier.BadgeInfo) -> ShapeModifier.Shape? {
         switch badge.style {
         case .edgeToEdge:
-            switch badge.stack.value.shape {
+            switch badge.stack.shape {
             case .pill, .none:
                 // Edge-to-edge badge cannot have pill shape
                 return nil
@@ -258,7 +257,7 @@ fileprivate extension View {
                 }
             }
         case .nested, .overlaid:
-            switch badge.stack.value.shape {
+            switch badge.stack.shape {
             case .rectangle(let radius):
                 return .rectangle(.init(topLeft: radius?.topLeading,
                                         topRight: radius?.topTrailing,
@@ -415,7 +414,7 @@ private func badge(style: PaywallComponent.BadgeStyle, alignment: PaywallCompone
         BadgeModifier.BadgeInfo(
             style: style,
             alignment: alignment,
-            stack: PaywallComponent.CodableBox(PaywallComponent.StackComponent(
+            stack: PaywallComponent.StackComponent(
                 components: [
                     PaywallComponent.text(
                         PaywallComponent.TextComponent(
@@ -434,7 +433,7 @@ private func badge(style: PaywallComponent.BadgeStyle, alignment: PaywallCompone
                 padding: .init(top: 4, bottom: 4, leading: 16, trailing: 16),
                 margin: .init(top: 10, bottom: 10, leading: 10, trailing: 10),
                 shape: .rectangle(.init(topLeading: 8.0, topTrailing: 8, bottomLeading: 8, bottomTrailing: 8))
-            )), badgeViewModels: [
+            ), badgeViewModels: [
                 .text(
                     // swiftlint:disable:next force_try
                     try! TextComponentViewModel(

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
@@ -291,6 +291,68 @@ extension View {
     }
 }
 
+#if DEBUG
+
+// As of Xcode 16, there is a limit of 15 views per PreviewProvider.
+// To work around this, we can create multiple PreviewProviders with different sets of previews.
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct BadgeEdgeToEdge_Previews: PreviewProvider {
+
+    static var previews: some View {
+        let alignments: [PaywallComponent.TwoDimensionAlignment] = [
+            .topLeading, .top, .topTrailing, .bottomLeading, .bottom, .bottomTrailing
+        ]
+        ForEach(alignments, id: \.self) { alignment in
+            badge(style: .edgeToEdge, alignment: alignment)
+                .previewDisplayName("edgeToEdge - \(alignment)")
+        }
+        .previewLayout(.sizeThatFits)
+        .padding(30)
+        .padding(.vertical, 50)
+        .previewRequiredEnvironmentProperties()
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct BadgeOverlaid_Previews: PreviewProvider {
+
+    static var previews: some View {
+        let alignments: [PaywallComponent.TwoDimensionAlignment] = [
+            .topLeading, .top, .topTrailing, .bottomLeading, .bottom, .bottomTrailing
+        ]
+        ForEach(alignments, id: \.self) { alignment in
+            badge(style: .overlaid, alignment: alignment)
+                .previewDisplayName("overlaid - \(alignment)")
+        }
+        .previewLayout(.sizeThatFits)
+        .padding(30)
+        .padding(.vertical, 50)
+        .previewRequiredEnvironmentProperties()
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct BadgeNested_Previews: PreviewProvider {
+
+    static var previews: some View {
+        let alignments: [PaywallComponent.TwoDimensionAlignment] = [
+            .topLeading, .top, .topTrailing, .bottomLeading, .bottom, .bottomTrailing
+        ]
+        ForEach(alignments, id: \.self) { alignment in
+            badge(style: .nested, alignment: alignment)
+                .previewDisplayName("nested - \(alignment)")
+        }
+        .previewLayout(.sizeThatFits)
+        .padding(30)
+        .padding(.vertical, 50)
+        .previewRequiredEnvironmentProperties()
+    }
+
+}
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @ViewBuilder
 // swiftlint:disable:next function_body_length
@@ -402,64 +464,6 @@ private func badge(style: PaywallComponent.BadgeStyle, alignment: PaywallCompone
     )
 }
 
-// As of Xcode 16, there is a limit of 15 views per PreviewProvider.
-// To work around this, we can create multiple PreviewProviders with different sets of previews.
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-struct BadgeEdgeToEdge_Previews: PreviewProvider {
-
-    static var previews: some View {
-        let alignments: [PaywallComponent.TwoDimensionAlignment] = [
-            .topLeading, .top, .topTrailing, .bottomLeading, .bottom, .bottomTrailing
-        ]
-        ForEach(alignments, id: \.self) { alignment in
-            badge(style: .edgeToEdge, alignment: alignment)
-                .previewDisplayName("edgeToEdge - \(alignment)")
-        }
-        .previewLayout(.sizeThatFits)
-        .padding(30)
-        .padding(.vertical, 50)
-        .previewRequiredEnvironmentProperties()
-    }
-
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-struct BadgeOverlaid_Previews: PreviewProvider {
-
-    static var previews: some View {
-        let alignments: [PaywallComponent.TwoDimensionAlignment] = [
-            .topLeading, .top, .topTrailing, .bottomLeading, .bottom, .bottomTrailing
-        ]
-        ForEach(alignments, id: \.self) { alignment in
-            badge(style: .overlaid, alignment: alignment)
-                .previewDisplayName("overlaid - \(alignment)")
-        }
-        .previewLayout(.sizeThatFits)
-        .padding(30)
-        .padding(.vertical, 50)
-        .previewRequiredEnvironmentProperties()
-    }
-
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-struct BadgeNested_Previews: PreviewProvider {
-
-    static var previews: some View {
-        let alignments: [PaywallComponent.TwoDimensionAlignment] = [
-            .topLeading, .top, .topTrailing, .bottomLeading, .bottom, .bottomTrailing
-        ]
-        ForEach(alignments, id: \.self) { alignment in
-            badge(style: .nested, alignment: alignment)
-                .previewDisplayName("nested - \(alignment)")
-        }
-        .previewLayout(.sizeThatFits)
-        .padding(30)
-        .padding(.vertical, 50)
-        .previewRequiredEnvironmentProperties()
-    }
-
-}
+#endif
 
 #endif

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -90,32 +90,14 @@ struct ViewModelFactory {
                 )
             )
         case .stack(let component):
-            let viewModels = try component.components.map { component in
-                try self.toViewModel(
-                    component: component,
-                    packageValidator: packageValidator,
-                    offering: offering,
-                    localizationProvider: localizationProvider,
-                    uiConfigProvider: uiConfigProvider
-                )
-            }
-
-            let badgeViewModels = try component.badge?.stack.value.components.map { component in
-                try self.toViewModel(
-                    component: component,
-                    packageValidator: packageValidator,
-                    offering: offering,
-                    localizationProvider: localizationProvider,
-                    uiConfigProvider: uiConfigProvider
-                )
-            }
-
             return .stack(
-                try StackComponentViewModel(component: component,
-                                            viewModels: viewModels,
-                                            badgeViewModels: badgeViewModels ?? [],
-                                            uiConfigProvider: uiConfigProvider,
-                                            localizationProvider: localizationProvider)
+                try toStackViewModel(
+                    component: component,
+                    packageValidator: packageValidator,
+                    localizationProvider: localizationProvider,
+                    uiConfigProvider: uiConfigProvider,
+                    offering: offering
+                )
             )
         case .button(let component):
             let stackViewModel = try toStackViewModel(
@@ -273,10 +255,24 @@ struct ViewModelFactory {
             )
         }
 
+        let badgeViewModels = try component.badge.flatMap { badge in
+            [
+                PaywallComponentViewModel.stack(
+                    try toStackViewModel(
+                        component: badge.stack,
+                        packageValidator: packageValidator,
+                        localizationProvider: localizationProvider,
+                        uiConfigProvider: uiConfigProvider,
+                        offering: offering
+                    )
+                )
+            ]
+        } ?? []
+
         return try StackComponentViewModel(
             component: component,
             viewModels: viewModels,
-            badgeViewModels: [],
+            badgeViewModels: badgeViewModels,
             uiConfigProvider: uiConfigProvider,
             localizationProvider: localizationProvider
         )

--- a/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
@@ -512,50 +512,31 @@ public extension PaywallComponent {
     enum BadgeStyle: String, Codable, Sendable, Hashable, Equatable {
 
         case edgeToEdge = "edge_to_edge"
-        case overlaid = "overlaid"
+        case overlaid = "overlay"
         case nested = "nested"
 
     }
 
-    struct Badge: Codable, Sendable, Hashable, Equatable {
+    final class Badge: Codable, Sendable, Hashable, Equatable {
 
         public let style: BadgeStyle
         public let alignment: TwoDimensionAlignment
-        public let stack: CodableBox<StackComponent>
+        public let stack: StackComponent
 
-    }
-
-    // Holds a reference to a `Codable` value.
-    final class CodableBox<T: Codable>: Codable {
-
-        public let value: T
-
-        public init(_ value: T) { self.value = value }
-
-        public required init(from decoder: Decoder) throws {
-            value = try T(from: decoder)
+        public static func == (lhs: Badge, rhs: Badge) -> Bool {
+            return lhs.style == rhs.style &&
+                   lhs.alignment == rhs.alignment &&
+                   lhs.stack == rhs.stack
         }
 
-        public func encode(to encoder: Encoder) throws {
-            try value.encode(to: encoder)
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(style)
+            hasher.combine(alignment)
+            hasher.combine(stack)
         }
 
     }
 
-}
-
-extension PaywallComponent.CodableBox: Sendable where T: Sendable {}
-
-extension PaywallComponent.CodableBox: Equatable where T: Equatable {
-    public static func == (lhs: PaywallComponent.CodableBox<T>, rhs: PaywallComponent.CodableBox<T>) -> Bool {
-        return lhs.value == rhs.value
-    }
-}
-
-extension PaywallComponent.CodableBox: Hashable where T: Hashable {
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(value)
-    }
 }
 
 #endif

--- a/Tests/UnitTests/Paywalls/Components/StackComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/StackComponentTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 class StackComponentTests: TestCase {
 
-    func testUnknownTypeWithSuccessfulFallbackDecodingAndEncodesAndRedecodes() throws {
+    func testStack() throws {
         let jsonStack = """
         {
             "type": "stack",
@@ -39,6 +39,141 @@ class StackComponentTests: TestCase {
             PaywallComponent.StackComponent.self,
             from: jsonStack.data(using: .utf8)!
         )
+    }
+
+    func testStackWithBadge() throws {
+        let jsonStack = """
+        {
+            "type": "stack",
+            "dimension": {
+                "type": "vertical",
+                "alignment": "center",
+                "distribution": "start"
+            },
+            "size": {
+                "width": { "type": "fill" },
+                "height": { "type": "fill" }
+            },
+            "padding": {
+                "top": 0,
+                "bottom": 0,
+                "leading": 0,
+                "trailing": 0
+            },
+            "margin": {
+                "top": 0,
+                "bottom": 0,
+                "leading": 0,
+                "trailing": 0
+            },
+            "components": [],
+            "badge": {
+                "alignment": "top",
+                "stack": {
+                    "background_color": {
+                        "light": {
+                            "type": "hex",
+                            "value": "#11D483FF"
+                        }
+                    },
+                    "badge": null,
+                    "border": null,
+                    "components": [
+                        {
+                            "background_color": null,
+                            "color": {
+                                "light": {
+                                    "type": "hex",
+                                    "value": "#000000"
+                                }
+                            },
+                            "font_name": null,
+                            "font_size": 14,
+                            "font_weight": "regular",
+                            "horizontal_alignment": "center",
+                            "id": "7x9oXp0T5U",
+                            "margin": {
+                                "bottom": 0,
+                                "leading": 0,
+                                "top": 0,
+                                "trailing": 0
+                            },
+                            "name": "",
+                            "padding": {
+                                "bottom": 0,
+                                "leading": 0,
+                                "top": 0,
+                                "trailing": 0
+                            },
+                            "size": {
+                                "height": {
+                                    "type": "fit",
+                                    "value": null
+                                },
+                                "width": {
+                                    "type": "fit",
+                                    "value": null
+                                }
+                            },
+                            "text_lid": "tYSI61kmt9",
+                            "type": "text"
+                        }
+                    ],
+                    "dimension": {
+                        "alignment": "center",
+                        "distribution": "center",
+                        "type": "vertical"
+                    },
+                    "id": "WMKBhff2YS",
+                    "margin": {
+                        "bottom": 0,
+                        "leading": 0,
+                        "top": 0,
+                        "trailing": 0
+                    },
+                    "name": "",
+                    "padding": {
+                        "bottom": 4,
+                        "leading": 8,
+                        "top": 4,
+                        "trailing": 8
+                    },
+                    "shadow": null,
+                    "shape": {
+                        "corners": {
+                            "bottom_leading": 0,
+                            "bottom_trailing": 0,
+                            "top_leading": 0,
+                            "top_trailing": 0
+                        },
+                        "type": "pill"
+                    },
+                    "size": {
+                        "height": {
+                            "type": "fit",
+                            "value": null
+                        },
+                        "width": {
+                            "type": "fill",
+                            "value": null
+                        }
+                    },
+                    "spacing": 0,
+                    "type": "stack"
+                },
+                "style": "overlay"
+            }
+        }
+        """
+
+        let stack = try JSONDecoder.default.decode(
+            PaywallComponent.StackComponent.self,
+            from: jsonStack.data(using: .utf8)!
+        )
+
+        expect(stack).notTo(beNil())
+        expect(stack.badge).notTo(beNil())
+        expect(stack.badge?.stack.components.count).to(equal(1))
     }
 
 }


### PR DESCRIPTION
## Motivation

Badge was not rendering on package and had some padding issues

## Description

- Badge is no longer using a box for codables
- Everything in `ViewModelFactory` is `toStackViewModel` for stacks
- `toStackViewModel` is doing badge view modeling
  - Models that whole stack (instead of the stacks components) which then includes the correct padding and margin on the stack

### Example

1) Badge was not showing before this (because badge wasn't being view model-ed on package's stack)
2) Badge didn't have any padding inside it (because view model was happening on its stacks components and needed to include stack)

👇 

![Simulator Screenshot - iPhone 16 - 2025-01-27 at 17 42 58](https://github.com/user-attachments/assets/391f398c-3dd0-4952-9a57-2b153eb90839)
