### PR TITLE
Upgrade RevenueCat SDK to be able to test paywalls v2

### DIFF
--- a/Examples/MagicWeather/MagicWeather.xcodeproj/project.pbxproj
+++ b/Examples/MagicWeather/MagicWeather.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios-spm";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.5.0;
+				minimumVersion = 5.16.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Examples/MagicWeather/MagicWeather.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/MagicWeather/MagicWeather.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-ios-spm",
       "state" : {
-        "revision" : "c7058bfd80d7f42ca6aa392bf1fab769d1158bf1",
-        "version" : "5.5.0"
+        "revision" : "8bfab6b8e76e2bdc88d48dae1e34bc6e842f0bf8",
+        "version" : "5.16.1"
       }
     }
   ],


### PR DESCRIPTION
Upgrading the SPM version of the sample app to minimum version 5.16.0 to support paywalls v2
