### PR TITLE
UI preview mode: disable log in and log out

### DIFF
--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -29,6 +29,7 @@ enum BackendError: Error, Equatable {
     case invalidWebRedemptionToken
     case purchaseBelongsToOtherUser
     case expiredWebRedemptionToken(obfuscatedEmail: String)
+    case unsupportedInUIPreviewMode(Source)
 
 }
 
@@ -73,6 +74,12 @@ extension BackendError {
         return .unexpectedBackendResponse(error,
                                           extraContext: extraContext,
                                           .init(file: file, function: function, line: line))
+    }
+
+    static func unsupportedInUIPreviewMode(
+        file: String = #fileID, function: String = #function, line: UInt = #line
+    ) -> Self {
+        return .unsupportedInUIPreviewMode(.init(file: file, function: function, line: line))
     }
 
 }
@@ -142,6 +149,10 @@ extension BackendError: PurchasesErrorConvertible {
                                            extraUserInfo: [
                                             .obfuscatedEmail: obfuscatedEmail
                                            ])
+        case let .unsupportedInUIPreviewMode(source):
+            return ErrorUtils.unsupportedInUIPreviewModeError(fileName: source.file,
+                                                              functionName: source.function,
+                                                              line: source.line)
 
         }
     }
@@ -182,7 +193,8 @@ extension BackendError {
              .unexpectedBackendResponse,
              .invalidWebRedemptionToken,
              .purchaseBelongsToOtherUser,
-             .expiredWebRedemptionToken:
+             .expiredWebRedemptionToken,
+             .unsupportedInUIPreviewMode:
             return nil
         }
     }
@@ -204,7 +216,8 @@ extension BackendError {
                 .missingCachedCustomerInfo,
                 .invalidWebRedemptionToken,
                 .purchaseBelongsToOtherUser,
-                .expiredWebRedemptionToken:
+                .expiredWebRedemptionToken,
+                .unsupportedInUIPreviewMode:
             return nil
 
         case let .unexpectedBackendResponse(error, _, _):

--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -556,6 +556,22 @@ enum ErrorUtils {
         return ErrorUtils.error(with: .featureNotSupportedWithStoreKit1,
                                 fileName: fileName, functionName: functionName, line: line)
     }
+
+    /**
+     * Constructs an Error with the ``ErrorCode/unsupportedError`` code.
+     *
+     * - Note: This error is used  when trying to use a feature that isn't supported
+     * by StoreKit 1 when the SDK is running in StoreKit 1 mode.
+     */
+    static func unsupportedInUIPreviewModeError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> PurchasesError {
+        return ErrorUtils.error(with: .unsupportedError,
+                                message: "Operation not supported in UI preview mode",
+                                fileName: fileName,
+                                functionName: functionName,
+                                line: line)
+    }
 }
 
 extension ErrorUtils {

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -86,12 +86,22 @@ class IdentityManager: CurrentUserProvider {
     }
 
     func logIn(appUserID: String, completion: @escaping IdentityAPI.LogInResponseHandler) {
+        guard self.currentAppUserID != Self.uiPreviewModeAppUserID && appUserID != Self.uiPreviewModeAppUserID else {
+            completion(.failure(.unsupportedInUIPreviewMode()))
+            return
+        }
+
         self.attributeSyncing.syncSubscriberAttributes(currentAppUserID: self.currentAppUserID) {
             self.performLogIn(appUserID: appUserID, completion: completion)
         }
     }
 
     func logOut(completion: @escaping (PurchasesError?) -> Void) {
+        guard self.currentAppUserID != Self.uiPreviewModeAppUserID else {
+            completion(ErrorUtils.unsupportedInUIPreviewModeError())
+            return
+        }
+
         self.attributeSyncing.syncSubscriberAttributes(currentAppUserID: self.currentAppUserID) {
             self.performLogOut(completion: completion)
         }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation
Even though no calls to `logIn` or `logOut` should happen in UI preview mode, it's still appropriate to make sure that the SDK properly controls that scenario.

### Description
* With this PR, the SDK implements early returns in the `IdentityManager` for the `logIn` and `logOut` methods, preventing any logic in this scenario (including any log in request to the backend)
* Calling `logIn` using the app user ID reserved for UI preview mode also fails, **even if UI preview mode is not enabled**