### PR TITLE
[Diagnostics] Fix store kit error description tracking

### DIFF
--- a/Sources/Error Handling/StoreKitErrorHelper.swift
+++ b/Sources/Error Handling/StoreKitErrorHelper.swift
@@ -27,9 +27,9 @@ enum StoreKitErrorUtils {
             return storeKitError.trackingDescription
         } else if let storeKitError = underlyingError as? StoreKit.Product.PurchaseError {
             return storeKitError.trackingDescription
+        } else {
+            return Self.extractStoreKitErrorDescription(from: underlyingError)
         }
-
-        return nil
     }
 
 }

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -196,6 +196,7 @@ class SK2ProductsManagerDiagnosticsTrackingTests: ProductsManagerTests {
         expect(params?.storeKitVersion) == .storeKit2
         expect(params?.errorMessage).to(beNil())
         expect(params?.errorCode).to(beNil())
+        expect(params?.storeKitErrorDescription).to(beNil())
     }
 
     #if swift(>=5.9)
@@ -222,6 +223,7 @@ class SK2ProductsManagerDiagnosticsTrackingTests: ProductsManagerTests {
         expect(params?.storeKitVersion) == .storeKit2
         expect(params?.errorMessage) == "Products request error: Unable to Complete Request"
         expect(params?.errorCode) == 2
+        expect(params?.storeKitErrorDescription) == StoreKitError.unknown.trackingDescription
     }
     #endif
 


### PR DESCRIPTION
### Description
Noticed that obtaining the store kit error description actually didn't try to get the store kit error when it was nested. I was able to reproduce in an existing test (by adding a new assertion), which gets fixed with the changes in this PR.