### PR TITLE
Document Weak PurchasesDelegate Reference

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -76,6 +76,13 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     /// or one of is overloads.
     @objc public static var isConfigured: Bool { Self.purchases.value != nil }
 
+    /**
+     * The delegate for ``Purchases`` responsible for handling updating your app's state in response to updated
+     * customer info or promotional product purchases.
+     *
+     * - Warning: The delegate is not retained by `Purchases`, so your app must retain a reference to the delegate
+     * to prevent it from being unintentionally deallocated.
+     */
     @objc public var delegate: PurchasesDelegate? {
         get { self.privateDelegate }
         set {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -80,7 +80,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
      * The delegate for ``Purchases`` responsible for handling updating your app's state in response to updated
      * customer info or promotional product purchases.
      *
-     * - Warning: The delegate is not retained by `Purchases`, so your app must retain a reference to the delegate
+     * - Warning: The delegate is not retained by ``Purchases``, so your app must retain a reference to the delegate
      * to prevent it from being unintentionally deallocated.
      */
     @objc public var delegate: PurchasesDelegate? {


### PR DESCRIPTION
### Motivation
`Purchases`'s `delegate` property is a computed property and isn't marked or documented as being weak, but the underlying `privateDelegate` that backs it is weak. This means that if a developer sets a PurchasesDelegate like this:

```swift
Purchases.shared.delegate = MyPurchasesDelegate()
```

the delegate will be deallocated. Since we only retain a _reference_ to the delegate, none of the log messages in the `Purchases.delegate.set` block will be logged, and future calls to the delegate will not be received. It's possible for this to happen without the developer's knowledge, so this PR documents the behavior.

### Description
This PR documents the fact that `Purchases.delegate` uses a weak reference.