### PR TITLE
Add no quotes hints to build settings in `Local.xcconfig.SAMPLE`

### DIFF
--- a/Local.xcconfig.SAMPLE
+++ b/Local.xcconfig.SAMPLE
@@ -30,8 +30,8 @@
 // Add new compiler flags like this:
 // SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) NEW_FLAG
 
-// Set your RevenueCat API key for local development here:
-// REVENUECAT_API_KEY = your-api-key
+// Set your RevenueCat API key for local development here (without quotes!):
+// REVENUECAT_API_KEY = your-api-key-without-quotes
 
-// Set your your RevenueCat Proxy URL for local development here:
-// REVENUECAT_PROXY_URL = your-revenuecat-proxy-url
+// Set your your RevenueCat Proxy URL for local development here (without quotes!):
+// REVENUECAT_PROXY_URL = your-revenuecat-proxy-url-without-quotes


### PR DESCRIPTION
Greatly improves #4795

### Motivation
Using double quotes for strings is set in stone for us, developers. But the strings in `xcconfig`'s files for Build Settings don't use quotes. This PR tries to break that habit only for the `Local.xcconfig` file.

### Description
Add some hints in `Local.xcconfig.SAMPLE` to prevent adding quotes in the Build settings specified in `Local.xcconfig`