### PR TITLE
Use array instead of sets in diagnostics events

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -809,6 +809,10 @@
 		7571BE9F2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7571BE9E2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift */; };
 		75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */; };
 		75DAE4822D7234C200AEC012 /* DiagnosticsEvent+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */; };
+		75DAE4842D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DAE4832D72356700AEC012 /* AnyEncodable+Equatable.swift */; };
+		75DAE4852D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DAE4832D72356700AEC012 /* AnyEncodable+Equatable.swift */; };
+		75DAE4862D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DAE4832D72356700AEC012 /* AnyEncodable+Equatable.swift */; };
+		75DAE4872D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DAE4832D72356700AEC012 /* AnyEncodable+Equatable.swift */; };
 		7706ED3E2C6E374D0004B9F9 /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7706ED3D2C6E374D0004B9F9 /* ButtonStyles.swift */; };
 		7707A94C2CAD93AC006E0313 /* PaywallButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94B2CAD93AC006E0313 /* PaywallButtonComponent.swift */; };
 		7707A94E2CAD94D2006E0313 /* ButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94D2CAD94D2006E0313 /* ButtonComponentViewModel.swift */; };
@@ -2117,6 +2121,7 @@
 		756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiagnosticsEvent+Equatable.swift"; sourceTree = "<group>"; };
 		7571BE9E2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift; sourceTree = "<group>"; };
 		75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerUIPreviewModeTests.swift; sourceTree = "<group>"; };
+		75DAE4832D72356700AEC012 /* AnyEncodable+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyEncodable+Equatable.swift"; sourceTree = "<group>"; };
 		7706ED3D2C6E374D0004B9F9 /* ButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyles.swift; sourceTree = "<group>"; };
 		7707A93B2CAD8AA2006E0313 /* Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig; sourceTree = "<group>"; };
 		7707A94B2CAD93AC006E0313 /* PaywallButtonComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallButtonComponent.swift; sourceTree = "<group>"; };
@@ -4130,6 +4135,7 @@
 				575A8EE02922C56300936709 /* AsyncTestHelpers.swift */,
 				4F69EB082A14406E00ED6D4B /* Matchers.swift */,
 				756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */,
+				75DAE4832D72356700AEC012 /* AnyEncodable+Equatable.swift */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -5991,6 +5997,7 @@
 				57544C29285FA95E004E54D5 /* MockAttributeSyncing.swift in Sources */,
 				57057FF928B0048900995F21 /* TestLogHandler.swift in Sources */,
 				4F69EB0A2A14406E00ED6D4B /* Matchers.swift in Sources */,
+				75DAE4862D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */,
 				7571BE9F2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift in Sources */,
 				2D90F8C226FD20F7009B9142 /* MockETagManager.swift in Sources */,
 				2D90F8B526FD2093009B9142 /* MockSystemInfo.swift in Sources */,
@@ -6651,6 +6658,7 @@
 				5722482727C2BD3200C524A7 /* LockTests.swift in Sources */,
 				351B514526D449E600BD2BD7 /* MockAttributionTypeFactory.swift in Sources */,
 				4FE0685F2A5F54C500B8F56C /* PackageTypeTests.swift in Sources */,
+				75DAE4872D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */,
 				4D72E8622B221EA600BF9EFE /* StoreEnvironmentTests.swift in Sources */,
 				575A8EE12922C56300936709 /* AsyncTestHelpers.swift in Sources */,
 				572247F727BF1ADF00C524A7 /* ArrayExtensionsTests.swift in Sources */,
@@ -6707,6 +6715,7 @@
 				4F2018732A15797D0061F6EF /* TestLogHandler.swift in Sources */,
 				4F90AFCB2A3915340047E63F /* TestMessage.swift in Sources */,
 				4F15B4A22A678A9C005BEFE8 /* MockStoreTransaction.swift in Sources */,
+				75DAE4852D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */,
 				2D3BFAD226DEA46600370B11 /* MockProductsRequest.swift in Sources */,
 				4F83F6B82A5DB78C003F90A5 /* OSVersionEquivalent.swift in Sources */,
 				2D1015DB275A4EAE0086173F /* AvailabilityChecks.swift in Sources */,
@@ -6740,6 +6749,7 @@
 				4F7C37B22A27E2E8001E17D3 /* AsyncTestHelpers.swift in Sources */,
 				4F6BEE362A27B0F200CD9322 /* MainThreadMonitor.swift in Sources */,
 				4F83F6BB2A5DB80B003F90A5 /* OSVersionEquivalent.swift in Sources */,
+				75DAE4842D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */,
 				4F83F6BA2A5DB807003F90A5 /* CurrentTestCaseTracker.swift in Sources */,
 				4F6BEE3B2A27B45300CD9322 /* StoreKitTestHelpers.swift in Sources */,
 				4F6BEE1F2A27B02400CD9322 /* CustomEntitlementsComputationIntegrationTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -806,11 +806,9 @@
 		6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECF627761D375C8431EB866 /* StoreProduct.swift */; };
 		75425E0F2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75425E0E2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift */; };
 		756FFA1D2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */; };
-		756FFA1E2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */; };
-		756FFA1F2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */; };
-		756FFA202D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */; };
 		7571BE9F2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7571BE9E2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift */; };
 		75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */; };
+		75DAE4822D7234C200AEC012 /* DiagnosticsEvent+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */; };
 		7706ED3E2C6E374D0004B9F9 /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7706ED3D2C6E374D0004B9F9 /* ButtonStyles.swift */; };
 		7707A94C2CAD93AC006E0313 /* PaywallButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94B2CAD93AC006E0313 /* PaywallButtonComponent.swift */; };
 		7707A94E2CAD94D2006E0313 /* ButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94D2CAD94D2006E0313 /* ButtonComponentViewModel.swift */; };
@@ -5955,7 +5953,7 @@
 				4D322E3A2B7E7B570004AF53 /* PurchasesOrchestratorSK1Tests.swift in Sources */,
 				1EFA95162CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift in Sources */,
 				4F5D52D92A5713A800E1C758 /* DebugViewSwiftUITests.swift in Sources */,
-				756FFA1E2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */,
+				75DAE4822D7234C200AEC012 /* DiagnosticsEvent+Equatable.swift in Sources */,
 				4D322E382B7E7B170004AF53 /* PurchasesOrchestratorSK2Tests.swift in Sources */,
 				FDAC7B572CD3FD8500DFC0D9 /* MockWinBackOfferEligibilityCalculator.swift in Sources */,
 				2D9C5EC826F280510057FC45 /* StoreProductTests.swift in Sources */,
@@ -6688,7 +6686,6 @@
 				4F7E3A812B02DF5A0051234A /* MockSandboxEnvironmentDetector.swift in Sources */,
 				4F1E84022A6062C9000AF177 /* ImageSnapshot.swift in Sources */,
 				2D3BFAD326DEA47100370B11 /* MockSKProductDiscount.swift in Sources */,
-				756FFA202D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */,
 				4FDF10ED2A726291004F3680 /* SK1ProductFetcher.swift in Sources */,
 				4F83F6B72A5DB782003F90A5 /* CurrentTestCaseTracker.swift in Sources */,
 				57DE80BE28077010008D6C6F /* XCTestCase+Extensions.swift in Sources */,
@@ -6742,7 +6739,6 @@
 			files = (
 				4F7C37B22A27E2E8001E17D3 /* AsyncTestHelpers.swift in Sources */,
 				4F6BEE362A27B0F200CD9322 /* MainThreadMonitor.swift in Sources */,
-				756FFA1F2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */,
 				4F83F6BB2A5DB80B003F90A5 /* OSVersionEquivalent.swift in Sources */,
 				4F83F6BA2A5DB807003F90A5 /* CurrentTestCaseTracker.swift in Sources */,
 				4F6BEE3B2A27B45300CD9322 /* StoreKitTestHelpers.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -809,8 +809,6 @@
 		7571BE9F2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7571BE9E2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift */; };
 		75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */; };
 		75DAE4822D7234C200AEC012 /* DiagnosticsEvent+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */; };
-		75DAE4842D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DAE4832D72356700AEC012 /* AnyEncodable+Equatable.swift */; };
-		75DAE4852D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DAE4832D72356700AEC012 /* AnyEncodable+Equatable.swift */; };
 		75DAE4862D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DAE4832D72356700AEC012 /* AnyEncodable+Equatable.swift */; };
 		75DAE4872D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DAE4832D72356700AEC012 /* AnyEncodable+Equatable.swift */; };
 		7706ED3E2C6E374D0004B9F9 /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7706ED3D2C6E374D0004B9F9 /* ButtonStyles.swift */; };
@@ -6715,7 +6713,6 @@
 				4F2018732A15797D0061F6EF /* TestLogHandler.swift in Sources */,
 				4F90AFCB2A3915340047E63F /* TestMessage.swift in Sources */,
 				4F15B4A22A678A9C005BEFE8 /* MockStoreTransaction.swift in Sources */,
-				75DAE4852D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */,
 				2D3BFAD226DEA46600370B11 /* MockProductsRequest.swift in Sources */,
 				4F83F6B82A5DB78C003F90A5 /* OSVersionEquivalent.swift in Sources */,
 				2D1015DB275A4EAE0086173F /* AvailabilityChecks.swift in Sources */,
@@ -6749,7 +6746,6 @@
 				4F7C37B22A27E2E8001E17D3 /* AsyncTestHelpers.swift in Sources */,
 				4F6BEE362A27B0F200CD9322 /* MainThreadMonitor.swift in Sources */,
 				4F83F6BB2A5DB80B003F90A5 /* OSVersionEquivalent.swift in Sources */,
-				75DAE4842D72356700AEC012 /* AnyEncodable+Equatable.swift in Sources */,
 				4F83F6BA2A5DB807003F90A5 /* CurrentTestCaseTracker.swift in Sources */,
 				4F6BEE3B2A27B45300CD9322 /* StoreKitTestHelpers.swift in Sources */,
 				4F6BEE1F2A27B02400CD9322 /* CustomEntitlementsComputationIntegrationTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -805,6 +805,10 @@
 		57FFD2522922DBED00A9A878 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
 		6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECF627761D375C8431EB866 /* StoreProduct.swift */; };
 		75425E0F2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75425E0E2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift */; };
+		756FFA1D2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */; };
+		756FFA1E2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */; };
+		756FFA1F2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */; };
+		756FFA202D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */; };
 		7571BE9F2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7571BE9E2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift */; };
 		75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */; };
 		7706ED3E2C6E374D0004B9F9 /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7706ED3D2C6E374D0004B9F9 /* ButtonStyles.swift */; };
@@ -2112,6 +2116,7 @@
 		57FDAABF28493C13009A48F1 /* MockSandboxEnvironmentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSandboxEnvironmentDetector.swift; sourceTree = "<group>"; };
 		57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreTransaction.swift; sourceTree = "<group>"; };
 		75425E0E2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentsDataTests.swift; sourceTree = "<group>"; };
+		756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiagnosticsEvent+Equatable.swift"; sourceTree = "<group>"; };
 		7571BE9E2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift; sourceTree = "<group>"; };
 		75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerUIPreviewModeTests.swift; sourceTree = "<group>"; };
 		7706ED3D2C6E374D0004B9F9 /* ButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyles.swift; sourceTree = "<group>"; };
@@ -4126,6 +4131,7 @@
 				57057FF728B0048900995F21 /* TestLogHandler.swift */,
 				575A8EE02922C56300936709 /* AsyncTestHelpers.swift */,
 				4F69EB082A14406E00ED6D4B /* Matchers.swift */,
+				756FFA1C2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -5949,6 +5955,7 @@
 				4D322E3A2B7E7B570004AF53 /* PurchasesOrchestratorSK1Tests.swift in Sources */,
 				1EFA95162CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift in Sources */,
 				4F5D52D92A5713A800E1C758 /* DebugViewSwiftUITests.swift in Sources */,
+				756FFA1E2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */,
 				4D322E382B7E7B170004AF53 /* PurchasesOrchestratorSK2Tests.swift in Sources */,
 				FDAC7B572CD3FD8500DFC0D9 /* MockWinBackOfferEligibilityCalculator.swift in Sources */,
 				2D9C5EC826F280510057FC45 /* StoreProductTests.swift in Sources */,
@@ -6530,6 +6537,7 @@
 				35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift in Sources */,
 				03A98D322D2441B8009BCA61 /* PaywallDataDecodingTests.swift in Sources */,
 				4F8DDB692AAA9189000188F2 /* OperationDispatcherTests.swift in Sources */,
+				756FFA1D2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */,
 				57FFD2512922DBED00A9A878 /* MockStoreTransaction.swift in Sources */,
 				57CB2A7A29CCC61600C91439 /* CustomerInfoResponseHandlerTests.swift in Sources */,
 				F591492826B9956C00D32E58 /* MockTransaction.swift in Sources */,
@@ -6680,6 +6688,7 @@
 				4F7E3A812B02DF5A0051234A /* MockSandboxEnvironmentDetector.swift in Sources */,
 				4F1E84022A6062C9000AF177 /* ImageSnapshot.swift in Sources */,
 				2D3BFAD326DEA47100370B11 /* MockSKProductDiscount.swift in Sources */,
+				756FFA202D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */,
 				4FDF10ED2A726291004F3680 /* SK1ProductFetcher.swift in Sources */,
 				4F83F6B72A5DB782003F90A5 /* CurrentTestCaseTracker.swift in Sources */,
 				57DE80BE28077010008D6C6F /* XCTestCase+Extensions.swift in Sources */,
@@ -6733,6 +6742,7 @@
 			files = (
 				4F7C37B22A27E2E8001E17D3 /* AsyncTestHelpers.swift in Sources */,
 				4F6BEE362A27B0F200CD9322 /* MainThreadMonitor.swift in Sources */,
+				756FFA1F2D722B46007C0A93 /* DiagnosticsEvent+Equatable.swift in Sources */,
 				4F83F6BB2A5DB80B003F90A5 /* OSVersionEquivalent.swift in Sources */,
 				4F83F6BA2A5DB807003F90A5 /* CurrentTestCaseTracker.swift in Sources */,
 				4F6BEE3B2A27B45300CD9322 /* StoreKitTestHelpers.swift in Sources */,

--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-struct DiagnosticsEvent: Codable, Equatable {
+struct DiagnosticsEvent: Codable {
 
     let version: Int = 1
     let eventType: DiagnosticsEvent.EventType
@@ -54,17 +54,6 @@ extension DiagnosticsEvent {
         case requestedProductIdsKey
         case notFoundProductIdsKey
 
-    }
-
-}
-
-extension DiagnosticsEvent {
-
-    static func == (lhs: DiagnosticsEvent, rhs: DiagnosticsEvent) -> Bool {
-        return lhs.version == rhs.version &&
-               lhs.eventType == rhs.eventType &&
-               lhs.properties == rhs.properties &&
-               lhs.timestamp == rhs.timestamp
     }
 
 }

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -28,8 +28,8 @@ protocol DiagnosticsTrackerType {
                               errorMessage: String?,
                               errorCode: Int?,
                               storeKitErrorDescription: String?,
-                              requestedProductIds: Set<String>,
-                              notFoundProductIds: Set<String>,
+                              requestedProductIds: [String],
+                              notFoundProductIds: [String],
                               responseTime: TimeInterval)
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -95,8 +95,8 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                               errorMessage: String?,
                               errorCode: Int?,
                               storeKitErrorDescription: String?,
-                              requestedProductIds: Set<String>,
-                              notFoundProductIds: Set<String>,
+                              requestedProductIds: [String],
+                              notFoundProductIds: [String],
                               responseTime: TimeInterval) {
         self.track(
             DiagnosticsEvent(eventType: .appleProductsRequest,

--- a/Sources/Misc/Codable/AnyEncodable.swift
+++ b/Sources/Misc/Codable/AnyEncodable.swift
@@ -109,18 +109,4 @@ extension AnyEncodable: Decodable {
 
 }
 
-extension AnyEncodable: Equatable {
-
-    static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool {
-        do {
-            let lhsData = try lhs.encodedJSON
-            let rhsData = try rhs.encodedJSON
-            return lhsData == rhsData
-        } catch {
-            return false
-        }
-    }
-
-}
-
 // swiftlint:enable cyclomatic_complexity

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -162,8 +162,8 @@ private extension ProductsManager {
                                                     errorMessage: errorMessage,
                                                     errorCode: errorCode,
                                                     storeKitErrorDescription: storeKitErrorDescription,
-                                                    requestedProductIds: requestedProductIds,
-                                                    notFoundProductIds: notFoundProductIds,
+                                                    requestedProductIds: Array(requestedProductIds),
+                                                    notFoundProductIds: Array(notFoundProductIds),
                                                     responseTime: responseTime)
         }
     }

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -159,8 +159,8 @@ class SK1ProductsManagerDiagnosticsTrackingTests: ProductsManagerTests {
         let params = self.mockDiagnosticsTracker.trackedProductsRequestParams.value.first
         expect(params?.wasSuccessful) == true
         expect(params?.storeKitVersion) == .storeKit1
-        expect(params?.requestedProductIds) == Set([identifier, notFoundIdentifier])
-        expect(params?.notFoundProductIds) == Set([notFoundIdentifier])
+        expect(params?.requestedProductIds) == [identifier, notFoundIdentifier]
+        expect(params?.notFoundProductIds) == [notFoundIdentifier]
         expect(params?.errorMessage).to(beNil())
         expect(params?.errorCode).to(beNil())
     }
@@ -198,8 +198,8 @@ class SK2ProductsManagerDiagnosticsTrackingTests: ProductsManagerTests {
         let params = self.mockDiagnosticsTracker.trackedProductsRequestParams.value.first
         expect(params?.wasSuccessful) == true
         expect(params?.storeKitVersion) == .storeKit2
-        expect(params?.requestedProductIds) == Set([identifier, notFoundIdentifier])
-        expect(params?.notFoundProductIds) == Set([notFoundIdentifier])
+        expect(params?.requestedProductIds) == [identifier, notFoundIdentifier]
+        expect(params?.notFoundProductIds) == [notFoundIdentifier]
         expect(params?.errorMessage).to(beNil())
         expect(params?.errorCode).to(beNil())
         expect(params?.storeKitErrorDescription).to(beNil())

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -160,7 +160,7 @@ class SK1ProductsManagerDiagnosticsTrackingTests: ProductsManagerTests {
         expect(params.wasSuccessful) == true
         expect(params.storeKitVersion) == .storeKit1
         expect(Set(params.requestedProductIds)) == [identifier, notFoundIdentifier]
-        expect(params.notFoundProductIds) == [notFoundIdentifier]
+        expect(Set(params.notFoundProductIds)) == [notFoundIdentifier]
         expect(params.errorMessage).to(beNil())
         expect(params.errorCode).to(beNil())
     }
@@ -199,7 +199,7 @@ class SK2ProductsManagerDiagnosticsTrackingTests: ProductsManagerTests {
         expect(params.wasSuccessful) == true
         expect(params.storeKitVersion) == .storeKit2
         expect(Set(params.requestedProductIds)) == [identifier, notFoundIdentifier]
-        expect(params.notFoundProductIds) == [notFoundIdentifier]
+        expect(Set(params.notFoundProductIds)) == [notFoundIdentifier]
         expect(params.errorMessage).to(beNil())
         expect(params.errorCode).to(beNil())
         expect(params.storeKitErrorDescription).to(beNil())

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -156,13 +156,13 @@ class SK1ProductsManagerDiagnosticsTrackingTests: ProductsManagerTests {
         }
 
         expect(self.mockDiagnosticsTracker.trackedProductsRequestParams.value).toEventually(haveCount(1))
-        let params = self.mockDiagnosticsTracker.trackedProductsRequestParams.value.first
-        expect(params?.wasSuccessful) == true
-        expect(params?.storeKitVersion) == .storeKit1
-        expect(params?.requestedProductIds) == [identifier, notFoundIdentifier]
-        expect(params?.notFoundProductIds) == [notFoundIdentifier]
-        expect(params?.errorMessage).to(beNil())
-        expect(params?.errorCode).to(beNil())
+        let params = try XCTUnwrap(self.mockDiagnosticsTracker.trackedProductsRequestParams.value.first)
+        expect(params.wasSuccessful) == true
+        expect(params.storeKitVersion) == .storeKit1
+        expect(Set(params.requestedProductIds)) == [identifier, notFoundIdentifier]
+        expect(params.notFoundProductIds) == [notFoundIdentifier]
+        expect(params.errorMessage).to(beNil())
+        expect(params.errorCode).to(beNil())
     }
 
 }
@@ -195,14 +195,14 @@ class SK2ProductsManagerDiagnosticsTrackingTests: ProductsManagerTests {
         }
 
         expect(self.mockDiagnosticsTracker.trackedProductsRequestParams.value).toEventually(haveCount(1))
-        let params = self.mockDiagnosticsTracker.trackedProductsRequestParams.value.first
-        expect(params?.wasSuccessful) == true
-        expect(params?.storeKitVersion) == .storeKit2
-        expect(params?.requestedProductIds) == [identifier, notFoundIdentifier]
-        expect(params?.notFoundProductIds) == [notFoundIdentifier]
-        expect(params?.errorMessage).to(beNil())
-        expect(params?.errorCode).to(beNil())
-        expect(params?.storeKitErrorDescription).to(beNil())
+        let params = try XCTUnwrap(self.mockDiagnosticsTracker.trackedProductsRequestParams.value.first)
+        expect(params.wasSuccessful) == true
+        expect(params.storeKitVersion) == .storeKit2
+        expect(Set(params.requestedProductIds)) == [identifier, notFoundIdentifier]
+        expect(params.notFoundProductIds) == [notFoundIdentifier]
+        expect(params.errorMessage).to(beNil())
+        expect(params.errorCode).to(beNil())
+        expect(params.storeKitErrorDescription).to(beNil())
     }
 
     #if swift(>=5.9)

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -86,8 +86,8 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
          errorMessage: String?,
          errorCode: Int?,
          storeKitErrorDescription: String?,
-         requestedProductIds: Set<String>,
-         notFoundProductIds: Set<String>,
+         requestedProductIds: [String],
+         notFoundProductIds: [String],
          responseTime: TimeInterval)
     ]> = .init([])
     // swiftlint:disable:next function_parameter_count
@@ -96,8 +96,8 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                               errorMessage: String?,
                               errorCode: Int?,
                               storeKitErrorDescription: String?,
-                              requestedProductIds: Set<String>,
-                              notFoundProductIds: Set<String>,
+                              requestedProductIds: [String],
+                              notFoundProductIds: [String],
                               responseTime: TimeInterval) {
         self.trackedProductsRequestParams.modify {
             $0.append(

--- a/Tests/UnitTests/TestHelpers/AnyEncodable+Equatable.swift
+++ b/Tests/UnitTests/TestHelpers/AnyEncodable+Equatable.swift
@@ -14,7 +14,8 @@
 import Foundation
 @testable import RevenueCat
 
-extension AnyEncodable: @retroactive Equatable {
+// Specifying the module names silences the warning in Xcode 16+
+extension RevenueCat.AnyEncodable: Swift.Equatable {
 
     public static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool {
         do {

--- a/Tests/UnitTests/TestHelpers/AnyEncodable+Equatable.swift
+++ b/Tests/UnitTests/TestHelpers/AnyEncodable+Equatable.swift
@@ -7,20 +7,23 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  DiagnosticsEvent+Equatable.swift
+//  AnyEncodable+Equatable.swift
 //
 //  Created by Antonio Pallares on 28/2/25.
 
 import Foundation
 @testable import RevenueCat
 
-extension DiagnosticsEvent: @retroactive Equatable {
+extension AnyEncodable: @retroactive Equatable {
 
-    public static func == (lhs: DiagnosticsEvent, rhs: DiagnosticsEvent) -> Bool {
-        return lhs.version == rhs.version &&
-               lhs.eventType == rhs.eventType &&
-               lhs.properties == rhs.properties &&
-               lhs.timestamp == rhs.timestamp
+    public static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool {
+        do {
+            let lhsData = try lhs.prettyPrintedData
+            let rhsData = try rhs.prettyPrintedData
+            return lhsData == rhsData
+        } catch {
+            return false
+        }
     }
 
 }

--- a/Tests/UnitTests/TestHelpers/DiagnosticsEvent+Equatable.swift
+++ b/Tests/UnitTests/TestHelpers/DiagnosticsEvent+Equatable.swift
@@ -1,0 +1,40 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DiagnosticsEvent+Equatable.swift
+//
+//  Created by Antonio Pallares on 28/2/25.
+
+import Foundation
+@testable import RevenueCat
+
+extension DiagnosticsEvent: @retroactive Equatable {
+
+    public static func == (lhs: DiagnosticsEvent, rhs: DiagnosticsEvent) -> Bool {
+        return lhs.version == rhs.version &&
+               lhs.eventType == rhs.eventType &&
+               lhs.properties == rhs.properties &&
+               lhs.timestamp == rhs.timestamp
+    }
+
+}
+
+extension AnyEncodable: @retroactive Equatable {
+
+    public static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool {
+        do {
+            let lhsData = try lhs.prettyPrintedData
+            let rhsData = try rhs.prettyPrintedData
+            return lhsData == rhsData
+        } catch {
+            return false
+        }
+    }
+
+}

--- a/Tests/UnitTests/TestHelpers/DiagnosticsEvent+Equatable.swift
+++ b/Tests/UnitTests/TestHelpers/DiagnosticsEvent+Equatable.swift
@@ -14,7 +14,8 @@
 import Foundation
 @testable import RevenueCat
 
-extension DiagnosticsEvent: @retroactive Equatable {
+// Specifying the module names silences the warning in Xcode 16+
+extension RevenueCat.DiagnosticsEvent: Swift.Equatable {
 
     public static func == (lhs: DiagnosticsEvent, rhs: DiagnosticsEvent) -> Bool {
         return lhs.version == rhs.version &&


### PR DESCRIPTION
### Motivation
Some unit tests were flaky because of the use of `Set`s for Diagnostics events

### Description
This PR changes the `Set`s in DIagnostics events to be `Array`s, so that the order is predictable for tests. Note that the event parameters using `Set` were still being sent as `Array`s in the JSON anyways...

### Notes
Ideally, we should find a way to limit the use of `Set`s in `AnyEncodable`, otherwise we might introduce flaky tests in the future.