### PR TITLE
fix: Remove NavigationView/NavigationStack from AppWarningView

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
@@ -92,18 +92,22 @@ private struct TextButtonStyle: PrimitiveButtonStyle {
 struct AppUpdateWarningView_Previews: PreviewProvider {
 
     static var previews: some View {
-        Group {
+        NavigationView {
             AppUpdateWarningView(
-                onUpdateAppClick: {
-
-                },
-                onContinueAnywayClick: {
-
-                }
+                onUpdateAppClick: { },
+                onContinueAnywayClick: { }
             )
+            .environment(\.colorScheme, .light)
+        }
+
+        NavigationView {
+            AppUpdateWarningView(
+                onUpdateAppClick: { },
+                onContinueAnywayClick: { }
+            )
+            .environment(\.colorScheme, .dark)
         }
     }
-
 }
 
 #endif

--- a/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
@@ -39,46 +39,31 @@ struct AppUpdateWarningView: View {
         self.onContinueAnywayClick = onContinueAnywayClick
     }
 
-    @ViewBuilder
-    var content: some View {
-        ZStack {
-            List {
-                Section {
-                    CompatibilityContentUnavailableView(
-                        localization[.updateWarningTitle],
-                        systemImage: "arrow.up.circle.fill",
-                        description: Text(localization[.updateWarningDescription])
-                    )
-                }
-
-                Section {
-                    Button(localization[.updateWarningUpdate]) {
-                        onUpdateAppClick()
-                    }
-                    .buttonStyle(ProminentButtonStyle())
-                    .padding(.top, 4)
-
-                    Button(localization[.updateWarningIgnore]) {
-                        onContinueAnywayClick()
-                    }
-                    .buttonStyle(TextButtonStyle())
-                }
-                .listRowSeparator(.hidden)
+    var body: some View {
+        List {
+            Section {
+                CompatibilityContentUnavailableView(
+                    localization[.updateWarningTitle],
+                    systemImage: "arrow.up.circle.fill",
+                    description: Text(localization[.updateWarningDescription])
+                )
             }
+
+            Section {
+                Button(localization[.updateWarningUpdate]) {
+                    onUpdateAppClick()
+                }
+                .buttonStyle(ProminentButtonStyle())
+                .padding(.top, 4)
+
+                Button(localization[.updateWarningIgnore]) {
+                    onContinueAnywayClick()
+                }
+                .buttonStyle(TextButtonStyle())
+            }
+            .listRowSeparator(.hidden)
         }
         .dismissCircleButtonToolbar()
-    }
-
-    var body: some View {
-        if #available(iOS 16.0, *) {
-            NavigationStack {
-                content
-            }
-        } else {
-            NavigationView {
-                content
-            }
-        }
     }
 }
 


### PR DESCRIPTION
### Motivation
~This tries to address https://github.com/RevenueCat/purchases-ios/issues/4790~

For some reason, we missed that `AppWarningView` is already embebed in a NavigationStack / NavigationView. 


