### PR TITLE
Fixed issues with finding some locales (ex: `zh-Hans` and `zh-Hant`)

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		030890812D2B764D0069677B /* VariableHandlerV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030890802D2B76450069677B /* VariableHandlerV2.swift */; };
 		030890842D2B77E70069677B /* VariableHandlerV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030890832D2B77E20069677B /* VariableHandlerV2Tests.swift */; };
 		030F918A2D55C1D20085103F /* LocaleFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030F91892D55C1AB0085103F /* LocaleFinder.swift */; };
+		030F918C2D55C9DC0085103F /* LocaleFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030F918B2D55C9D80085103F /* LocaleFinderTests.swift */; };
 		0313FD41268A506400168386 /* DateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313FD40268A506400168386 /* DateProvider.swift */; };
 		0354AA462D4029C300F9E330 /* TabControlButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0354AA3E2D4029C300F9E330 /* TabControlButtonComponentViewModel.swift */; };
 		0354AA472D4029C300F9E330 /* TabControlComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0354AA402D4029C300F9E330 /* TabControlComponentViewModel.swift */; };
@@ -1285,6 +1286,7 @@
 		030890802D2B76450069677B /* VariableHandlerV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableHandlerV2.swift; sourceTree = "<group>"; };
 		030890832D2B77E20069677B /* VariableHandlerV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableHandlerV2Tests.swift; sourceTree = "<group>"; };
 		030F91892D55C1AB0085103F /* LocaleFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleFinder.swift; sourceTree = "<group>"; };
+		030F918B2D55C9D80085103F /* LocaleFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleFinderTests.swift; sourceTree = "<group>"; };
 		0313FD40268A506400168386 /* DateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateProvider.swift; sourceTree = "<group>"; };
 		0354AA3D2D4029C300F9E330 /* TabControlButtonComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabControlButtonComponentView.swift; sourceTree = "<group>"; };
 		0354AA3E2D4029C300F9E330 /* TabControlButtonComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabControlButtonComponentViewModel.swift; sourceTree = "<group>"; };
@@ -2543,6 +2545,7 @@
 		030890822D2B77DD0069677B /* PaywallsV2 */ = {
 			isa = PBXGroup;
 			children = (
+				030F918B2D55C9D80085103F /* LocaleFinderTests.swift */,
 				03C06FC42D4553BB00600693 /* PresentedPartialsTests.swift */,
 				030890832D2B77E20069677B /* VariableHandlerV2Tests.swift */,
 			);
@@ -6952,6 +6955,7 @@
 				88AD4C482C24E8EA00943C3E /* ExternalPurchaseAndRestoreTests.swift in Sources */,
 				887A633D2C1D177800E1A461 /* Template2ViewTests.swift in Sources */,
 				887A633E2C1D177800E1A461 /* Template3ViewTests.swift in Sources */,
+				030F918C2D55C9DC0085103F /* LocaleFinderTests.swift in Sources */,
 				887A633F2C1D177800E1A461 /* Template4ViewTests.swift in Sources */,
 				887A63402C1D177800E1A461 /* Template5ViewTests.swift in Sources */,
 				887A63412C1D177800E1A461 /* BaseSnapshotTest.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		030890812D2B764D0069677B /* VariableHandlerV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030890802D2B76450069677B /* VariableHandlerV2.swift */; };
 		030890842D2B77E70069677B /* VariableHandlerV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030890832D2B77E20069677B /* VariableHandlerV2Tests.swift */; };
+		030F918A2D55C1D20085103F /* LocaleFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030F91892D55C1AB0085103F /* LocaleFinder.swift */; };
 		0313FD41268A506400168386 /* DateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313FD40268A506400168386 /* DateProvider.swift */; };
 		0354AA462D4029C300F9E330 /* TabControlButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0354AA3E2D4029C300F9E330 /* TabControlButtonComponentViewModel.swift */; };
 		0354AA472D4029C300F9E330 /* TabControlComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0354AA402D4029C300F9E330 /* TabControlComponentViewModel.swift */; };
@@ -1283,6 +1284,7 @@
 /* Begin PBXFileReference section */
 		030890802D2B76450069677B /* VariableHandlerV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableHandlerV2.swift; sourceTree = "<group>"; };
 		030890832D2B77E20069677B /* VariableHandlerV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableHandlerV2Tests.swift; sourceTree = "<group>"; };
+		030F91892D55C1AB0085103F /* LocaleFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleFinder.swift; sourceTree = "<group>"; };
 		0313FD40268A506400168386 /* DateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateProvider.swift; sourceTree = "<group>"; };
 		0354AA3D2D4029C300F9E330 /* TabControlButtonComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabControlButtonComponentView.swift; sourceTree = "<group>"; };
 		0354AA3E2D4029C300F9E330 /* TabControlButtonComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabControlButtonComponentViewModel.swift; sourceTree = "<group>"; };
@@ -2545,6 +2547,14 @@
 				030890832D2B77E20069677B /* VariableHandlerV2Tests.swift */,
 			);
 			path = PaywallsV2;
+			sourceTree = "<group>";
+		};
+		030F91882D55C0FF0085103F /* Localizations */ = {
+			isa = PBXGroup;
+			children = (
+				030F91892D55C1AB0085103F /* LocaleFinder.swift */,
+			);
+			path = Localizations;
 			sourceTree = "<group>";
 		};
 		0354AA452D4029C300F9E330 /* Tabs */ = {
@@ -4956,6 +4966,7 @@
 			children = (
 				88B1BAE32C813A3C001B7EE5 /* PaywallsV2View.swift */,
 				2C7457492CEA6B06004ACE52 /* EnvironmentObjects */,
+				030F91882D55C0FF0085103F /* Localizations */,
 				0308907F2D2B76340069677B /* Variables */,
 				2C7457442CEA652B004ACE52 /* ViewHelpers */,
 				2C7457452CEA653A004ACE52 /* ViewModelHelpers */,
@@ -6810,6 +6821,7 @@
 				887A60CA2C1D037000E1A461 /* RemoteImage.swift in Sources */,
 				887A607B2C1D037000E1A461 /* Bundle+Extensions.swift in Sources */,
 				03C72F6D2D32CDFB00297FEC /* FamilySharingTogglePreview.swift in Sources */,
+				030F918A2D55C1D20085103F /* LocaleFinder.swift in Sources */,
 				353756662C382C2800A1B8D6 /* CustomerCenterError.swift in Sources */,
 				887A60CF2C1D037000E1A461 /* View+PresentPaywallFooter.swift in Sources */,
 				3537566B2C382C2800A1B8D6 /* CustomerCenterView.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		030890842D2B77E70069677B /* VariableHandlerV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030890832D2B77E20069677B /* VariableHandlerV2Tests.swift */; };
 		030F918A2D55C1D20085103F /* LocaleFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030F91892D55C1AB0085103F /* LocaleFinder.swift */; };
 		030F918C2D55C9DC0085103F /* LocaleFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030F918B2D55C9D80085103F /* LocaleFinderTests.swift */; };
+		030F918E2D5664410085103F /* LocaleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030F918D2D5664410085103F /* LocaleExtensions.swift */; };
 		0313FD41268A506400168386 /* DateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313FD40268A506400168386 /* DateProvider.swift */; };
 		0354AA462D4029C300F9E330 /* TabControlButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0354AA3E2D4029C300F9E330 /* TabControlButtonComponentViewModel.swift */; };
 		0354AA472D4029C300F9E330 /* TabControlComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0354AA402D4029C300F9E330 /* TabControlComponentViewModel.swift */; };
@@ -1287,6 +1288,7 @@
 		030890832D2B77E20069677B /* VariableHandlerV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableHandlerV2Tests.swift; sourceTree = "<group>"; };
 		030F91892D55C1AB0085103F /* LocaleFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleFinder.swift; sourceTree = "<group>"; };
 		030F918B2D55C9D80085103F /* LocaleFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleFinderTests.swift; sourceTree = "<group>"; };
+		030F918D2D5664410085103F /* LocaleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleExtensions.swift; sourceTree = "<group>"; };
 		0313FD40268A506400168386 /* DateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateProvider.swift; sourceTree = "<group>"; };
 		0354AA3D2D4029C300F9E330 /* TabControlButtonComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabControlButtonComponentView.swift; sourceTree = "<group>"; };
 		0354AA3E2D4029C300F9E330 /* TabControlButtonComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabControlButtonComponentViewModel.swift; sourceTree = "<group>"; };
@@ -2555,6 +2557,7 @@
 		030F91882D55C0FF0085103F /* Localizations */ = {
 			isa = PBXGroup;
 			children = (
+				030F918D2D5664410085103F /* LocaleExtensions.swift */,
 				030F91892D55C1AB0085103F /* LocaleFinder.swift */,
 			);
 			path = Localizations;
@@ -6801,6 +6804,7 @@
 				77089F9E2CD39EC100848CD5 /* ShadowModifier.swift in Sources */,
 				3537566F2C382C2800A1B8D6 /* WrongPlatformView.swift in Sources */,
 				0354AA462D4029C300F9E330 /* TabControlButtonComponentViewModel.swift in Sources */,
+				030F918E2D5664410085103F /* LocaleExtensions.swift in Sources */,
 				0354AA472D4029C300F9E330 /* TabControlComponentViewModel.swift in Sources */,
 				0354AA482D4029C300F9E330 /* TabsComponentView.swift in Sources */,
 				0354AA492D4029C300F9E330 /* TabControlButtonComponentView.swift in Sources */,

--- a/RevenueCatUI/Templates/V2/Localizations/LocaleExtensions.swift
+++ b/RevenueCatUI/Templates/V2/Localizations/LocaleExtensions.swift
@@ -1,0 +1,45 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  LocaleExtensions.swift
+//
+//  Created by Josh Holtz on 2/7/25.
+
+import Foundation
+
+extension Locale {
+
+    static var preferredLocales: [Self] {
+        return Self.preferredLanguages.map(Locale.init(identifier:))
+    }
+
+    func matchesLanguage(_ rhs: Locale) -> Bool {
+        self.removingRegion == rhs.removingRegion
+    }
+
+    // swiftlint:disable:next identifier_name
+    var rc_languageCode: String? {
+        #if swift(>=5.9)
+        // `Locale.languageCode` is deprecated
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, visionOS 1.0, *) {
+            return self.language.languageCode?.identifier
+        } else {
+            return self.languageCode
+        }
+        #else
+        return self.languageCode
+        #endif
+    }
+
+    /// - Returns: the same locale as `self` but removing its region.
+    private var removingRegion: Self? {
+        return self.rc_languageCode.map(Locale.init(identifier:))
+    }
+
+}

--- a/RevenueCatUI/Templates/V2/Localizations/LocaleFinder.swift
+++ b/RevenueCatUI/Templates/V2/Localizations/LocaleFinder.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  LocaleFinder.swift
+//
+//  Created by Josh Holtz on 2/6/25.
+
+import Foundation
+
+extension Dictionary where Key == String {
+
+    func findLocale(_ locale: Locale) -> Value? {
+        let localeIdentifier = locale.identifier
+
+        if let exactMatch = self[localeIdentifier] {
+            return exactMatch
+        }
+
+        // For zh-Hans and zh-Hant
+        let underscoreUocaleIdentifier = localeIdentifier.replacingOccurrences(of: "-", with: "_")
+        if let exactMatch = self[underscoreUocaleIdentifier] {
+            return exactMatch
+        }
+
+        return nil
+    }
+
+}

--- a/RevenueCatUI/Templates/V2/Localizations/LocaleFinder.swift
+++ b/RevenueCatUI/Templates/V2/Localizations/LocaleFinder.swift
@@ -23,8 +23,13 @@ extension Dictionary where Key == String {
         }
 
         // For zh-Hans and zh-Hant
-        let underscoreUocaleIdentifier = localeIdentifier.replacingOccurrences(of: "-", with: "_")
-        if let exactMatch = self[underscoreUocaleIdentifier] {
+        let underscoreLocaleIdentifier = localeIdentifier.replacingOccurrences(of: "-", with: "_")
+        if let exactMatch = self[underscoreLocaleIdentifier] {
+            return exactMatch
+        }
+
+        // For matching language without region
+        if let noRegionLocaleIdentifier = locale.rc_languageCode, let exactMatch = self[noRegionLocaleIdentifier] {
             return exactMatch
         }
 

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -410,35 +410,4 @@ fileprivate extension PaywallsV2View {
     }
 }
 
-fileprivate extension Locale {
-
-    static var preferredLocales: [Self] {
-        return Self.preferredLanguages.map(Locale.init(identifier:))
-    }
-
-    func matchesLanguage(_ rhs: Locale) -> Bool {
-        self.removingRegion == rhs.removingRegion
-    }
-
-    // swiftlint:disable:next identifier_name
-    var rc_languageCode: String? {
-        #if swift(>=5.9)
-        // `Locale.languageCode` is deprecated
-        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, visionOS 1.0, *) {
-            return self.language.languageCode?.identifier
-        } else {
-            return self.languageCode
-        }
-        #else
-        return self.languageCode
-        #endif
-    }
-
-    /// - Returns: the same locale as `self` but removing its region.
-    private var removingRegion: Self? {
-        return self.rc_languageCode.map(Locale.init(identifier:))
-    }
-
-}
-
 #endif

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -352,9 +352,9 @@ fileprivate extension PaywallsV2View {
         let chosenLocale = Self.preferredLocale(from: paywallLocales) ?? defaultLocale
 
         // STEP 3: Get localization for one of preferred locales in order
-        if let localizedStrings = componentsLocalizations[chosenLocale.identifier] {
+        if let localizedStrings = componentsLocalizations.findLocale(chosenLocale) {
             return .init(locale: chosenLocale, localizedStrings: localizedStrings)
-        } else if let localizedStrings = componentsLocalizations[defaultLocale.identifier] {
+        } else if let localizedStrings = componentsLocalizations.findLocale(defaultLocale) {
             Logger.error(Strings.paywall_could_not_find_localization("\(chosenLocale)"))
             return .init(locale: defaultLocale, localizedStrings: localizedStrings)
         } else {

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -50,7 +50,7 @@ struct UIConfigProvider {
     }
 
     func getLocalizations(for locale: Locale) -> [String: String] {
-        guard let localizations = self.uiConfig.localizations[locale.identifier] else {
+        guard let localizations = self.uiConfig.localizations.findLocale(locale) else {
             Logger.error("Could not find localizations for '\(locale.identifier)'")
             return [:]
         }

--- a/Tests/RevenueCatUITests/PaywallsV2/LocaleFinderTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/LocaleFinderTests.swift
@@ -46,4 +46,17 @@ class LocaleFinderTest: TestCase {
         expect(foundLocalizations).to(equal(Self.expectedTranslations))
     }
 
+    func test_es_MX() {
+        let localizations = [
+            "zh_Hans": Self.wrongTranslations,
+            "es": Self.expectedTranslations,
+            "es_ES": Self.wrongTranslations
+        ]
+
+        let locale = Locale(identifier: "es_MX")
+
+        let foundLocalizations = localizations.findLocale(locale)
+        expect(foundLocalizations).to(equal(Self.expectedTranslations))
+    }
+
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/LocaleFinderTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/LocaleFinderTests.swift
@@ -1,0 +1,49 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  LocaleFinderTests.swift
+//
+//  Created by Josh Holtz on 2/6/25.
+
+import Nimble
+import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+class LocaleFinderTest: TestCase {
+
+    static let expectedTranslations = ["expected": "translations"]
+    static let wrongTranslations = ["wrong": "translations"]
+
+    func test_en_US() {
+        let localizations = [
+            "en_US": Self.expectedTranslations,
+            "es_ES": Self.wrongTranslations
+        ]
+
+        let locale = Locale(identifier: "en_US")
+
+        let foundLocalizations = localizations.findLocale(locale)
+        expect(foundLocalizations).to(equal(Self.expectedTranslations))
+    }
+
+    func test_zh_Hans() {
+        let localizations = [
+            "zh_Hans": Self.expectedTranslations,
+            "es_ES": Self.wrongTranslations
+        ]
+
+        let locale = Locale(identifier: "zh-Hans")
+
+        let foundLocalizations = localizations.findLocale(locale)
+        expect(foundLocalizations).to(equal(Self.expectedTranslations))
+    }
+
+}


### PR DESCRIPTION
### Motivation

There were issues with finding locales like `zh-Hans` and `zh-Hant`

### Description

1. Attempt to look for the locale identifier as is
2. If nothing, replace `-` with `_`

| Example |
|--------|
| ![Simulator Screenshot - iPhone 16 - 2025-02-06 at 22 25 52](https://github.com/user-attachments/assets/4529070b-2067-43ea-8e62-ee2669a00840) | 
