### PR TITLE
Adds `buildServer.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ Local.xcconfig
 
 # Gets created when Cursor is used with the sswg Swift extension
 /.index-build/
+
+# xcode-build-server
+/buildServer.json


### PR DESCRIPTION
## Motiviation
This helps those of us using/experimenting with [xcode-build-server](https://github.com/SolaWing/xcode-build-server). The `buildServer.json` file is machine-specific as it contains absolute paths so it's probably best to exclude it from source control.