### PR TITLE
feat: Dont show cancel path if lifetime subscription

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -29,15 +29,18 @@ import RevenueCat
     typealias CurrentVersionFetcher = () -> String?
 
     private lazy var currentAppVersion: String? = currentVersionFetcher()
+
     @Published
     private(set) var purchaseInformation: PurchaseInformation?
+
     @Published
     private(set) var appIsLatestVersion: Bool = defaultAppIsLatestVersion
-    private(set) var purchasesProvider: CustomerCenterPurchasesType
-    private(set) var customerCenterStoreKitUtilities: CustomerCenterStoreKitUtilitiesType
 
     @Published
     private(set) var onUpdateAppClick: (() -> Void)?
+
+    private(set) var purchasesProvider: CustomerCenterPurchasesType
+    private(set) var customerCenterStoreKitUtilities: CustomerCenterStoreKitUtilitiesType
 
     /// Whether or not the Customer Center should warn the customer that they're on an outdated version of the app.
     var shouldShowAppUpdateWarnings: Bool {
@@ -147,28 +150,28 @@ import RevenueCat
 private extension CustomerCenterViewModel {
 
     func loadPurchaseInformation() async throws {
-            let customerInfo = try await purchasesProvider.customerInfo(fetchPolicy: .fetchCurrent)
+        let customerInfo = try await purchasesProvider.customerInfo(fetchPolicy: .fetchCurrent)
 
-            let hasActiveProducts =
-            !customerInfo.activeSubscriptions.isEmpty || !customerInfo.nonSubscriptions.isEmpty
+        let hasActiveProducts =  !customerInfo.activeSubscriptions.isEmpty ||
+        !customerInfo.nonSubscriptions.isEmpty
 
-            if !hasActiveProducts {
-                self.purchaseInformation = nil
-                self.state = .success
-                return
-            }
+        if !hasActiveProducts {
+            self.purchaseInformation = nil
+            self.state = .success
+            return
+        }
 
-            guard let activeTransaction = findActiveTransaction(customerInfo: customerInfo) else {
-                Logger.warning(Strings.could_not_find_subscription_information)
-                self.purchaseInformation = nil
-                throw CustomerCenterError.couldNotFindSubscriptionInformation
-            }
+        guard let activeTransaction = findActiveTransaction(customerInfo: customerInfo) else {
+            Logger.warning(Strings.could_not_find_subscription_information)
+            self.purchaseInformation = nil
+            throw CustomerCenterError.couldNotFindSubscriptionInformation
+        }
 
-            let entitlement = customerInfo.entitlements.all.values
-                .first(where: { $0.productIdentifier == activeTransaction.productIdentifier })
+        let entitlement = customerInfo.entitlements.all.values
+            .first(where: { $0.productIdentifier == activeTransaction.productIdentifier })
 
-            self.purchaseInformation = try await createPurchaseInformation(for: activeTransaction,
-                                                                           entitlement: entitlement)
+        self.purchaseInformation = try await createPurchaseInformation(for: activeTransaction,
+                                                                       entitlement: entitlement)
     }
 
     func loadCustomerCenterConfig() async throws {

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
@@ -27,21 +27,33 @@ import SwiftUI
 class ManageSubscriptionsViewModel: ObservableObject {
 
     let screen: CustomerCenterConfigData.Screen
-    let paths: [CustomerCenterConfigData.HelpPath]
+
+    var relevantPathsForPurchase: [CustomerCenterConfigData.HelpPath] {
+        if purchaseInformation?.explanation == .lifetime {
+            return paths.filter { $0.type != .cancel }
+        } else {
+            return paths
+        }
+    }
 
     @Published
     var showRestoreAlert: Bool = false
+
     @Published
     var showPurchases: Bool = false
 
     @Published
     var feedbackSurveyData: FeedbackSurveyData?
+
     @Published
     var loadingPath: CustomerCenterConfigData.HelpPath?
+
     @Published
     var promotionalOfferData: PromotionalOfferData?
+
     @Published
     var inAppBrowserURL: IdentifiableURL?
+
     @Published
     var state: CustomerCenterViewState {
         didSet {
@@ -53,13 +65,15 @@ class ManageSubscriptionsViewModel: ObservableObject {
 
     @Published
     private(set) var purchaseInformation: PurchaseInformation?
+
     @Published
     private(set) var refundRequestStatus: RefundRequestStatus?
 
-    private var purchasesProvider: ManageSubscriptionsPurchaseType
-    private let loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType
     private let customerCenterActionHandler: CustomerCenterActionHandler?
     private var error: Error?
+    private let loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType
+    private let paths: [CustomerCenterConfigData.HelpPath]
+    private var purchasesProvider: ManageSubscriptionsPurchaseType
 
     init(screen: CustomerCenterConfigData.Screen,
          customerCenterActionHandler: CustomerCenterActionHandler?,

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsButtonsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsButtonsView.swift
@@ -25,16 +25,11 @@ struct ManageSubscriptionsButtonsView: View {
 
     @ObservedObject
     var viewModel: ManageSubscriptionsViewModel
-    @Binding
-    var loadingPath: CustomerCenterConfigData.HelpPath?
-    @Environment(\.openURL)
-    var openURL
 
-    @Environment(\.localization)
-    private var localization: CustomerCenterConfigData.Localization
+    var loadingPath: CustomerCenterConfigData.HelpPath?
 
     var body: some View {
-        ForEach(self.viewModel.paths, id: \.id) { path in
+        ForEach(self.viewModel.relevantPathsForPurchase, id: \.id) { path in
             ManageSubscriptionButton(path: path, viewModel: self.viewModel)
         }
     }
@@ -45,13 +40,10 @@ struct ManageSubscriptionsButtonsView: View {
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-struct ManageSubscriptionButton: View {
+private struct ManageSubscriptionButton: View {
 
     let path: CustomerCenterConfigData.HelpPath
-    @ObservedObject var viewModel: ManageSubscriptionsViewModel
-
-    @Environment(\.appearance)
-    private var appearance: CustomerCenterConfigData.Appearance
+    let viewModel: ManageSubscriptionsViewModel
 
     var body: some View {
         AsyncButton(action: {

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -128,7 +128,7 @@ struct ManageSubscriptionsView: View {
                 Section {
                     ManageSubscriptionsButtonsView(
                         viewModel: self.viewModel,
-                        loadingPath: self.$viewModel.loadingPath
+                        loadingPath: self.viewModel.loadingPath
                     )
                 } header: {
                     if let subtitle = self.viewModel.screen.subtitle {
@@ -149,7 +149,7 @@ struct ManageSubscriptionsView: View {
 
                 Section {
                     ManageSubscriptionsButtonsView(viewModel: self.viewModel,
-                                                   loadingPath: self.$viewModel.loadingPath)
+                                                   loadingPath: self.viewModel.loadingPath)
                 }
             }
         }

--- a/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
@@ -50,6 +50,16 @@ class ManageSubscriptionsViewModelTests: TestCase {
         expect(viewModel.showRestoreAlert) == false
     }
 
+    func testLifetimeSubscriptionDoesNotShowCancel() {
+        let viewModel = ManageSubscriptionsViewModel(
+            screen: ManageSubscriptionsViewModelTests.screen,
+            customerCenterActionHandler: nil,
+            purchaseInformation: PurchaseInformation.mockLifetime
+        )
+
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .cancel })).to(beFalse())
+    }
+
     func testStateChangeToError() {
         let viewModel = ManageSubscriptionsViewModel(screen: ManageSubscriptionsViewModelTests.screen,
                                                      customerCenterActionHandler: nil)
@@ -432,6 +442,20 @@ private class MockLoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
 
     }
 
+}
+
+private extension PurchaseInformation {
+    static var mockLifetime: PurchaseInformation {
+        PurchaseInformation(
+            title: "",
+            durationTitle: "",
+            explanation: .lifetime,
+            price: .paid(""),
+            expirationOrRenewal: PurchaseInformation.ExpirationOrRenewal(label: .expires, date: .date("")),
+            productIdentifier: "",
+            store: .appStore
+        )
+    }
 }
 
 #endif


### PR DESCRIPTION
### Motivation
Display only the paths that are relevant to the subscription

### Description
Doing this in the backend requires some extra work, so for now we'll handle it in the client. `ManageSubscriptionsViewModel` has the relevant change. The other changes are just removing some unnecessary code, and re-organising stuff.
