### PR TITLE
[CI]: Run iOS 13 tests in all-test CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1467,6 +1467,7 @@ workflows:
       - build-tv-watch-and-macos
       - build-visionos
       - docs-build
+      - run-test-ios-13
       - run-test-ios-14
       - run-test-ios-15
       - run-test-ios-16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1347,6 +1347,7 @@ workflows:
       - lint
       - run-test-ios-17
       - run-test-ios-18
+      - run-test-ios-13
       - pod-lib-lint
       - run-revenuecat-ui-ios-17
       - run-revenuecat-ui-ios-18


### PR DESCRIPTION
### Description
This PR runs the iOS 13 tests when the `all-test` workflow is run since the SDK supports iOS 13+
