### PR TITLE
Fix Gradient Preview on iOS 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,3 @@ Our full SDK reference [can be found here](https://revenuecat.github.io/purchase
 
 ## Contributing
 Contributions are always welcome! To learn how you can contribute, please see the [Contributing Guide](./Contributing/CONTRIBUTING.md).
-
-trivial change so we can get a PR to test

--- a/README.md
+++ b/README.md
@@ -71,3 +71,5 @@ Our full SDK reference [can be found here](https://revenuecat.github.io/purchase
 
 ## Contributing
 Contributions are always welcome! To learn how you can contribute, please see the [Contributing Guide](./Contributing/CONTRIBUTING.md).
+
+trivial change so we can get a PR to test

--- a/RevenueCatUI/Views/GradientView.swift
+++ b/RevenueCatUI/Views/GradientView.swift
@@ -117,6 +117,9 @@ struct GradientView_Previews: PreviewProvider {
         .previewDisplayName("Linear")
     }
 
+    /// Helper view to preview linear gradients with different angles. This is useful so to keep down the
+    /// number of views in the container holding all of the previews to avoid compilation issues
+    /// with the preview.
     private struct LinearGradientPreview: View {
 
         let label: String

--- a/RevenueCatUI/Views/GradientView.swift
+++ b/RevenueCatUI/Views/GradientView.swift
@@ -105,23 +105,29 @@ struct GradientView_Previews: PreviewProvider {
         .previewDisplayName("Linear 90º - Light (should be red)")
 
         VStack {
-            Text("Linear 0º")
-            gradientView(style: .linear(0))
-            Text("Linear 45º")
-            gradientView(style: .linear(45))
-            Text("Linear 90º")
-            gradientView(style: .linear(90))
-            Text("Linear 135º")
-            gradientView(style: .linear(135))
-            Text("Linear 180º")
-            gradientView(style: .linear(180))
-            Text("Linear 225º")
-            gradientView(style: .linear(225))
-            Text("Linear 270º")
-            gradientView(style: .linear(270))
+            LinearGradientPreview(label: "Linear 0º", degrees: 0)
+            LinearGradientPreview(label: "Linear 45º", degrees: 45)
+            LinearGradientPreview(label: "Linear 90º", degrees: 90)
+            LinearGradientPreview(label: "Linear 135º", degrees: 135)
+            LinearGradientPreview(label: "Linear 180º", degrees: 180)
+            LinearGradientPreview(label: "Linear 225º", degrees: 225)
+            LinearGradientPreview(label: "Linear 270º", degrees: 270)
         }
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Linear")
+    }
+
+    private struct LinearGradientPreview: View {
+
+        let label: String
+        let degrees: Int
+
+        var body: some View {
+            VStack {
+                Text(label)
+                gradientView(style: .linear(degrees))
+            }
+        }
     }
 
 }


### PR DESCRIPTION
### Motivation
The `spm-revenuecat-ui-ios-15` CI job is [currently failing](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/25075/workflows/cb710f05-3ac7-4c86-9cc3-8cd532afac0b/jobs/288868) due to compilation issues with the `GradientView` previews - the preview has more than 10 views inside a container, which SwiftUI doesn't allow:

<img width="1999" alt="CI failure" src="https://github.com/user-attachments/assets/501a02cc-8d50-4476-a98e-811fc8af08d5" />

### Description
This PR addresses the build issue by abstracting the title and gradient to a private, preview-only `LinearGradientPreview` view, which halves the number of views in the `VStack`. This doesn't affect the look of the preview:

#### Before Change
<img width="1026" alt="before" src="https://github.com/user-attachments/assets/c4f0ee3c-9c8b-471d-b13c-497fc0370240" />

#### After Change
<img width="980" alt="Screenshot 2025-02-05 at 10 30 38 AM" src="https://github.com/user-attachments/assets/16f5f523-bd60-4021-bfa1-b6065b3f1b57" />

I'm not yet sure why the existing code worked on newer iOS versions but failed in the iOS 15 job - looking into that now
