### PR TITLE
`Offering` `hasPaywall` getter

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 #if !os(macOS) && !os(tvOS)
 
-/// A SwiftUI view for displaying a `PaywallData` for an `Offering`.
+/// A SwiftUI view for displaying the paywall for an `Offering`.
 ///
 /// ### Related Articles
 /// [Documentation](https://rev.cat/paywalls)
@@ -91,11 +91,11 @@ public struct PaywallView: View {
 
     /// Create a view to display the paywall in a given `Offering`.
     ///
-    /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
+    /// - Parameter offering: The `Offering` containing the desired paywall to display.
     /// - Parameter fonts: An optional `PaywallFontProvider`.
     /// - Parameter displayCloseButton: Set this to `true` to automatically include a close button.
     ///
-    /// - Note: if `offering` does not have a current paywall, or it fails to load due to invalid data,
+    /// - Note: if `offering` does not have a current paywall (`hasPaywall == false`), or it fails to load due to invalid data,
     /// a default paywall will be displayed.
     /// - Note: Specifying this parameter means that it will ignore the offering configured in an active experiment.
     /// - Warning: `Purchases` must have been configured prior to displaying it.

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -95,8 +95,8 @@ public struct PaywallView: View {
     /// - Parameter fonts: An optional `PaywallFontProvider`.
     /// - Parameter displayCloseButton: Set this to `true` to automatically include a close button.
     ///
-    /// - Note: if `offering` does not have a current paywall (`hasPaywall == false`), or it fails to load due to invalid data,
-    /// a default paywall will be displayed.
+    /// - Note: if `offering` does not have a current paywall (`hasPaywall == false`), or it fails to load
+    /// due to invalid data, a default paywall will be displayed.
     /// - Note: Specifying this parameter means that it will ignore the offering configured in an active experiment.
     /// - Warning: `Purchases` must have been configured prior to displaying it.
     public init(

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -21,7 +21,7 @@ import RevenueCat
 
 import UIKit
 
-/// A view controller for displaying `PaywallData` for an `Offering`.
+/// A view controller for displaying the paywall for an `Offering`.
 ///
 /// - Seealso: ``PaywallView`` for `SwiftUI`.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
@@ -43,7 +43,7 @@ public class PaywallViewController: UIViewController {
     }
 
     /// Initialize a `PaywallViewController` with an optional `Offering`.
-    /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
+    /// - Parameter offering: The `Offering` containing the desired paywall to display.
     /// `Offerings.current` will be used by default.
     /// - Parameter displayCloseButton: Set this to `true` to automatically include a close button.
     /// - Parameter shouldBlockTouchEvents: Whether to interecept all touch events propagated through this VC
@@ -66,7 +66,7 @@ public class PaywallViewController: UIViewController {
     }
 
     /// Initialize a `PaywallViewController` with an optional `Offering` and ``PaywallFontProvider``.
-    /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
+    /// - Parameter offering: The `Offering` containing the desired paywall to display.
     /// `Offerings.current` will be used by default.
     /// - Parameter fonts: A ``PaywallFontProvider``.
     /// - Parameter displayCloseButton: Set this to `true` to automatically include a close button.
@@ -90,7 +90,7 @@ public class PaywallViewController: UIViewController {
     }
 
     /// Initialize a `PaywallViewController` with an offering identifier.
-    /// - Parameter offeringIdentifier: The identifier for the offering with `PaywallData` to display.
+    /// - Parameter offeringIdentifier: The identifier for the offering with paywall to display.
     /// - Parameter fonts: A ``PaywallFontProvider``.
     /// - Parameter displayCloseButton: Set this to `true` to automatically include a close button.
     /// - Parameter shouldBlockTouchEvents: Whether to interecept all touch events propagated through this VC

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -78,7 +78,7 @@ extension View {
     /// - Note: If loading the `CustomerInfo` fails (for example, if Internet is offline),
     /// the paywall won't be displayed.
     ///
-    /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
+    /// - Parameter offering: The `Offering` containing the desired paywall to display.
     /// If `nil` (the default), `Offerings.current` will be used. Note that specifying this parameter means
     /// that it will ignore the offering configured in an active experiment.
     /// - Parameter fonts: An optional ``PaywallFontProvider``.
@@ -136,7 +136,7 @@ extension View {
     /// - Note: If loading the `CustomerInfo` fails (for example, if Internet is offline),
     /// the paywall won't be displayed.
     ///
-    /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
+    /// - Parameter offering: The `Offering` containing the desired paywall to display.
     /// If `nil` (the default), `Offerings.current` will be used. Note that specifying this parameter means
     /// that it will ignore the offering configured in an active experiment.
     /// - Parameter fonts: An optional ``PaywallFontProvider``.
@@ -212,7 +212,7 @@ extension View {
     /// - Note: If loading the `CustomerInfo` fails (for example, if Internet is offline),
     /// the paywall won't be displayed.
     ///
-    /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
+    /// - Parameter offering: The `Offering` containing the desired paywall to display.
     /// If `nil` (the default), `Offerings.current` will be used. Note that specifying this parameter means
     /// that it will ignore the offering configured in an active experiment.
     /// - Parameter fonts: An optional ``PaywallFontProvider``.
@@ -296,7 +296,7 @@ extension View {
     /// - Note: If loading the `CustomerInfo` fails (for example, if Internet is offline),
     /// the paywall won't be displayed.
     ///
-    /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
+    /// - Parameter offering: The `Offering` containing the desired paywall to display.
     /// If `nil` (the default), `Offerings.current` will be used. Note that specifying this parameter means
     /// that it will ignore the offering configured in an active experiment.
     /// - Parameter fonts: An optional ``PaywallFontProvider``.

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -68,11 +68,15 @@ import Foundation
 
     /**
      Paywall configuration defined in RevenueCat dashboard.
+
+     Use ``hasPaywall`` to check if the offering has a paywall.
      */
     public let paywall: PaywallData?
 
     /**
      Paywall components configuration defined in RevenueCat dashboard.
+
+     Use ``hasPaywall`` to check if the offering has a paywall.
      */
     public let paywallComponents: PaywallComponents?
 

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -77,6 +77,13 @@ import Foundation
     public let paywallComponents: PaywallComponents?
 
     /**
+     Whether the offering contains a paywall.
+     */
+    public var hasPaywall: Bool {
+        return paywall != nil || paywallComponents != nil
+    }
+
+    /**
      Draft paywall components configuration defined in RevenueCat dashboard.
      */
     @_spi(Internal) public let draftPaywallComponents: PaywallComponents?

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/OfferingAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/OfferingAPI.swift
@@ -37,6 +37,8 @@ func checkOfferingAPI() {
     let metadataOptionalInt: Int? = off.getMetadataValue(for: "", default: nil)
     let metadataDecodable: Data? = off.getMetadataValue(for: "")
     let _: PaywallData? = off.paywall
+    let _: Offering.PaywallComponents? = off.paywallComponents
+    let bool: Bool = off.hasPaywall
 
     print(off!, ident, sDesc, aPacks, lPack!, annPack!, smPack!, thmPack!, twmPack!,
           mPack!, wPack!, pPack!, package!, metadata, metadataString, metadataInt, metadataOptionalInt!,

--- a/Tests/UnitTests/Networking/Responses/BaseHTTPResponseTest.swift
+++ b/Tests/UnitTests/Networking/Responses/BaseHTTPResponseTest.swift
@@ -16,7 +16,7 @@ import XCTest
 
 class BaseHTTPResponseTest: TestCase {
 
-    func decodeFixture<T: HTTPResponseBody>(
+    static func decodeFixture<T: HTTPResponseBody>(
         _ name: String,
         file: StaticString = #filePath,
         line: UInt = #line
@@ -25,7 +25,7 @@ class BaseHTTPResponseTest: TestCase {
     }
 
     @_disfavoredOverload
-    func decodeFixture<T: Decodable>(
+    static func decodeFixture<T: Decodable>(
         _ name: String,
         file: StaticString = #filePath,
         line: UInt = #line
@@ -33,7 +33,7 @@ class BaseHTTPResponseTest: TestCase {
         return try T.create(with: self.data(for: name, file: file, line: line))
     }
 
-    private func data(
+    private static func data(
         for fileName: String,
         file: StaticString,
         line: UInt
@@ -42,7 +42,7 @@ class BaseHTTPResponseTest: TestCase {
             Bundle(for: BundleToken.self).url(forResource: fileName,
                                               withExtension: "json",
                                               subdirectory: "Fixtures"),
-            "Could not find file with name: '\(name).json'",
+            "Could not find file with name: '\(fileName).json'",
             file: file, line: line
         )
         return try XCTUnwrap(Data(contentsOf: url), file: file, line: line)

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
@@ -28,7 +28,7 @@ class CustomerInfoDecodingTests: BaseHTTPResponseTest {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.customerInfo = try self.decodeFixture("CustomerInfo")
+        self.customerInfo = try Self.decodeFixture("CustomerInfo")
     }
 
     func testSchemaVersion() {
@@ -162,7 +162,7 @@ class CustomerInfoVersion2DecodingTests: BaseHTTPResponseTest {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.customerInfo = try self.decodeFixture("CustomerInfo-v2")
+        self.customerInfo = try Self.decodeFixture("CustomerInfo-v2")
     }
 
     func testSchemaVersion() {
@@ -244,7 +244,7 @@ class CustomerInfoInvalidDataDecodingTests: BaseHTTPResponseTest {
 
     func testDecodingCustomerInfoWithInvalidSubscriptionFailsToDecode() throws {
         expect {
-            let _: CustomerInfo = try self.decodeFixture("CustomerInfoWithInvalidSubscription")
+            let _: CustomerInfo = try Self.decodeFixture("CustomerInfoWithInvalidSubscription")
         }
         .to(throwError(ErrorCode.customerInfoError))
     }

--- a/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsWithPaywallComponents.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsWithPaywallComponents.json
@@ -188,6 +188,80 @@
                     }
                 }
             }
+        },
+        {
+            "description": "Offering with only draft paywall",
+            "identifier": "only_draft_paywall_components",
+            "packages": [
+                {
+                    "identifier": "$rc_monthly",
+                    "platform_product_identifier": "com.revenuecat.monthly_4.99.1_week_intro"
+                }
+            ],
+            "draft_paywall_components": {
+                "default_locale": "en_US",
+                "revision": 4,
+                "template_name": "newComponentsTEST",
+                "asset_base_url": "https://assets.pawwalls.com",
+                "components_localizations": [],
+                "components_config": {
+                    "base": {
+                        "background": {
+                            "type": "color",
+                            "value": {
+                                "light": {
+                                    "type": "hex",
+                                    "value": "#110000ff"
+                                }
+                            }
+                        },
+                        "stack": {
+                            "type": "stack",
+                            "components": [
+                                {
+                                    "type": "text",
+                                    "fontWeight": "bold",
+                                    "text_lid": "title",
+                                    "font_size": 24,
+                                    "color": {
+                                        "light": {
+                                            "type": "hex",
+                                            "value": "#FFFFFFff"
+                                        }
+                                    },
+                                    "size": {
+                                        "width": {
+                                            "type": "fit"
+                                        },
+                                        "height": {
+                                            "type": "fill"
+                                        }
+                                    },
+                                    "horizontal_alignment": "center",
+                                    "margin": {},
+                                    "padding": {}
+                                }
+                            ],
+                            "margin": {},
+                            "padding": {},
+                            "size": {
+                                "width": {
+                                    "type": "fill"
+                                },
+                                "height": {
+                                    "type": "fill"
+                                }
+                            },
+                            "dimension": {
+                                "type": "vertical",
+                                "alignment": "leading",
+                                "distribution": "end"
+                            },
+                            "spacing": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/Tests/UnitTests/Networking/Responses/GetIntroEligibilityDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/GetIntroEligibilityDecodingTests.swift
@@ -22,7 +22,7 @@ class GetIntroEligibilityDecodingTests: BaseHTTPResponseTest {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.response = try self.decodeFixture("GetIntroEligibility")
+        self.response = try Self.decodeFixture("GetIntroEligibility")
     }
 
     func testResponseDataIsCorrect() throws {

--- a/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
@@ -22,7 +22,7 @@ class OfferingsDecodingTests: BaseHTTPResponseTest {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.response = try self.decodeFixture("Offerings")
+        self.response = try Self.decodeFixture("Offerings")
     }
 
     func testDecodesAllOfferings() throws {

--- a/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
@@ -22,7 +22,7 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.response = try self.decodeFixture("OfferingsWithPaywallComponents")
+        self.response = try Self.decodeFixture("OfferingsWithPaywallComponents")
     }
 
     func testDecodesPaywallComponentsNoDraftPaywallComponents() throws {
@@ -61,6 +61,26 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
         expect(components.componentsConfig.base.stack.spacing) == 16
         expect(components.componentsConfig.base.stack.dimension) == .vertical(.center, .center)
         expect(components.componentsConfig.base.stack.components).to(haveCount(1))
+
+        let draftComponents = try XCTUnwrap(offering.draftPaywallComponents)
+        expect(draftComponents.templateName) == "newComponentsTEST"
+        expect(draftComponents.revision) == 4
+        expect(draftComponents.componentsConfig.base.background) == .color(.init(light: .hex("#110000ff"), dark: nil))
+        expect(draftComponents.componentsConfig.base.stickyFooter) == nil
+        expect(draftComponents.componentsConfig.base.stack.spacing) == 0
+        expect(draftComponents.componentsConfig.base.stack.dimension) == .vertical(.leading, .end)
+        expect(draftComponents.componentsConfig.base.stack.components).to(haveCount(1))
+    }
+
+    func testDecodesPaywallComponentsWithOnlyDraftPaywallComponents() throws {
+        let offering = try XCTUnwrap(self.response.offerings[safe: 2])
+
+        expect(offering.identifier) == "only_draft_paywall_components"
+        expect(offering.description) == "Offering with only draft paywall"
+        expect(offering.metadata) == [:]
+        expect(offering.packages).to(haveCount(1))
+
+        XCTAssertNil(offering.paywallComponents)
 
         let draftComponents = try XCTUnwrap(offering.draftPaywallComponents)
         expect(draftComponents.templateName) == "newComponentsTEST"

--- a/Tests/UnitTests/Networking/Responses/PaywallDataDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PaywallDataDecodingTests.swift
@@ -22,7 +22,7 @@ class PaywallDataDecodingTests: BaseHTTPResponseTest {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.response = try self.decodeFixture("Offerings")
+        self.response = try Self.decodeFixture("Offerings")
     }
 
     func testDecodesPaywallData() throws {

--- a/Tests/UnitTests/Networking/Responses/PostOfferDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PostOfferDecodingTests.swift
@@ -22,7 +22,7 @@ class PostOfferDecodingTests: BaseHTTPResponseTest {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.response = try self.decodeFixture("PostOffer")
+        self.response = try Self.decodeFixture("PostOffer")
     }
 
     func testResponseDataIsCorrect() throws {

--- a/Tests/UnitTests/Networking/Responses/ProductEntitlementMappingDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/ProductEntitlementMappingDecodingTests.swift
@@ -22,7 +22,7 @@ class ProductEntitlementMappingDecodingTests: BaseHTTPResponseTest {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.response = try self.decodeFixture("ProductsEntitlements")
+        self.response = try Self.decodeFixture("ProductsEntitlements")
     }
 
     func testDataIsCorrect() {

--- a/Tests/UnitTests/Networking/Responses/UIConfigDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/UIConfigDecodingTests.swift
@@ -20,7 +20,7 @@ import XCTest
 class UIConfigDecodingTests: BaseHTTPResponseTest {
 
     func testDecodesPaywallData() throws {
-        let uiConfig: UIConfig = try self.decodeFixture("UIConfig")
+        let uiConfig: UIConfig = try Self.decodeFixture("UIConfig")
 
         expect(uiConfig.app.colors).to(equal([
             "primary": .init(light: .hex("#ffcc00")),

--- a/Tests/UnitTests/Paywalls/PaywallDataMultiTierTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataMultiTierTests.swift
@@ -24,7 +24,7 @@ class PaywallDataMultiTierTests: BaseHTTPResponseTest {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.paywall = try self.decodeFixture("PaywallData-multitier1")
+        self.paywall = try Self.decodeFixture("PaywallData-multitier1")
     }
 
     func testConfiguration() throws {

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -18,7 +18,7 @@ import XCTest
 class PaywallDataTests: BaseHTTPResponseTest {
 
     func testSample1() throws {
-        let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
+        let paywall: PaywallData = try Self.decodeFixture("PaywallData-Sample1")
 
         expect(paywall.templateName) == "1"
         expect(paywall.assetBaseURL) == URL(string: "https://rc-paywalls.s3.amazonaws.com")!
@@ -96,7 +96,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
         // This logic only works on iOS 16+
         try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
-        let paywall: PaywallData = try self.decodeFixture("PaywallData-chinese")
+        let paywall: PaywallData = try Self.decodeFixture("PaywallData-chinese")
 
         let traditional = try XCTUnwrap(paywall.config(for: Locale(identifier: "zh-Hant")))
         let simplified = try XCTUnwrap(paywall.config(for: Locale(identifier: "zh-Hans")))
@@ -108,7 +108,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
     }
 
     func testModifyingImages() throws {
-        var paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
+        var paywall: PaywallData = try Self.decodeFixture("PaywallData-Sample1")
         var expected = paywall.config.images
 
         paywall.config.images.header = nil
@@ -118,7 +118,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
     }
 
     func testFindsLocaleWithOnlyLanguage() throws {
-        let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
+        let paywall: PaywallData = try Self.decodeFixture("PaywallData-Sample1")
 
         let enConfig = try XCTUnwrap(paywall.config(for: Locale(identifier: "en")))
         expect(enConfig.title) == "Paywall"
@@ -128,7 +128,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
     }
 
     func testLocalizedConfigurationFallsBackToLanguageWithDifferentRegion() throws {
-        let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
+        let paywall: PaywallData = try Self.decodeFixture("PaywallData-Sample1")
 
         let (_, enConfig) = try XCTUnwrap(paywall.localizedConfiguration(for: [
             .init(identifier: "en_IN"),
@@ -138,7 +138,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
     }
 
     func testLocalizedConfigurationLooksForCurrentLocaleWithoutRegionBeforePreferedLocales() throws {
-        let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
+        let paywall: PaywallData = try Self.decodeFixture("PaywallData-Sample1")
 
         let (_, enConfig) = try XCTUnwrap(paywall.localizedConfiguration(for: [
             .init(identifier: "en_IN"),
@@ -163,13 +163,13 @@ class PaywallDataTests: BaseHTTPResponseTest {
     }
 
     func testDoesNotFindLocaleWithMissingLanguage() throws {
-        let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
+        let paywall: PaywallData = try Self.decodeFixture("PaywallData-Sample1")
 
         expect(paywall.config(for: Locale(identifier: "fr"))).to(beNil())
     }
 
     func testMissingCurrentLocaleLoadsAvailableLocale() throws {
-        let paywall: PaywallData = try self.decodeFixture("PaywallData-missing_current_locale")
+        let paywall: PaywallData = try Self.decodeFixture("PaywallData-missing_current_locale")
 
         let localization = try XCTUnwrap(paywall.localizedConfiguration)
         expect(localization.callToAction) == "Comprar"
@@ -177,7 +177,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
     }
 
     func testEmptyImageNamesAreParsedAsNil() throws {
-        let paywall: PaywallData = try self.decodeFixture("PaywallData-empty_images")
+        let paywall: PaywallData = try Self.decodeFixture("PaywallData-empty_images")
 
         let images = paywall.config.images
         expect(images.header).to(beNil())
@@ -186,7 +186,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
     }
 
     func testMultiTierLocalizationIsNil() throws {
-        let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
+        let paywall: PaywallData = try Self.decodeFixture("PaywallData-Sample1")
         expect(paywall.localizedConfigurationByTier(for: [.init(identifier: "en_US")]))
             .to(beNil())
     }

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -11,7 +11,7 @@ import Nimble
 import StoreKit
 import XCTest
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 class OfferingsTests: TestCase {
 
@@ -540,6 +540,142 @@ class OfferingsTests: TestCase {
         )
 
         expect(offerings.current).to(beNil())
+    }
+
+    // MARK: - Offering from OfferingResponse.Offering
+
+    func testCreateOfferingWithoutPaywall() throws {
+        let annualProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.yearly_10.99.2_week_intro")
+        let monthlyProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.monthly_4.99.1_week_intro")
+        let products = [
+            "com.revenuecat.yearly_10.99.2_week_intro": StoreProduct(sk1Product: annualProduct),
+            "com.revenuecat.monthly_4.99.1_week_intro": StoreProduct(sk1Product: monthlyProduct)
+        ]
+
+        let offeringResponse: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("Offerings")
+        let offeringResponse0 = try XCTUnwrap(offeringResponse.offerings[safe: 0])
+
+        expect(offeringResponse0.identifier) == "default"
+        expect(offeringResponse0.description) == "standard set of packages"
+
+        let uiConfig: UIConfig = try XCTUnwrap(BaseHTTPResponseTest.decodeFixture("UIConfig"))
+
+        let offering = try XCTUnwrap(
+            self.offeringsFactory.createOffering(from: products,
+                                                 offering: offeringResponse0,
+                                                 uiConfig: uiConfig)
+            )
+
+        expect(offering.paywall).to(beNil())
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.draftPaywallComponents).to(beNil())
+        expect(offering.hasPaywall) == false
+    }
+
+    func testCreateOfferingWithPaywallData() throws {
+        let annualProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.yearly_10.99.2_week_intro")
+        let monthlyProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.monthly_4.99.1_week_intro")
+        let products = [
+            "com.revenuecat.yearly_10.99.2_week_intro": StoreProduct(sk1Product: annualProduct),
+            "com.revenuecat.monthly_4.99.1_week_intro": StoreProduct(sk1Product: monthlyProduct)
+        ]
+
+        let offeringResponse: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("Offerings")
+        let offeringResponse0 = try XCTUnwrap(offeringResponse.offerings[safe: 2])
+
+        expect(offeringResponse0.identifier) == "paywall"
+        expect(offeringResponse0.description) == "Offering with paywall"
+
+        let uiConfig: UIConfig = try XCTUnwrap(BaseHTTPResponseTest.decodeFixture("UIConfig"))
+
+        let offering = try XCTUnwrap(
+            self.offeringsFactory.createOffering(from: products,
+                                                 offering: offeringResponse0,
+                                                 uiConfig: uiConfig)
+            )
+
+        expect(offering.paywall).toNot(beNil())
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.draftPaywallComponents).to(beNil())
+        expect(offering.hasPaywall) == true
+    }
+
+    func testCreateOfferingWithPaywallComponents() throws {
+        let monthlyProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.monthly_4.99.1_week_intro")
+        let products = [
+            "com.revenuecat.monthly_4.99.1_week_intro": StoreProduct(sk1Product: monthlyProduct)
+        ]
+
+        let offeringResp: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let offeringResponse0 = try XCTUnwrap(offeringResp.offerings[safe: 0])
+
+        expect(offeringResponse0.identifier) == "paywall_components"
+        expect(offeringResponse0.description) == "Offering with paywall components"
+
+        let uiConfig: UIConfig = try XCTUnwrap(BaseHTTPResponseTest.decodeFixture("UIConfig"))
+
+        let offering = try XCTUnwrap(
+            self.offeringsFactory.createOffering(from: products,
+                                                 offering: offeringResponse0,
+                                                 uiConfig: uiConfig)
+            )
+
+        expect(offering.paywall).to(beNil())
+        expect(offering.paywallComponents).toNot(beNil())
+        expect(offering.draftPaywallComponents).to(beNil())
+        expect(offering.hasPaywall) == true
+    }
+
+    func testCreateOfferingWithPaywallComponentsAndDraftPaywallComponents() throws {
+        let monthlyProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.monthly_4.99.1_week_intro")
+        let products = [
+            "com.revenuecat.monthly_4.99.1_week_intro": StoreProduct(sk1Product: monthlyProduct)
+        ]
+
+        let offeringResp: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let offeringResponse0 = try XCTUnwrap(offeringResp.offerings[safe: 1])
+
+        expect(offeringResponse0.identifier) == "paywall_components_with_draft"
+        expect(offeringResponse0.description) == "Offering with paywall components + draft paywall"
+
+        let uiConfig: UIConfig = try XCTUnwrap(BaseHTTPResponseTest.decodeFixture("UIConfig"))
+
+        let offering = try XCTUnwrap(
+            self.offeringsFactory.createOffering(from: products,
+                                                 offering: offeringResponse0,
+                                                 uiConfig: uiConfig)
+            )
+
+        expect(offering.paywall).to(beNil())
+        expect(offering.paywallComponents).toNot(beNil())
+        expect(offering.draftPaywallComponents).toNot(beNil())
+        expect(offering.hasPaywall) == true
+    }
+
+    func testCreateOfferingWithOnlyDraftPaywallComponents() throws {
+        let monthlyProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.monthly_4.99.1_week_intro")
+        let products = [
+            "com.revenuecat.monthly_4.99.1_week_intro": StoreProduct(sk1Product: monthlyProduct)
+        ]
+
+        let offeringResp: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let offeringResponse0 = try XCTUnwrap(offeringResp.offerings[safe: 2])
+
+        expect(offeringResponse0.identifier) == "only_draft_paywall_components"
+        expect(offeringResponse0.description) == "Offering with only draft paywall"
+
+        let uiConfig: UIConfig = try XCTUnwrap(BaseHTTPResponseTest.decodeFixture("UIConfig"))
+
+        let offering = try XCTUnwrap(
+            self.offeringsFactory.createOffering(from: products,
+                                                 offering: offeringResponse0,
+                                                 uiConfig: uiConfig)
+            )
+
+        expect(offering.paywall).to(beNil())
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.draftPaywallComponents).toNot(beNil())
+        expect(offering.hasPaywall) == false
     }
 
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Checking whether an `Offering` has a paywall can be confusing now that we have v1 and v2 paywalls.

### Description
* This PR adds the `hasPaywall` getter to `Offering` to make it easier to know whether an `Offering` has a paywall or not
* Related to this, I also used this PR to update the documentation of `PaywallView` (and related) that was implying `PaywallData` to mean "paywall", which is not true anymore since v2 paywalls.