### PR TITLE
chore: Run pod lib lint on every PR

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   health-check:
     runs-on: macos-latest
+    name: iOS PR Health Check
+    continue-on-error: true  # Don't block PRs for now
 
     steps:
       - name: Checkout code

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Ruby environment
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,28 @@
+name: Health Check Workflow [TEST]
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  workflow_dispatch:  # Allow manual trigger from GitHub UI
+
+jobs:
+  health-check:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby environment
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4.1'
+
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle install
+
+      - name: Check pods and deployment targets
+        run: bundle exec fastlane check_pods


### PR DESCRIPTION
### Motivation
The CircleCI workflow takes too much time to run. The goal is to dispatch some of that into GH actions that's free, to run that regularly on every pull-request.

### Description
Just a test.
