### PR TITLE
Add default refundWindowDuration to HelpPath.init

### DIFF
--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -343,7 +343,7 @@ public struct CustomerCenterConfigData: Equatable {
                     openMethod: OpenMethod? = nil,
                     type: PathType,
                     detail: PathDetail?,
-                    refundWindowDuration: RefundWindowDuration?) {
+                    refundWindowDuration: RefundWindowDuration? = .forever) {
             self.id = id
             self.title = title
             self.url = url

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerCenterConfigDataAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerCenterConfigDataAPI.swift
@@ -24,7 +24,10 @@ func checkCustomerCenterConfigData(_ data: CustomerCenterConfigData) {
                                             productId: productId)
 }
 
-func checkHelpPath(_ path: CustomerCenterConfigData.HelpPath) {
+func checkHelpPath(
+    _ path: CustomerCenterConfigData.HelpPath,
+    isoDuration: ISODuration
+) {
     let id: String = path.id
     let title: String = path.title
     let url: URL? = path.url
@@ -38,6 +41,14 @@ func checkHelpPath(_ path: CustomerCenterConfigData.HelpPath) {
                                                      openMethod: openMethod,
                                                      type: type,
                                                      detail: detail)
+
+    let _: CustomerCenterConfigData.HelpPath = .init(id: id,
+                                                     title: title,
+                                                     url: url,
+                                                     openMethod: openMethod,
+                                                     type: type,
+                                                     detail: detail,
+                                                     refundWindowDuration: .duration(isoDuration))
 }
 
 func checkHelpPathDetail(_ detail: CustomerCenterConfigData.HelpPath.PathDetail) {


### PR DESCRIPTION
### Description
`CustomerCenterConfigData.HelpPath.init()` has a non-optional `refundHelpWindow` parameter that would be a breaking change if released. This PR provides a default value of `.forever` to this initializer to prevent it from being a breaking change.
