### PR TITLE
[Diagnostics] Add `requestedProductIds` and `notFoundProductIds` to `appleProductsRequest`

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -51,6 +51,8 @@ extension DiagnosticsEvent {
         case errorCodeKey
         case skErrorDescriptionKey
         case eTagHitKey
+        case requestedProductIdsKey
+        case notFoundProductIdsKey
 
     }
 

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -28,6 +28,8 @@ protocol DiagnosticsTrackerType {
                               errorMessage: String?,
                               errorCode: Int?,
                               storeKitErrorDescription: String?,
+                              requestedProductIds: Set<String>,
+                              notFoundProductIds: Set<String>,
                               responseTime: TimeInterval)
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -93,6 +95,8 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                               errorMessage: String?,
                               errorCode: Int?,
                               storeKitErrorDescription: String?,
+                              requestedProductIds: Set<String>,
+                              notFoundProductIds: Set<String>,
                               responseTime: TimeInterval) {
         self.track(
             DiagnosticsEvent(eventType: .appleProductsRequest,
@@ -102,6 +106,8 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                                 .errorMessageKey: AnyEncodable(errorMessage),
                                 .errorCodeKey: AnyEncodable(errorCode),
                                 .skErrorDescriptionKey: AnyEncodable(storeKitErrorDescription),
+                                .requestedProductIdsKey: AnyEncodable(requestedProductIds),
+                                .notFoundProductIdsKey: AnyEncodable(notFoundProductIds),
                                 .responseTimeMillisKey: AnyEncodable(responseTime * 1000)
                              ],
                              timestamp: self.dateProvider.now())

--- a/Sources/Diagnostics/Networking/DiagnosticsEventsRequest.swift
+++ b/Sources/Diagnostics/Networking/DiagnosticsEventsRequest.swift
@@ -98,6 +98,10 @@ private extension DiagnosticsEvent.DiagnosticsPropertyKey {
             return "sk_error_description"
         case .eTagHitKey:
             return "etag_hit"
+        case .requestedProductIdsKey:
+            return "requested_product_ids"
+        case .notFoundProductIdsKey:
+            return "not_found_product_ids"
         }
     }
 

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -150,14 +150,17 @@ class SK1ProductsManagerDiagnosticsTrackingTests: ProductsManagerTests {
                                          diagnosticsTracker: self.mockDiagnosticsTracker)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
+        let notFoundIdentifier = "unknown_identifier"
         _ = waitUntilValue(timeout: Self.requestDispatchTimeout) { completed in
-            manager.products(withIdentifiers: Set([identifier]), completion: completed)
+            manager.products(withIdentifiers: Set([identifier, notFoundIdentifier]), completion: completed)
         }
 
         expect(self.mockDiagnosticsTracker.trackedProductsRequestParams.value).toEventually(haveCount(1))
         let params = self.mockDiagnosticsTracker.trackedProductsRequestParams.value.first
         expect(params?.wasSuccessful) == true
         expect(params?.storeKitVersion) == .storeKit1
+        expect(params?.requestedProductIds) == Set([identifier, notFoundIdentifier])
+        expect(params?.notFoundProductIds) == Set([notFoundIdentifier])
         expect(params?.errorMessage).to(beNil())
         expect(params?.errorCode).to(beNil())
     }
@@ -186,14 +189,17 @@ class SK2ProductsManagerDiagnosticsTrackingTests: ProductsManagerTests {
                                          diagnosticsTracker: self.mockDiagnosticsTracker)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
+        let notFoundIdentifier = "unknown_identifier"
         _ = waitUntilValue(timeout: Self.requestDispatchTimeout) { completed in
-            manager.products(withIdentifiers: Set([identifier]), completion: completed)
+            manager.products(withIdentifiers: Set([identifier, notFoundIdentifier]), completion: completed)
         }
 
         expect(self.mockDiagnosticsTracker.trackedProductsRequestParams.value).toEventually(haveCount(1))
         let params = self.mockDiagnosticsTracker.trackedProductsRequestParams.value.first
         expect(params?.wasSuccessful) == true
         expect(params?.storeKitVersion) == .storeKit2
+        expect(params?.requestedProductIds) == Set([identifier, notFoundIdentifier])
+        expect(params?.notFoundProductIds) == Set([notFoundIdentifier])
         expect(params?.errorMessage).to(beNil())
         expect(params?.errorCode).to(beNil())
         expect(params?.storeKitErrorDescription).to(beNil())

--- a/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
@@ -142,6 +142,8 @@ class DiagnosticsTrackerTests: TestCase {
                                           errorMessage: "test error message",
                                           errorCode: 1234,
                                           storeKitErrorDescription: "store_kit_error_type",
+                                          requestedProductIds: ["test_product_id_1", "test_product_id_2"],
+                                          notFoundProductIds: ["test_product_id_2"],
                                           responseTime: 50)
         let emptyErrorMessage: String? = nil
         let emptyErrorCode: Int? = nil
@@ -151,6 +153,8 @@ class DiagnosticsTrackerTests: TestCase {
                                           errorMessage: emptyErrorMessage,
                                           errorCode: emptyErrorCode,
                                           storeKitErrorDescription: emptySkErrorDescription,
+                                          requestedProductIds: ["test_product_id_3", "test_product_id_4"],
+                                          notFoundProductIds: [],
                                           responseTime: 20)
 
         let entries = await self.handler.getEntries()
@@ -162,6 +166,8 @@ class DiagnosticsTrackerTests: TestCase {
                     .successfulKey: AnyEncodable(false),
                     .errorMessageKey: AnyEncodable("test error message"),
                     .skErrorDescriptionKey: AnyEncodable("store_kit_error_type"),
+                    .requestedProductIdsKey: AnyEncodable(["test_product_id_1", "test_product_id_2"]),
+                    .notFoundProductIdsKey: AnyEncodable(["test_product_id_2"]),
                     .errorCodeKey: AnyEncodable(1234)],
                   timestamp: Self.eventTimestamp1),
             .init(eventType: .appleProductsRequest,
@@ -171,6 +177,8 @@ class DiagnosticsTrackerTests: TestCase {
                     .successfulKey: AnyEncodable(true),
                     .errorMessageKey: AnyEncodable(emptyErrorMessage),
                     .skErrorDescriptionKey: AnyEncodable(emptySkErrorDescription),
+                    .requestedProductIdsKey: AnyEncodable(["test_product_id_3", "test_product_id_4"]),
+                    .notFoundProductIdsKey: AnyEncodable([]),
                     .errorCodeKey: AnyEncodable(emptyErrorCode)],
                   timestamp: Self.eventTimestamp1)
         ]

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -86,6 +86,8 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
          errorMessage: String?,
          errorCode: Int?,
          storeKitErrorDescription: String?,
+         requestedProductIds: Set<String>,
+         notFoundProductIds: Set<String>,
          responseTime: TimeInterval)
     ]> = .init([])
     // swiftlint:disable:next function_parameter_count
@@ -94,6 +96,8 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                               errorMessage: String?,
                               errorCode: Int?,
                               storeKitErrorDescription: String?,
+                              requestedProductIds: Set<String>,
+                              notFoundProductIds: Set<String>,
                               responseTime: TimeInterval) {
         self.trackedProductsRequestParams.modify {
             $0.append(
@@ -102,6 +106,8 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                 errorMessage,
                 errorCode,
                 storeKitErrorDescription,
+                requestedProductIds,
+                notFoundProductIds,
                 responseTime)
             )
         }


### PR DESCRIPTION
### Description
This adds `requestedProductIdsKey` and `notFoundProductIdsKey` properties to the `appleProductsRequest`. This won't be used by Grafana but will be in the future DW events.