### PR TITLE
Fix potential wrong count on diagnosis sync

### DIFF
--- a/Sources/Diagnostics/DiagnosticsFileHandler.swift
+++ b/Sources/Diagnostics/DiagnosticsFileHandler.swift
@@ -16,7 +16,7 @@ import Foundation
 protocol DiagnosticsFileHandlerType: Sendable {
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func getEntries() async -> [DiagnosticsEvent]
+    func getEntries() async -> [DiagnosticsEvent?]
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     func appendEvent(diagnosticsEvent: DiagnosticsEvent) async
@@ -59,10 +59,10 @@ actor DiagnosticsFileHandler: DiagnosticsFileHandlerType {
         await self.fileHandler.append(line: jsonString)
     }
 
-    func getEntries() async -> [DiagnosticsEvent] {
+    func getEntries() async -> [DiagnosticsEvent?] {
         do {
             return try await self.fileHandler.readLines()
-                .compactMap { try? JSONDecoder.default.decode(jsonData: $0.asData) }
+                .map { try? JSONDecoder.default.decode(jsonData: $0.asData) }
                 .extractValues()
         } catch {
             Logger.error(Strings.diagnostics.error_fetching_events(error: error))

--- a/Sources/Diagnostics/Networking/DiagnosticsSynchronizer.swift
+++ b/Sources/Diagnostics/Networking/DiagnosticsSynchronizer.swift
@@ -48,15 +48,17 @@ actor DiagnosticsSynchronizer: DiagnosticsSynchronizerType {
         self.syncInProgress = true
         defer { self.syncInProgress = false }
 
-        let events = await self.handler.getEntries()
-        let count = events.count
+        let optionalEvents = await self.handler.getEntries()
+        let count = optionalEvents.count
 
-        guard !events.isEmpty else {
+        guard !optionalEvents.isEmpty else {
             Logger.verbose(Strings.diagnostics.event_sync_with_empty_store)
             return
         }
 
         Logger.verbose(Strings.diagnostics.event_sync_starting(count: count))
+
+        let events = optionalEvents.compactMap { $0 }
 
         do {
             try await self.internalAPI.postDiagnosticsEvents(events: events)

--- a/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsFileHandlerTests.swift
@@ -164,12 +164,35 @@ class DiagnosticsFileHandlerTests: TestCase {
         expect(result).to(beTrue())
     }
 
+    // MARK: - Invalid entries
+
+    func testGetEntriesWithInvalidLine() async throws {
+        await self.fileHandler.append(line: Self.invalidEntryLine)
+        await self.fileHandler.append(line: Self.line1)
+        await self.fileHandler.append(line: Self.line2)
+
+        let content1 = DiagnosticsEvent(eventType: .customerInfoVerificationResult,
+                                        properties: [.verificationResultKey: AnyEncodable("FAILED")],
+                                        timestamp: Date(millisecondsSince1970: 1712235359000))
+
+        let content2 = DiagnosticsEvent(eventType: .customerInfoVerificationResult,
+                                        properties: [.verificationResultKey: AnyEncodable("FAILED")],
+                                        timestamp: Date(millisecondsSince1970: 1712238959000))
+
+        let entries = await self.handler.getEntries()
+        expect(entries[0]).to(beNil())
+        expect(entries[1]).to(equal(content1))
+        expect(entries[2]).to(equal(content2))
+    }
+
 }
 
 // MARK: - Private
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension DiagnosticsFileHandlerTests {
+
+    static let invalidEntryLine = "This is an invalid diagnostics event entry"
 
     static let line1 = """
     {

--- a/Tests/UnitTests/Diagnostics/DiagnosticsSynchronizerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsSynchronizerTests.swift
@@ -177,6 +177,19 @@ class DiagnosticsSynchronizerTests: TestCase {
         expect(self.userDefaults.removeObjectForKeyCalledValues) == [cacheKey]
     }
 
+    func testSyncMultipleEventsWithInvalidEvent() async throws {
+        let event1 = await self.storeEvent()
+        await fileHandler.append(line: "Invalid entry line")
+        let event2 = await self.storeEvent(timestamp: Self.eventTimestamp2)
+
+        try await self.synchronizer.syncDiagnosticsIfNeeded()
+
+        expect(self.api.invokedPostDiagnosticsEvents) == true
+        expect(self.api.invokedPostDiagnosticsEventsParameters) == [[ event1, event2 ]]
+
+        await self.verifyEmptyStore()
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation
If for any reason, an invalid entry line gets written into the diagnostics cache file, then duplicated events will potentially be sent.

### Description
This PR makes sure that the number of lines deleted always matches the number of lines read, even if some lines couldn't be decoded to `DiagnosticsEvent`.