### PR TITLE
[Paywalls] Fix onRestoreComplete callback not being called

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -68,9 +68,10 @@ struct ButtonComponentView: View {
 
         Logger.debug(Strings.restoring_purchases)
 
-        let (_, success) = try await self.purchaseHandler.restorePurchases()
+        let (customerInfo, success) = try await self.purchaseHandler.restorePurchases()
         if success {
             Logger.debug(Strings.restored_purchases)
+            self.purchaseHandler.setRestored(customerInfo)
         } else {
             Logger.debug(Strings.restore_purchases_with_empty_result)
         }


### PR DESCRIPTION
The `onRestoreComplete` callback was not being called because were not setting the corresponding `customerInfo` variable.

In Paywalls V1 we used to show an alert message informing of the successful restore. When closed, the paywall was dismissed and the callback invoked.

https://github.com/RevenueCat/purchases-ios/blob/main/RevenueCatUI/Views/FooterView.swift#L237

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
