### PR TITLE
fix: Avoid the use of return switch

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -35,6 +35,12 @@ custom_rules:
     regex: "\\: XCTestCase \\{"
     name: "XCTestCase Superclass"
     message: "Test classes must inherit `TestCase` instead."
+  return_switch_forbidden:
+      included: ["*.swift"]
+      name: "Forbidden 'return swift' usage"
+      regex: '\breturn\s+swift\b'
+      message: "'return switch' is not allowed in iOS 15."
+      severity: error
 
 identifier_name:
   max_length: 


### PR DESCRIPTION
### Motivation
This PR tries to avoid using `return switch` because it breaks the CI
