### PR TITLE
Add Internal support for draft paywall previews

### DIFF
--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -19,6 +19,7 @@ struct PaywallViewConfiguration {
     var mode: PaywallViewMode
     var fonts: PaywallFontProvider
     var displayCloseButton: Bool
+    let useDraftPaywall: Bool
     var introEligibility: TrialOrIntroEligibilityChecker?
     var purchaseHandler: PurchaseHandler
     var locale: Locale
@@ -29,6 +30,7 @@ struct PaywallViewConfiguration {
         mode: PaywallViewMode = .default,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
+        useDraftPaywall: Bool = false,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         purchaseHandler: PurchaseHandler,
         locale: Locale = .current
@@ -38,6 +40,7 @@ struct PaywallViewConfiguration {
         self.mode = mode
         self.fonts = fonts
         self.displayCloseButton = displayCloseButton
+        self.useDraftPaywall = useDraftPaywall
         self.introEligibility = introEligibility
         self.purchaseHandler = purchaseHandler
         self.locale = locale
@@ -72,6 +75,7 @@ extension PaywallViewConfiguration {
         mode: PaywallViewMode = .default,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
+        useDraftPaywall: Bool = false,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         purchaseHandler: PurchaseHandler = PurchaseHandler.default(),
         locale: Locale = .current
@@ -84,6 +88,7 @@ extension PaywallViewConfiguration {
             mode: mode,
             fonts: fonts,
             displayCloseButton: displayCloseButton,
+            useDraftPaywall: useDraftPaywall,
             introEligibility: introEligibility,
             purchaseHandler: handler,
             locale: locale

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Nacho Soto.
 
-import RevenueCat
+@_spi(Internal) import RevenueCat
 import SwiftUI
 
 #if !os(macOS) && !os(tvOS)
@@ -31,6 +31,7 @@ public struct PaywallView: View {
     private let fonts: PaywallFontProvider
     private let displayCloseButton: Bool
     private let paywallViewOwnsPurchaseHandler: Bool
+    private let useDraftPaywall: Bool
 
     private var locale: Locale
 
@@ -105,12 +106,31 @@ public struct PaywallView: View {
         performPurchase: PerformPurchase? = nil,
         performRestore: PerformRestore? = nil
     ) {
+        self.init(
+            offering: offering,
+            fonts: fonts,
+            displayCloseButton: displayCloseButton,
+            useDraftPaywall: false,
+            performPurchase: performPurchase,
+            performRestore: performRestore
+            )
+    }
+
+    @_spi(Internal) public init(
+        offering: Offering,
+        fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        displayCloseButton: Bool = false,
+        useDraftPaywall: Bool,
+        performPurchase: PerformPurchase? = nil,
+        performRestore: PerformRestore? = nil
+    ) {
         let purchaseHandler = PurchaseHandler.default(performPurchase: performPurchase, performRestore: performRestore)
         self.init(
             configuration: .init(
                 offering: offering,
                 fonts: fonts,
                 displayCloseButton: displayCloseButton,
+                useDraftPaywall: useDraftPaywall,
                 purchaseHandler: purchaseHandler
             )
         )
@@ -198,6 +218,7 @@ public struct PaywallView: View {
             } else if self.introEligibility.isConfigured, self.purchaseHandler.isConfigured {
                 if let offering = self.offering, let customerInfo = self.customerInfo {
                     self.paywallView(for: offering,
+                                     useDraftPaywall: false, // TODO: implement
                                      activelySubscribedProductIdentifiers: customerInfo.activeSubscriptions,
                                      fonts: self.fonts,
                                      checker: self.introEligibility,
@@ -243,6 +264,7 @@ public struct PaywallView: View {
     // swiftlint:disable:next function_body_length
     private func paywallView(
         for offering: Offering,
+        useDraftPaywall: Bool,
         activelySubscribedProductIdentifiers: Set<String>,
         fonts: PaywallFontProvider,
         checker: TrialOrIntroEligibilityChecker,
@@ -253,7 +275,7 @@ public struct PaywallView: View {
             countries: offering.paywall?.zeroDecimalPlaceCountries
         )
 
-        if let paywallComponents = offering.paywallComponents {
+        if let paywallComponents = useDraftPaywall ? offering.draftPaywallComponents : offering.paywallComponents {
 
             // For fallback view or footer
             let paywall: PaywallData = .createDefault(with: offering.availablePackages,

--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -33,7 +33,7 @@ struct OfferingsResponse {
         @DefaultDecodable.EmptyDictionary
         var metadata: [String: AnyDecodable]
         var paywallComponents: PaywallComponentsData?
-
+        var draftPaywallComponents: PaywallComponentsData?
     }
 
     struct Placements {

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -77,6 +77,11 @@ import Foundation
     public let paywallComponents: PaywallComponents?
 
     /**
+     Draft paywall components configuration defined in RevenueCat dashboard.
+     */
+    @_spi(Internal) public let draftPaywallComponents: PaywallComponents?
+
+    /**
      Array of ``Package`` objects available for purchase.
      */
     @objc public let availablePackages: [Package]
@@ -176,12 +181,32 @@ import Foundation
     }
 
     /// Initialize an ``Offering`` given a list of ``Package``s.
-    public init(
+    public convenience init(
         identifier: String,
         serverDescription: String,
         metadata: [String: Any] = [:],
         paywall: PaywallData? = nil,
         paywallComponents: PaywallComponents? = nil,
+        availablePackages: [Package]
+    ) {
+        self.init(
+            identifier: identifier,
+            serverDescription: serverDescription,
+            metadata: metadata,
+            paywall: paywall,
+            paywallComponents: paywallComponents,
+            draftPaywallComponents: nil,
+            availablePackages: availablePackages
+        )
+    }
+
+    init(
+        identifier: String,
+        serverDescription: String,
+        metadata: [String: Any] = [:],
+        paywall: PaywallData? = nil,
+        paywallComponents: PaywallComponents? = nil,
+        draftPaywallComponents: PaywallComponents?,
         availablePackages: [Package]
     ) {
         self.identifier = identifier
@@ -190,6 +215,7 @@ import Foundation
         self._metadata = Metadata(data: metadata)
         self.paywall = paywall
         self.paywallComponents = paywallComponents
+        self.draftPaywallComponents = draftPaywallComponents
 
         var foundPackages: [PackageType: Package] = [:]
 

--- a/Sources/Purchasing/OfferingsFactory.swift
+++ b/Sources/Purchasing/OfferingsFactory.swift
@@ -62,11 +62,22 @@ class OfferingsFactory {
             return nil
         }()
 
+        let paywallDraftComponents: Offering.PaywallComponents? = {
+            if let uiConfig, let paywallDraftComponents = offering.draftPaywallComponents {
+                return .init(
+                    uiConfig: uiConfig,
+                    data: paywallDraftComponents
+                )
+            }
+            return nil
+        }()
+
         return Offering(identifier: offering.identifier,
                         serverDescription: offering.description,
                         metadata: offering.metadata.mapValues(\.asAny),
                         paywall: offering.paywall,
                         paywallComponents: paywallComponents,
+                        draftPaywallComponents: paywallDraftComponents,
                         availablePackages: availablePackages)
     }
 


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests

### Motivation
We need a way to show paywalls in the draft state for the Paywall Previews functionality in the RC app

### Description
Adds some new  `@_spi`-protected public APIs regarding draft paywalls:
    * `draftPaywallComponents` property in `Offering`, to know if there's a draft paywall available.
    * A new `init` in `PaywallView` that adds the `useDraftPaywall` parameter to show the draft paywall instead of the published one.