### PR TITLE
Add RCStoreMessageTypeWinBackOffer to Objc API Tester

### DIFF
--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
@@ -258,7 +258,6 @@ NSURL *url;
         case RCStoreMessageTypeGeneric:
         case RCStoreMessageTypeWinBackOffer:
             NSLog(@"%ld", (long)smt);
-            break;
     }
 
     RCPurchasesAreCompletedBy pacb = RCPurchasesAreCompletedByRevenueCat;

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
@@ -256,7 +256,9 @@ NSURL *url;
         case RCStoreMessageTypeBillingIssue:
         case RCStoreMessageTypePriceIncreaseConsent:
         case RCStoreMessageTypeGeneric:
+        case RCStoreMessageTypeWinBackOffer:
             NSLog(@"%ld", (long)smt);
+            break;
     }
 
     RCPurchasesAreCompletedBy pacb = RCPurchasesAreCompletedByRevenueCat;


### PR DESCRIPTION
### Description
It looks like we forgot to add `RCStoreMessageTypeWinBackOffer` to the Objective-C API tester - this PR adds it in!
