### PR TITLE
feat: Hide refund for purchases in trial period

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigTestData.swift
@@ -151,6 +151,7 @@ enum CustomerCenterConfigTestData {
                                    date: .date("June 1st, 2024")),
         productIdentifier: "product_id",
         store: .appStore,
+        isTrial: false,
         isLifetime: false,
         latestPurchaseDate: nil,
         customerInfoRequestedDate: Date()
@@ -165,6 +166,7 @@ enum CustomerCenterConfigTestData {
                                    date: .date("June 1st, 2024")),
         productIdentifier: "product_id",
         store: .appStore,
+        isTrial: false,
         isLifetime: false,
         latestPurchaseDate: nil,
         customerInfoRequestedDate: Date()
@@ -179,6 +181,7 @@ enum CustomerCenterConfigTestData {
                                    date: .date("June 1st, 2024")),
         productIdentifier: "product_id",
         store: .appStore,
+        isTrial: false,
         isLifetime: false,
         latestPurchaseDate: nil,
         customerInfoRequestedDate: Date()

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
@@ -265,7 +265,7 @@ private extension Array<CustomerCenterConfigData.HelpPath> {
 
         return filter {
             // if it's cancel, it cannot be a lifetime subscription
-            ($0.type != .cancel || (!purchaseInformation.isLifetime)) &&
+            ($0.type != .cancel || !purchaseInformation.isLifetime) &&
 
             // if it's refundRequest, it cannot be free  nor within trial period
             ($0.type != .refundRequest || (purchaseInformation.price != .free || !purchaseInformation.isTrial)) &&

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
@@ -264,8 +264,8 @@ private extension Array<CustomerCenterConfigData.HelpPath> {
         }
 
         return filter {
-            // if it's cancel, it cannot be a lifetime subscription
-            ($0.type != .cancel || !purchaseInformation.isLifetime) &&
+            // if it's cancel, it cannot be a lifetime subscription nor within trial period
+            ($0.type != .cancel || (!purchaseInformation.isLifetime || !purchaseInformation.isTrial)) &&
 
             // if it's refundRequest, it cannot be free
             ($0.type != .refundRequest || purchaseInformation.price != .free) &&

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
@@ -265,7 +265,7 @@ private extension Array<CustomerCenterConfigData.HelpPath> {
 
         return filter {
             // if it's cancel, it cannot be a lifetime subscription
-            ($0.type != .cancel || (!purchaseInformation.isLifetime) &&
+            ($0.type != .cancel || (!purchaseInformation.isLifetime)) &&
 
             // if it's refundRequest, it cannot be free  nor within trial period
             ($0.type != .refundRequest || (purchaseInformation.price != .free || !purchaseInformation.isTrial)) &&

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
@@ -264,11 +264,11 @@ private extension Array<CustomerCenterConfigData.HelpPath> {
         }
 
         return filter {
-            // if it's cancel, it cannot be a lifetime subscription nor within trial period
-            ($0.type != .cancel || (!purchaseInformation.isLifetime || !purchaseInformation.isTrial)) &&
+            // if it's cancel, it cannot be a lifetime subscription
+            ($0.type != .cancel || (!purchaseInformation.isLifetime) &&
 
-            // if it's refundRequest, it cannot be free
-            ($0.type != .refundRequest || purchaseInformation.price != .free) &&
+            // if it's refundRequest, it cannot be free  nor within trial period
+            ($0.type != .refundRequest || (purchaseInformation.price != .free || !purchaseInformation.isTrial)) &&
 
             // if it has a refundDuration, check it's still valid
             ($0.refundWindowDuration?.isWithin(purchaseInformation) ?? true)

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
@@ -268,7 +268,7 @@ private extension Array<CustomerCenterConfigData.HelpPath> {
             ($0.type != .cancel || !purchaseInformation.isLifetime) &&
 
             // if it's refundRequest, it cannot be free  nor within trial period
-            ($0.type != .refundRequest || (purchaseInformation.price != .free || !purchaseInformation.isTrial)) &&
+            ($0.type != .refundRequest || (purchaseInformation.price != .free && !purchaseInformation.isTrial)) &&
 
             // if it has a refundDuration, check it's still valid
             ($0.refundWindowDuration?.isWithin(purchaseInformation) ?? true)

--- a/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
@@ -121,7 +121,7 @@ final class ManageSubscriptionsViewModelTests: TestCase {
         let latestPurchaseDate = Date()
         let twoDays: TimeInterval = 2 * 24 * 60 * 60
         let purchase = PurchaseInformation.mockNonLifetime(
-            price: .paid(""), // just to proove price is ignored if is in trial
+            price: .paid(""), // just to prove price is ignored if is in trial
             isTrial: true,
             latestPurchaseDate: latestPurchaseDate,
             customerInfoRequestedDate: latestPurchaseDate.addingTimeInterval(twoDays))

--- a/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
@@ -28,7 +28,7 @@ import XCTest
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 @MainActor
-class ManageSubscriptionsViewModelTests: TestCase {
+final class ManageSubscriptionsViewModelTests: TestCase {
 
     private let error = TestError(message: "An error occurred")
 
@@ -105,6 +105,24 @@ class ManageSubscriptionsViewModelTests: TestCase {
         let twoDays: TimeInterval = 2 * 24 * 60 * 60
         let purchase = PurchaseInformation.mockNonLifetime(
             price: .free,
+            latestPurchaseDate: latestPurchaseDate,
+            customerInfoRequestedDate: latestPurchaseDate.addingTimeInterval(twoDays))
+
+        let viewModel = ManageSubscriptionsViewModel(
+            screen: ManageSubscriptionsViewModelTests.managementScreen(refundWindowDuration: .forever),
+            customerCenterActionHandler: nil,
+            purchaseInformation: purchase)
+
+        expect(viewModel.relevantPathsForPurchase.count) == 3
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .refundRequest })).to(beFalse())
+    }
+
+    func testDoesNotShowRefundIfPurchaseIsWithinTrial() {
+        let latestPurchaseDate = Date()
+        let twoDays: TimeInterval = 2 * 24 * 60 * 60
+        let purchase = PurchaseInformation.mockNonLifetime(
+            price: .paid(""), // just to proove price is ignored if is in trial
+            isTrial: true,
             latestPurchaseDate: latestPurchaseDate,
             customerInfoRequestedDate: latestPurchaseDate.addingTimeInterval(twoDays))
 
@@ -505,7 +523,9 @@ private struct MockStoreProductDiscount: StoreProductDiscountType {
 }
 
 private extension PurchaseInformation {
-    static func mockLifetime(customerInfoRequestedDate: Date = Date()) -> PurchaseInformation {
+    static func mockLifetime(
+        customerInfoRequestedDate: Date = Date()
+    ) -> PurchaseInformation {
         PurchaseInformation(
             title: "",
             durationTitle: "",
@@ -514,6 +534,7 @@ private extension PurchaseInformation {
             expirationOrRenewal: PurchaseInformation.ExpirationOrRenewal(label: .expires, date: .date("")),
             productIdentifier: "",
             store: .appStore,
+            isTrial: false,
             isLifetime: true,
             latestPurchaseDate: nil,
             customerInfoRequestedDate: customerInfoRequestedDate
@@ -522,6 +543,7 @@ private extension PurchaseInformation {
 
     static func mockNonLifetime(
         price: PurchaseInformation.PriceDetails = .paid("5"),
+        isTrial: Bool = false,
         latestPurchaseDate: Date = Date(),
         customerInfoRequestedDate: Date = Date()) -> PurchaseInformation {
         PurchaseInformation(
@@ -535,6 +557,7 @@ private extension PurchaseInformation {
             ),
             productIdentifier: "",
             store: .appStore,
+            isTrial: isTrial,
             isLifetime: false,
             latestPurchaseDate: latestPurchaseDate,
             customerInfoRequestedDate: customerInfoRequestedDate

--- a/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
@@ -62,7 +62,8 @@ final class PurchaseInformationTests: TestCase {
             type: .subscription(
                 isActive: true,
                 willRenew: true,
-                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062")
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
+                isTrial: false
             )
         )
 
@@ -108,7 +109,8 @@ final class PurchaseInformationTests: TestCase {
             type: .subscription(
                 isActive: true,
                 willRenew: true,
-                expiresDate: nil
+                expiresDate: nil,
+                isTrial: false
             )
         )
 
@@ -154,7 +156,8 @@ final class PurchaseInformationTests: TestCase {
             type: .subscription(
                 isActive: true,
                 willRenew: false,
-                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062")
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
+                isTrial: false
             )
         )
 
@@ -200,7 +203,8 @@ final class PurchaseInformationTests: TestCase {
             type: .subscription(
                 isActive: false,
                 willRenew: false,
-                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2000")
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2000"),
+                isTrial: false
             )
         )
 
@@ -233,7 +237,8 @@ final class PurchaseInformationTests: TestCase {
             type: .subscription(
                 isActive: true,
                 willRenew: true,
-                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062")
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
+                isTrial: false
             )
         )
 
@@ -266,7 +271,8 @@ final class PurchaseInformationTests: TestCase {
             type: .subscription(
                 isActive: true,
                 willRenew: false,
-                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062")
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
+                isTrial: false
             )
         )
 
@@ -299,7 +305,8 @@ final class PurchaseInformationTests: TestCase {
             type: .subscription(
                 isActive: false,
                 willRenew: false,
-                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2000")
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2000"),
+                isTrial: false
             )
         )
 
@@ -332,7 +339,8 @@ final class PurchaseInformationTests: TestCase {
             type: .subscription(
                 isActive: true,
                 willRenew: false,
-                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062")
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
+                isTrial: false
             )
         )
 
@@ -365,7 +373,8 @@ final class PurchaseInformationTests: TestCase {
             type: .subscription(
                 isActive: true,
                 willRenew: false,
-                expiresDate: nil
+                expiresDate: nil,
+                isTrial: false
             )
         )
 
@@ -399,7 +408,8 @@ final class PurchaseInformationTests: TestCase {
             type: .subscription(
                 isActive: true,
                 willRenew: true,
-                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062")
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
+                isTrial: false
             )
         )
 
@@ -432,7 +442,8 @@ final class PurchaseInformationTests: TestCase {
             type: .subscription(
                 isActive: true,
                 willRenew: false,
-                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062")
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
+                isTrial: false
             )
         )
 
@@ -465,7 +476,8 @@ final class PurchaseInformationTests: TestCase {
             type: .subscription(
                 isActive: false,
                 willRenew: false,
-                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2000")
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2000"),
+                isTrial: false
             )
         )
 
@@ -495,7 +507,8 @@ final class PurchaseInformationTests: TestCase {
             type: .subscription(
                 isActive: false,
                 willRenew: false,
-                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2000")
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2000"),
+                isTrial: false
             )
         )
 


### PR DESCRIPTION
### Motivation
We shouldn't show the refund path if the product is within the trial period

### Description
Follow up of https://github.com/RevenueCat/purchases-ios/pull/4805
