### PR TITLE
UI Preview Mode: app user ID

### DIFF
--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -36,6 +36,7 @@ class IdentityManager: CurrentUserProvider {
 
     init(
         deviceCache: DeviceCache,
+        systemInfo: SystemInfo,
         backend: Backend,
         customerInfoManager: CustomerInfoManager,
         attributeSyncing: AttributeSyncing,
@@ -50,10 +51,14 @@ class IdentityManager: CurrentUserProvider {
             Logger.warn(Strings.identity.logging_in_with_empty_appuserid)
         }
 
-        let appUserID = appUserID?.notEmptyOrWhitespaces
+        let appUserID = if systemInfo.dangerousSettings.uiPreviewMode {
+            Self.uiPreviewModeAppUserID
+        } else {
+            appUserID?.notEmptyOrWhitespaces
             ?? deviceCache.cachedAppUserID
             ?? deviceCache.cachedLegacyAppUserID
             ?? Self.generateRandomID()
+        }
 
         Logger.user(Strings.identity.identifying_app_user_id)
 
@@ -100,6 +105,7 @@ class IdentityManager: CurrentUserProvider {
         "$RCAnonymousID:\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())"
     }
 
+    private static let uiPreviewModeAppUserID: String = "$RCPREVIEWMODE"
 }
 
 extension IdentityManager {

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -105,7 +105,7 @@ class IdentityManager: CurrentUserProvider {
         "$RCAnonymousID:\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())"
     }
 
-    private static let uiPreviewModeAppUserID: String = "$RCPREVIEWMODE"
+    static let uiPreviewModeAppUserID: String = "$RCPREVIEWMODE"
 }
 
 extension IdentityManager {

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -47,14 +47,15 @@ class IdentityManager: CurrentUserProvider {
         self.customerInfoManager = customerInfoManager
         self.attributeSyncing = attributeSyncing
 
-        if appUserID?.isEmpty == true {
-            Logger.warn(Strings.identity.logging_in_with_empty_appuserid)
-        }
-
-        let appUserID = if systemInfo.dangerousSettings.uiPreviewMode {
-            Self.uiPreviewModeAppUserID
+        let finalAppUserID: String
+        if systemInfo.dangerousSettings.uiPreviewMode {
+            Logger.debug(Strings.identity.logging_in_with_preview_mode_appuserid)
+            finalAppUserID = Self.uiPreviewModeAppUserID
         } else {
-            appUserID?.notEmptyOrWhitespaces
+            if appUserID?.isEmpty == true {
+                Logger.warn(Strings.identity.logging_in_with_empty_appuserid)
+            }
+            finalAppUserID = appUserID?.notEmptyOrWhitespaces
             ?? deviceCache.cachedAppUserID
             ?? deviceCache.cachedLegacyAppUserID
             ?? Self.generateRandomID()
@@ -62,9 +63,9 @@ class IdentityManager: CurrentUserProvider {
 
         Logger.user(Strings.identity.identifying_app_user_id)
 
-        deviceCache.cache(appUserID: appUserID)
+        deviceCache.cache(appUserID: finalAppUserID)
         deviceCache.cleanupSubscriberAttributes()
-        self.invalidateCachesIfNeeded(appUserID: appUserID)
+        self.invalidateCachesIfNeeded(appUserID: finalAppUserID)
     }
 
     var currentAppUserID: String {
@@ -105,7 +106,7 @@ class IdentityManager: CurrentUserProvider {
         "$RCAnonymousID:\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())"
     }
 
-    static let uiPreviewModeAppUserID: String = "$RCPREVIEWMODE"
+    static let uiPreviewModeAppUserID: String = "$RC_PREVIEW_MODE_USER"
 }
 
 extension IdentityManager {

--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -22,6 +22,8 @@ enum IdentityStrings {
 
     case logging_in_with_static_string
 
+    case logging_in_with_preview_mode_appuserid
+
     case login_success
 
     case log_out_called_for_user
@@ -58,6 +60,8 @@ extension IdentityStrings: LogMessage {
             return "The appUserID passed to logIn is a constant string known at compile time. " +
             "This is likely a programmer error. This ID is used to identify the current user. " +
             "See https://docs.revenuecat.com/docs/user-ids for more information."
+        case .logging_in_with_preview_mode_appuserid:
+            return "Using the default preview mode appUserID. The passed appUserID was ignored."
         case .login_success:
             return "Log in successful"
         case .log_out_called_for_user:

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -401,6 +401,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                                                       attributionFetcher: attributionFetcher,
                                                                       attributionDataMigrator: attributionDataMigrator)
         let identityManager = IdentityManager(deviceCache: deviceCache,
+                                              systemInfo: systemInfo,
                                               backend: backend,
                                               customerInfoManager: customerInfoManager,
                                               attributeSyncing: subscriberAttributesManager,

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -402,9 +402,9 @@ class IdentityManagerTests: TestCase {
             finishTransactions: false,
             dangerousSettings: dangerousSettings
         )
-        
+
         let manager = create(appUserID: nil)
-        
+
         expect(manager.currentAppUserID) == IdentityManager.uiPreviewModeAppUserID
         expect(manager.currentUserIsAnonymous) == false
     }
@@ -416,9 +416,9 @@ class IdentityManagerTests: TestCase {
             finishTransactions: false,
             dangerousSettings: dangerousSettings
         )
-        
+
         let manager = create(appUserID: "test_user")
-        
+
         expect(manager.currentAppUserID) == IdentityManager.uiPreviewModeAppUserID
         expect(manager.currentUserIsAnonymous) == false
     }
@@ -430,9 +430,9 @@ class IdentityManagerTests: TestCase {
             finishTransactions: false,
             dangerousSettings: dangerousSettings
         )
-        
+
         let manager = create(appUserID: "test_user")
-        
+
         expect(manager.currentAppUserID) == "test_user"
         expect(manager.currentUserIsAnonymous) == false
     }
@@ -444,7 +444,7 @@ class IdentityManagerTests: TestCase {
             finishTransactions: false,
             dangerousSettings: dangerousSettings
         )
-        
+
         let manager = create(appUserID: nil)
 
         expect(manager.currentAppUserID) != IdentityManager.uiPreviewModeAppUserID

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -6,7 +6,7 @@
 import Nimble
 import XCTest
 
-@testable import RevenueCat
+@testable @_spi(Internal) import RevenueCat
 
 class IdentityManagerTests: TestCase {
 
@@ -17,10 +17,12 @@ class IdentityManagerTests: TestCase {
 
     private var mockIdentityAPI: MockIdentityAPI!
     private var mockCustomerInfo: CustomerInfo!
+    private var mockSystemInfo: MockSystemInfo!
 
     @discardableResult
     private func create(appUserID: String?) -> IdentityManager {
         return IdentityManager(deviceCache: self.mockDeviceCache,
+                               systemInfo: self.mockSystemInfo,
                                backend: self.mockBackend,
                                customerInfoManager: self.mockCustomerInfoManager,
                                attributeSyncing: self.mockAttributeSyncing,
@@ -33,9 +35,9 @@ class IdentityManagerTests: TestCase {
         self.mockIdentityAPI = try XCTUnwrap(mockBackend.identity as? MockIdentityAPI)
         self.mockCustomerInfo = .emptyInfo
 
-        let systemInfo = MockSystemInfo(finishTransactions: false)
+        self.mockSystemInfo = MockSystemInfo(finishTransactions: false)
 
-        self.mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: systemInfo)
+        self.mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.mockSystemInfo)
         self.mockCustomerInfoManager = MockCustomerInfoManager(
             offlineEntitlementsManager: MockOfflineEntitlementsManager(),
             operationDispatcher: MockOperationDispatcher(),
@@ -43,7 +45,7 @@ class IdentityManagerTests: TestCase {
             backend: MockBackend(),
             transactionFetcher: MockStoreKit2TransactionFetcher(),
             transactionPoster: MockTransactionPoster(),
-            systemInfo: systemInfo
+            systemInfo: self.mockSystemInfo
         )
         self.mockAttributeSyncing = MockAttributeSyncing()
     }
@@ -389,6 +391,64 @@ class IdentityManagerTests: TestCase {
         expect(self.mockDeviceCache
             .invokedClearLatestNetworkAndAdvertisingIdsSentParameters?.appUserID) == "test-user-id"
         expect(self.mockBackend.invokedClearHTTPClientCachesCount) == 1
+    }
+
+    // MARK: - UI Preview mode user
+
+    func testConfigureWithUIPreviewModeUsesPreviewModeUserID() {
+        let dangerousSettings = DangerousSettings(uiPreviewMode: true)
+        self.mockSystemInfo = MockSystemInfo(
+            platformInfo: nil,
+            finishTransactions: false,
+            dangerousSettings: dangerousSettings
+        )
+        
+        let manager = create(appUserID: nil)
+        
+        expect(manager.currentAppUserID) == IdentityManager.uiPreviewModeAppUserID
+        expect(manager.currentUserIsAnonymous) == false
+    }
+
+    func testConfigureWithUIPreviewModeIgnoresProvidedAppUserID() {
+        let dangerousSettings = DangerousSettings(uiPreviewMode: true)
+        self.mockSystemInfo = MockSystemInfo(
+            platformInfo: nil,
+            finishTransactions: false,
+            dangerousSettings: dangerousSettings
+        )
+        
+        let manager = create(appUserID: "test_user")
+        
+        expect(manager.currentAppUserID) == IdentityManager.uiPreviewModeAppUserID
+        expect(manager.currentUserIsAnonymous) == false
+    }
+
+    func testConfigureWithoutUIPreviewModeUsesNormalAppUserID() {
+        let dangerousSettings = DangerousSettings(uiPreviewMode: false)
+        self.mockSystemInfo = MockSystemInfo(
+            platformInfo: nil,
+            finishTransactions: false,
+            dangerousSettings: dangerousSettings
+        )
+        
+        let manager = create(appUserID: "test_user")
+        
+        expect(manager.currentAppUserID) == "test_user"
+        expect(manager.currentUserIsAnonymous) == false
+    }
+
+    func testConfigureWithoutUIPreviewModeUsesAnonymousIDWhenNoUserProvided() {
+        let dangerousSettings = DangerousSettings(uiPreviewMode: false)
+        self.mockSystemInfo = MockSystemInfo(
+            platformInfo: nil,
+            finishTransactions: false,
+            dangerousSettings: dangerousSettings
+        )
+        
+        let manager = create(appUserID: nil)
+
+        expect(manager.currentAppUserID) != IdentityManager.uiPreviewModeAppUserID
+        assertCorrectlyIdentifiedWithAnonymous(manager)
     }
 }
 

--- a/Tests/UnitTests/Mocks/MockIdentityManager.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityManager.swift
@@ -24,6 +24,7 @@ class MockIdentityManager: IdentityManager {
         self.mockAppUserID = mockAppUserID
 
         super.init(deviceCache: mockDeviceCache,
+                   systemInfo: mockSystemInfo,
                    backend: mockBackend,
                    customerInfoManager: MockCustomerInfoManager(
                     offlineEntitlementsManager: MockOfflineEntitlementsManager(),


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation
The SDK uses a fixed, specific user ID when initialized in UI preview mode in order to prevent cluttering usage statistics for the developer

### Description
When using the UI preview mode introduced in #4714, the SDK will force the `appUserID` to be `"$RCPREVIEWMODE"`.
