### PR TITLE
fix: Remove force unwrapping from PurchaseHistoryView

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,7 +10,6 @@ excluded:
   - .build
 
 opt_in_rules:
-  - force_unwrapping
   - sorted_imports
   - missing_docs
   - convenience_type

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,7 @@ excluded:
   - .build
 
 opt_in_rules:
+  - force_unwrapping
   - sorted_imports
   - missing_docs
   - convenience_type

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
@@ -81,10 +81,13 @@ struct PurchaseHistoryView: View {
                 Section(header: Text(
                     localization[.accountDetails]
                 )) {
-                    CompatibilityLabeledContent(
-                        localization[.dateWhenAppWasPurchased],
-                        content: dateFormatter.string(from: info.originalPurchaseDate!)
-                    )
+                    if let originalPurchaseDate = info.originalPurchaseDate {
+                        CompatibilityLabeledContent(
+                            localization[.dateWhenAppWasPurchased],
+                            content: dateFormatter.string(from: originalPurchaseDate)
+                        )
+
+                    }
 
                     CompatibilityLabeledContent(
                         localization[.userId],


### PR DESCRIPTION
### Motivation
While debugging another thing, I noticed this was in production. This removes the force unwrap