### PR TITLE
Fix SDK Compilation on Xcode 16.3/iOS 18.4 Beta 1

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -324,7 +324,7 @@ enum TransactionType {
 
 }
 
-extension SubscriptionInfo: Transaction {
+extension RevenueCat.SubscriptionInfo: Transaction {
 
     var type: TransactionType {
         .subscription(isActive: isActive,


### PR DESCRIPTION
### Motivation
This PR addresses GH issue https://github.com/RevenueCat/purchases-ios/issues/4813. Apple released iOS 18.4 beta 1 and Xcode 16.3, which introduces the [SubscriptionInfo](https://developer.apple.com/documentation/storekit/subscriptioninfo) typealias. This caused a name resolution conflict in `PurchaseInformation.swift` where the extension on `SubscriptionInfo` can't tell if it should resolve to `StoreKit.SubscriptionInfo` or `RevenueCat.SubscriptionInfo`.

<img width="1728" alt="Screenshot 2025-02-21 at 10 15 27 PM" src="https://github.com/user-attachments/assets/a4723972-0e42-4a1e-bfae-297b2d77fdab" />

### Description
This PR makes the extension's reference to `SubscriptionInfo` explicitly reference `RevenueCat.SubscriptionInfo`, which resolves the compilation issue.

### Note to the Reviewer
Our iOS 18 CI jobs aren't using Xcode 16.3 yet, so just because this PR passes CI doesn't necessarily mean it will work. I've tested and confirmed that `RevenueCatUI` on this branch builds for me on Xcode 16.3, but would appreciate it if you could try building as well to be safe.