### PR TITLE
Run `all-tests` on `main` and notify Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,6 +418,7 @@ jobs:
           name: SPM Release Build
           command: swift build -c release --target RevenueCat
           no_output_timeout: 30m
+      - slack-notify-on-fail
 
   spm-release-build-xcode-16:
     executor:
@@ -430,6 +431,7 @@ jobs:
           name: SPM Release Build
           command: swift build -c release --target RevenueCat
           no_output_timeout: 30m
+      - slack-notify-on-fail
 
   spm-release-build-xcode-15:
     executor:
@@ -442,6 +444,7 @@ jobs:
           name: SPM Release Build
           command: swift build -c release --target RevenueCat
           no_output_timeout: 30m
+      - slack-notify-on-fail
 
   spm-xcode-14-1:
     executor:
@@ -458,6 +461,7 @@ jobs:
           name: SPM RevenueCatUI Release Build
           command: swift build -c release --target RevenueCatUI
           no_output_timeout: 30m
+      - slack-notify-on-fail
 
   pod-lib-lint:
     executor:
@@ -468,7 +472,6 @@ jobs:
       - run:
           name: Check pods and deployment targets
           command: bundle exec fastlane check_pods
-      - slack-notify-on-fail
 
   spm-release-build:
     executor:
@@ -483,6 +486,7 @@ jobs:
           name: SPM RevenueCatUI Release Build
           command: swift build -c release --target RevenueCatUI
           no_output_timeout: 30m
+      - slack-notify-on-fail
 
   api-tests:
     executor:
@@ -493,6 +497,7 @@ jobs:
       - run:
           name: API Tests
           command: bundle exec fastlane run_api_tests
+      - slack-notify-on-fail
 
   spm-receipt-parser:
     executor:
@@ -503,6 +508,7 @@ jobs:
           name: SPM Receipt Parser
           command: swift build -c release --target ReceiptParser
           no_output_timeout: 30m
+      - slack-notify-on-fail
 
   spm-revenuecat-ui-ios-15:
     executor:
@@ -532,6 +538,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
+      - slack-notify-on-fail
 
   spm-revenuecat-ui-ios-16:
     executor:
@@ -565,6 +572,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
+      - slack-notify-on-fail
 
   run-revenuecat-ui-ios-17:
     executor:
@@ -598,7 +606,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify-on-fail
 
   run-revenuecat-ui-ios-18:
     executor:
@@ -632,7 +639,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify-on-fail
 
   spm-revenuecat-ui-watchos:
     executor:
@@ -657,6 +663,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
+      - slack-notify-on-fail
 
   run-test-macos:
     executor:
@@ -680,6 +687,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify-on-fail
 
   run-test-ios-18:
     executor:
@@ -708,7 +716,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify-on-fail
 
   run-test-ios-17:
     executor:
@@ -737,7 +744,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify-on-fail
 
   run-test-ios-16:
     executor:
@@ -770,6 +776,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify-on-fail
 
   run-test-ios-15:
     executor:
@@ -802,6 +809,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify-on-fail
 
   run-test-tvos:
     executor:
@@ -821,6 +829,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify-on-fail
 
   run-test-watchos:
     executor:
@@ -848,6 +857,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify-on-fail
 
   run-test-ios-14:
     executor:
@@ -884,6 +894,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify-on-fail
 
   run-test-ios-13:
     executor:
@@ -919,6 +930,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify-on-fail
 
   build-tv-watch-and-macos:
     executor:
@@ -930,6 +942,7 @@ jobs:
           name: Build tvOS, watchOS and macOS
           command: bundle exec fastlane build_tv_watch_mac
           no_output_timeout: 30m
+      - slack-notify-on-fail
 
   build-visionos:
     executor:
@@ -941,6 +954,7 @@ jobs:
           name: Build visionOS
           command: bundle exec fastlane build_visionos
           no_output_timeout: 30m
+      - slack-notify-on-fail
 
   backend-integration-tests-SK1:
     executor:
@@ -948,6 +962,7 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-SK1"
+      - slack-notify-on-fail
 
   backend-integration-tests-SK2:
     executor:
@@ -955,12 +970,15 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-SK2"
+      - slack-notify-on-fail
+
   backend-integration-tests-other:
     executor:
       name: macos-executor
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-Other"
+      - slack-notify-on-fail
 
   backend-integration-tests-offline:
     executor:
@@ -968,6 +986,7 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-Offline"
+      - slack-notify-on-fail
 
   backend-integration-tests-custom-entitlements:
     executor:
@@ -975,6 +994,8 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-CustomEntitlements"
+      - slack-notify-on-fail
+
   release-checks:
     executor:
       name: macos-executor
@@ -1009,6 +1030,7 @@ jobs:
       - store_artifacts:
           path: RevenueCatUI.xcframework.zip
           destination: RevenueCatUI.xcframework.zip
+      - slack-notify-on-fail
 
   docs-build:
     executor:
@@ -1025,6 +1047,7 @@ jobs:
           command: bundle exec fastlane build_docs
           environment:
             DOCS_IOS_VERSION: "17.4"
+      - slack-notify-on-fail
 
   docs-deploy:
     executor:
@@ -1041,6 +1064,7 @@ jobs:
           command: bundle exec fastlane build_and_publish_docs
           environment:
             DOCS_IOS_VERSION: "17.4"
+      - slack-notify-on-fail
 
   make-release:
     executor:
@@ -1054,6 +1078,7 @@ jobs:
           name: Deploy new version
           command: bundle exec fastlane release
           no_output_timeout: 30m
+      - slack-notify-on-fail
 
   push-revenuecat-pod:
     executor:
@@ -1066,6 +1091,7 @@ jobs:
           name: Deploy new version
           command: bundle exec fastlane push_revenuecat_pod
           no_output_timeout: 30m
+      - slack-notify-on-fail
 
   push-revenuecatui-pod:
     executor:
@@ -1078,6 +1104,7 @@ jobs:
           name: Deploy new version
           command: bundle exec fastlane push_revenuecatui_pod
           no_output_timeout: 30m
+      - slack-notify-on-fail
 
   prepare-next-version:
     executor:
@@ -1107,6 +1134,7 @@ jobs:
             bundle exec pod install
       - scan-and-archive:
           directory: Tests/InstallationTests/CocoapodsInstallation
+      - slack-notify-on-fail
 
   installation-tests-swift-package-manager:
     executor:
@@ -1120,6 +1148,7 @@ jobs:
           directory: Tests/InstallationTests/SPMInstallation/
       - scan-and-archive-all-platforms:
           directory: Tests/InstallationTests/SPMInstallation/
+      - slack-notify-on-fail
 
   installation-tests-custom-entitlement-computation-swift-package-manager:
     executor:
@@ -1133,6 +1162,7 @@ jobs:
           directory: Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/
       - scan:
           directory: Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/
+      - slack-notify-on-fail
 
   installation-tests-receipt-parser:
     executor:
@@ -1146,6 +1176,7 @@ jobs:
           directory: Tests/InstallationTests/ReceiptParserInstallation/
       - scan-and-archive-all-platforms:
           directory: Tests/InstallationTests/ReceiptParserInstallation/
+      - slack-notify-on-fail
 
   installation-tests-carthage:
     executor:
@@ -1168,6 +1199,7 @@ jobs:
 
       - install-dependencies-scan-and-archive:
           directory: Tests/InstallationTests/CarthageInstallation/
+      - slack-notify-on-fail
 
   installation-tests-xcode-direct-integration:
     executor:
@@ -1179,6 +1211,7 @@ jobs:
 
       - install-dependencies-scan-and-archive:
           directory: Tests/InstallationTests/XcodeDirectInstallation/
+      - slack-notify-on-fail
 
   lint:
     executor:
@@ -1199,7 +1232,6 @@ jobs:
           path: fastlane/test_output
       - store_artifacts:
           path: fastlane/test_output
-      - slack-notify-on-fail
 
   danger:
     docker:
@@ -1295,6 +1327,7 @@ jobs:
       - run:
           name: Submit Purchase Tester
           command: bundle exec fastlane deploy_purchase_tester dry_run:<< parameters.dry_run >>
+      - slack-notify-on-fail
 
   emerge_purchases_ui_snapshot_tests:
     executor:
@@ -1308,7 +1341,6 @@ jobs:
       - run:
           name: Build Paywalls Tester
           command: bundle exec fastlane build_paywalls_tester_for_emerge
-      - slack-notify-on-fail
 
   deploy-to-spm:
     docker:
@@ -1357,27 +1389,13 @@ workflows:
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
-      - lint:
-          context:
-            - slack-secrets-ios
-      - run-test-ios-17:
-          context:
-            - slack-secrets-ios
-      - run-test-ios-18:
-          context:
-            - slack-secrets-ios
-      - pod-lib-lint:
-          context:
-            - slack-secrets-ios
-      - run-revenuecat-ui-ios-17:
-          context:
-            - slack-secrets-ios
-      - run-revenuecat-ui-ios-18:
-          context:
-            - slack-secrets-ios
-      - emerge_purchases_ui_snapshot_tests:
-          context:
-            - slack-secrets-ios
+      - lint
+      - run-test-ios-17
+      - run-test-ios-18
+      - pod-lib-lint
+      - run-revenuecat-ui-ios-17
+      - run-revenuecat-ui-ios-18
+      - emerge_purchases_ui_snapshot_tests
 
   create-tag:
     when:
@@ -1478,45 +1496,97 @@ workflows:
     when:
       or:
         - matches:
-            pattern: "^release/.*$"
+            pattern: "^(release/.*|main)$"
             value: << pipeline.git.branch >>
-        - equal:
-            - "run-manual-tests"
-            - << pipeline.parameters.action >>
-        - equal:
-            - "run-from-github-comments"
-            - << pipeline.parameters.GHA_Meta >>
+        - equal: ["run-manual-tests", << pipeline.parameters.action >>]
+        - equal: ["run-from-github-comments", << pipeline.parameters.GHA_Meta >>]
     jobs:
-      - backend-integration-tests-SK1
-      - backend-integration-tests-SK2
-      - backend-integration-tests-custom-entitlements
-      - backend-integration-tests-other
-      - build-tv-watch-and-macos
-      - build-visionos
-      - docs-build
-      - run-test-ios-14
-      - run-test-ios-15
-      - run-test-ios-16
-      - run-test-macos
-      - run-test-tvos
-      - run-test-watchos
-      - spm-receipt-parser
-      - spm-release-build
-      - spm-release-build-xcode-14
-      - spm-release-build-xcode-15
-      - spm-revenuecat-ui-ios-15
-      - spm-revenuecat-ui-ios-16
-      - run-revenuecat-ui-ios-17
-      - run-revenuecat-ui-ios-18
-      - spm-revenuecat-ui-watchos
-      - installation-tests-cocoapods
-      - installation-tests-swift-package-manager
-      - installation-tests-custom-entitlement-computation-swift-package-manager
-      - installation-tests-carthage
-      - installation-tests-xcode-direct-integration
-      - installation-tests-receipt-parser
-      - api-tests
+      - backend-integration-tests-SK1:
+          context:
+            - slack-secrets-ios
+      - backend-integration-tests-SK2:
+          context:
+            - slack-secrets-ios
+      - backend-integration-tests-custom-entitlements:
+          context:
+            - slack-secrets-ios
+      - backend-integration-tests-other:
+          context:
+            - slack-secrets-ios
+      - backend-integration-tests-offline:
+          context:
+            - slack-secrets-ios
+      - build-tv-watch-and-macos:
+          context:
+            - slack-secrets-ios
+      - build-visionos:
+          context:
+            - slack-secrets-ios
+      - docs-build:
+          context:
+            - slack-secrets-ios
+      - run-test-ios-14:
+          context:
+            - slack-secrets-ios
+      - run-test-ios-15:
+          context:
+            - slack-secrets-ios
+      - run-test-ios-16:
+          context:
+            - slack-secrets-ios
+      - run-test-macos:
+          context:
+            - slack-secrets-ios
+      - run-test-tvos:
+          context:
+            - slack-secrets-ios
+      - run-test-watchos:
+          context:
+            - slack-secrets-ios
+      - spm-receipt-parser:
+          context:
+            - slack-secrets-ios
+      - spm-release-build:
+          context:
+            - slack-secrets-ios
+      - spm-release-build-xcode-14:
+          context:
+            - slack-secrets-ios
+      - spm-release-build-xcode-15:
+          context:
+            - slack-secrets-ios
+      - spm-revenuecat-ui-ios-15:
+          context:
+            - slack-secrets-ios
+      - spm-revenuecat-ui-ios-16:
+          context:
+            - slack-secrets-ios
+      - spm-revenuecat-ui-watchos:
+          context:
+            - slack-secrets-ios
+      - installation-tests-cocoapods:
+          context:
+            - slack-secrets-ios
+      - installation-tests-swift-package-manager:
+          context:
+            - slack-secrets-ios
+      - installation-tests-custom-entitlement-computation-swift-package-manager:
+          context:
+            - slack-secrets-ios
+      - installation-tests-carthage:
+          context:
+            - slack-secrets-ios
+      - installation-tests-xcode-direct-integration:
+          context:
+            - slack-secrets-ios
+      - installation-tests-receipt-parser:
+          context:
+            - slack-secrets-ios
+      - api-tests:
+          context:
+            - slack-secrets-ios
       - deploy-purchase-tester:
           dry_run: true
-      - emerge_purchases_ui_snapshot_tests
+          context:
+            - slack-secrets-ios
 


### PR DESCRIPTION
- Run `all-tests` workflow on `main` and notify Slack if failures
- Cleaned up some duplicated jobs in between `all-tests` and `build-test`
- Invoked a job that we were not calling