### PR TITLE
Hooks up purchase handler preference keys for Paywalls V2

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -23,7 +23,6 @@ import SwiftUI
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
 @available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
-// swiftlint:disable:next type_body_length
 public struct PaywallView: View {
 
     private let contentToDisplay: PaywallViewConfiguration.Content
@@ -294,7 +293,8 @@ public struct PaywallView: View {
                 PaywallsV2View(
                     paywallComponents: paywallComponents,
                     offering: offering,
-                    introEligibilityChecker: .default(),
+                    purchaseHandler: purchaseHandler,
+                    introEligibilityChecker: checker,
                     showZeroDecimalPlacePrices: showZeroDecimalPlacePrices,
                     onDismiss: {
                         guard let onRequestedDismissal = self.onRequestedDismissal else {
@@ -305,8 +305,6 @@ public struct PaywallView: View {
                     },
                     fallbackContent: .paywallV1View(dataForV1DefaultPaywall)
                 )
-                .environmentObject(self.introEligibility)
-                .environmentObject(self.purchaseHandler)
             }
         } else {
 

--- a/RevenueCatUI/Templates/V2/Previews/PreviewMock.swift
+++ b/RevenueCatUI/Templates/V2/Previews/PreviewMock.swift
@@ -82,7 +82,6 @@ struct PreviewRequiredEnvironmentProperties: ViewModifier {
     func body(content: Content) -> some View {
         content
             .environmentObject(IntroOfferEligibilityContext(introEligibilityChecker: .default()))
-            .environmentObject(PurchaseHandler.default())
             .environmentObject(self.packageContext ?? Self.defaultPackageContext)
             .environment(\.screenCondition, screenCondition)
             .environment(\.componentViewState, componentViewState)

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
@@ -386,6 +386,7 @@ struct FamilySharingTogglePreview_Previews: PreviewProvider {
                                 PreviewMock.weeklyPremiumPackage,
                                 PreviewMock.monthlyPremiumPackage
                                ]),
+            purchaseHandler: PurchaseHandler.default(),
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
@@ -395,6 +395,7 @@ struct MultiTierPreview_Previews: PreviewProvider {
                                 PreviewMock.weeklyPremiumPackage,
                                 PreviewMock.monthlyPremiumPackage
                                ]),
+            purchaseHandler: PurchaseHandler.default(),
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -201,6 +201,7 @@ struct Template1Preview_Previews: PreviewProvider {
             offering: .init(identifier: "default",
                             serverDescription: "",
                             availablePackages: [package]),
+            purchaseHandler: PurchaseHandler.default(),
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/PaywallPresenter.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/PaywallPresenter.swift
@@ -30,7 +30,28 @@ struct PaywallPresenter: View {
                 purchaseHandler: handler
             )
 
-            PaywallView(configuration: configuration)
+            PaywallView(offering: offering)
+                .onPurchaseStarted({ package in
+                    print("Paywall Handler - onPurchaseStarted")
+                })
+                .onPurchaseCompleted({ customerInfo in
+                    print("Paywall Handler - onPurchaseCompleted")
+                })
+                .onPurchaseFailure({ error in
+                    print("Paywall Handler - onPurchaseFailure")
+                })
+                .onPurchaseCancelled({
+                    print("Paywall Handler - onPurchaseCancelled")
+                })
+                .onRestoreStarted({
+                    print("Paywall Handler - onRestoreStarted")
+                })
+                .onRestoreCompleted({ customerInfo in
+                    print("Paywall Handler - onRestoreCompleted")
+                })
+                .onRestoreFailure({ error in
+                    print("Paywall Handler - onRestoreFailure")
+                })
 
 #if !os(watchOS)
         case .footer:


### PR DESCRIPTION
### Motivation

Purchase events callbacks were not being executed

### Description

`PaywallsV2View` did not have the preference keys configured
