### PR TITLE
feat: Add onClose handler support for CustomerCenter

### DIFF
--- a/RevenueCatUI/CustomerCenter/ButtonStyles.swift
+++ b/RevenueCatUI/CustomerCenter/ButtonStyles.swift
@@ -51,12 +51,21 @@ struct ProminentButtonStyle: PrimitiveButtonStyle {
 @available(watchOS, unavailable)
 struct DismissCircleButton: View {
 
-    @Environment(\.localization) private var localization
-    @Environment(\.dismiss) private var dismiss
+    @Environment(\.dismiss)
+    private var dismiss
+
+    @Environment(\.localization)
+    private var localization
+
+    var customDismiss: (() -> Void)?
 
     var body: some View {
         Button {
-            self.dismiss()
+            if let customDismiss {
+                customDismiss()
+            } else {
+                self.dismiss()
+            }
         } label: {
             Circle()
                 .fill(Color(uiColor: .secondarySystemFill))
@@ -88,7 +97,7 @@ struct DismissCircleButtonToolbarModifier: ViewModifier {
             content
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        DismissCircleButton()
+                        DismissCircleButton(customDismiss: navigationOptions.onCloseHandler)
                     }
                 }
         } else {
@@ -104,7 +113,7 @@ struct DismissCircleButtonToolbarModifier: ViewModifier {
 @available(watchOS, unavailable)
 extension View {
     /// Adds a toolbar with a dismiss button if `navigationOptions.shouldShowCloseButton` is true.
-    func dismissCircleButtonToolbar() -> some View {
+    func dismissCircleButtonToolbarIfNeeded() -> some View {
         modifier(DismissCircleButtonToolbarModifier())
     }
 }

--- a/RevenueCatUI/CustomerCenter/ButtonStyles.swift
+++ b/RevenueCatUI/CustomerCenter/ButtonStyles.swift
@@ -61,7 +61,11 @@ struct DismissCircleButton: View {
 
     var body: some View {
         Button {
-            dismiss()
+            if let customDismiss {
+                customDismiss()
+            } else {
+                self.dismiss()
+            }
         } label: {
             Circle()
                 .fill(Color(uiColor: .secondarySystemFill))

--- a/RevenueCatUI/CustomerCenter/ButtonStyles.swift
+++ b/RevenueCatUI/CustomerCenter/ButtonStyles.swift
@@ -61,11 +61,7 @@ struct DismissCircleButton: View {
 
     var body: some View {
         Button {
-            if let customDismiss {
-                customDismiss()
-            } else {
-                self.dismiss()
-            }
+            dismiss()
         } label: {
             Circle()
                 .fill(Color(uiColor: .secondarySystemFill))

--- a/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
+++ b/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
@@ -59,14 +59,12 @@ extension View {
         isPresented: Binding<Bool>,
         customerCenterActionHandler: CustomerCenterActionHandler? = nil,
         presentationMode: CustomerCenterPresentationMode = .default,
-        onDismiss: (() -> Void)? = nil,
-        onClose: (() -> Void)? = nil
+        onDismiss: (() -> Void)? = nil
     ) -> some View {
         self.modifier(
             PresentingCustomerCenterModifier(
                 isPresented: isPresented,
                 onDismiss: onDismiss,
-                onClose: onClose,
                 myAppPurchaseLogic: nil,
                 customerCenterActionHandler: customerCenterActionHandler,
                 presentationMode: presentationMode
@@ -87,13 +85,9 @@ private struct PresentingCustomerCenterModifier: ViewModifier {
     /// The closure to execute when dismissing the sheet / fullScreen present
     let onDismiss: (() -> Void)?
 
-    /// The closure to execute when tapping on the close button
-    let onClose: (() -> Void)?
-
     init(
         isPresented: Binding<Bool>,
         onDismiss: (() -> Void)?,
-        onClose: (() -> Void)?,
         myAppPurchaseLogic: MyAppPurchaseLogic?,
         customerCenterActionHandler: CustomerCenterActionHandler?,
         presentationMode: CustomerCenterPresentationMode,
@@ -102,7 +96,6 @@ private struct PresentingCustomerCenterModifier: ViewModifier {
         self._isPresented = isPresented
         self.presentationMode = presentationMode
         self.onDismiss = onDismiss
-        self.onClose = onClose
         self.customerCenterActionHandler = customerCenterActionHandler
         self._purchaseHandler = .init(wrappedValue: purchaseHandler ??
                                       PurchaseHandler.default(performPurchase: myAppPurchaseLogic?.performPurchase,
@@ -124,8 +117,7 @@ private struct PresentingCustomerCenterModifier: ViewModifier {
                         self.customerCenterView(
                             navigationOptions: CustomerCenterNavigationOptions(
                                 usesExistingNavigation: false,
-                                shouldShowCloseButton: true,
-                                onCloseHandler: onClose
+                                shouldShowCloseButton: true
                             )
                         )
                     }
@@ -136,8 +128,7 @@ private struct PresentingCustomerCenterModifier: ViewModifier {
                         self.customerCenterView(
                             navigationOptions: CustomerCenterNavigationOptions(
                                 usesExistingNavigation: false,
-                                shouldShowCloseButton: true,
-                                onCloseHandler: onClose
+                                shouldShowCloseButton: true
                             )
                         )
                     }

--- a/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
+++ b/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
@@ -52,7 +52,6 @@ extension View {
     ///   Defaults to `.default`.
     ///   - onDismiss: A callback triggered when either the sheet / fullscreen present is dismissed
     ///     Ensure you set `isPresented = false` when this is called.
-    ///   - onClose: A callback that replaces environment dismiss
     ///
     /// - Returns: A view modified to support presenting the Customer Center.
     public func presentCustomerCenter(

--- a/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
+++ b/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
@@ -114,23 +114,13 @@ private struct PresentingCustomerCenterModifier: ViewModifier {
             case .sheet:
                 content
                     .sheet(isPresented: self.$isPresented, onDismiss: onDismiss) {
-                        self.customerCenterView(
-                            navigationOptions: CustomerCenterNavigationOptions(
-                                usesExistingNavigation: false,
-                                shouldShowCloseButton: true
-                            )
-                        )
+                        self.customerCenterView()
                     }
 
             case .fullScreen:
                 content
                     .fullScreenCover(isPresented: self.$isPresented, onDismiss: onDismiss) {
-                        self.customerCenterView(
-                            navigationOptions: CustomerCenterNavigationOptions(
-                                usesExistingNavigation: false,
-                                shouldShowCloseButton: true
-                            )
-                        )
+                        self.customerCenterView()
                     }
 
             @unknown default:
@@ -139,12 +129,9 @@ private struct PresentingCustomerCenterModifier: ViewModifier {
         }
     }
 
-    private func customerCenterView(
-        navigationOptions: CustomerCenterNavigationOptions
-    ) -> some View {
+    private func customerCenterView() -> some View {
         CustomerCenterView(
-            customerCenterActionHandler: self.customerCenterActionHandler,
-            navigationOptions: navigationOptions
+            customerCenterActionHandler: self.customerCenterActionHandler
         )
             .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
     }

--- a/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
+++ b/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
@@ -25,19 +25,36 @@ import SwiftUI
 #endif
 extension View {
 
-    /// Presents the ``CustomerCenter``.
-    /// Example:
+    /// Presents the ``CustomerCenter`` as a modal or sheet.
+    ///
+    /// This modifier allows you to display the Customer Center, which provides support and account-related actions.
+    ///
+    /// ## Example Usage:
     /// ```swift
-    /// var body: some View {
-    ///    YourApp()
-    ///      .presentCustomerCenter()
+    /// struct ContentView: View {
+    ///     @State private var isCustomerCenterPresented = false
+    ///
+    ///     var body: some View {
+    ///         Button("Open Customer Center") {
+    ///             isCustomerCenterPresented = true
+    ///         }
+    ///         .presentCustomerCenter(
+    ///             isPresented: $isCustomerCenterPresented
+    ///         )
+    ///     }
     /// }
     /// ```
-    /// - Parameter isPresented: Binding indicating whether the customer center should be displayed
-    /// - Parameter onDismiss: Callback executed when the customer center wants to be dismissed.
-    /// Make sure you stop presenting the customer center when this is called
-    /// - Parameter customerCenterActionHandler: Allows to listen to certain events during the customer center flow.
-    /// - Parameter presentationMode: The desired presentation mode of the customer center. Defaults to `.sheet`.
+    ///
+    /// - Parameters:
+    ///   - isPresented: A binding that determines whether the Customer Center is visible.
+    ///   - customerCenterActionHandler: An optional handler for responding to events within the Customer Center.
+    ///   - presentationMode: Specifies how the Customer Center should be presented (e.g., as a sheet or fullscreen).
+    ///   Defaults to `.default`.
+    ///   - onDismiss: A callback triggered when either the sheet / fullscreen present is dismissed
+    ///     Ensure you set `isPresented = false` when this is called.
+    ///   - onClose: A callback that replaces environment dismiss
+    ///
+    /// - Returns: A view modified to support presenting the Customer Center.
     public func presentCustomerCenter(
         isPresented: Binding<Bool>,
         customerCenterActionHandler: CustomerCenterActionHandler? = nil,
@@ -45,16 +62,17 @@ extension View {
         onDismiss: (() -> Void)? = nil,
         onClose: (() -> Void)? = nil
     ) -> some View {
-        return self.modifier(PresentingCustomerCenterModifier(
-            isPresented: isPresented,
-            onDismiss: onDismiss,
-            onClose: onClose,
-            myAppPurchaseLogic: nil,
-            customerCenterActionHandler: customerCenterActionHandler,
-            presentationMode: presentationMode
-        ))
+        self.modifier(
+            PresentingCustomerCenterModifier(
+                isPresented: isPresented,
+                onDismiss: onDismiss,
+                onClose: onClose,
+                myAppPurchaseLogic: nil,
+                customerCenterActionHandler: customerCenterActionHandler,
+                presentationMode: presentationMode
+            )
+        )
     }
-
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
@@ -80,7 +80,7 @@ struct AppUpdateWarningView: View {
                 })
                 .scrollableIfNecessary(.vertical)
             }
-            .dismissCircleButtonToolbar()
+            .dismissCircleButtonToolbarIfNeeded()
     }
 }
 

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationOptions.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationOptions.swift
@@ -34,12 +34,24 @@ public struct CustomerCenterNavigationOptions {
     /// - `false`: Does not display a close button, avoiding redundancy with the back button in a stacked navigation.
     public let shouldShowCloseButton: Bool
 
-    /// The default configuration for `CustomerCenterNavigationOptions`.
+    /// A custom handler to execute when dismissing the Customer Center.
     ///
-    /// - `usesNavigationStack`: `true` (default to modern navigation).
-    /// - `usesExistingNavigation`: `false` (wraps content in a new navigation stack by default).
-    /// - `shouldShowCloseButton`: `true` (displays a close button by default).
-    public static let `default` = CustomerCenterNavigationOptions()
+    /// `dismissHandler` allows developers to define a custom method for handling the dismissal of
+    /// the Customer Center. This is useful in cases where the default SwiftUI dismissal (`@Environment(\.dismiss)`)
+    /// is insufficient, such as when integrating with hybrid frameworks.
+    ///
+    /// If provided, this closure is called instead of the default dismissal behavior, giving the developer
+    /// full control over the dismissal process.
+    ///
+    /// - Example Usage in SwiftUI:
+    /// ```swift
+    /// let options = CustomerCenterNavigationOptions(dismissHandler: {
+    ///     dismiss()
+    /// })
+    /// ```
+    ///
+    ///
+    public let onCloseHandler: (() -> Void)?
 
     /// Initializes a new instance of `CustomerCenterNavigationOptions`.
     ///
@@ -47,13 +59,27 @@ public struct CustomerCenterNavigationOptions {
     ///   - usesNavigationStack: Whether to use the modern iOS 16+ `NavigationStack` system. Defaults to `true`.
     ///   - usesExistingNavigation: Whether to push onto an existing navigation stack. Defaults to `false`.
     ///   - shouldShowCloseButton: Whether to display a close button in the toolbar. Defaults to `true`.
+    ///   - onCloseHandler: Custom handler to be called when tapping on the close button. When set to `nil`,
+    ///   environment `dismiss` is called
     public init(
         usesNavigationStack: Bool = true,
         usesExistingNavigation: Bool = false,
-        shouldShowCloseButton: Bool = true
+        shouldShowCloseButton: Bool = true,
+        onCloseHandler: (() -> Void)? = nil
     ) {
         self.usesNavigationStack = usesNavigationStack
         self.usesExistingNavigation = usesExistingNavigation
         self.shouldShowCloseButton = shouldShowCloseButton
+        self.onCloseHandler = onCloseHandler
     }
+}
+
+public extension CustomerCenterNavigationOptions {
+
+    /// The default configuration for `CustomerCenterNavigationOptions`.
+    ///
+    /// - `usesNavigationStack`: `true` (default to modern navigation).
+    /// - `usesExistingNavigation`: `false` (wraps content in a new navigation stack by default).
+    /// - `shouldShowCloseButton`: `true` (displays a close button by default).
+    static let `default` = CustomerCenterNavigationOptions()
 }

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationOptions.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationOptions.swift
@@ -50,7 +50,6 @@ public struct CustomerCenterNavigationOptions {
     /// })
     /// ```
     ///
-    ///
     public let onCloseHandler: (() -> Void)?
 
     /// Initializes a new instance of `CustomerCenterNavigationOptions`.
@@ -81,5 +80,6 @@ public extension CustomerCenterNavigationOptions {
     /// - `usesNavigationStack`: `true` (default to modern navigation).
     /// - `usesExistingNavigation`: `false` (wraps content in a new navigation stack by default).
     /// - `shouldShowCloseButton`: `true` (displays a close button by default).
+    /// - `onCloseHandler`: `nil` (environment dismiss is used instead when showing the close button).
     static let `default` = CustomerCenterNavigationOptions()
 }

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationOptions.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterNavigationOptions.swift
@@ -34,9 +34,9 @@ public struct CustomerCenterNavigationOptions {
     /// - `false`: Does not display a close button, avoiding redundancy with the back button in a stacked navigation.
     public let shouldShowCloseButton: Bool
 
-    /// A custom handler to execute when dismissing the Customer Center.
+    /// A custom handler to execute when closing the Customer Center from the close button in the navigation bar.
     ///
-    /// `dismissHandler` allows developers to define a custom method for handling the dismissal of
+    /// `onCloseHandler` allows developers to define a custom method for handling the dismissal of
     /// the Customer Center. This is useful in cases where the default SwiftUI dismissal (`@Environment(\.dismiss)`)
     /// is insufficient, such as when integrating with hybrid frameworks.
     ///
@@ -45,7 +45,7 @@ public struct CustomerCenterNavigationOptions {
     ///
     /// - Example Usage in SwiftUI:
     /// ```swift
-    /// let options = CustomerCenterNavigationOptions(dismissHandler: {
+    /// let options = CustomerCenterNavigationOptions(onCloseHandler: {
     ///     dismiss()
     /// })
     /// ```

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -115,7 +115,7 @@ private extension CustomerCenterView {
             ErrorView()
                 .environment(\.customerCenterPresentationMode, self.mode)
                 .environment(\.navigationOptions, self.navigationOptions)
-                .dismissCircleButtonToolbar()
+                .dismissCircleButtonToolbarIfNeeded()
 
         case .notLoaded:
             TintedProgressView()

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -151,7 +151,7 @@ struct ManageSubscriptionsView: View {
                 }
             }
         }
-        .dismissCircleButtonToolbar()
+        .dismissCircleButtonToolbarIfNeeded()
         .restorePurchasesAlert(isPresented: self.$viewModel.showRestoreAlert)
         .applyIf(self.viewModel.screen.type == .management, apply: {
             $0.navigationTitle(self.viewModel.screen.title)

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -64,7 +64,7 @@ struct NoSubscriptionsView: View {
             }
 
         }
-        .dismissCircleButtonToolbar()
+        .dismissCircleButtonToolbarIfNeeded()
     }
 
 }

--- a/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/WrongPlatformView.swift
@@ -102,7 +102,7 @@ struct WrongPlatformView: View {
                 }
             }
         }
-        .dismissCircleButtonToolbar()
+        .dismissCircleButtonToolbarIfNeeded()
         .applyIfLet(screen, apply: { view, screen in
             view.navigationTitle(screen.title).navigationBarTitleDisplayMode(.inline)
         })

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -164,6 +164,8 @@ struct SamplePaywallsList: View {
 
             #if os(iOS)
             Section("Customer Center") {
+                CustomerCenterView(navigationOptions: CustomerCenterNavigationOptions(shouldShowCloseButton: true))
+
                 NavigationLink {
                     CustomerCenterView(
                         customerCenterActionHandler: handleCustomerCenterAction,
@@ -210,15 +212,13 @@ struct SamplePaywallsList: View {
         .presentCustomerCenter(
             isPresented: self.$presentingCustomerCenterSheet,
             customerCenterActionHandler: self.handleCustomerCenterAction,
-            onDismiss: { self.presentingCustomerCenterFullScreen = false },
-            onClose: { self.presentingCustomerCenterFullScreen = false }
+            onDismiss: { self.presentingCustomerCenterFullScreen = false }
         )
         .presentCustomerCenter(
             isPresented: self.$presentingCustomerCenterFullScreen,
             customerCenterActionHandler: self.handleCustomerCenterAction,
             presentationMode: .fullScreen,
-            onDismiss: { self.presentingCustomerCenterFullScreen = false },
-            onClose: { self.presentingCustomerCenterFullScreen = false }
+            onDismiss: { self.presentingCustomerCenterFullScreen = false }
         )
         #endif
     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -209,17 +209,17 @@ struct SamplePaywallsList: View {
         #if os(iOS)
         .presentCustomerCenter(
             isPresented: self.$presentingCustomerCenterSheet,
-            customerCenterActionHandler: self.handleCustomerCenterAction
-        ) {
-            self.presentingCustomerCenterSheet = false
-        }
+            customerCenterActionHandler: self.handleCustomerCenterAction,
+            onDismiss: { self.presentingCustomerCenterFullScreen = false },
+            onClose: { self.presentingCustomerCenterFullScreen = false }
+        )
         .presentCustomerCenter(
             isPresented: self.$presentingCustomerCenterFullScreen,
             customerCenterActionHandler: self.handleCustomerCenterAction,
-            presentationMode: .fullScreen
-        ) {
-            self.presentingCustomerCenterFullScreen = false
-        }
+            presentationMode: .fullScreen,
+            onDismiss: { self.presentingCustomerCenterFullScreen = false },
+            onClose: { self.presentingCustomerCenterFullScreen = false }
+        )
         #endif
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -164,8 +164,6 @@ struct SamplePaywallsList: View {
 
             #if os(iOS)
             Section("Customer Center") {
-                CustomerCenterView(navigationOptions: CustomerCenterNavigationOptions(shouldShowCloseButton: true))
-
                 NavigationLink {
                     CustomerCenterView(
                         customerCenterActionHandler: handleCustomerCenterAction,


### PR DESCRIPTION
### Motivation
While working on kmp support for CustomerCenter, I realised there's no way to close programmatically the view. The close button does not work because it works with the environment dismiss

I'll need to update hybrid commons after this, and then kmp 🚀 

### Description
The PR adds `onCloseHandler` that overrides the environment dismiss behavior.
- Update `NavigationOptions`
- Update docs

