### PR TITLE
UI Preview Mode: mock `CustomerInfo`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -798,6 +798,7 @@
 		57FFD2512922DBED00A9A878 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
 		57FFD2522922DBED00A9A878 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
 		6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECF627761D375C8431EB866 /* StoreProduct.swift */; };
+		75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */; };
 		7706ED3E2C6E374D0004B9F9 /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7706ED3D2C6E374D0004B9F9 /* ButtonStyles.swift */; };
 		7707A94C2CAD93AC006E0313 /* PaywallButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94B2CAD93AC006E0313 /* PaywallButtonComponent.swift */; };
 		7707A94E2CAD94D2006E0313 /* ButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94D2CAD94D2006E0313 /* ButtonComponentViewModel.swift */; };
@@ -2097,6 +2098,7 @@
 		57FDAABD28493A29009A48F1 /* SandboxEnvironmentDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxEnvironmentDetectorTests.swift; sourceTree = "<group>"; };
 		57FDAABF28493C13009A48F1 /* MockSandboxEnvironmentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSandboxEnvironmentDetector.swift; sourceTree = "<group>"; };
 		57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreTransaction.swift; sourceTree = "<group>"; };
+		75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerUIPreviewModeTests.swift; sourceTree = "<group>"; };
 		7706ED3D2C6E374D0004B9F9 /* ButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyles.swift; sourceTree = "<group>"; };
 		7707A93B2CAD8AA2006E0313 /* Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig; sourceTree = "<group>"; };
 		7707A94B2CAD93AC006E0313 /* PaywallButtonComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallButtonComponent.swift; sourceTree = "<group>"; };
@@ -4114,6 +4116,7 @@
 			children = (
 				37E35E992F1916C7F3911E7B /* CustomerInfoManagerTests.swift */,
 				4F3D56622A1E66A10070105A /* CustomerInfoManagerPostReceiptTests.swift */,
+				75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */,
 				37E35294EBC1E5A879C95540 /* IdentityManagerTests.swift */,
 			);
 			path = Identity;
@@ -6397,6 +6400,7 @@
 				5733D00928CFA7A4008638D8 /* MockPaymentQueueWrapper.swift in Sources */,
 				2DDF41CA24F6F4C3005BC22D /* ArraySlice_UInt8+ExtensionsTests.swift in Sources */,
 				2DDF41E124F6F527005BC22D /* MockReceiptParser.swift in Sources */,
+				75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */,
 				57E415EB2846962500EA5460 /* PurchasesSyncPurchasesTests.swift in Sources */,
 				4FE6FEEB2AA940E300780B45 /* StoredEventSerializerTests.swift in Sources */,
 				5766AAC5283E843300FA6091 /* PurchasesConfiguringTests.swift in Sources */,

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -192,7 +192,7 @@ class CustomerInfoManager {
         guard !self.systemInfo.dangerousSettings.uiPreviewMode else {
             return self.createPreviewCustomerInfo()
         }
-        
+
         let cachedCustomerInfoData = self.withData {
             $0.deviceCache.cachedCustomerInfoData(appUserID: appUserID)
         }
@@ -443,11 +443,13 @@ private extension CustomerInfoManager {
 
     /// Generates a dummy `CustomerInfo` with hardcoded information exclusively for UI Preview mode.
     private func createPreviewCustomerInfo() -> CustomerInfo {
-        let previewSubscriber = CustomerInfoResponse.Subscriber(originalAppUserId: IdentityManager.uiPreviewModeAppUserID,
-                                                                firstSeen: Date(),
-                                                                subscriptions: [:],
-                                                                nonSubscriptions: [:],
-                                                                entitlements: [:])
+        let previewSubscriber = CustomerInfoResponse.Subscriber(
+            originalAppUserId: IdentityManager.uiPreviewModeAppUserID,
+            firstSeen: Date(),
+            subscriptions: [:],
+            nonSubscriptions: [:],
+            entitlements: [:]
+        )
         let previewCustomerInfoResponse = CustomerInfoResponse(subscriber: previewSubscriber,
                                                                requestDate: Date(),
                                                                rawData: [:])

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -189,6 +189,10 @@ class CustomerInfoManager {
     }
 
     func cachedCustomerInfo(appUserID: String) -> CustomerInfo? {
+        guard !self.systemInfo.dangerousSettings.uiPreviewMode else {
+            return self.createPreviewCustomerInfo()
+        }
+        
         let cachedCustomerInfoData = self.withData {
             $0.deviceCache.cachedCustomerInfoData(appUserID: appUserID)
         }

--- a/Tests/UnitTests/Identity/CustomerInfoManagerUIPreviewModeTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerUIPreviewModeTests.swift
@@ -1,0 +1,114 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerInfoManagerUIPreviewModeTests.swift
+//
+//  Created by Antonio Pallares on 14/2/25.
+
+import Foundation
+import Nimble
+import XCTest
+
+@_spi(Internal) @testable import RevenueCat
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+class CustomerInfoManagerUIPreviewModeTests: BaseCustomerInfoManagerTests {
+
+    override func setUpWithError() throws {
+
+        // Enable UI Preview Mode
+        self.mockSystemInfo = MockSystemInfo(
+            platformInfo: nil,
+            finishTransactions: true,
+            dangerousSettings: DangerousSettings(uiPreviewMode: true)
+        )
+
+        try super.setUpWithError()
+    }
+
+    func testFetchCustomerInfoDoesNotCallBackendInUIPreviewMode() async throws {
+        _ = try await self.customerInfoManager.fetchAndCacheCustomerInfo(
+            appUserID: "any_user",
+            isAppBackgrounded: false
+        )
+
+        expect(self.mockBackend.invokedGetSubscriberData) == false
+    }
+
+    func testCustomerInfoIsNotCachedInUIPreviewMode() async throws {
+        _ = try await self.customerInfoManager.fetchAndCacheCustomerInfo(
+            appUserID: "any_user",
+            isAppBackgrounded: false
+        )
+
+        expect(self.mockDeviceCache.cacheCustomerInfoCount) == 0
+    }
+
+    func testCachedCustomerInfoInUIPreviewModeReturnsMockCustomerInfo() async throws {
+        let info = try XCTUnwrap(self.customerInfoManager.cachedCustomerInfo(appUserID: "any_user"))
+
+        expect(info.originalAppUserId) == IdentityManager.uiPreviewModeAppUserID
+    }
+
+    func testUIPreviewModeCustomerInfoHasExpectedValues() async throws {
+        let info = try await self.customerInfoManager.fetchAndCacheCustomerInfo(
+            appUserID: "any_user",
+            isAppBackgrounded: false
+        )
+
+        expect(info.originalAppUserId) == IdentityManager.uiPreviewModeAppUserID
+    }
+
+    func testCustomerInfoReturnsMockInUIPreviewModeForAllFetchPolicies() async throws {
+        let policies: [CacheFetchPolicy] = [
+            .fromCacheOnly,
+            .fetchCurrent,
+            .cachedOrFetched,
+            .notStaleCachedOrFetched
+        ]
+
+        for policy in policies {
+            let info = try await self.customerInfoManager.customerInfo(
+                appUserID: "any_user",
+                fetchPolicy: policy
+            )
+
+            expect(self.mockBackend.invokedGetSubscriberData) == false
+            expect(info.originalAppUserId) == IdentityManager.uiPreviewModeAppUserID
+            expect(self.mockDeviceCache.cacheCustomerInfoCount) == 0
+        }
+    }
+
+    func testUnfinishedTransactionsIgnoredInUIPreviewMode() async throws {
+        self.mockTransationFetcher.stubbedUnfinishedTransactions = [
+            Self.createTransaction(),
+            Self.createTransaction()
+        ]
+
+        mockBackend.stubbedGetCustomerInfoResult = .success(mockCustomerInfo)
+
+        let info = try await self.customerInfoManager.fetchAndCacheCustomerInfo(
+            appUserID: "any_user",
+            isAppBackgrounded: false
+        )
+
+        expect(self.mockBackend.invokedGetSubscriberData) == false
+        expect(self.mockTransactionPoster.invokedHandlePurchasedTransaction.value) == false
+        expect(info.originalAppUserId) == IdentityManager.uiPreviewModeAppUserID
+    }
+}
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+private extension CustomerInfoManagerUIPreviewModeTests {
+
+    static func createTransaction() -> StoreTransaction {
+        return .init(sk1Transaction: MockTransaction())
+    }
+
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests

### Motivation
In UI Preview mode, the SDK should not make the requests to obtain the `CustomerInfo`.

### Description
When in UI Preview mode, the SDK:
* Avoids caching `CustomerInfo`
* Always returns mocked `CustomerInfo` (if requested either from the cache or from the backend)