### PR TITLE
[Paywalls V2] Fixes parsing generic fonts.

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -199,10 +199,14 @@ struct TextComponentView_Previews: PreviewProvider {
                             "id_1": .string("Hello, world")
                         ]
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
+                        fonts: [
+                            "generic": .init(ios: .name("serif"))
+                        ]
+                    )),
                     component: .init(
                         text: "id_1",
-                        fontName: "serif",
+                        fontName: "generic",
                         color: .init(light: .hex("#000000")),
                         fontSize: 40
                     )
@@ -220,12 +224,12 @@ struct TextComponentView_Previews: PreviewProvider {
                     ),
                     uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
                         fonts: [
-                            "primary": .init(ios: .name("Chalkduster"))
+                            "generic": .init(ios: .name("sans-serif"))
                         ]
                     )),
                     component: .init(
                         text: "id_1",
-                        fontName: "sanserif",
+                        fontName: "generic",
                         color: .init(light: .hex("#000000")),
                         fontSize: 40
                     )
@@ -243,12 +247,12 @@ struct TextComponentView_Previews: PreviewProvider {
                     ),
                     uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
                         fonts: [
-                            "primary": .init(ios: .name("Chalkduster"))
+                            "generic": .init(ios: .name("monospace"))
                         ]
                     )),
                     component: .init(
                         text: "id_1",
-                        fontName: "monospace",
+                        fontName: "generic",
                         color: .init(light: .hex("#000000")),
                         fontSize: 40
                     )

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -286,16 +286,11 @@ extension TextComponentStyle {
             return GenericFont.sansSerif.makeFont(fontSize: fontSize)
         }
 
-        // Check if name is a generic font (serfic, sansserif, monospace)
-        if let genericFont = GenericFont(rawValue: name) {
-            return genericFont.makeFont(fontSize: fontSize)
-        }
-
-        let customFont = self.resolveCustomFont(size: fontSize, name: name, uiConfigProvider: uiConfigProvider)
+        let customFont = self.resolveFont(size: fontSize, name: name, uiConfigProvider: uiConfigProvider)
         return customFont ?? GenericFont.sansSerif.makeFont(fontSize: fontSize)
     }
 
-    static private func resolveCustomFont(
+    static private func resolveFont(
         size fontSize: CGFloat,
         name: String,
         uiConfigProvider: UIConfigProvider
@@ -303,6 +298,11 @@ extension TextComponentStyle {
         guard let familyName = uiConfigProvider.getFontFamily(for: name)  else {
             Logger.warning("Mapping for '\(name)' could not be found. Falling back to system font.")
             return nil
+        }
+
+        // Check if the family name is a generic font (serif, sans-serif, monospace)
+        if let genericFont = GenericFont(rawValue: familyName) {
+            return genericFont.makeFont(fontSize: fontSize)
         }
 
         guard let customFont = UIFont(name: familyName, size: fontSize) else {


### PR DESCRIPTION
## Bug
Generic fonts (`sans-serif`, `serif` and `monospace`) weren't displaying at all.

## Cause
This was caused by the fact that the font _display_ name was matched against the generic font, instead of the actual font name. 

## Fix
The fix is to look up the font name using its display name in `ui_config`, like we do for other custom fonts.