### PR TITLE
fix: Track impression in CustomerCenter only once

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -77,6 +77,7 @@ import RevenueCat
     internal let customerCenterActionHandler: CustomerCenterActionHandler?
 
     private var error: Error?
+    private var impressionData: CustomerCenterEvent.Data?
 
     init(
         customerCenterActionHandler: CustomerCenterActionHandler?,
@@ -131,13 +132,17 @@ import RevenueCat
     }
 
     func trackImpression(darkMode: Bool, displayMode: CustomerCenterPresentationMode) {
-        let isSandbox = purchasesProvider.isSandbox
+        guard impressionData == nil else {
+            return
+        }
+
         let eventData = CustomerCenterEvent.Data(locale: .current,
                                                  darkMode: darkMode,
-                                                 isSandbox: isSandbox,
+                                                 isSandbox: purchasesProvider.isSandbox,
                                                  displayMode: displayMode)
-        let event = CustomerCenterEvent.impression(CustomerCenterEventCreationData(), eventData)
+        defer { self.impressionData = eventData }
 
+        let event = CustomerCenterEvent.impression(CustomerCenterEventCreationData(), eventData)
         purchasesProvider.track(customerCenterEvent: event)
     }
 

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -91,13 +91,13 @@ public struct CustomerCenterView: View {
             .task {
                 await loadInformationIfNeeded()
             }
-            .task {
+            .environmentObject(self.viewModel)
+            .onAppear {
 #if DEBUG
                 guard ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else { return }
 #endif
                 self.trackImpression()
             }
-            .environmentObject(self.viewModel)
     }
 
 }

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -786,6 +786,9 @@ class CustomerCenterViewModelTests: TestCase {
         if case .impression = trackedEvent {} else {
             fail("Expected an impression event")
         }
+
+        viewModel.trackImpression(darkMode: darkMode, displayMode: displayMode)
+        expect(mockPurchases.trackedEvents.count) == 1
     }
 
     func testShouldShowAppUpdateWarningsTrue() {

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -788,6 +788,8 @@ class CustomerCenterViewModelTests: TestCase {
         }
 
         viewModel.trackImpression(darkMode: darkMode, displayMode: displayMode)
+        viewModel.trackImpression(darkMode: darkMode, displayMode: displayMode)
+        viewModel.trackImpression(darkMode: darkMode, displayMode: displayMode)
         expect(mockPurchases.trackedEvents.count) == 1
     }
 


### PR DESCRIPTION
### Motivation
We've noticed `trackImpression` gets called multiple times per session. This PR addresses that

### Description
`impression` event should be tracked only once per session
The PR adds a simple check like its done in the Android repository, and updates a test to make sure its only tracked once