### PR TITLE
UI Preview Mode: mock products

### DIFF
--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -66,6 +66,9 @@ extension OfferingsResponse {
         )
     }
 
+    var packages: [Offering.Package] {
+        return self.offerings.flatMap { $0.packages }
+    }
 }
 
 extension OfferingsResponse.Offering.Package: Codable, Equatable {}

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -192,7 +192,7 @@ private extension OfferingsManager {
             return
         }
 
-        self.productsManager.products(withIdentifiers: productIdentifiers) { result in
+        self.fetchProducts(withIdentifiers: productIdentifiers) { result in
             let products = result.value ?? []
 
             guard products.isEmpty == false else {
@@ -273,6 +273,58 @@ private extension OfferingsManager {
                 completion(value)
             }
         }
+    }
+
+    private func fetchProducts(withIdentifiers identifiers: Set<String>, completion: @escaping ProductsManagerType.Completion) {
+        if self.systemInfo.dangerousSettings.uiPreviewMode {
+            let mockProducts = self.createMockProducts(productIdentifiers: identifiers)
+            completion(.success(mockProducts))
+        } else {
+            self.productsManager.products(withIdentifiers: identifiers, completion: completion)
+        }
+    }
+
+    private func createMockProducts(productIdentifiers: Set<String>) -> Set<StoreProduct> {
+        let productTypes = [
+            (type: "weekly", price: 1.99, period: SubscriptionPeriod(value: 1, unit: .week)),
+            (type: "monthly", price: 5.99, period: SubscriptionPeriod(value: 1, unit: .month)),
+            (type: "yearly", price: 59.99, period: SubscriptionPeriod(value: 1, unit: .year)),
+            (type: "lifetime", price: 199.99, period: nil)
+        ]
+
+        let products = productIdentifiers.enumerated().map { index, identifier -> StoreProduct in
+            let productType = productTypes[index % productTypes.count]
+
+            let introductoryDiscount: TestStoreProductDiscount? = {
+                guard productType.period != nil && Bool.random() else { return nil }
+                return TestStoreProductDiscount(
+                    identifier: "intro",
+                    price: 0,
+                    localizedPriceString: "$0.00",
+                    paymentMode: .freeTrial,
+                    subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .week),
+                    numberOfPeriods: 1,
+                    type: .introductory
+                )
+            }()
+
+            let testProduct = TestStoreProduct(
+                localizedTitle: "PRO \(productType.type)",
+                price: Decimal(productType.price),
+                localizedPriceString: String(format: "$%.2f", productType.price),
+                productIdentifier: identifier,
+                productType: productType.period == nil ? .nonConsumable : .autoRenewableSubscription,
+                localizedDescription: "\(productType.type) subscription",
+                subscriptionGroupIdentifier: productType.period == nil ? nil : "group",
+                subscriptionPeriod: productType.period,
+                introductoryDiscount: introductoryDiscount,
+                discounts: []
+            )
+
+            return testProduct.toStoreProduct()
+        }
+
+        return Set(products)
     }
 
 }

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -294,7 +294,7 @@ private extension OfferingsManager {
         productIdentifiers: Set<String>,
         fromResponse response: OfferingsResponse
     ) -> Set<StoreProduct> {
-        let packagesByProductID = response.packages.dictionaryWithKeys { $0.platformProductIdentifier }
+        let packagesByProductID = response.packages.dictionaryAllowingDuplicateKeys { $0.platformProductIdentifier }
         let products = productIdentifiers.map { identifier -> StoreProduct in
             let productType = self.mockProductType(from: packagesByProductID[identifier],
                                                    productIdentifier: identifier)

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -12,7 +12,7 @@
 //  Created by Juanpe Catalán on 9/8/21.
 
 import Nimble
-@testable import RevenueCat
+@testable @_spi(Internal) import RevenueCat
 import StoreKit
 import XCTest
 
@@ -476,6 +476,69 @@ extension OfferingsManagerTests {
 
         self.logger.verifyMessageWasLogged("NSURLErrorDomain error \(underlyingError.code)",
                                            level: .error)
+    }
+
+    func testProductsManagerIsNotUsedInUIPreviewModeWhenGetOfferingsSuccess() throws {
+        // given
+        let mockSystemInfoWithPreviewMode = MockSystemInfo(
+            platformInfo: .init(flavor: "iOS", version: "3.2.1"),
+            finishTransactions: true,
+            dangerousSettings: DangerousSettings(uiPreviewMode: true)
+        )
+
+        self.offeringsManager = OfferingsManager(
+            deviceCache: self.mockDeviceCache,
+            operationDispatcher: self.mockOperationDispatcher,
+            systemInfo: mockSystemInfoWithPreviewMode,
+            backend: self.mockBackend,
+            offeringsFactory: self.mockOfferingsFactory,
+            productsManager: self.mockProductsManager
+        )
+
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
+
+        // when
+        let result: Result<Offerings, OfferingsManager.Error>? = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) { result in
+                completed(result)
+            }
+        }
+
+        // then
+        expect(result).to(beSuccess())
+        expect(self.mockProductsManager.invokedProducts) == false
+        expect(result?.value?.current?.availablePackages).toNot(beEmpty())
+    }
+
+    func testProductsManagerIsNotUsedInUIPreviewModeWhenGetOfferingsFailure() throws {
+        // given
+        let mockSystemInfoWithPreviewMode = MockSystemInfo(
+            platformInfo: .init(flavor: "iOS", version: "3.2.1"),
+            finishTransactions: true,
+            dangerousSettings: DangerousSettings(uiPreviewMode: true)
+        )
+
+        self.offeringsManager = OfferingsManager(
+            deviceCache: self.mockDeviceCache,
+            operationDispatcher: self.mockOperationDispatcher,
+            systemInfo: mockSystemInfoWithPreviewMode,
+            backend: self.mockBackend,
+            offeringsFactory: self.mockOfferingsFactory,
+            productsManager: self.mockProductsManager
+        )
+
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .failure(MockData.unexpectedBackendResponseError)
+
+        // when
+        let result: Result<Offerings, OfferingsManager.Error>? = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) { result in
+                completed(result)
+            }
+        }
+
+        // then
+        expect(result).to(beFailure())
+        expect(self.mockProductsManager.invokedProducts) == false
     }
 
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation
The UI Preview Mode of the SDK should limit all the functionality of the SDK to only enable implementing the Paywall Previews functionality in the RevenueCat app.

### Description
Mock the `StoreProducts`, as we cannot fetch them from StoreKit