### PR TITLE
Add activity indicator to restore purchases button behavior

### DIFF
--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -21,6 +21,13 @@ import SwiftUI
 // @PublicForExternalTesting
 final class PurchaseHandler: ObservableObject {
 
+    enum ActionType {
+
+        case purchase
+        case restore
+
+    }
+
     private let purchases: PaywallPurchasesType
 
     /// Where responsibiliy for completing purchases lies
@@ -37,7 +44,12 @@ final class PurchaseHandler: ObservableObject {
 
     /// Whether a purchase or restore is currently in progress
     @Published
-    fileprivate(set) var actionInProgress: Bool = false
+    fileprivate(set) var actionTypeInProgress: ActionType? = nil
+
+    /// Whether a purchase or restore is currently in progress
+    var actionInProgress: Bool {
+        return actionTypeInProgress != nil
+    }
 
     /// Whether a purchase was successfully completed.
     @Published

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -44,7 +44,7 @@ final class PurchaseHandler: ObservableObject {
 
     /// Whether a purchase or restore is currently in progress
     @Published
-    fileprivate(set) var actionTypeInProgress: ActionType? = nil
+    fileprivate(set) var actionTypeInProgress: ActionType?
 
     /// Whether a purchase or restore is currently in progress
     var actionInProgress: Bool {
@@ -171,10 +171,10 @@ extension PurchaseHandler {
 
         defer {
             self.packageBeingPurchased = nil
-            self.actionInProgress = false
+            self.actionTypeInProgress = nil
         }
 
-        self.startAction()
+        self.startAction(.purchase)
 
         do {
             let result = try await self.purchases.purchase(package: package)
@@ -208,10 +208,10 @@ extension PurchaseHandler {
 
         defer {
             self.restoreInProgress = false
-            self.actionInProgress = false
+            self.actionTypeInProgress = nil
         }
 
-        self.startAction()
+        self.startAction(.purchase)
 
         let result = await externalPurchaseMethod(package)
 
@@ -262,10 +262,10 @@ extension PurchaseHandler {
         self.restoredCustomerInfo = nil
         self.restoreError = nil
 
-        self.startAction()
+        self.startAction(.restore)
         defer {
             self.restoreInProgress = false
-            self.actionInProgress = false
+            self.actionTypeInProgress = nil
         }
 
         do {
@@ -289,14 +289,14 @@ extension PurchaseHandler {
 
         defer {
             self.restoreInProgress = false
-            self.actionInProgress = false
+            self.actionTypeInProgress = nil
         }
 
         self.restoreInProgress = true
         self.restoredCustomerInfo = nil
         self.restoreError = nil
 
-        self.startAction()
+        self.startAction(.restore)
 
         let result = await externalRestoreMethod()
 
@@ -348,9 +348,9 @@ extension PurchaseHandler {
         return true
     }
 
-    private func startAction() {
+    private func startAction(_ type: PurchaseHandler.ActionType) {
         withAnimation(Constants.fastAnimation) {
-            self.actionInProgress = true
+            self.actionTypeInProgress = type
         }
     }
 

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -34,19 +34,30 @@ struct ButtonComponentView: View {
         self.onDismiss = onDismiss
     }
 
+    var showActivityIndicatorOverContent: Bool {
+        self.viewModel.shouldDisableWithPurchaseHandlerAction && self.purchaseHandler.actionInProgress
+    }
+
     var body: some View {
         AsyncButton {
             try await performAction()
         } label: {
-            StackComponentView(viewModel: viewModel.stackViewModel, onDismiss: self.onDismiss)
+            StackComponentView(
+                viewModel: self.viewModel.stackViewModel,
+                onDismiss: self.onDismiss,
+                showActivityIndicatorOverContent: self.showActivityIndicatorOverContent
+            )
         }
+        .applyIf(self.viewModel.shouldDisableWithPurchaseHandlerAction, apply: { view in
+            view.disabled(self.purchaseHandler.actionInProgress)
+        })
         #if canImport(SafariServices) && canImport(UIKit)
-        .sheet(isPresented: .isNotNil($inAppBrowserURL)) {
-            SafariView(url: inAppBrowserURL!)
+        .sheet(isPresented: .isNotNil(self.$inAppBrowserURL)) {
+            SafariView(url: self.inAppBrowserURL!)
         }
         #if os(iOS)
-        .presentCustomerCenter(isPresented: $showCustomerCenter, onDismiss: {
-            showCustomerCenter = false
+        .presentCustomerCenter(isPresented: self.$showCustomerCenter, onDismiss: {
+            self.showCustomerCenter = false
         })
         #endif
         #endif

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -34,7 +34,7 @@ struct ButtonComponentView: View {
         self.onDismiss = onDismiss
     }
 
-    // Show activity indicator only if restore action in purchase handler
+    /// Show activity indicator only if restore action in purchase handler
     var showActivityIndicatorOverContent: Bool {
         guard self.viewModel.isRestoreAction,
                 let actionType = self.purchaseHandler.actionTypeInProgress else {
@@ -49,6 +49,11 @@ struct ButtonComponentView: View {
         }
     }
 
+    /// Disable for any type of purchase handler action
+    var shouldBeDisabled: Bool {
+        return self.viewModel.isRestoreAction && self.purchaseHandler.actionInProgress
+    }
+
     var body: some View {
         AsyncButton {
             try await performAction()
@@ -59,11 +64,10 @@ struct ButtonComponentView: View {
                 showActivityIndicatorOverContent: self.showActivityIndicatorOverContent
             )
         }
-        // Disable for any type of purchase handler action
-        .applyIf(self.viewModel.isRestoreAction, apply: { view in
+        .applyIf(self.shouldBeDisabled, apply: { view in
             view
-                .disabled(self.purchaseHandler.actionInProgress)
-                .opacity(0.5)
+                .disabled(true)
+                .opacity(0.35)
         })
         #if canImport(SafariServices) && canImport(UIKit)
         .sheet(isPresented: .isNotNil(self.$inAppBrowserURL)) {

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -34,8 +34,19 @@ struct ButtonComponentView: View {
         self.onDismiss = onDismiss
     }
 
+    // Show activity indicator only if restore action in purchase handler
     var showActivityIndicatorOverContent: Bool {
-        self.viewModel.shouldDisableWithPurchaseHandlerAction && self.purchaseHandler.actionInProgress
+        guard self.viewModel.isRestoreAction,
+                let actionType = self.purchaseHandler.actionTypeInProgress else {
+            return false
+        }
+
+        switch actionType {
+        case .purchase:
+            return false
+        case .restore:
+            return true
+        }
     }
 
     var body: some View {
@@ -48,8 +59,11 @@ struct ButtonComponentView: View {
                 showActivityIndicatorOverContent: self.showActivityIndicatorOverContent
             )
         }
-        .applyIf(self.viewModel.shouldDisableWithPurchaseHandlerAction, apply: { view in
-            view.disabled(self.purchaseHandler.actionInProgress)
+        // Disable for any type of purchase handler action
+        .applyIf(self.viewModel.isRestoreAction, apply: { view in
+            view
+                .disabled(self.purchaseHandler.actionInProgress)
+                .opacity(0.5)
         })
         #if canImport(SafariServices) && canImport(UIKit)
         .sheet(isPresented: .isNotNil(self.$inAppBrowserURL)) {

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
@@ -86,7 +86,7 @@ class ButtonComponentViewModel {
         switch self.action {
         case .restorePurchases:
             return true
-        case .navigateTo(destination: let destination):
+        case .navigateTo:
             return false
         case .navigateBack:
             return false

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
@@ -82,7 +82,7 @@ class ButtonComponentViewModel {
         }
     }
 
-    var shouldDisableWithPurchaseHandlerAction: Bool {
+    var isRestoreAction: Bool {
         switch self.action {
         case .restorePurchases:
             return true

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
@@ -82,6 +82,17 @@ class ButtonComponentViewModel {
         }
     }
 
+    var shouldDisableWithPurchaseHandlerAction: Bool {
+        switch self.action {
+        case .restorePurchases:
+            return true
+        case .navigateTo(destination: let destination):
+            return false
+        case .navigateBack:
+            return false
+        }
+    }
+
 }
 
 fileprivate extension PaywallComponent.LocalizationDictionary {

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -35,6 +35,25 @@ struct PurchaseButtonComponentView: View {
         self.viewModel = viewModel
     }
 
+    /// Show activity indicator only if purchase action in purchase handler
+    var showActivityIndicatorOverContent: Bool {
+        guard let actionType = self.purchaseHandler.actionTypeInProgress else {
+            return false
+        }
+
+        switch actionType {
+        case .purchase:
+            return true
+        case .restore:
+            return false
+        }
+    }
+
+    /// Disable for any type of purchase handler action
+    var shouldBeDisabled: Bool {
+        return self.purchaseHandler.actionInProgress
+    }
+
     var body: some View {
         AsyncButton {
             guard !self.purchaseHandler.actionInProgress else { return }
@@ -53,10 +72,13 @@ struct PurchaseButtonComponentView: View {
             StackComponentView(
                 viewModel: viewModel.stackViewModel,
                 onDismiss: {},
-                showActivityIndicatorOverContent: self.purchaseHandler.actionInProgress
+                showActivityIndicatorOverContent: self.showActivityIndicatorOverContent
             )
         }
-        .disabled(self.purchaseHandler.actionInProgress)
+        .applyIf(self.shouldBeDisabled) {
+            $0.disabled(true)
+                .opacity(0.35)
+        }
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ProgressViewModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ProgressViewModifier.swift
@@ -26,7 +26,9 @@ struct ProgressViewModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             #if !os(watchOS)
-            .background(.ultraThinMaterial)
+            .applyIfLet(self.backgroundStyle, apply: { view, _ in
+                view.background(.ultraThinMaterial)
+            })
             #endif
             .overlay(progressView)
     }
@@ -40,7 +42,7 @@ struct ProgressViewModifier: ViewModifier {
                 .progressViewStyle(CircularProgressViewStyle(tint: bestTint(for: colorInfo)))
         case .image, .none:
             ProgressView()
-                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                .progressViewStyle(CircularProgressViewStyle(tint: .gray))
         }
     }
 


### PR DESCRIPTION
### Motivation

Paywalls V2 "Restore Purchases" behavior didn't have any type of activity or progress indicator

### Description

- If purchase...
  - Purchase buttons are disabled and show activity indicator
  - Restore buttons are just disabled (and 0.35 opacity)
- If restore...
  - Restore buttons are disabled and show activity indicator
  - Purchase buttons are just disabled (and 0.35 opacity)


https://github.com/user-attachments/assets/1ef9b08a-4b80-4ba6-9354-20cd0a6519f5



