### PR TITLE
[Paywalls V2] Fix footer spacing issues

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
@@ -47,6 +47,11 @@ struct RootView: View {
                     )
                 )
                 .fixedSize(horizontal: false, vertical: true)
+
+                // This spacer is to prevent the bottom most view from expanding into the
+                // safe space. iOS will take the bottom view and expand it to fill the
+                // the safe space and we don't want anything there.
+                Spacer()
             }
         }
     }

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -241,7 +241,7 @@ private struct LoadedPaywallsV2View: View {
             ComponentsView(
                 componentViewModels: [paywallState.componentViewModel],
                 onDismiss: self.onDismiss
-            )
+            )            
         }
         .environmentObject(self.selectedPackageContext)
         .frame(maxHeight: .infinity, alignment: .topLeading)
@@ -249,7 +249,7 @@ private struct LoadedPaywallsV2View: View {
             self.paywallState.componentsConfig.background
                 .asDisplayable(uiConfigProvider: uiConfigProvider).backgroundStyle
         )
-        .edgesIgnoringSafeArea(.top)
+        .edgesIgnoringSafeArea(.bottom)
     }
 
 }

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -241,7 +241,7 @@ private struct LoadedPaywallsV2View: View {
             ComponentsView(
                 componentViewModels: [paywallState.componentViewModel],
                 onDismiss: self.onDismiss
-            )            
+            )
         }
         .environmentObject(self.selectedPackageContext)
         .frame(maxHeight: .infinity, alignment: .topLeading)


### PR DESCRIPTION
### Motivation

Footer was showing empty space between footer and safe space on the bottom

### Description

- Ignoring edges on bottom instead of top (which I think was a typo)
- Added a spacer to the bottom of the footer to expand space to fill out the safe space

👇 This is what the `Spacer()` fixes

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 - 2025-01-28 at 23 13 08](https://github.com/user-attachments/assets/aefc197f-d14c-49da-b577-95a1521e4800) | <img width="614" alt="Screenshot 2025-01-28 at 11 12 54 PM" src="https://github.com/user-attachments/assets/0561f843-efdd-4e9f-95ed-05d98fcc7034" /> | 
