### PR TITLE
[Paywalls V2] Ignore top safe area edges for image

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -158,6 +158,7 @@ fileprivate extension ButtonComponentViewModel {
         let stackViewModel = try factory.toStackViewModel(
             component: component.stack,
             packageValidator: factory.packageValidator,
+            firstImageInfo: nil,
             localizationProvider: localizationProvider,
             uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
             offering: offering

--- a/RevenueCatUI/Templates/V2/Components/ComponentsView.swift
+++ b/RevenueCatUI/Templates/V2/Components/ComponentsView.swift
@@ -75,9 +75,11 @@ struct ComponentsView: View {
                 case .tabControlToggle(let viewModel):
                     TabControlToggleComponentView(viewModel: viewModel, onDismiss: onDismiss)
                 }
-            }.applyIf(index > 0 && self.ignoreSafeArea) { view in
-                view
-                    .padding(.top, self.safeAreaInsets.top)
+            }
+            // Applies a top padding to mimmic safe area insets
+            // This was designed to be applied to the 
+            .applyIf(index > 0 && self.ignoreSafeArea) { view in
+                view.padding(.top, self.safeAreaInsets.top)
             }
         }
     }

--- a/RevenueCatUI/Templates/V2/Components/ComponentsView.swift
+++ b/RevenueCatUI/Templates/V2/Components/ComponentsView.swift
@@ -23,7 +23,7 @@ struct ComponentsView: View {
     private var safeAreaInsets
 
     let componentViewModels: [PaywallComponentViewModel]
-    let ignoreSafeArea: Bool
+    let applySafeAreaInsetForZStackChildren: Bool
     private let onDismiss: () -> Void
 
     init(
@@ -32,7 +32,7 @@ struct ComponentsView: View {
         onDismiss: @escaping () -> Void
     ) {
         self.componentViewModels = componentViewModels
-        self.ignoreSafeArea = ignoreSafeArea
+        self.applySafeAreaInsetForZStackChildren = ignoreSafeArea
         self.onDismiss = onDismiss
     }
 
@@ -77,10 +77,11 @@ struct ComponentsView: View {
                 }
             }
             // Applies a top padding to mimmic safe area insets
-            // This was designed to be applied to the 
-            .applyIf(index > 0 && self.ignoreSafeArea) { view in
-                view.padding(.top, self.safeAreaInsets.top)
-            }
+            // This was designed to be applied to for ZStacks when
+            // they have a full width header image and are the first
+            // component in the paywall. This will keep the other
+            // components from going into the safe area.
+            .padding(.top, (self.applySafeAreaInsetForZStackChildren && index > 0) ? self.safeAreaInsets.top : 0)
         }
     }
 

--- a/RevenueCatUI/Templates/V2/Components/ComponentsView.swift
+++ b/RevenueCatUI/Templates/V2/Components/ComponentsView.swift
@@ -26,7 +26,11 @@ struct ComponentsView: View {
     let ignoreSafeArea: Bool
     private let onDismiss: () -> Void
 
-    init(componentViewModels: [PaywallComponentViewModel], ignoreSafeArea: Bool = false, onDismiss: @escaping () -> Void) {
+    init(
+        componentViewModels: [PaywallComponentViewModel],
+        ignoreSafeArea: Bool = false,
+        onDismiss: @escaping () -> Void
+    ) {
         self.componentViewModels = componentViewModels
         self.ignoreSafeArea = ignoreSafeArea
         self.onDismiss = onDismiss

--- a/RevenueCatUI/Templates/V2/Components/ComponentsView.swift
+++ b/RevenueCatUI/Templates/V2/Components/ComponentsView.swift
@@ -19,11 +19,16 @@ import SwiftUI
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct ComponentsView: View {
 
+    @Environment(\.safeAreaInsets)
+    private var safeAreaInsets
+
     let componentViewModels: [PaywallComponentViewModel]
+    let ignoreSafeArea: Bool
     private let onDismiss: () -> Void
 
-    init(componentViewModels: [PaywallComponentViewModel], onDismiss: @escaping () -> Void) {
+    init(componentViewModels: [PaywallComponentViewModel], ignoreSafeArea: Bool = false, onDismiss: @escaping () -> Void) {
         self.componentViewModels = componentViewModels
+        self.ignoreSafeArea = ignoreSafeArea
         self.onDismiss = onDismiss
     }
 
@@ -34,36 +39,41 @@ struct ComponentsView: View {
     @ViewBuilder
     // swiftlint:disable:next cyclomatic_complexity
     func layoutComponents(_ componentViewModels: [PaywallComponentViewModel]) -> some View {
-        ForEach(Array(componentViewModels.enumerated()), id: \.offset) { _, item in
-            switch item {
-            case .root(let viewModel):
-                RootView(viewModel: viewModel, onDismiss: onDismiss)
-            case .text(let viewModel):
-                TextComponentView(viewModel: viewModel)
-            case .image(let viewModel):
-                ImageComponentView(viewModel: viewModel)
-            case .icon(let viewModel):
-                IconComponentView(viewModel: viewModel)
-            case .stack(let viewModel):
-                StackComponentView(viewModel: viewModel, onDismiss: onDismiss)
-            case .button(let viewModel):
-                ButtonComponentView(viewModel: viewModel, onDismiss: onDismiss)
-            case .package(let viewModel):
-                PackageComponentView(viewModel: viewModel, onDismiss: onDismiss)
-            case .purchaseButton(let viewModel):
-                PurchaseButtonComponentView(viewModel: viewModel)
-            case .stickyFooter(let viewModel):
-                StickyFooterComponentView(viewModel: viewModel)
-            case .timeline(let viewModel):
-                TimelineComponentView(viewModel: viewModel)
-            case .tabs(let viewModel):
-                TabsComponentView(viewModel: viewModel, onDismiss: onDismiss)
-            case .tabControl(let viewModel):
-                TabControlComponentView(viewModel: viewModel, onDismiss: onDismiss)
-            case .tabControlButton(let viewModel):
-                TabControlButtonComponentView(viewModel: viewModel, onDismiss: onDismiss)
-            case .tabControlToggle(let viewModel):
-                TabControlToggleComponentView(viewModel: viewModel, onDismiss: onDismiss)
+        ForEach(Array(componentViewModels.enumerated()), id: \.offset) { index, item in
+            Group {
+                switch item {
+                case .root(let viewModel):
+                    RootView(viewModel: viewModel, onDismiss: onDismiss)
+                case .text(let viewModel):
+                    TextComponentView(viewModel: viewModel)
+                case .image(let viewModel):
+                    ImageComponentView(viewModel: viewModel)
+                case .icon(let viewModel):
+                    IconComponentView(viewModel: viewModel)
+                case .stack(let viewModel):
+                    StackComponentView(viewModel: viewModel, onDismiss: onDismiss)
+                case .button(let viewModel):
+                    ButtonComponentView(viewModel: viewModel, onDismiss: onDismiss)
+                case .package(let viewModel):
+                    PackageComponentView(viewModel: viewModel, onDismiss: onDismiss)
+                case .purchaseButton(let viewModel):
+                    PurchaseButtonComponentView(viewModel: viewModel)
+                case .stickyFooter(let viewModel):
+                    StickyFooterComponentView(viewModel: viewModel)
+                case .timeline(let viewModel):
+                    TimelineComponentView(viewModel: viewModel)
+                case .tabs(let viewModel):
+                    TabsComponentView(viewModel: viewModel, onDismiss: onDismiss)
+                case .tabControl(let viewModel):
+                    TabControlComponentView(viewModel: viewModel, onDismiss: onDismiss)
+                case .tabControlButton(let viewModel):
+                    TabControlButtonComponentView(viewModel: viewModel, onDismiss: onDismiss)
+                case .tabControlToggle(let viewModel):
+                    TabControlToggleComponentView(viewModel: viewModel, onDismiss: onDismiss)
+                }
+            }.applyIf(index > 0 && self.ignoreSafeArea) { view in
+                view
+                    .padding(.top, self.safeAreaInsets.top)
             }
         }
     }

--- a/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
@@ -204,6 +204,7 @@ fileprivate extension PackageComponentViewModel {
         let stackViewModel = try factory.toStackViewModel(
             component: component.stack,
             packageValidator: factory.packageValidator,
+            firstImageInfo: nil,
             localizationProvider: localizationProvider,
             uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
             offering: offering

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -152,6 +152,7 @@ fileprivate extension PurchaseButtonComponentViewModel {
         let stackViewModel = try factory.toStackViewModel(
             component: component.stack,
             packageValidator: factory.packageValidator,
+            firstImageInfo: nil,
             localizationProvider: localizationProvider,
             uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
             offering: offering

--- a/RevenueCatUI/Templates/V2/Components/Root/RootViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Root/RootViewModel.swift
@@ -19,15 +19,23 @@ import SwiftUI
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class RootViewModel {
 
+    struct FirstImageInfo {
+        let imageComponent: PaywallComponent.ImageComponent
+        let parentZStack: PaywallComponent.StackComponent?
+    }
+
     let stackViewModel: StackComponentViewModel
     let stickyFooterViewModel: StickyFooterComponentViewModel?
+    let firstImageInfo: FirstImageInfo?
 
     init(
         stackViewModel: StackComponentViewModel,
-        stickyFooterViewModel: StickyFooterComponentViewModel?
+        stickyFooterViewModel: StickyFooterComponentViewModel?,
+        firstImageInfo: FirstImageInfo?
     ) {
         self.stackViewModel = stackViewModel
         self.stickyFooterViewModel = stickyFooterViewModel
+        self.firstImageInfo = firstImageInfo
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -21,6 +21,9 @@ import SwiftUI
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct StackComponentView: View {
 
+    @Environment(\.safeAreaInsets)
+    private var safeAreaInsets
+
     @EnvironmentObject
     private var introOfferEligibilityContext: IntroOfferEligibilityContext
 
@@ -91,7 +94,11 @@ struct StackComponentView: View {
                       verticalAlignment: verticalAlignment.frameAlignment)
             case .zlayer(let alignment):
                 ZStack(alignment: alignment.stackAlignment) {
-                    ComponentsView(componentViewModels: self.viewModel.viewModels, onDismiss: self.onDismiss)
+                    ComponentsView(
+                        componentViewModels: self.viewModel.viewModels,
+                        ignoreSafeArea: true,
+                        onDismiss: self.onDismiss
+                    )
                 }
                 .size(style.size)
             }

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -21,9 +21,6 @@ import SwiftUI
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct StackComponentView: View {
 
-    @Environment(\.safeAreaInsets)
-    private var safeAreaInsets
-
     @EnvironmentObject
     private var introOfferEligibilityContext: IntroOfferEligibilityContext
 
@@ -96,7 +93,7 @@ struct StackComponentView: View {
                 ZStack(alignment: alignment.stackAlignment) {
                     ComponentsView(
                         componentViewModels: self.viewModel.viewModels,
-                        ignoreSafeArea: true,
+                        ignoreSafeArea: self.viewModel.shouldApplySafeAreaInset,
                         onDismiss: self.onDismiss
                     )
                 }
@@ -570,6 +567,7 @@ extension StackComponentViewModel {
             try factory.toViewModel(
                 component: component,
                 packageValidator: validator,
+                firstImageInfo: nil,
                 offering: offering,
                 localizationProvider: localizationProvider,
                 uiConfigProvider: uiConfigProvider
@@ -580,6 +578,7 @@ extension StackComponentViewModel {
             try factory.toViewModel(
                 component: component,
                 packageValidator: validator,
+                firstImageInfo: nil,
                 offering: offering,
                 localizationProvider: localizationProvider,
                 uiConfigProvider: uiConfigProvider

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
@@ -27,11 +27,13 @@ class StackComponentViewModel {
 
     let viewModels: [PaywallComponentViewModel]
     let badgeViewModels: [PaywallComponentViewModel]
+    let shouldApplySafeAreaInset: Bool
 
     init(
         component: PaywallComponent.StackComponent,
         viewModels: [PaywallComponentViewModel],
         badgeViewModels: [PaywallComponentViewModel],
+        shouldApplySafeAreaInset: Bool = false,
         uiConfigProvider: UIConfigProvider,
         localizationProvider: LocalizationProvider
     ) throws {
@@ -39,6 +41,7 @@ class StackComponentViewModel {
         self.viewModels = viewModels
         self.uiConfigProvider = uiConfigProvider
         self.badgeViewModels = badgeViewModels
+        self.shouldApplySafeAreaInset = shouldApplySafeAreaInset
         self.presentedOverrides = try self.component.overrides?.toPresentedOverrides { $0 }
     }
 

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -261,14 +261,15 @@ private struct LoadedPaywallsV2View: View {
         }
     }
 
-    func isFirstViewAnImage(_ viewModels: [PaywallComponentViewModel]) -> Bool {
+    // swiftlint:disable cyclomatic_complexity
+    private func isFirstViewAnImage(_ viewModels: [PaywallComponentViewModel]) -> Bool {
         guard let first = viewModels.first else {
             return false
         }
 
         switch first {
         case .root(let root):
-            return isFirstViewAnImage(root.stackViewModel.viewModels)
+            return self.isFirstViewAnImage(root.stackViewModel.viewModels)
         case .text:
             return false
         case .image:
@@ -276,11 +277,11 @@ private struct LoadedPaywallsV2View: View {
         case .icon:
             return false
         case .stack(let stack):
-            return isFirstViewAnImage(stack.viewModels)
+            return self.isFirstViewAnImage(stack.viewModels)
         case .button:
             return false
-        case .package(_):
-            return false
+        case .package(let package):
+            return self.isFirstViewAnImage(package.stackViewModel.viewModels)
         case .purchaseButton:
             return false
         case .stickyFooter:
@@ -288,7 +289,10 @@ private struct LoadedPaywallsV2View: View {
         case .timeline:
             return false
         case .tabs(let tabs):
-            return false
+            guard let firstTab = tabs.tabViewModels.first else {
+                return false
+            }
+            return self.isFirstViewAnImage(firstTab.stackViewModel.viewModels)
         case .tabControl:
             return false
         case .tabControlButton:

--- a/RevenueCatUI/Templates/V2/Previews/PreviewMock.swift
+++ b/RevenueCatUI/Templates/V2/Previews/PreviewMock.swift
@@ -86,6 +86,7 @@ struct PreviewRequiredEnvironmentProperties: ViewModifier {
             .environmentObject(self.packageContext ?? Self.defaultPackageContext)
             .environment(\.screenCondition, screenCondition)
             .environment(\.componentViewState, componentViewState)
+            .environment(\.safeAreaInsets, EdgeInsets())
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FallbackComponentPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FallbackComponentPreview.swift
@@ -120,6 +120,7 @@ struct FallbackComponentPreview_Previews: PreviewProvider {
         return try! factory.toViewModel(
             component: component,
             packageValidator: packageValidator,
+            firstImageInfo: nil,
             offering: offering,
             localizationProvider: localizationProvider,
             uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -54,7 +54,10 @@ fileprivate extension View {
         case .color(let color):
             switch color.effectiveColor(for: colorScheme) {
             case .hex:
-                self.background(color.toDynamicColor())
+                self.background(
+                    color.toDynamicColor()
+                        .edgesIgnoringSafeArea(.all)
+                )
             case .linear(let degrees, _):
                 self.background {
                     GradientView(
@@ -62,6 +65,7 @@ fileprivate extension View {
                         darkGradient: color.dark?.toGradient(),
                         gradientStyle: .linear(degrees)
                     )
+                    .edgesIgnoringSafeArea(.all)
                 }
             case .radial:
                 self.background {
@@ -70,6 +74,7 @@ fileprivate extension View {
                         darkGradient: color.dark?.toGradient(),
                         gradientStyle: .radial
                     )
+                    .edgesIgnoringSafeArea(.all)
                 }
             }
         case .image(let imageInfo):
@@ -85,6 +90,7 @@ fileprivate extension View {
                         .scaledToFill()
                         .ignoresSafeArea()
                 }
+                .edgesIgnoringSafeArea(.all)
             }
         }
     }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -28,7 +28,7 @@ struct ViewModelFactory {
         localizationProvider: LocalizationProvider,
         uiConfigProvider: UIConfigProvider
     ) throws -> RootViewModel {
-        let firstImageInfo = self.findImageViewIfItsTheFirst(.stack(componentsConfig.stack))
+        let firstImageInfo = self.findFullWidthImageViewIfItsTheFirst(.stack(componentsConfig.stack))
 
         let rootStackViewModel = try toStackViewModel(
             component: componentsConfig.stack,
@@ -331,15 +331,20 @@ struct ViewModelFactory {
         )
     }
 
-    // swiftlint:disable cyclomatic_complexity
-    private func findImageViewIfItsTheFirst(
+    // swiftlint:disable cyclomatic_complexity function_body_length
+    private func findFullWidthImageViewIfItsTheFirst(
         _ component: PaywallComponent
     ) -> RootViewModel.FirstImageInfo? {
         switch component {
         case .text:
             return nil
         case .image(let image):
-            return .init(imageComponent: image, parentZStack: nil)
+            switch image.size.width {
+            case .fill:
+                return .init(imageComponent: image, parentZStack: nil)
+            case .fit, .fixed:
+                return nil
+            }
         case .icon:
             return nil
         case .stack(let stack):
@@ -347,7 +352,7 @@ struct ViewModelFactory {
                 return nil
             }
 
-            let imageInfo = self.findImageViewIfItsTheFirst(first)
+            let imageInfo = self.findFullWidthImageViewIfItsTheFirst(first)
 
             switch stack.dimension {
             case .vertical, .horizontal:
@@ -366,7 +371,7 @@ struct ViewModelFactory {
             guard let first = package.stack.components.first else {
                 return nil
             }
-            return self.findImageViewIfItsTheFirst(first)
+            return self.findFullWidthImageViewIfItsTheFirst(first)
         case .purchaseButton:
             return nil
         case .stickyFooter:
@@ -377,7 +382,7 @@ struct ViewModelFactory {
             guard let first = tabs.tabs.first?.stack.components.first else {
                 return nil
             }
-            return self.findImageViewIfItsTheFirst(first)
+            return self.findFullWidthImageViewIfItsTheFirst(first)
         case .tabControl:
             return nil
         case .tabControlButton:

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -286,6 +286,7 @@ struct ViewModelFactory {
         }
     }
 
+    // swiftlint:disable:next function_parameter_count
     func toStackViewModel(
         component: PaywallComponent.StackComponent,
         packageValidator: PackageValidator,


### PR DESCRIPTION
### Motivation

Be smart about when and where to ignore safe area edges so header images expand all the way to the top edge.

### Description

1. In the `ViewModelFactory`, find if the first non-container type component is an image
    - If we find one, also pair it with its parent if its a ZStack
        - We need this so that we can apply safe area insets to the non-images in the ZStack so they stay pushed down
        - We add a new boolean into the `StackViewModel` of the containing ZStack that we need to apply safe area inset padding
2.  If we found that an image is first:
    - Apply `.edgesIgnoringSafeArea(.top)` to the entire paywall contents
    - Send the value of the safe area insets as an environment variable
3. When rendering the paywall, we apply the safe area insets into the ZStack components if needed so they stay pushed down

👉  See https://github.com/RevenueCat/purchases-ios/pull/4745 for the Paywall Tester changes


https://github.com/user-attachments/assets/f5b06e0b-051d-45d2-ac8c-302ba24d317d


