### PR TITLE
UI preview mode/always fetch offerings

### DIFF
--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -45,7 +45,7 @@ class OfferingsManager {
         fetchCurrent: Bool = false,
         completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
     ) {
-        guard !fetchCurrent else {
+        guard !fetchCurrent && !self.systemInfo.dangerousSettings.uiPreviewMode else {
             self.fetchFromNetwork(appUserID: appUserID, fetchPolicy: fetchPolicy, completion: completion)
             return
         }

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -541,6 +541,44 @@ extension OfferingsManagerTests {
         expect(self.mockProductsManager.invokedProducts) == false
     }
 
+    func testOfferingsForAppUserIdForcesNetworkRequestWhenUIPreviewModeIsTrueAndFetchCurrentIsFalse() throws {
+        // given
+        let mockSystemInfoWithPreviewMode = MockSystemInfo(
+            platformInfo: .init(flavor: "iOS", version: "3.2.1"),
+            finishTransactions: true,
+            dangerousSettings: DangerousSettings(uiPreviewMode: true)
+        )
+
+        self.offeringsManager = OfferingsManager(
+            deviceCache: self.mockDeviceCache,
+            operationDispatcher: self.mockOperationDispatcher,
+            systemInfo: mockSystemInfoWithPreviewMode,
+            backend: self.mockBackend,
+            offeringsFactory: self.mockOfferingsFactory,
+            productsManager: self.mockProductsManager
+        )
+
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
+        self.mockDeviceCache.stubbedOfferings = MockData.sampleOfferings
+
+        // when
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID, fetchCurrent: false) {
+                completed($0)
+            }
+        }
+
+        // then
+        expect(result).to(beSuccess())
+        expect(result?.value) !== MockData.sampleOfferings
+        expect(result?.value?["base"]).toNot(beNil())
+        expect(result?.value?["base"]!.monthly).toNot(beNil())
+        expect(result?.value?["base"]!.monthly?.storeProduct).toNot(beNil())
+
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserID) == true
+        expect(self.mockDeviceCache.cacheOfferingsCount) == 1
+    }
+
 }
 
 private extension OfferingsManagerTests {


### PR DESCRIPTION

### Checklist
- [x] If applicable, unit tests

### Motivation
To make sure that paywalls are always up-to-date when in UI Preview mode, the SDK should always fetch the Offerings from the network, ignoring the local cache

### Description
Always fetch Offerings from the network when `uiPreviewMode` is `true`
