### PR TITLE
Config item rename

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1441,7 +1441,7 @@
 		2DC5622524EC63430031F69B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2DD269162522A20A006AC4BC /* DictionaryExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionsTests.swift; sourceTree = "<group>"; };
 		2DD5003F2C519EB4009C19B7 /* ci_pre_xcodebuild.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_pre_xcodebuild.sh; sourceTree = "<group>"; };
-		2DD500412C519EB4009C19B7 /* ConfigItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigItem.swift; sourceTree = "<group>"; };
+		2DD500412C519EB4009C19B7 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		2DD500422C519EB4009C19B7 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		2DD500442C519EB4009C19B7 /* SamplePaywalls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplePaywalls.swift; sourceTree = "<group>"; };
 		2DD500462C519EB4009C19B7 /* ApplicationData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationData.swift; sourceTree = "<group>"; };
@@ -3066,7 +3066,7 @@
 		2DD500452C519EB4009C19B7 /* Config */ = {
 			isa = PBXGroup;
 			children = (
-				2DD500412C519EB4009C19B7 /* ConfigItem.swift */,
+				2DD500412C519EB4009C19B7 /* Constants.swift */,
 				2DD500422C519EB4009C19B7 /* Configuration.swift */,
 				2DD500442C519EB4009C19B7 /* SamplePaywalls.swift */,
 			);

--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -347,7 +347,25 @@ private struct RoundedCorner: Shape {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
-
+    
+    /// Disables the refreshable action for a view.
+    /// - Returns: A view with the refreshable action removed.
+    ///
+    /// This is useful when you want to disable the refreshable action for a view that may inherit it from its container.
+    ///
+    /// # Use case
+    /// When a `PaywallView` is presented, the presenting view may have a refreshable action. If the `refreshable` modifier is applied **after** the modifier that presents the `PaywallView` (e.g. with `.sheet`), then the `PaywallView` will also inherit the refreshable action.
+    /// ```swift
+    /// contentView
+    ///     .sheet(isPresented: $paywallPresented) {
+    ///         PaywallView(offering: offering)
+    ///     }
+    ///     .refreshable {
+    ///         // Some async code to refresh contentView
+    ///     }
+    /// ```
+    ///
+    /// `PaywallView` uses this `refreshableDisabled()` modifier to disable the inherited refreshable action, if any.
     @ViewBuilder
     func refreshableDisabled() -> some View {
         if let refreshKeyPath = \EnvironmentValues.refresh as? WritableKeyPath<EnvironmentValues, RefreshAction?> {

--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -347,14 +347,17 @@ private struct RoundedCorner: Shape {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
-    
+
     /// Disables the refreshable action for a view.
     /// - Returns: A view with the refreshable action removed.
     ///
-    /// This is useful when you want to disable the refreshable action for a view that may inherit it from its container.
+    /// This is useful when you want to disable the refreshable action for a view that may inherit it from its
+    /// container.
     ///
     /// # Use case
-    /// When a `PaywallView` is presented, the presenting view may have a refreshable action. If the `refreshable` modifier is applied **after** the modifier that presents the `PaywallView` (e.g. with `.sheet`), then the `PaywallView` will also inherit the refreshable action.
+    /// When a `PaywallView` is presented, the presenting view may have a refreshable action. If the `refreshable`
+    /// modifier is applied **after** the modifier that presents the `PaywallView` (e.g. with `.sheet`), then the
+    /// `PaywallView` will also inherit the refreshable action.
     /// ```swift
     /// contentView
     ///     .sheet(isPresented: $paywallPresented) {

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -209,7 +209,7 @@ public struct PaywallView: View {
                 }
                 onRequestedDismissal()
             }
-            // If the parent of the paywall uses refreshable, it is inherited by default
+            // If the parent view uses refreshable, it can be inherited by the paywall view
             // and pulling down in the paywall would execute the parent's refreshable action
             .refreshableDisabled()
     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		88B438082BDB0089000AF27C /* OfferingsPaywallsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B438072BDB0089000AF27C /* OfferingsPaywallsViewModel.swift */; };
 		88B4380A2BDB0A28000AF27C /* PaywallForID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B438092BDB0A28000AF27C /* PaywallForID.swift */; };
 		88B4380C2BDB0FCB000AF27C /* PaywallPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B4380B2BDB0FCB000AF27C /* PaywallPresenter.swift */; };
-		88BEB9262BF537F200A3D05F /* ConfigItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BEB9222BF537F200A3D05F /* ConfigItem.swift */; };
+		88BEB9262BF537F200A3D05F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BEB9222BF537F200A3D05F /* Constants.swift */; };
 		88BEB9272BF537F200A3D05F /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BEB9232BF537F200A3D05F /* Configuration.swift */; };
 		88BEB9282BF537F200A3D05F /* SamplePaywalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BEB9242BF537F200A3D05F /* SamplePaywalls.swift */; };
 		88DFC12E2BC7335200273B6D /* ApplicationData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC12D2BC7335200273B6D /* ApplicationData.swift */; };
@@ -124,7 +124,7 @@
 		88B438072BDB0089000AF27C /* OfferingsPaywallsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OfferingsPaywallsViewModel.swift; path = PaywallsTester/Data/OfferingsPaywallsViewModel.swift; sourceTree = SOURCE_ROOT; };
 		88B438092BDB0A28000AF27C /* PaywallForID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallForID.swift; sourceTree = "<group>"; };
 		88B4380B2BDB0FCB000AF27C /* PaywallPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallPresenter.swift; sourceTree = "<group>"; };
-		88BEB9222BF537F200A3D05F /* ConfigItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ConfigItem.swift; path = Config/ConfigItem.swift; sourceTree = "<group>"; };
+		88BEB9222BF537F200A3D05F /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = Config/Constants.swift; sourceTree = "<group>"; };
 		88BEB9232BF537F200A3D05F /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Config/Configuration.swift; sourceTree = "<group>"; };
 		88BEB9242BF537F200A3D05F /* SamplePaywalls.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SamplePaywalls.swift; path = Config/SamplePaywalls.swift; sourceTree = "<group>"; };
 		88DFC12D2BC7335200273B6D /* ApplicationData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationData.swift; sourceTree = "<group>"; };
@@ -252,7 +252,7 @@
 		4FC046CA2A572EF300A28BCF /* Config */ = {
 			isa = PBXGroup;
 			children = (
-				88BEB9222BF537F200A3D05F /* ConfigItem.swift */,
+				88BEB9222BF537F200A3D05F /* Constants.swift */,
 				88BEB9232BF537F200A3D05F /* Configuration.swift */,
 				88BEB9242BF537F200A3D05F /* SamplePaywalls.swift */,
 				880B2AF12BEC2D62006B9393 /* Preprocessor.sh */,
@@ -505,7 +505,7 @@
 				88DFC1882BCF3AB700273B6D /* LoginScreen.swift in Sources */,
 				88DFC1892BCF3AB700273B6D /* LoginWall.swift in Sources */,
 				88A543E92C387DB00039C6A5 /* APIKeyDashboardList.swift in Sources */,
-				88BEB9262BF537F200A3D05F /* ConfigItem.swift in Sources */,
+				88BEB9262BF537F200A3D05F /* Constants.swift in Sources */,
 				88BEB9272BF537F200A3D05F /* Configuration.swift in Sources */,
 				88DFC1932BCF490400273B6D /* OfferingsResponse.swift in Sources */,
 				88DFC14A2BC7463A00273B6D /* StringExtensions.swift in Sources */,

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
@@ -28,14 +28,14 @@ final class Configuration: ObservableObject {
     private init() {
 
         Purchases.logLevel = .verbose
-        Purchases.proxyURL = ConfigItem.proxyURL.flatMap { URL(string: $0) }
+        Purchases.proxyURL = Constants.proxyURL.flatMap { URL(string: $0) }
 
         self.configure()
     }
 
     private func configure() {
         Purchases.configure(
-            with: .init(withAPIKey: ConfigItem.apiKey)
+            with: .init(withAPIKey: Constants.apiKey)
                 .with(entitlementVerificationMode: .informational)
                 .with(diagnosticsEnabled: true)
                 .with(purchasesAreCompletedBy: .revenueCat, storeKitVersion: .storeKit2)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Constants.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Constants.swift
@@ -1,5 +1,5 @@
 //
-//  ConfigItem.swift
+//  Constants.swift
 //  PaywallsTester
 //
 //  Created by James Borthwick on 2024-05-13.
@@ -9,16 +9,20 @@ import Foundation
 
 // DO NOT MODIFY THIS FILE.
 // CI system adds the API key here.
-struct ConfigItem {
+enum Constants {
     /*
      To add your own API key for local development, add it in your local.xcconfig file like this:
      REVENUECAT_API_KEY = your-api-key
      */
-    static var apiKey: String { Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_API_KEY") as? String ?? "" }
+    static let apiKey: String = {
+        Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_API_KEY") as? String ?? ""
+    }()
 
     /*
      To add your own proxyURL for local development, add it in your local.xcconfig file like this:
      REVENUECAT_PROXY_URL = your-api-key
      */
-    static var proxyURL: String? { Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_PROXY_URL") as? String }
+    static let proxyURL: String? = {
+        Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_PROXY_URL") as? String
+    }()
 }

--- a/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
+++ b/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
@@ -4,6 +4,6 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 echo "Replacing API keys on PaywallsTester"
 
-file="$SCRIPT_DIR/../PaywallsTester/Config/ConfigItem.swift"
+file="$SCRIPT_DIR/../PaywallsTester/Config/Constants.swift"
 sed -i '' 's/static var apiKey: String { "" }/static var apiKey: String { "'"$REVENUECAT_XCODE_CLOUD_RC_APP_API_KEY"'" }/' $file
 

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -38,7 +38,7 @@ verify_no_included_apikeys() {
     "${SCRIPT_DIR}/../Examples/MagicWeather/MagicWeather/Constants.swift"
     "${SCRIPT_DIR}/../Examples/MagicWeatherSwiftUI/Shared/Constants.swift"
     "${SCRIPT_DIR}/../Tests/TestingApps/PurchaseTesterSwiftUI/Core/Constants.swift"
-    "${SCRIPT_DIR}/../Tests/TestingApps/PaywallsTester/PaywallsTester/Config/ConfigItem.swift"
+    "${SCRIPT_DIR}/../Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Constants.swift"
   )
   FILES_STAGED=$(git diff --cached --name-only)
   PATTERN="\"REVENUECAT_API_KEY\""


### PR DESCRIPTION
### Motivation
As pointed out by @facumenzella, for consistency with other projects and repos, the `Constants` name should be used instead of `ConfigItem`. `ConfigItem` contains the code that reads the RC API key from the bundle in PaywallsTester (see #4795)

### Description
* Renames `ConfigItem` to `Constants`
* Bonus: adds a more detailed explanation to `refreshableDisabled()` modifier introduced in #4793 (again, thanks @facumenzella for pointing this out!)