### PR TITLE
Correctly set PaywallsTester app API key by the CI

### DIFF
--- a/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
+++ b/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
@@ -5,5 +5,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 echo "Replacing API keys on PaywallsTester"
 
 file="$SCRIPT_DIR/../PaywallsTester/Config/Constants.swift"
-sed -i '' 's/static var apiKey: String { "" }/static var apiKey: String { "'"$REVENUECAT_XCODE_CLOUD_RC_APP_API_KEY"'" }/' $file
+sed -i '' 's/Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_API_KEY") as? String ?? ""/"'"$REVENUECAT_XCODE_CLOUD_RC_APP_API_KEY"'"/' $file
 


### PR DESCRIPTION
### Motivation
After the changes in #4795, the CI was not able to set the API key for the PaywallsTester app properly

### Description
Fixes the issue

### Notes
With this change, the CI edits the file `Constants.swift` in PurchasesTester by replacing
```swift
static let apiKey: String = {
    Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_API_KEY") as? String ?? ""
}()
```
with 
```swift
static let apiKey: String = {
    "paywallstester_app_api_key"
}()
```