### PR TITLE
Add prepaid as a period type

### DIFF
--- a/Sources/CodableExtensions/PeriodType+Extensions.swift
+++ b/Sources/CodableExtensions/PeriodType+Extensions.swift
@@ -52,6 +52,7 @@ private extension PeriodType {
         case .normal: return "normal"
         case .intro: return "intro"
         case .trial: return "trial"
+        case .prepaid: return "prepaid"
         }
     }
 

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -107,7 +107,8 @@ import Foundation
         self.willRenew = EntitlementInfo.willRenewWithExpirationDate(expirationDate: expiresDate,
                                                                      store: store,
                                                                      unsubscribeDetectedAt: unsubscribeDetectedAt,
-                                                                     billingIssueDetectedAt: billingIssuesDetectedAt)
+                                                                     billingIssueDetectedAt: billingIssuesDetectedAt,
+                                                                     periodType: periodType)
         self.price = price
 
         super.init()

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -71,7 +71,7 @@ extension Store: DefaultValueProvider {
     /// If the entitlement is under a trial period.
     @objc(RCTrial) case trial = 2
 
-    /// If the entitlement is under a prepaid period.
+    /// If the entitlement is under a prepaid period. This is Play Store only.
     @objc(RCPrepaid) case prepaid = 3
 }
 
@@ -245,7 +245,8 @@ extension PeriodType: DefaultValueProvider {
             willRenew: Self.willRenewWithExpirationDate(expirationDate: subscription.expiresDate,
                                                         store: subscription.store,
                                                         unsubscribeDetectedAt: subscription.unsubscribeDetectedAt,
-                                                        billingIssueDetectedAt: subscription.billingIssuesDetectedAt),
+                                                        billingIssueDetectedAt: subscription.billingIssuesDetectedAt,
+                                                        periodType: subscription.periodType),
             periodType: subscription.periodType,
             latestPurchaseDate: entitlement.purchaseDate,
             originalPurchaseDate: subscription.originalPurchaseDate,
@@ -307,13 +308,16 @@ extension EntitlementInfo {
     static func willRenewWithExpirationDate(expirationDate: Date?,
                                             store: Store,
                                             unsubscribeDetectedAt: Date?,
-                                            billingIssueDetectedAt: Date?) -> Bool {
+                                            billingIssueDetectedAt: Date?,
+                                            periodType: PeriodType?) -> Bool {
         let isPromo = store == .promotional
         let isLifetime = expirationDate == nil
         let hasUnsubscribed = unsubscribeDetectedAt != nil
         let hasBillingIssues = billingIssueDetectedAt != nil
+        // This is Play Store only for now. 
+        let isPrepaid = periodType == .prepaid
 
-        return !(isPromo || isLifetime || hasUnsubscribed || hasBillingIssues)
+        return !(isPromo || isLifetime || hasUnsubscribed || hasBillingIssues || isPrepaid)
     }
 
 }

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -70,6 +70,9 @@ extension Store: DefaultValueProvider {
 
     /// If the entitlement is under a trial period.
     @objc(RCTrial) case trial = 2
+
+    /// If the entitlement is under a prepaid period.
+    @objc(RCPrepaid) case prepaid = 3
 }
 
 extension PeriodType: CaseIterable {}

--- a/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/EntitlementInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/EntitlementInfoAPI.swift
@@ -61,7 +61,8 @@ func checkEntitlementInfoEnums() {
     switch pType! {
     case .intro,
          .trial,
-         .normal:
+         .normal,
+         .prepaid:
         print(pType!)
     @unknown default:
         fatalError()

--- a/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/PurchasesAPI.swift
@@ -45,7 +45,8 @@ func checkPurchasesEnums() {
     switch periodType! {
     case .normal,
          .intro,
-         .trial:
+         .trial,
+         .prepaid:
         print(periodType!)
     @unknown default:
         fatalError()

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCEntitlementInfoAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCEntitlementInfoAPI.m
@@ -58,6 +58,7 @@
         case RCIntro:
         case RCTrial:
         case RCNormal:
+        case RCPrepaid:
             NSLog(@"%ld", (long)pr);
     }
 }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
@@ -229,6 +229,7 @@ NSURL *url;
         case RCNormal:
         case RCIntro:
         case RCTrial:
+        case RCPrepaid:
             NSLog(@"%ld", (long)t);
     }
 

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/EntitlementInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/EntitlementInfoAPI.swift
@@ -61,7 +61,8 @@ func checkEntitlementInfoEnums() {
     switch pType! {
     case .intro,
          .trial,
-         .normal:
+         .normal,
+         .prepaid:
         print(pType!)
     @unknown default:
         fatalError()

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
@@ -49,7 +49,8 @@ func checkPurchasesEnums() {
     switch periodType! {
     case .normal,
          .intro,
-         .trial:
+         .trial,
+         .prepaid:
         print(periodType!)
     @unknown default:
         fatalError()

--- a/Tests/InstallationTests/CommonFiles/RevenueCat-Swift.h
+++ b/Tests/InstallationTests/CommonFiles/RevenueCat-Swift.h
@@ -1683,6 +1683,8 @@ typedef SWIFT_ENUM_NAMED(NSInteger, RCPeriodType, "PeriodType", open) {
   RCIntro SWIFT_COMPILE_NAME("intro") = 1,
 /// If the entitlement is under a trial period.
   RCTrial SWIFT_COMPILE_NAME("trial") = 2,
+/// If the entitlement is under a prepaid period.
+  RCPrepaid SWIFT_COMPILE_NAME("prepaid") = 3,
 };
 
 

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -1215,6 +1215,29 @@ class EntitlementInfosTests: TestCase {
             ]
         )
         try verifyPeriodType(.normal)
+
+        stubResponse(
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "2019-07-26T23:45:40Z"
+                ]
+            ],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "2019-07-26T23:30:41Z",
+                    "period_type": "prepaid",
+                    "purchase_date": "2019-07-26T23:45:40Z",
+                    "store": "play_store",
+                    "unsubscribe_detected_at": nil
+                ] as [String: Any?]
+            ]
+        )
+        try verifyPeriodType(.prepaid)
     }
 
     func testParsePeriodForNonSubscription() throws {
@@ -1249,7 +1272,7 @@ class EntitlementInfosTests: TestCase {
         try verifyPeriodType(.normal)
     }
 
-    func testPromoWillRenew() throws {
+    func testPromoWillNotRenew() throws {
         stubResponse(
             entitlements: [
                 "pro_cat": [
@@ -1267,6 +1290,32 @@ class EntitlementInfosTests: TestCase {
                     "period_type": "normal",
                     "purchase_date": "2021-02-27T02:35:25Z",
                     "store": "promotional",
+                    "unsubscribe_detected_at": nil
+                ] as [String: Any?]
+            ]
+        )
+
+        try verifyRenewal(false)
+    }
+
+    func testPrepaidWillNotRenew() throws {
+        stubResponse(
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2221-01-10T02:35:25Z",
+                    "product_identifier": "rc_promo_pro_cat_lifetime",
+                    "purchase_date": "2021-02-27T02:35:25Z"
+                ]
+            ],
+            subscriptions: [
+                "rc_promo_pro_cat_lifetime": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2221-01-10T02:35:25Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "2021-02-27T02:35:25Z",
+                    "period_type": "prepaid",
+                    "purchase_date": "2021-02-27T02:35:25Z",
+                    "store": "play_store",
                     "unsubscribe_detected_at": nil
                 ] as [String: Any?]
             ]


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

Add prepaid as a period type like we have done in [android](https://github.com/RevenueCat/purchases-android/pull/2141#event-16278601110).

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
