### PR TITLE
fix: Revisit environment values for CustomerCenter

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseDetailViewModel.swift
@@ -26,17 +26,14 @@ import RevenueCat
 @available(watchOS, unavailable)
 final class PurchaseDetailViewModel: ObservableObject {
 
-    @Environment(\.localization)
-    private var localization: CustomerCenterConfigData.Localization
-
     @Published var items: [PurchaseDetailItem] = []
     var debugItems: [PurchaseDetailItem] = []
 
-    var localizedOwnership: String? {
+    var localizedOwnership: CCLocalizedString? {
         switch purchaseInfo {
         case .subscription(let subscriptionInfo):
             return subscriptionInfo.ownershipType == .familyShared
-                ? localization[.sharedThroughFamilyMember]
+                ? .sharedThroughFamilyMember
                 : nil
         case .nonSubscription:
             return nil

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -113,9 +113,13 @@ private extension CustomerCenterView {
         switch self.viewModel.state {
         case .error:
             ErrorView()
+                .environment(\.customerCenterPresentationMode, self.mode)
+                .environment(\.navigationOptions, self.navigationOptions)
                 .dismissCircleButtonToolbar()
+
         case .notLoaded:
             TintedProgressView()
+
         case .success:
             if let configuration = self.viewModel.configuration {
                 destinationView(configuration: configuration)

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -119,11 +119,11 @@ private extension CustomerCenterView {
         case .success:
             if let configuration = self.viewModel.configuration {
                 destinationView(configuration: configuration)
-                    .environment(\.localization, configuration.localization)
                     .environment(\.appearance, configuration.appearance)
-                    .environment(\.supportInformation, configuration.support)
+                    .environment(\.localization, configuration.localization)
                     .environment(\.customerCenterPresentationMode, self.mode)
                     .environment(\.navigationOptions, self.navigationOptions)
+                    .environment(\.supportInformation, configuration.support)
             } else {
                 TintedProgressView()
             }

--- a/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
@@ -24,20 +24,20 @@ import SwiftUI
 @available(watchOS, unavailable)
 struct FeedbackSurveyView: View {
 
-    @StateObject
-    private var viewModel: FeedbackSurveyViewModel
-
-    @Environment(\.localization)
-    private var localization: CustomerCenterConfigData.Localization
-
     @Environment(\.appearance)
     private var appearance: CustomerCenterConfigData.Appearance
 
     @Environment(\.colorScheme)
     private var colorScheme
 
+    @Environment(\.localization)
+    private var localization: CustomerCenterConfigData.Localization
+
     @Environment(\.customerCenterPresentationMode)
     private var mode: CustomerCenterPresentationMode
+
+    @StateObject
+    private var viewModel: FeedbackSurveyViewModel
 
     @Binding
     private var isPresented: Bool
@@ -87,10 +87,18 @@ struct FeedbackSurveyView: View {
                         }
                     )
                     .interactiveDismissDisabled()
+                    .environment(\.appearance, appearance)
+                    .environment(\.localization, localization)
                 })
         }
         .navigationTitle(self.viewModel.feedbackSurveyData.configuration.title)
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            print("""
+            FeedbackSurveyView
+            \(mode)
+            """)
+        }
     }
 
     private func dismissView() {

--- a/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
@@ -93,12 +93,6 @@ struct FeedbackSurveyView: View {
         }
         .navigationTitle(self.viewModel.feedbackSurveyData.configuration.title)
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear {
-            print("""
-            FeedbackSurveyView
-            \(mode)
-            """)
-        }
     }
 
     private func dismissView() {

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsButtonsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsButtonsView.swift
@@ -50,7 +50,8 @@ struct ManageSubscriptionButton: View {
     let path: CustomerCenterConfigData.HelpPath
     @ObservedObject var viewModel: ManageSubscriptionsViewModel
 
-    @Environment(\.appearance) private var appearance: CustomerCenterConfigData.Appearance
+    @Environment(\.appearance)
+    private var appearance: CustomerCenterConfigData.Appearance
 
     var body: some View {
         AsyncButton(action: {

--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -25,15 +25,19 @@ import SwiftUI
 @available(watchOS, unavailable)
 struct PromotionalOfferView: View {
 
-    @StateObject
-    private var viewModel: PromotionalOfferViewModel
-    @Environment(\.localization)
-    private var localization: CustomerCenterConfigData.Localization
     @Environment(\.appearance)
     private var appearance: CustomerCenterConfigData.Appearance
+
     @Environment(\.colorScheme)
     private var colorScheme
+
+    @Environment(\.localization)
+    private var localization: CustomerCenterConfigData.Localization
+
     @State private var isLoading: Bool = false
+
+    @StateObject
+    private var viewModel: PromotionalOfferViewModel
 
     private let onDismissPromotionalOfferView: (PromotionalOfferViewAction) -> Void
 
@@ -90,6 +94,10 @@ struct PromotionalOfferView: View {
             }
         }
         .onAppear {
+            print("""
+            PromotionalOfferView
+            \(appearance)
+            """)
             self.viewModel.onPromotionalOfferPurchaseFlowComplete = self.dismissPromotionalOfferView
         }
     }
@@ -143,8 +151,10 @@ struct PromotionalOfferHeaderView: View {
 
     @Environment(\.appearance)
     private var appearance: CustomerCenterConfigData.Appearance
+
     @Environment(\.colorScheme)
     private var colorScheme
+
     @ObservedObject
     private(set) var viewModel: PromotionalOfferViewModel
 

--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -94,10 +94,6 @@ struct PromotionalOfferView: View {
             }
         }
         .onAppear {
-            print("""
-            PromotionalOfferView
-            \(appearance)
-            """)
             self.viewModel.onPromotionalOfferPurchaseFlowComplete = self.dismissPromotionalOfferView
         }
     }

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseDetailView.swift
@@ -34,8 +34,8 @@ struct PurchaseDetailView: View {
                     )
                 }
             } footer: {
-                if let ownership = viewModel.localizedOwnership {
-                    Text(ownership)
+                if let ownershipKey = viewModel.localizedOwnership {
+                    Text(localization[ownershipKey])
                 }
             }
 

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
@@ -18,6 +18,7 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 struct PurchaseHistoryView: View {
+
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
 
@@ -110,7 +111,6 @@ struct PurchaseHistoryView: View {
             PurchaseDetailView(
                 viewModel: PurchaseDetailViewModel(purchaseInfo: $0))
             .environment(\.localization, localization)
-            .environment(\.navigationOptions, navigationOptions)
         }
         .navigationTitle(localization[.purchaseHistory])
         .listStyle(.insetGrouped)

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseLinkView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseLinkView.swift
@@ -18,6 +18,7 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 struct PurchaseLinkView: View {
+
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
 

--- a/RevenueCatUI/CustomerCenter/Views/TintedProgressView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/TintedProgressView.swift
@@ -23,8 +23,8 @@ import SwiftUI
 @available(watchOS, unavailable)
 struct TintedProgressView: View {
 
-    @Environment(\.appearance) private var appearance: CustomerCenterConfigData.Appearance
-    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorScheme)
+    private var colorScheme
 
     var body: some View {
         ProgressView()
@@ -42,13 +42,6 @@ struct TintedProgressView_Previews: PreviewProvider {
 
     static var previews: some View {
         TintedProgressView()
-            .environment(\.appearance, CustomerCenterConfigData.Appearance(
-                accentColor: .init(light: "#ffffff", dark: "#000000"),
-                textColor: .init(light: "#000000", dark: "#ffffff"),
-                backgroundColor: .init(light: "#000000", dark: "#ffffff"),
-                buttonTextColor: .init(light: "#000000", dark: "#ffffff"),
-                buttonBackgroundColor: .init(light: "#000000", dark: "#ffffff")
-            ))
     }
 
 }


### PR DESCRIPTION
### Motivation
This PR revisits every `.environment` use inside CustomerCenter. The root cause is related to https://github.com/RevenueCat/purchases-ios/pull/4704

### Description
1. Order alphabetically environment declarations in each view
2. Set explicit environment values for each view
3. Reordered `ManageSubscriptionsView` moving all navigation modifiers to the same place

> I am still thinking what's the best way to test this, or write type-safe code.