### PR TITLE
Rename RC Billing to Web Billing

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -140,7 +140,7 @@ struct WrongPlatformView_Previews: PreviewProvider {
         .init(store: .rcBilling,
               managementURL: URL(string: "https://api.revenuecat.com/rcbilling/v1/customerportal/1234/portal"),
               customerInfo: CustomerInfoFixtures.customerInfoWithRCBillingSubscriptions,
-              displayName: "RCBilling"),
+              displayName: "Web Billing"),
         .init(store: .stripe,
               managementURL: nil,
               customerInfo: CustomerInfoFixtures.customerInfoWithStripeSubscriptions,

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -40,7 +40,7 @@ import Foundation
     /// For entitlements granted via the Amazon Store.
     @objc(RCAmazon) case amazon = 6
 
-    /// For entitlements granted via RC Billing
+    /// For entitlements granted via RevenueCat's Web Billing
     @objc(RCBilling) case rcBilling = 7
 
     /// For entitlements granted via RevenueCat's External Purchases API.


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
RevenueCat Billing product is being renamed to Web Billing
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
- Rename "RevenueCat Billing"/"RC Billing" to "Web Billing" in a couple of places. 
- Store enum remains unchanged
