### PR TITLE
Fix for survey answered event not being tracked when not setting a `customerCenterActionHandler`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -312,6 +312,8 @@
 		354895D6267BEDE3001DC5B1 /* ReservedSubscriberAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 354895D5267BEDE3001DC5B1 /* ReservedSubscriberAttributes.swift */; };
 		3551E39D2C4A6A1400D27C25 /* TintedProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3551E39C2C4A6A1400D27C25 /* TintedProgressView.swift */; };
 		35549323269E298B005F9AE9 /* OfferingsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35549322269E298B005F9AE9 /* OfferingsFactory.swift */; };
+		35617C762D5A3BC500612B7A /* FeedbackSurveyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35617C752D5A3BC000612B7A /* FeedbackSurveyViewModelTests.swift */; };
+		35617C782D5A460400612B7A /* MockLoadPromotionalOfferUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35617C772D5A45F900612B7A /* MockLoadPromotionalOfferUseCase.swift */; };
 		356523A82CF7719C00B6E3EA /* CustomerCenterPresentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 356523A72CF7719B00B6E3EA /* CustomerCenterPresentationMode.swift */; };
 		356523AA2CF885D300B6E3EA /* MockCustomerCenterPurchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 356523A92CF885CE00B6E3EA /* MockCustomerCenterPurchases.swift */; };
 		356523AC2CF890F400B6E3EA /* CustomerCenterEventsRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 356523AB2CF890EA00B6E3EA /* CustomerCenterEventsRequestTests.swift */; };
@@ -1637,6 +1639,8 @@
 		354895D5267BEDE3001DC5B1 /* ReservedSubscriberAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservedSubscriberAttributes.swift; sourceTree = "<group>"; };
 		3551E39C2C4A6A1400D27C25 /* TintedProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TintedProgressView.swift; sourceTree = "<group>"; };
 		35549322269E298B005F9AE9 /* OfferingsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingsFactory.swift; sourceTree = "<group>"; };
+		35617C752D5A3BC000612B7A /* FeedbackSurveyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackSurveyViewModelTests.swift; sourceTree = "<group>"; };
+		35617C772D5A45F900612B7A /* MockLoadPromotionalOfferUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoadPromotionalOfferUseCase.swift; sourceTree = "<group>"; };
 		356523A72CF7719B00B6E3EA /* CustomerCenterPresentationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterPresentationMode.swift; sourceTree = "<group>"; };
 		356523A92CF885CE00B6E3EA /* MockCustomerCenterPurchases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCustomerCenterPurchases.swift; sourceTree = "<group>"; };
 		356523AB2CF890EA00B6E3EA /* CustomerCenterEventsRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterEventsRequestTests.swift; sourceTree = "<group>"; };
@@ -3872,6 +3876,7 @@
 				FD6186522D1393E2007843DA /* Mocks */,
 				35A99C822CCB95950074AB41 /* SubscriptionInformationFixtures.swift */,
 				3544DA692C2C848E00704E9D /* CustomerCenterViewModelTests.swift */,
+				35617C752D5A3BC000612B7A /* FeedbackSurveyViewModelTests.swift */,
 				3544DA6A2C2C848E00704E9D /* ManageSubscriptionsViewModelTests.swift */,
 				1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */,
 				35A99C802CCB8D530074AB41 /* PurchaseInformationTests.swift */,
@@ -5202,6 +5207,7 @@
 		FD6186522D1393E2007843DA /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				35617C772D5A45F900612B7A /* MockLoadPromotionalOfferUseCase.swift */,
 				356523A92CF885CE00B6E3EA /* MockCustomerCenterPurchases.swift */,
 				FD6186532D1393FA007843DA /* MockCustomerCenterStoreKitUtilities.swift */,
 			);
@@ -6931,6 +6937,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8834AFA52C2B9375005A72FE /* PresentIfNeededTests.swift in Sources */,
+				35617C762D5A3BC500612B7A /* FeedbackSurveyViewModelTests.swift in Sources */,
 				887A632B2C1D177800E1A461 /* LocalizedAlertErrorTests.swift in Sources */,
 				887A632C2C1D177800E1A461 /* PackageVariablesTests.swift in Sources */,
 				887A632D2C1D177800E1A461 /* PaywallDataValidationTests.swift in Sources */,
@@ -6962,6 +6969,7 @@
 				030F918C2D55C9DC0085103F /* LocaleFinderTests.swift in Sources */,
 				887A633F2C1D177800E1A461 /* Template4ViewTests.swift in Sources */,
 				887A63402C1D177800E1A461 /* Template5ViewTests.swift in Sources */,
+				35617C782D5A460400612B7A /* MockLoadPromotionalOfferUseCase.swift in Sources */,
 				887A63412C1D177800E1A461 /* BaseSnapshotTest.swift in Sources */,
 				887A63422C1D177800E1A461 /* ImageLoaderTests.swift in Sources */,
 				887A63432C1D177800E1A461 /* LocalizationTests.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/Data/FeedbackSurveyData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/FeedbackSurveyData.swift
@@ -22,7 +22,7 @@ import RevenueCat
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-class FeedbackSurveyData: ObservableObject {
+class FeedbackSurveyData: ObservableObject, Equatable {
 
     var configuration: CustomerCenterConfigData.HelpPath.FeedbackSurvey
     var path: CustomerCenterConfigData.HelpPath
@@ -36,6 +36,10 @@ class FeedbackSurveyData: ObservableObject {
         self.onOptionSelected = onOptionSelected
     }
 
+    static func == (lhs: FeedbackSurveyData, rhs: FeedbackSurveyData) -> Bool {
+        return lhs.configuration == rhs.configuration &&
+               lhs.path == rhs.path
+    }
 }
 
 #endif

--- a/RevenueCatUI/CustomerCenter/Data/PromotionalOfferData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PromotionalOfferData.swift
@@ -14,7 +14,7 @@
 import Foundation
 import RevenueCat
 
-struct PromotionalOfferData: Identifiable {
+struct PromotionalOfferData: Identifiable, Equatable {
 
     let id = UUID()
     let promotionalOffer: PromotionalOffer

--- a/RevenueCatUI/CustomerCenter/ViewModels/FeedbackSurveyViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/FeedbackSurveyViewModel.swift
@@ -59,9 +59,10 @@ class FeedbackSurveyViewModel: ObservableObject {
         for option: CustomerCenterConfigData.HelpPath.FeedbackSurvey.Option,
         darkMode: Bool,
         displayMode: CustomerCenterPresentationMode,
+        locale: Locale = .current,
         dismissView: () -> Void
     ) async {
-        trackSurveyAnswerSubmitted(option: option, darkMode: darkMode, displayMode: displayMode)
+        trackSurveyAnswerSubmitted(option: option, darkMode: darkMode, displayMode: displayMode, locale: locale)
 
         self.customerCenterActionHandler?(.feedbackSurveyCompleted(option.id))
 
@@ -116,9 +117,10 @@ private extension FeedbackSurveyViewModel {
 
     func trackSurveyAnswerSubmitted(option: CustomerCenterConfigData.HelpPath.FeedbackSurvey.Option,
                                     darkMode: Bool,
-                                    displayMode: CustomerCenterPresentationMode) {
+                                    displayMode: CustomerCenterPresentationMode,
+                                    locale: Locale) {
         let isSandbox = purchasesProvider.isSandbox
-        let surveyOptionData = CustomerCenterAnswerSubmittedEvent.Data(locale: .current,
+        let surveyOptionData = CustomerCenterAnswerSubmittedEvent.Data(locale: locale,
                                                                        darkMode: darkMode,
                                                                        isSandbox: isSandbox,
                                                                        displayMode: displayMode,

--- a/RevenueCatUI/CustomerCenter/ViewModels/FeedbackSurveyViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/FeedbackSurveyViewModel.swift
@@ -61,10 +61,9 @@ class FeedbackSurveyViewModel: ObservableObject {
         displayMode: CustomerCenterPresentationMode,
         dismissView: () -> Void
     ) async {
-        if let customerCenterActionHandler = self.customerCenterActionHandler {
-            trackSurveyAnswerSubmitted(option: option, darkMode: darkMode, displayMode: displayMode)
-            customerCenterActionHandler(.feedbackSurveyCompleted(option.id))
-        }
+        trackSurveyAnswerSubmitted(option: option, darkMode: darkMode, displayMode: displayMode)
+
+        self.customerCenterActionHandler?(.feedbackSurveyCompleted(option.id))
 
         if let promotionalOffer = option.promotionalOffer,
            promotionalOffer.eligible {

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -18,7 +18,7 @@ import Foundation
 // swiftlint:disable missing_docs nesting file_length type_body_length
 public typealias RCColor = PaywallColor
 
-public struct CustomerCenterConfigData {
+public struct CustomerCenterConfigData: Equatable {
 
     public let screens: [Screen.ScreenType: Screen]
     public let appearance: Appearance
@@ -41,7 +41,7 @@ public struct CustomerCenterConfigData {
         self.productId = productId
     }
 
-    public struct Localization {
+    public struct Localization: Equatable {
 
         let locale: String
         let localizedStrings: [String: String]
@@ -51,7 +51,7 @@ public struct CustomerCenterConfigData {
             self.localizedStrings = localizedStrings
         }
 
-        public enum CommonLocalizedString: String {
+        public enum CommonLocalizedString: String, Equatable {
 
             case copy = "copy"
             case noThanks = "no_thanks"
@@ -327,7 +327,7 @@ public struct CustomerCenterConfigData {
         }
     }
 
-    public struct HelpPath {
+    public struct HelpPath: Equatable {
 
         public let id: String
         public let title: String
@@ -350,14 +350,14 @@ public struct CustomerCenterConfigData {
             self.detail = detail
         }
 
-        public enum PathDetail {
+        public enum PathDetail: Equatable {
 
             case promotionalOffer(PromotionalOffer)
             case feedbackSurvey(FeedbackSurvey)
 
         }
 
-        public enum PathType: String {
+        public enum PathType: String, Equatable {
 
             case missingPurchase = "MISSING_PURCHASE"
             case refundRequest = "REFUND_REQUEST"
@@ -385,7 +385,7 @@ public struct CustomerCenterConfigData {
 
         }
 
-        public enum OpenMethod: String {
+        public enum OpenMethod: String, Equatable {
 
             case inApp = "IN_APP"
             case external = "EXTERNAL"
@@ -403,7 +403,7 @@ public struct CustomerCenterConfigData {
 
         }
 
-        public struct PromotionalOffer {
+        public struct PromotionalOffer: Equatable {
 
             public let iosOfferId: String
             public let eligible: Bool
@@ -425,7 +425,7 @@ public struct CustomerCenterConfigData {
 
         }
 
-        public struct FeedbackSurvey {
+        public struct FeedbackSurvey: Equatable {
 
             public let title: String
             public let options: [Option]
@@ -435,7 +435,7 @@ public struct CustomerCenterConfigData {
                 self.options = options
             }
 
-            public struct Option {
+            public struct Option: Equatable {
 
                 public let id: String
                 public let title: String
@@ -453,7 +453,7 @@ public struct CustomerCenterConfigData {
 
     }
 
-    public struct Appearance {
+    public struct Appearance: Equatable {
 
         public let accentColor: ColorInformation
         public let textColor: ColorInformation
@@ -473,7 +473,7 @@ public struct CustomerCenterConfigData {
             self.buttonBackgroundColor = buttonBackgroundColor
         }
 
-        public struct ColorInformation {
+        public struct ColorInformation: Equatable {
 
             public var light: RCColor?
             public var dark: RCColor?
@@ -506,7 +506,7 @@ public struct CustomerCenterConfigData {
 
     }
 
-    public struct Screen {
+    public struct Screen: Equatable {
 
         public let type: ScreenType
         public let title: String
@@ -520,7 +520,7 @@ public struct CustomerCenterConfigData {
             self.paths = paths
         }
 
-        public enum ScreenType: String {
+        public enum ScreenType: String, Equatable {
             case management = "MANAGEMENT"
             case noActive = "NO_ACTIVE"
             case unknown
@@ -539,7 +539,7 @@ public struct CustomerCenterConfigData {
 
     }
 
-    public struct Support {
+    public struct Support: Equatable {
 
         public let email: String
         public let shouldWarnCustomerToUpdate: Bool

--- a/Tests/RevenueCatUITests/CustomerCenter/FeedbackSurveyViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/FeedbackSurveyViewModelTests.swift
@@ -1,0 +1,494 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  FeedbackSurveyViewModelTests.swift
+//
+//  Created by Cesar de la Vega on 10/2/25.
+
+// swiftlint:disable type_body_length file_length
+
+import Nimble
+@testable import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@MainActor
+class FeedbackSurveyViewModelTests: TestCase {
+
+    let mockLoadPromotionalOfferUseCase = MockLoadPromotionalOfferUseCase()
+    let mockPurchases = MockCustomerCenterPurchases()
+
+    func testInitialState() {
+        let data = FeedbackSurveyData(
+            configuration: Self.feedbackSurvey,
+            path: Self.path,
+            onOptionSelected: {}
+        )
+
+        let viewModel = FeedbackSurveyViewModel(feedbackSurveyData: data) { _ in
+
+        }
+
+        expect(viewModel.feedbackSurveyData).to(equal(data))
+    }
+
+    func testHandleActionWithoutPromotionalOfferDismissesView() async {
+        let option = Self.option
+
+        let data = FeedbackSurveyData(
+            configuration: Self.feedbackSurvey,
+            path: Self.path,
+            onOptionSelected: {}
+        )
+
+        let viewModel = FeedbackSurveyViewModel(
+            feedbackSurveyData: data,
+            purchasesProvider: mockPurchases,
+            loadPromotionalOfferUseCase: mockLoadPromotionalOfferUseCase,
+            customerCenterActionHandler: nil
+        )
+
+        let dismissViewExpectation = expectation(description: "Dismiss view should be called")
+
+        await viewModel.handleAction(for: option,
+                                     darkMode: false,
+                                     displayMode: CustomerCenterPresentationMode.fullScreen) {
+            dismissViewExpectation.fulfill()
+        }
+
+        await fulfillment(of: [dismissViewExpectation], timeout: 1.0)
+    }
+
+    func testHandleActionWithoutPromotionalDoesNotSetLoadingOption() async {
+        let option = Self.option
+
+        let data = FeedbackSurveyData(
+            configuration: Self.feedbackSurvey,
+            path: Self.path,
+            onOptionSelected: {}
+        )
+
+        let viewModel = FeedbackSurveyViewModel(
+            feedbackSurveyData: data,
+            purchasesProvider: mockPurchases,
+            loadPromotionalOfferUseCase: mockLoadPromotionalOfferUseCase,
+            customerCenterActionHandler: nil
+        )
+
+        await viewModel.handleAction(for: option,
+                                     darkMode: false,
+                                     displayMode: CustomerCenterPresentationMode.fullScreen) {
+        }
+
+        expect(viewModel.loadingOption).to(beNil())
+    }
+
+    func testHandleActionWithoutPromotionalOfferTriggersOnOptionSelectedCallback() async {
+        let option = Self.option
+
+        let onOptionSelectedExpectation = expectation(description: "OnOptionSelected should be called")
+
+        let data = FeedbackSurveyData(
+            configuration: Self.feedbackSurvey,
+            path: Self.path,
+            onOptionSelected: {
+                onOptionSelectedExpectation.fulfill()
+            }
+        )
+
+        let viewModel = FeedbackSurveyViewModel(
+            feedbackSurveyData: data,
+            purchasesProvider: mockPurchases,
+            loadPromotionalOfferUseCase: mockLoadPromotionalOfferUseCase,
+            customerCenterActionHandler: nil
+        )
+
+        await viewModel.handleAction(for: option,
+                                     darkMode: false,
+                                     displayMode: CustomerCenterPresentationMode.fullScreen) {
+        }
+
+        await fulfillment(of: [onOptionSelectedExpectation], timeout: 1.0)
+    }
+
+    func testHandleActionWithoutPromotionalOfferAndNoCustomerCenterActionHandlerTracksEvent() async throws {
+        let option = Self.option
+        let path = Self.path
+        let data = FeedbackSurveyData(
+            configuration: Self.feedbackSurvey,
+            path: path,
+            onOptionSelected: {}
+        )
+
+        let viewModel = FeedbackSurveyViewModel(
+            feedbackSurveyData: data,
+            purchasesProvider: mockPurchases,
+            loadPromotionalOfferUseCase: mockLoadPromotionalOfferUseCase,
+            customerCenterActionHandler: nil
+        )
+
+        await viewModel.handleAction(for: option,
+                                     darkMode: false,
+                                     displayMode: CustomerCenterPresentationMode.fullScreen,
+                                     locale: Locale(identifier: "en_US")) {
+        }
+
+        expect(self.mockPurchases.trackCallCount) == 1
+        let event = try XCTUnwrap(self.mockPurchases.trackedEvents[0] as? CustomerCenterAnswerSubmittedEvent)
+        expect(event.data.localeIdentifier) == "en_US"
+        expect(event.data.darkMode) == false
+        expect(event.data.isSandbox) == mockPurchases.isSandbox
+        expect(event.data.displayMode) == RevenueCat.CustomerCenterPresentationMode.fullScreen
+        expect(event.data.revisionID) == 0
+        expect(event.data.additionalContext).to(beNil())
+        expect(event.data.surveyOptionTitleKey) == option.title
+        expect(event.data.path) == .cancel
+        expect(event.data.surveyOptionID) == option.id
+        expect(event.data.url).to(beNil())
+    }
+
+    func testHandleActionWithoutPromotionalOfferTracksEvent() async throws {
+        let option = Self.option
+        let path = Self.path
+        let data = FeedbackSurveyData(
+            configuration: Self.feedbackSurvey,
+            path: path,
+            onOptionSelected: {}
+        )
+
+        let viewModel = FeedbackSurveyViewModel(
+            feedbackSurveyData: data,
+            purchasesProvider: mockPurchases,
+            loadPromotionalOfferUseCase: mockLoadPromotionalOfferUseCase,
+            customerCenterActionHandler: { _ in}
+        )
+
+        await viewModel.handleAction(for: option,
+                                     darkMode: false,
+                                     displayMode: CustomerCenterPresentationMode.fullScreen,
+                                     locale: Locale(identifier: "en_US")) {
+        }
+
+        expect(self.mockPurchases.trackCallCount) == 1
+        let event = try XCTUnwrap(self.mockPurchases.trackedEvents[0] as? CustomerCenterAnswerSubmittedEvent)
+        expect(event.data.localeIdentifier) == "en_US"
+        expect(event.data.darkMode) == false
+        expect(event.data.isSandbox) == mockPurchases.isSandbox
+        expect(event.data.displayMode) == RevenueCat.CustomerCenterPresentationMode.fullScreen
+        expect(event.data.revisionID) == 0
+        expect(event.data.additionalContext).to(beNil())
+        expect(event.data.surveyOptionTitleKey) == option.title
+        expect(event.data.path) == .cancel
+        expect(event.data.surveyOptionID) == option.id
+        expect(event.data.url).to(beNil())
+    }
+
+    func testHandleActionWithoutPromotionalOfferCallsHandler() async throws {
+        let option = Self.option
+        let path = Self.path
+        let data = FeedbackSurveyData(
+            configuration: Self.feedbackSurvey,
+            path: path,
+            onOptionSelected: {}
+        )
+
+        let handlerCalledExpectation = expectation(description: "customerCenterActionHandler should be called")
+        var optionCalled: String?
+        let viewModel = FeedbackSurveyViewModel(
+            feedbackSurveyData: data,
+            purchasesProvider: mockPurchases,
+            loadPromotionalOfferUseCase: mockLoadPromotionalOfferUseCase) { action in
+                switch action {
+                case .feedbackSurveyCompleted(let option):
+                    handlerCalledExpectation.fulfill()
+                    optionCalled = option
+                default:
+                    return
+                }
+            }
+
+        await viewModel.handleAction(for: option,
+                                     darkMode: false,
+                                     displayMode: CustomerCenterPresentationMode.fullScreen,
+                                     locale: Locale(identifier: "en_US")) {
+        }
+
+        await fulfillment(of: [handlerCalledExpectation], timeout: 1.0)
+        expect(optionCalled) == option.id
+    }
+
+    func testHandleActionWithPromotionalOfferTracksEvent() async throws {
+        let option = Self.optionWithPromo
+        let path = Self.path
+        let data = FeedbackSurveyData(
+            configuration: Self.feedbackSurvey,
+            path: path,
+            onOptionSelected: {}
+        )
+
+        let viewModel = FeedbackSurveyViewModel(
+            feedbackSurveyData: data,
+            purchasesProvider: mockPurchases,
+            loadPromotionalOfferUseCase: mockLoadPromotionalOfferUseCase,
+            customerCenterActionHandler: { _ in }
+        )
+
+        await viewModel.handleAction(for: option,
+                                     darkMode: false,
+                                     displayMode: CustomerCenterPresentationMode.fullScreen,
+                                     locale: Locale(identifier: "en_US")) {
+        }
+
+        expect(self.mockPurchases.trackCallCount) == 1
+        let event = try XCTUnwrap(self.mockPurchases.trackedEvents[0] as? CustomerCenterAnswerSubmittedEvent)
+        expect(event.data.localeIdentifier) == "en_US"
+        expect(event.data.darkMode) == false
+        expect(event.data.isSandbox) == mockPurchases.isSandbox
+        expect(event.data.displayMode) == RevenueCat.CustomerCenterPresentationMode.fullScreen
+        expect(event.data.revisionID) == 0
+        expect(event.data.additionalContext).to(beNil())
+        expect(event.data.surveyOptionTitleKey) == option.title
+        expect(event.data.path) == .cancel
+        expect(event.data.surveyOptionID) == option.id
+        expect(event.data.url).to(beNil())
+    }
+
+    func testHandleActionWithPromotionalOfferAndNoCustomerCenterActionHandlerTracksEvent() async throws {
+        let option = Self.optionWithPromo
+        let path = Self.path
+        let data = FeedbackSurveyData(
+            configuration: Self.feedbackSurvey,
+            path: path,
+            onOptionSelected: {}
+        )
+
+        let viewModel = FeedbackSurveyViewModel(
+            feedbackSurveyData: data,
+            purchasesProvider: mockPurchases,
+            loadPromotionalOfferUseCase: mockLoadPromotionalOfferUseCase,
+            customerCenterActionHandler: nil
+        )
+
+        await viewModel.handleAction(for: option,
+                                     darkMode: false,
+                                     displayMode: CustomerCenterPresentationMode.fullScreen,
+                                     locale: Locale(identifier: "en_US")) {
+        }
+
+        expect(self.mockPurchases.trackCallCount) == 1
+        let event = try XCTUnwrap(self.mockPurchases.trackedEvents[0] as? CustomerCenterAnswerSubmittedEvent)
+        expect(event.data.localeIdentifier) == "en_US"
+        expect(event.data.darkMode) == false
+        expect(event.data.isSandbox) == mockPurchases.isSandbox
+        expect(event.data.displayMode) == RevenueCat.CustomerCenterPresentationMode.fullScreen
+        expect(event.data.revisionID) == 0
+        expect(event.data.additionalContext).to(beNil())
+        expect(event.data.surveyOptionTitleKey) == option.title
+        expect(event.data.path) == .cancel
+        expect(event.data.surveyOptionID) == option.id
+        expect(event.data.url).to(beNil())
+    }
+
+    func testHandleActionWithPromotionalOfferCallsHandler() async throws {
+        let option = Self.optionWithPromo
+        let path = Self.path
+        let data = FeedbackSurveyData(
+            configuration: Self.feedbackSurvey,
+            path: path,
+            onOptionSelected: {}
+        )
+
+        let handlerCalledExpectation = expectation(description: "customerCenterActionHandler should be called")
+        var optionCalled: String?
+        let viewModel = FeedbackSurveyViewModel(
+            feedbackSurveyData: data,
+            purchasesProvider: mockPurchases,
+            loadPromotionalOfferUseCase: mockLoadPromotionalOfferUseCase) { action in
+                switch action {
+                case .feedbackSurveyCompleted(let option):
+                    handlerCalledExpectation.fulfill()
+                    optionCalled = option
+                default:
+                    return
+                }
+            }
+
+        await viewModel.handleAction(for: option,
+                                     darkMode: false,
+                                     displayMode: CustomerCenterPresentationMode.fullScreen,
+                                     locale: Locale(identifier: "en_US")) {
+        }
+
+        await fulfillment(of: [handlerCalledExpectation], timeout: 1.0)
+        expect(optionCalled) == option.id
+    }
+
+    func testHandleActionWithPromotionalOfferLoadsPromotionalOfferAndDoesNotTriggerMainAction() async throws {
+        let option = Self.optionWithPromo
+        let path = Self.path
+        var optionCalled: Bool = false
+        let data = FeedbackSurveyData(
+            configuration: Self.feedbackSurvey,
+            path: path,
+            onOptionSelected: {
+                optionCalled = true
+            }
+        )
+
+        mockLoadPromotionalOfferUseCase.mockedProduct = Self.product
+        mockLoadPromotionalOfferUseCase.mockedPromoOfferDetails = Self.promoOfferDetails
+        let signedData = PromotionalOffer.SignedData(
+            identifier: "id",
+            keyIdentifier: "key_i",
+            nonce: UUID(),
+            signature: "a signature",
+            timestamp: 1234
+        )
+        let discount = MockStoreProductDiscount(
+            offerIdentifier: "offer_id",
+            currencyCode: "usd",
+            price: 1,
+            localizedPriceString: "$1.00",
+            paymentMode: .payAsYouGo,
+            subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            numberOfPeriods: 1,
+            type: .introductory
+        )
+
+        mockLoadPromotionalOfferUseCase.mockedPromotionalOffer = PromotionalOffer(
+            discount: discount,
+            signedData: signedData
+        )
+        let viewModel = FeedbackSurveyViewModel(
+            feedbackSurveyData: data,
+            purchasesProvider: mockPurchases,
+            loadPromotionalOfferUseCase: mockLoadPromotionalOfferUseCase) { _ in }
+
+        await viewModel.handleAction(for: option,
+                                     darkMode: false,
+                                     displayMode: CustomerCenterPresentationMode.fullScreen,
+                                     locale: Locale(identifier: "en_US")) {
+        }
+
+        expect(optionCalled).to(beFalse())
+    }
+
+    func testHandleActionWithPromotionalOfferTriggersMainActionIfLoadingFails() async throws {
+        let option = Self.optionWithPromo
+        let path = Self.path
+        var optionCalled: Bool = false
+        let data = FeedbackSurveyData(
+            configuration: Self.feedbackSurvey,
+            path: path,
+            onOptionSelected: {
+                optionCalled = true
+            }
+        )
+
+        mockLoadPromotionalOfferUseCase.mockedProduct = Self.product
+        mockLoadPromotionalOfferUseCase.mockedPromoOfferDetails = Self.promoOfferDetails
+        mockLoadPromotionalOfferUseCase.mockedPromotionalOffer = nil
+
+        let viewModel = FeedbackSurveyViewModel(
+            feedbackSurveyData: data,
+            purchasesProvider: mockPurchases,
+            loadPromotionalOfferUseCase: mockLoadPromotionalOfferUseCase) { _ in }
+
+        await viewModel.handleAction(for: option,
+                                     darkMode: false,
+                                     displayMode: CustomerCenterPresentationMode.fullScreen,
+                                     locale: Locale(identifier: "en_US")) {
+        }
+
+        expect(optionCalled).to(beTrue())
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private extension FeedbackSurveyViewModelTests {
+
+    static let promoOfferDetails = CustomerCenterConfigData.HelpPath.PromotionalOffer(
+        iosOfferId: "offer_id",
+        eligible: true,
+        title: "Wait",
+        subtitle: "Here's an offer for you",
+        productMapping: [
+            "product_id": "offer_id"
+        ]
+    )
+
+    static let product = PurchaseInformationFixtures.product(
+        id: "product_id",
+        title: "yearly",
+        duration: .year,
+        price: Decimal(29.99),
+        offerIdentifier: "offer_id"
+    )
+
+    static let option = CustomerCenterConfigData.HelpPath.FeedbackSurvey.Option(
+        id: "1",
+        title: "Too expensive",
+        promotionalOffer: nil
+    )
+
+    static let optionWithPromo = CustomerCenterConfigData.HelpPath.FeedbackSurvey.Option(
+        id: "2",
+        title: "No too expensive",
+        promotionalOffer: CustomerCenterConfigData.HelpPath.PromotionalOffer(
+            iosOfferId: "offer_id",
+            eligible: true,
+            title: "title",
+            subtitle: "subtitle",
+            productMapping: ["monthly": "offer_id"]
+        )
+    )
+
+    static let feedbackSurvey = CustomerCenterConfigData.HelpPath.FeedbackSurvey(
+        title: "Why are you cancelling?",
+        options: [
+            option,
+            optionWithPromo,
+            .init(
+                id: "3",
+                title: "Bought by mistake",
+                promotionalOffer: nil
+            )
+        ]
+    )
+
+    static let path = CustomerCenterConfigData.HelpPath(
+        id: "4",
+        title: "Cancel subscription",
+        url: nil,
+        openMethod: nil,
+        type: .cancel,
+        detail: .feedbackSurvey(feedbackSurvey))
+
+}
+
+private struct MockStoreProductDiscount: StoreProductDiscountType {
+
+    let offerIdentifier: String?
+    let currencyCode: String?
+    let price: Decimal
+    let localizedPriceString: String
+    let paymentMode: StoreProductDiscount.PaymentMode
+    let subscriptionPeriod: SubscriptionPeriod
+    let numberOfPeriods: Int
+    let type: StoreProductDiscount.DiscountType
+
+}

--- a/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
@@ -414,36 +414,6 @@ private struct MockStoreProductDiscount: StoreProductDiscountType {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(macOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
-private class MockLoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
-
-    var offerToLoadPromoFor: RevenueCat.CustomerCenterConfigData.HelpPath.PromotionalOffer?
-
-    var mockedProduct: StoreProduct?
-    var mockedPromotionalOffer: PromotionalOffer?
-    var mockedPromoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer?
-
-    func execute(
-        promoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer
-    ) async -> Result<PromotionalOfferData, Error> {
-        self.offerToLoadPromoFor = promoOfferDetails
-        if let mockedProduct = mockedProduct,
-           let mockedPromotionalOffer = mockedPromotionalOffer,
-           let mockedPromoOfferDetails = mockedPromoOfferDetails {
-            return .success(PromotionalOfferData(promotionalOffer: mockedPromotionalOffer,
-                                                 product: mockedProduct,
-                                                 promoOfferDetails: mockedPromoOfferDetails))
-        } else {
-            return .failure(CustomerCenterError.couldNotFindOfferForActiveProducts)
-        }
-
-    }
-
-}
-
 private extension PurchaseInformation {
     static var mockLifetime: PurchaseInformation {
         PurchaseInformation(

--- a/Tests/RevenueCatUITests/CustomerCenter/Mocks/MockLoadPromotionalOfferUseCase.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/Mocks/MockLoadPromotionalOfferUseCase.swift
@@ -1,0 +1,46 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockLoadPromotionalOfferUseCase.swift
+//
+//  Created by Cesar de la Vega on 10/2/25.
+
+import Foundation
+import RevenueCat
+@testable import RevenueCatUI
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+class MockLoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
+
+    var offerToLoadPromoFor: RevenueCat.CustomerCenterConfigData.HelpPath.PromotionalOffer?
+
+    var mockedProduct: StoreProduct?
+    var mockedPromotionalOffer: PromotionalOffer?
+    var mockedPromoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer?
+
+    func execute(
+        promoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer
+    ) async -> Result<PromotionalOfferData, Error> {
+        self.offerToLoadPromoFor = promoOfferDetails
+        if let mockedProduct = mockedProduct,
+           let mockedPromotionalOffer = mockedPromotionalOffer,
+           let mockedPromoOfferDetails = mockedPromoOfferDetails {
+            return .success(PromotionalOfferData(promotionalOffer: mockedPromotionalOffer,
+                                                 product: mockedProduct,
+                                                 promoOfferDetails: mockedPromoOfferDetails))
+        } else {
+            return .failure(CustomerCenterError.couldNotFindOfferForActiveProducts)
+        }
+
+    }
+
+}


### PR DESCRIPTION
If `customerCenterActionHandler` is not set, we are not tracking survey answered submitted events