### PR TITLE
feat: Enable cancellation in CustomerCenter for catalyst

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptionsViewModel.swift
@@ -24,24 +24,29 @@ import SwiftUI
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 @MainActor
-class ManageSubscriptionsViewModel: ObservableObject {
+final class ManageSubscriptionsViewModel: ObservableObject {
 
     let screen: CustomerCenterConfigData.Screen
     let paths: [CustomerCenterConfigData.HelpPath]
 
     @Published
     var showRestoreAlert: Bool = false
+
     @Published
     var showPurchases: Bool = false
 
     @Published
     var feedbackSurveyData: FeedbackSurveyData?
+
     @Published
     var loadingPath: CustomerCenterConfigData.HelpPath?
+
     @Published
     var promotionalOfferData: PromotionalOfferData?
+
     @Published
     var inAppBrowserURL: IdentifiableURL?
+
     @Published
     var state: CustomerCenterViewState {
         didSet {
@@ -238,11 +243,7 @@ private extension CustomerCenterConfigData.Screen {
 
     var filteredPaths: [CustomerCenterConfigData.HelpPath] {
         return self.paths.filter { path in
-            #if targetEnvironment(macCatalyst)
-                return path.type == .refundRequest
-            #else
-                return path.type != .unknown
-            #endif
+            return path.type != .unknown
         }
     }
 


### PR DESCRIPTION
## Motivation

On macOS (Catalyst), the Customer Center currently does not display the option to cancel, only the option to refund. 

## Description

This PR removes the filter that was previously applied, which prevented the cancel option from appearing. After testing all affected paths, they appear to work as expected. There is no known reason or documentation indicating why this filter was originally applied.