### PR TITLE
chore: Add integration test for analytics events

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -537,6 +537,8 @@
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
 		57045B3C29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */; };
+		5704CDC72D6F6F2D00C7F01A /* EventsManagerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5704CDC62D6F6F2800C7F01A /* EventsManagerIntegrationTests.swift */; };
+		5704CDC92D706E5700C7F01A /* AnalyticsStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5704CDC82D706E5500C7F01A /* AnalyticsStrings.swift */; };
 		57057FF828B0048900995F21 /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57057FF728B0048900995F21 /* TestLogHandler.swift */; };
 		57057FF928B0048900995F21 /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57057FF728B0048900995F21 /* TestLogHandler.swift */; };
 		57069A5428E3918400B86355 /* AsyncExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57069A5328E3918400B86355 /* AsyncExtensions.swift */; };
@@ -1880,6 +1882,8 @@
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
 		57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProductEntitlementMappingOperation.swift; sourceTree = "<group>"; };
 		57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingCallback.swift; sourceTree = "<group>"; };
+		5704CDC62D6F6F2800C7F01A /* EventsManagerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsManagerIntegrationTests.swift; sourceTree = "<group>"; };
+		5704CDC82D706E5500C7F01A /* AnalyticsStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsStrings.swift; sourceTree = "<group>"; };
 		57057FF728B0048900995F21 /* TestLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLogHandler.swift; sourceTree = "<group>"; };
 		57069A5328E3918400B86355 /* AsyncExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncExtensions.swift; sourceTree = "<group>"; };
 		57069A5D28E398E100B86355 /* AsyncExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncExtensionsTests.swift; sourceTree = "<group>"; };
@@ -2885,6 +2889,7 @@
 		2D11F5DF250FF658005A70E8 /* Strings */ = {
 			isa = PBXGroup;
 			children = (
+				5704CDC82D706E5500C7F01A /* AnalyticsStrings.swift */,
 				2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */,
 				B302206D2728B798008F1A0D /* BackendErrorStrings.swift */,
 				F5714EE426DC2F1D00635477 /* CodableStrings.swift */,
@@ -3606,6 +3611,7 @@
 		2DE20B6D264087FB004C597D /* BackendIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
+				5704CDC62D6F6F2800C7F01A /* EventsManagerIntegrationTests.swift */,
 				4F90AFC92A39152A0047E63F /* Helpers */,
 				4FCBA8522A1539D0004134BD /* __Snapshots__ */,
 				579234E127F777EE00B39C68 /* BaseBackendIntegrationTests.swift */,
@@ -6095,6 +6101,7 @@
 				2DDF419624F6F331005BC22D /* ProductsRequestFactory.swift in Sources */,
 				1E8A60422CDBD75A0034ACF3 /* WebPurchaseRedemption.swift in Sources */,
 				2DDF419724F6F331005BC22D /* DateExtensions.swift in Sources */,
+				5704CDC92D706E5700C7F01A /* AnalyticsStrings.swift in Sources */,
 				9A65E0A52591A23500DE00B0 /* PurchaseStrings.swift in Sources */,
 				57EAE52B274332830060EB74 /* Obsoletions.swift in Sources */,
 				57E9CF0F290B2A4B00EE12D1 /* CachingTrialOrIntroPriceEligibilityChecker.swift in Sources */,
@@ -6682,6 +6689,7 @@
 				2DE20B6F264087FB004C597D /* StoreKitIntegrationTests.swift in Sources */,
 				4F83F6B62A5DB773003F90A5 /* TestCase.swift in Sources */,
 				4FCBA84F2A15391B004134BD /* SnapshotTesting+Extensions.swift in Sources */,
+				5704CDC72D6F6F2D00C7F01A /* EventsManagerIntegrationTests.swift in Sources */,
 				4FFFE6E72AA948A600B2955C /* PaywallEventsIntegrationTests.swift in Sources */,
 				4FF017C32AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift in Sources */,
 				4FA696BD2A0020A000D228B1 /* MainThreadMonitor.swift in Sources */,

--- a/Sources/Logging/Strings/AnalyticsStrings.swift
+++ b/Sources/Logging/Strings/AnalyticsStrings.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Analytics.swift
+//
+//  Created by Facundo Menzella on 27/2/25.
+
+import Foundation
+
+// swiftlint:disable identifier_name
+enum AnalyticsStrings {
+
+    case flush_events_success
+}
+
+extension AnalyticsStrings: LogMessage {
+    var category: String { return "analytics" }
+
+    var description: String {
+        switch self {
+        case .flush_events_success:
+            return "Events flush succeeded"
+        }
+    }
+}

--- a/Sources/Logging/Strings/Strings.swift
+++ b/Sources/Logging/Strings/Strings.swift
@@ -15,6 +15,7 @@ import Foundation
 enum Strings {
 
     static let attribution = AttributionStrings.self
+    static let analytics = AnalyticsStrings.self
     static let codable = CodableStrings.self
     static let configure = ConfigureStrings.self
     static let backendError = BackendErrorStrings.self

--- a/Sources/Paywalls/Events/PaywallEventsManager.swift
+++ b/Sources/Paywalls/Events/PaywallEventsManager.swift
@@ -84,6 +84,7 @@ actor PaywallEventsManager: PaywallEventsManagerType {
 
         do {
             try await self.internalAPI.postPaywallEvents(events: events)
+            Logger.debug(Strings.analytics.flush_events_success)
 
             await self.store.clear(count)
 

--- a/Tests/BackendIntegrationTests/EventsManagerIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/EventsManagerIntegrationTests.swift
@@ -1,0 +1,124 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  EventsManagerIntegrationTests.swift
+//
+//  Created by Facundo Menzella on 26/2/25.
+
+import Nimble
+import XCTest
+
+#if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+@testable import RevenueCat_CustomEntitlementComputation
+#else
+@testable import RevenueCat
+#endif
+
+@MainActor
+final class EventsManagerIntegrationTests: BaseBackendIntegrationTests {
+
+    override var apiKey: String { return Constants.customEntitlementComputationApiKey }
+
+    var eventsManager: PaywallEventsManager!
+
+    func testPostingPaywallsDoesNotFail() async throws {
+        let events = [
+            PaywallEvent.cancel(
+                Self.eventCreationData, Self.eventData
+            ),
+            PaywallEvent.close(
+                Self.eventCreationData, Self.eventData
+            ),
+            PaywallEvent.impression(
+                Self.eventCreationData, Self.eventData
+            )
+        ]
+
+        for event in events {
+            await eventsManager.track(
+                featureEvent: event
+            )
+        }
+
+        _ = try await eventsManager.flushEvents(count: 100)
+
+        self.logger.verifyMessageWasLogged(
+            Strings.paywalls.event_flush_starting(count: events.count)
+        )
+
+        try self.logger.verifyMessageWasLogged(
+            Strings.analytics.flush_events_success,
+            level: .debug,
+            expectedCount: 1
+        )
+    }
+
+    func testPostingCustomerCenterDoesNotFail() async throws {
+        let locale = Locale(identifier: "es_ES")
+        await eventsManager.track(
+            featureEvent: CustomerCenterEvent.impression(
+                Self.customerCenterCreationData,
+                CustomerCenterEvent.Data(
+                    locale: locale,
+                    darkMode: true,
+                    isSandbox: true,
+                    displayMode: .fullScreen
+                )
+            )
+        )
+
+        await eventsManager.track(
+            featureEvent: CustomerCenterAnswerSubmittedEvent.answerSubmitted(
+                Self.customerCenterCreationData,
+                CustomerCenterAnswerSubmittedEvent.Data(
+                    locale: locale,
+                    darkMode: true,
+                    isSandbox: true,
+                    displayMode: .fullScreen,
+                    path: .cancel,
+                    url: nil,
+                    surveyOptionID: "",
+                    surveyOptionTitleKey: "",
+                    revisionID: 1
+                )
+            )
+        )
+
+        _ = try await eventsManager.flushEvents(count: 2)
+
+        self.logger.verifyMessageWasLogged(
+            Strings.paywalls.event_flush_starting(count: 2)
+        )
+
+        try self.logger.verifyMessageWasLogged(
+            Strings.analytics.flush_events_success,
+            level: .debug,
+            expectedCount: 1
+        )
+    }
+
+    static let customerCenterCreationData: CustomerCenterEventCreationData = .init(
+        id: .init(uuidString: "72164C05-2BDC-4807-8918-A4105F727DEB")!,
+        date: .init(timeIntervalSince1970: 1694029328)
+    )
+
+    static let eventCreationData: PaywallEvent.CreationData = .init(
+        id: .init(uuidString: "72164C05-2BDC-4807-8918-A4105F727DEB")!,
+        date: .init(timeIntervalSince1970: 1694029328)
+    )
+
+    static let eventData: PaywallEvent.Data = .init(
+        offeringIdentifier: "offering",
+        paywallRevision: 0,
+        sessionID: .init(uuidString: "98CC0F1D-7665-4093-9624-1D7308FFF4DB")!,
+        displayMode: .fullScreen,
+        localeIdentifier: "es_ES",
+        darkMode: true
+    )
+}


### PR DESCRIPTION
### Motivation
This week we realized some events were not being sent to the backend. Even more, when we tried to add it we realized they errored out.

Mimics https://github.com/RevenueCat/purchases-android/pull/2189 

### Description

This PR adds a basic test to just make sure nothing's broken Ideally, the list of events should be generated somehow, but for now this is enough IMO.

### Next steps
1. Refactor `PaywallEventsManager` to `EventsManager`
2. Move analytics debug logs from `Strings.paywalls` to `Strings.analytics`
