### PR TITLE
fix: Remove  buttonStyle for PurchaseHistory

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -91,7 +91,6 @@ struct ManageSubscriptionsView: View {
                             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
                 }
 
                 Section {

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
@@ -43,7 +43,6 @@ struct PurchaseHistoryView: View {
                             } label: {
                                 PurchaseLinkView(purchaseInfo: activeSubscription)
                             }
-                            .buttonStyle(.plain)
                         }
                     }
                 }
@@ -58,7 +57,6 @@ struct PurchaseHistoryView: View {
                             } label: {
                                 PurchaseLinkView(purchaseInfo: inactiveSubscription)
                             }
-                            .buttonStyle(.plain)
                         }
                     }
                 }
@@ -74,7 +72,6 @@ struct PurchaseHistoryView: View {
                             } label: {
                                 PurchaseLinkView(purchaseInfo: inactiveSubscription)
                             }
-                            .buttonStyle(.plain)
                         }
                     }
                 }

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseLinkView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseLinkView.swift
@@ -18,6 +18,10 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 struct PurchaseLinkView: View {
+
+    @Environment(\.colorScheme)
+    private var colorScheme
+
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
 
@@ -41,14 +45,14 @@ struct PurchaseLinkView: View {
             if let price = purchaseInfo.paidPrice {
                 Text(price)
                     .font(.subheadline)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.secondary)
             }
 
             Image(systemName: "chevron.forward")
                 .foregroundStyle(.secondary)
         }
         .contentShape(Rectangle())
-        .tint(.black)
+        .tint(colorScheme == .dark ? .white : .black)
         .onAppear {
             Task {
                 guard

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseLinkView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseLinkView.swift
@@ -29,6 +29,7 @@ struct PurchaseLinkView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(productName ?? purchaseInfo.productIdentifier)
                     .font(.headline)
+                    .foregroundStyle(.primary)
 
                 Text(dateString)
                     .font(.subheadline)
@@ -47,6 +48,7 @@ struct PurchaseLinkView: View {
                 .foregroundStyle(.secondary)
         }
         .contentShape(Rectangle())
+        .tint(.black)
         .onAppear {
             Task {
                 guard


### PR DESCRIPTION
### Motivation
After some feedback, this removes the `.buttonStyle(.plain)` modifier from buttons to get some tap feedback.

https://github.com/user-attachments/assets/760f4d69-4e6e-4b90-ab57-cbba241cf8c7

