### PR TITLE
UI Preview mode: avoid intro eligibility request

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -803,6 +803,7 @@
 		57FFD2522922DBED00A9A878 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
 		6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECF627761D375C8431EB866 /* StoreProduct.swift */; };
 		75425E0F2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75425E0E2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift */; };
+		7571BE9F2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7571BE9E2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift */; };
 		75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */; };
 		7706ED3E2C6E374D0004B9F9 /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7706ED3D2C6E374D0004B9F9 /* ButtonStyles.swift */; };
 		7707A94C2CAD93AC006E0313 /* PaywallButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94B2CAD93AC006E0313 /* PaywallButtonComponent.swift */; };
@@ -2107,6 +2108,7 @@
 		57FDAABF28493C13009A48F1 /* MockSandboxEnvironmentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSandboxEnvironmentDetector.swift; sourceTree = "<group>"; };
 		57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreTransaction.swift; sourceTree = "<group>"; };
 		75425E0E2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentsDataTests.swift; sourceTree = "<group>"; };
+		7571BE9E2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift; sourceTree = "<group>"; };
 		75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerUIPreviewModeTests.swift; sourceTree = "<group>"; };
 		7706ED3D2C6E374D0004B9F9 /* ButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyles.swift; sourceTree = "<group>"; };
 		7707A93B2CAD8AA2006E0313 /* Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig; sourceTree = "<group>"; };
@@ -2961,6 +2963,7 @@
 				4D322E3B2B7E7E250004AF53 /* PurchasesOrchestratorCommonTests.swift */,
 				2D34D9D127481D9B00C05DB6 /* TrialOrIntroPriceEligibilityCheckerSK2Tests.swift */,
 				35E1CE1F26E022C20008560A /* TrialOrIntroPriceEligibilityCheckerSK1Tests.swift */,
+				7571BE9E2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift */,
 				2D69384426DFF93300FCDBC0 /* StoreProductTests.swift */,
 				4FC972162A712DCC008593DE /* CachingProductsManagerTests.swift */,
 				2D9C5EC926F2805C0057FC45 /* ProductsManagerTests.swift */,
@@ -5969,6 +5972,7 @@
 				57544C29285FA95E004E54D5 /* MockAttributeSyncing.swift in Sources */,
 				57057FF928B0048900995F21 /* TestLogHandler.swift in Sources */,
 				4F69EB0A2A14406E00ED6D4B /* Matchers.swift in Sources */,
+				7571BE9F2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift in Sources */,
 				2D90F8C226FD20F7009B9142 /* MockETagManager.swift in Sources */,
 				2D90F8B526FD2093009B9142 /* MockSystemInfo.swift in Sources */,
 				2D90F8C126FD20F2009B9142 /* MockHTTPClient.swift in Sources */,

--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -54,6 +54,11 @@ class TrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheckerTy
 
     func checkEligibility(productIdentifiers: Set<String>,
                           completion: @escaping ReceiveIntroEligibilityBlock) {
+        guard !self.systemInfo.dangerousSettings.uiPreviewMode else {
+            completion([:])
+            return
+        }
+        
         guard !productIdentifiers.isEmpty else {
             Logger.warn(Strings.eligibility.check_eligibility_no_identifiers)
             completion([:])

--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -58,7 +58,7 @@ class TrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheckerTy
             completion([:])
             return
         }
-        
+
         guard !productIdentifiers.isEmpty else {
             Logger.warn(Strings.eligibility.check_eligibility_no_identifiers)
             completion([:])

--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -55,6 +55,8 @@ class TrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheckerTy
     func checkEligibility(productIdentifiers: Set<String>,
                           completion: @escaping ReceiveIntroEligibilityBlock) {
         guard !self.systemInfo.dangerousSettings.uiPreviewMode else {
+            // No check eligibility request should happen in UI preview mode.
+            // Thus, the eligibility status for all product identifiers are set to `.unknown`
             let result = productIdentifiers.reduce(into: [:]) { resultDict, productId in
                 resultDict[productId] = IntroEligibility(eligibilityStatus: IntroEligibilityStatus.unknown)
             }

--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -55,7 +55,10 @@ class TrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheckerTy
     func checkEligibility(productIdentifiers: Set<String>,
                           completion: @escaping ReceiveIntroEligibilityBlock) {
         guard !self.systemInfo.dangerousSettings.uiPreviewMode else {
-            completion([:])
+            let result = productIdentifiers.reduce(into: [:]) { resultDict, productId in
+                resultDict[productId] = IntroEligibility(eligibilityStatus: IntroEligibilityStatus.unknown)
+            }
+            completion(result)
             return
         }
 

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift
@@ -70,7 +70,6 @@ class TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests: StoreKitConfigTestC
         expect(self.receiptFetcher.receiptDataCalled) == false
         expect(self.mockIntroEligibilityCalculator.invokedCheckTrialOrIntroDiscountEligibility) == false
         expect(self.mockOfferingsAPI.invokedGetIntroEligibility) == false
-        expect(eligibilities).to(beEmpty())
     }
 
     func testSK2CheckEligibilityInPreviewModeDoesNothing() throws {
@@ -90,6 +89,5 @@ class TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests: StoreKitConfigTestC
         expect(self.mockIntroEligibilityCalculator.invokedCheckTrialOrIntroDiscountEligibility) == false
         expect(self.mockProductsManager.invokedSk2StoreProducts) == false
         expect(self.mockOfferingsAPI.invokedGetIntroEligibility) == false
-        expect(eligibilities).to(beEmpty())
     }
 }

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift
@@ -1,0 +1,95 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift
+//
+//  Created by Antonio Pallares on 20/2/25.
+
+// swiftlint:disable type_name
+
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+@available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 7.0, *)
+class TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests: StoreKitConfigTestCase {
+
+    private var receiptFetcher: MockReceiptFetcher!
+    private var trialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityChecker!
+    private var mockIntroEligibilityCalculator: MockIntroEligibilityCalculator!
+    private let mockBackend = MockBackend()
+    private var mockOfferingsAPI: MockOfferingsAPI!
+    private var mockProductsManager: MockProductsManager!
+    private var mockSystemInfo: MockSystemInfo!
+
+    private func setupUIPreviewMode(storeKitVersion: StoreKitVersion) throws {
+        let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
+        self.mockSystemInfo = MockSystemInfo(platformInfo: platformInfo,
+                                             finishTransactions: true,
+                                             uiPreviewMode: true,
+                                             storeKitVersion: storeKitVersion)
+        self.receiptFetcher = MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: mockSystemInfo)
+        self.mockProductsManager = MockProductsManager(diagnosticsTracker: nil,
+                                                       systemInfo: mockSystemInfo,
+                                                       requestTimeout: Configuration.storeKitRequestTimeoutDefault)
+        self.mockIntroEligibilityCalculator = MockIntroEligibilityCalculator(productsManager: mockProductsManager,
+                                                                             receiptParser: MockReceiptParser())
+
+        self.mockOfferingsAPI = try XCTUnwrap(self.mockBackend.offerings as? MockOfferingsAPI)
+        let mockOperationDispatcher = MockOperationDispatcher()
+        let userProvider = MockCurrentUserProvider(mockAppUserID: "app_user")
+        self.trialOrIntroPriceEligibilityChecker = TrialOrIntroPriceEligibilityChecker(
+            systemInfo: self.mockSystemInfo,
+            receiptFetcher: self.receiptFetcher,
+            introEligibilityCalculator: self.mockIntroEligibilityCalculator,
+            backend: self.mockBackend,
+            currentUserProvider: userProvider,
+            operationDispatcher: mockOperationDispatcher,
+            productsManager: self.mockProductsManager
+        )
+    }
+
+    func testSK1CheckEligibilityInPreviewModeDoesNothing() throws {
+        try setupUIPreviewMode(storeKitVersion: .storeKit1)
+
+        let productIdentifiers: Set<String> = ["com.test.product1", "com.test.product2"]
+
+        let eligibilities = waitUntilValue { completed in
+            self.trialOrIntroPriceEligibilityChecker.checkEligibility(
+                productIdentifiers: productIdentifiers,
+                completion: completed
+            )
+        }
+
+        expect(self.receiptFetcher.receiptDataCalled) == false
+        expect(self.mockIntroEligibilityCalculator.invokedCheckTrialOrIntroDiscountEligibility) == false
+        expect(self.mockOfferingsAPI.invokedGetIntroEligibility) == false
+        expect(eligibilities).to(beEmpty())
+    }
+
+    func testSK2CheckEligibilityInPreviewModeDoesNothing() throws {
+        try setupUIPreviewMode(storeKitVersion: .storeKit2)
+
+        let productIdentifiers: Set<String> = ["com.test.product1", "com.test.product2"]
+
+        // Verify early return with empty dictionary
+        let eligibilities = waitUntilValue { completed in
+            self.trialOrIntroPriceEligibilityChecker.checkEligibility(
+                productIdentifiers: productIdentifiers,
+                completion: completed
+            )
+        }
+
+        expect(self.receiptFetcher.receiptDataCalled) == false
+        expect(self.mockIntroEligibilityCalculator.invokedCheckTrialOrIntroDiscountEligibility) == false
+        expect(self.mockProductsManager.invokedSk2StoreProducts) == false
+        expect(self.mockOfferingsAPI.invokedGetIntroEligibility) == false
+        expect(eligibilities).to(beEmpty())
+    }
+}

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -21,12 +21,15 @@ class MockSystemInfo: SystemInfo {
     convenience init(platformInfo: Purchases.PlatformInfo? = nil,
                      finishTransactions: Bool,
                      customEntitlementsComputation: Bool = false,
+                     uiPreviewMode: Bool = false,
                      storeKitVersion: StoreKitVersion = .default,
                      responseVerificationMode: Signing.ResponseVerificationMode = .disabled,
                      clock: ClockType = TestClock()) {
         let dangerousSettings = DangerousSettings(
             autoSyncPurchases: true,
-            customEntitlementComputation: customEntitlementsComputation
+            customEntitlementComputation: customEntitlementsComputation,
+            internalSettings: DangerousSettings.Internal.default,
+            uiPreviewMode: uiPreviewMode
         )
         self.init(platformInfo: platformInfo,
                   finishTransactions: finishTransactions,


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation
In UI Preview mode, the SDK should only make the requests strictly required for the UI Preview mode functionality.

### Description
This PR just implements an early return with all `IntroEligibility` statuses set to `unknown`.
