### PR TITLE
Empty strings in proxyURL parameters in `Local.xcconfig`

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Constants.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Constants.swift
@@ -25,7 +25,9 @@ enum Constants {
     static let proxyURL: String? = {
         guard
             var scheme = Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_PROXY_URL_SCHEME") as? String,
-        let host = Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_PROXY_URL_HOST") as? String else {
+            !scheme.isEmpty,
+            let host = Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_PROXY_URL_HOST") as? String,
+            !host.isEmpty else {
             return nil
         }
         if !scheme.hasSuffix(":") {


### PR DESCRIPTION
### Motivation
If no value is set in `Local.xcconfig` for either `REVENUECAT_PROXY_URL_SCHEME` or `REVENUECAT_PROXY_URL_HOST`, then reading the variable returns an empty string.

### Description
This PR considers that case so that if any of the two is empty, then no proxy URL is returned.
