### PR TITLE
Have snapshot tests use same encoding as SDK

### DIFF
--- a/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncoding.1.json
+++ b/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncoding.1.json
@@ -1,28 +1,28 @@
 {
   "entitlement_verification" : 0,
-  "request_date" : 668454178,
+  "request_date" : "2022-03-08T17:42:58Z",
   "schema_version" : "3",
   "subscriber" : {
     "entitlements" : {
       "premium" : {
-        "expires_date" : -326323164,
+        "expires_date" : "1990-08-30T02:40:36Z",
         "product_identifier" : "com.revenuecat.monthly_4.99.1_week_intro",
-        "purchase_date" : -326323164
+        "purchase_date" : "1990-08-30T02:40:36Z"
       },
       "tip" : {
         "product_identifier" : "com.revenuecat.product.tip",
-        "purchase_date" : -323644764
+        "purchase_date" : "1990-09-30T02:40:36Z"
       }
     },
-    "first_seen" : 668454178,
+    "first_seen" : "2022-03-08T17:42:58Z",
     "management_url" : "https:\/\/apps.apple.com\/account\/subscriptions",
     "non_subscriptions" : {
       "com.revenuecat.product.tip" : [
         {
           "id" : "17459f5ff7",
           "is_sandbox" : false,
-          "original_purchase_date" : 668563468,
-          "purchase_date" : 666230608,
+          "original_purchase_date" : "2022-03-10T00:04:28Z",
+          "purchase_date" : "2022-02-11T00:03:28Z",
           "store" : "app_store",
           "store_transaction_id" : "340001090153249"
         }
@@ -30,24 +30,24 @@
     },
     "original_app_user_id" : "$RCAnonymousID:5b6fdbac3a0c4f879e43d269ecdf9ba1",
     "original_application_version" : "1.0",
-    "original_purchase_date" : 671414604,
+    "original_purchase_date" : "2022-04-12T00:03:24Z",
     "subscriptions" : {
       "com.revenuecat.ABCDNA12U.ProductName" : {
-        "expires_date" : 671414615,
+        "expires_date" : "2022-04-12T00:03:35Z",
         "is_sandbox" : true,
-        "original_purchase_date" : 671414608,
+        "original_purchase_date" : "2022-04-12T00:03:28Z",
         "ownership_type" : "PURCHASED",
         "period_type" : "intro",
-        "purchase_date" : 671414608,
+        "purchase_date" : "2022-04-12T00:03:28Z",
         "store" : "app_store"
       },
       "com.revenuecat.monthly_4.99.1_week_intro" : {
-        "expires_date" : 671414615,
+        "expires_date" : "2022-04-12T00:03:35Z",
         "is_sandbox" : true,
-        "original_purchase_date" : 671414608,
+        "original_purchase_date" : "2022-04-12T00:03:28Z",
         "ownership_type" : "PURCHASED",
         "period_type" : "intro",
-        "purchase_date" : 671414608,
+        "purchase_date" : "2022-04-12T00:03:28Z",
         "store" : "app_store"
       }
     }

--- a/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncodingWithFailedVerificationResponse.1.json
+++ b/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncodingWithFailedVerificationResponse.1.json
@@ -1,28 +1,28 @@
 {
   "entitlement_verification" : 2,
-  "request_date" : 668454178,
+  "request_date" : "2022-03-08T17:42:58Z",
   "schema_version" : "3",
   "subscriber" : {
     "entitlements" : {
       "premium" : {
-        "expires_date" : -326323164,
+        "expires_date" : "1990-08-30T02:40:36Z",
         "product_identifier" : "com.revenuecat.monthly_4.99.1_week_intro",
-        "purchase_date" : -326323164
+        "purchase_date" : "1990-08-30T02:40:36Z"
       },
       "tip" : {
         "product_identifier" : "com.revenuecat.product.tip",
-        "purchase_date" : -323644764
+        "purchase_date" : "1990-09-30T02:40:36Z"
       }
     },
-    "first_seen" : 668454178,
+    "first_seen" : "2022-03-08T17:42:58Z",
     "management_url" : "https:\/\/apps.apple.com\/account\/subscriptions",
     "non_subscriptions" : {
       "com.revenuecat.product.tip" : [
         {
           "id" : "17459f5ff7",
           "is_sandbox" : false,
-          "original_purchase_date" : 668563468,
-          "purchase_date" : 666230608,
+          "original_purchase_date" : "2022-03-10T00:04:28Z",
+          "purchase_date" : "2022-02-11T00:03:28Z",
           "store" : "app_store",
           "store_transaction_id" : "340001090153249"
         }
@@ -30,24 +30,24 @@
     },
     "original_app_user_id" : "$RCAnonymousID:5b6fdbac3a0c4f879e43d269ecdf9ba1",
     "original_application_version" : "1.0",
-    "original_purchase_date" : 671414604,
+    "original_purchase_date" : "2022-04-12T00:03:24Z",
     "subscriptions" : {
       "com.revenuecat.ABCDNA12U.ProductName" : {
-        "expires_date" : 671414615,
+        "expires_date" : "2022-04-12T00:03:35Z",
         "is_sandbox" : true,
-        "original_purchase_date" : 671414608,
+        "original_purchase_date" : "2022-04-12T00:03:28Z",
         "ownership_type" : "PURCHASED",
         "period_type" : "intro",
-        "purchase_date" : 671414608,
+        "purchase_date" : "2022-04-12T00:03:28Z",
         "store" : "app_store"
       },
       "com.revenuecat.monthly_4.99.1_week_intro" : {
-        "expires_date" : 671414615,
+        "expires_date" : "2022-04-12T00:03:35Z",
         "is_sandbox" : true,
-        "original_purchase_date" : 671414608,
+        "original_purchase_date" : "2022-04-12T00:03:28Z",
         "ownership_type" : "PURCHASED",
         "period_type" : "intro",
-        "purchase_date" : 671414608,
+        "purchase_date" : "2022-04-12T00:03:28Z",
         "store" : "app_store"
       }
     }

--- a/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncodingWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncodingWithVerifiedResponse.1.json
@@ -1,28 +1,28 @@
 {
   "entitlement_verification" : 1,
-  "request_date" : 668454178,
+  "request_date" : "2022-03-08T17:42:58Z",
   "schema_version" : "3",
   "subscriber" : {
     "entitlements" : {
       "premium" : {
-        "expires_date" : -326323164,
+        "expires_date" : "1990-08-30T02:40:36Z",
         "product_identifier" : "com.revenuecat.monthly_4.99.1_week_intro",
-        "purchase_date" : -326323164
+        "purchase_date" : "1990-08-30T02:40:36Z"
       },
       "tip" : {
         "product_identifier" : "com.revenuecat.product.tip",
-        "purchase_date" : -323644764
+        "purchase_date" : "1990-09-30T02:40:36Z"
       }
     },
-    "first_seen" : 668454178,
+    "first_seen" : "2022-03-08T17:42:58Z",
     "management_url" : "https:\/\/apps.apple.com\/account\/subscriptions",
     "non_subscriptions" : {
       "com.revenuecat.product.tip" : [
         {
           "id" : "17459f5ff7",
           "is_sandbox" : false,
-          "original_purchase_date" : 668563468,
-          "purchase_date" : 666230608,
+          "original_purchase_date" : "2022-03-10T00:04:28Z",
+          "purchase_date" : "2022-02-11T00:03:28Z",
           "store" : "app_store",
           "store_transaction_id" : "340001090153249"
         }
@@ -30,24 +30,24 @@
     },
     "original_app_user_id" : "$RCAnonymousID:5b6fdbac3a0c4f879e43d269ecdf9ba1",
     "original_application_version" : "1.0",
-    "original_purchase_date" : 671414604,
+    "original_purchase_date" : "2022-04-12T00:03:24Z",
     "subscriptions" : {
       "com.revenuecat.ABCDNA12U.ProductName" : {
-        "expires_date" : 671414615,
+        "expires_date" : "2022-04-12T00:03:35Z",
         "is_sandbox" : true,
-        "original_purchase_date" : 671414608,
+        "original_purchase_date" : "2022-04-12T00:03:28Z",
         "ownership_type" : "PURCHASED",
         "period_type" : "intro",
-        "purchase_date" : 671414608,
+        "purchase_date" : "2022-04-12T00:03:28Z",
         "store" : "app_store"
       },
       "com.revenuecat.monthly_4.99.1_week_intro" : {
-        "expires_date" : 671414615,
+        "expires_date" : "2022-04-12T00:03:35Z",
         "is_sandbox" : true,
-        "original_purchase_date" : 671414608,
+        "original_purchase_date" : "2022-04-12T00:03:28Z",
         "ownership_type" : "PURCHASED",
         "period_type" : "intro",
-        "purchase_date" : 671414608,
+        "purchase_date" : "2022-04-12T00:03:28Z",
         "store" : "app_store"
       }
     }

--- a/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
+++ b/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
@@ -91,7 +91,8 @@ func verifySnapshot<Value, Format>(
 
 extension Snapshotting where Value == Encodable, Format == String {
 
-    /// Uses a copy of the SDK's `JSONEncoder.prettyPrinted`, but with `JSONEncoder.OutputFormatting.withoutEscapingSlashes`.
+    /// Uses a copy of the SDK's `JSONEncoder.prettyPrinted`,
+    /// but with `JSONEncoder.OutputFormatting.withoutEscapingSlashes`.
     static var formattedJson: Snapshotting {
         return self.formattedJson(backwardsCompatible: false)
     }

--- a/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
+++ b/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
@@ -91,14 +91,12 @@ func verifySnapshot<Value, Format>(
 
 extension Snapshotting where Value == Encodable, Format == String {
 
-    /// Equivalent to `.json`, but with `JSONEncoder.KeyEncodingStrategy.convertToSnakeCase`
-    /// and `JSONEncoder.OutputFormatting.withoutEscapingSlashes` if available.
+    /// Uses SDK's `JSONEncoder.prettyPrinted`, but with `JSONEncoder.OutputFormatting.withoutEscapingSlashes`.
     static var formattedJson: Snapshotting {
         return self.formattedJson(backwardsCompatible: false)
     }
 
-    /// Equivalent to `.formattedJson`, but not using `JSONEncoder.OutputFormatting.withoutEscapingSlashes`
-    /// so its output is equivalent regardless of iOS version.
+    /// Uses SDK's `JSONEncoder.prettyPrinted`
     static var backwardsCompatibleFormattedJson: Snapshotting {
         return self.formattedJson(backwardsCompatible: true)
     }
@@ -175,27 +173,22 @@ private extension Encodable {
     }
 
     func asFormattedData(backwardsCompatible: Bool) throws -> Data {
+        // Copy the encoder used in the SDK to get similar results
+        let sdkEncoder = JSONEncoder.prettyPrinted
+
         let encoder = JSONEncoder()
-        encoder.keyEncodingStrategy = .convertToSnakeCase
-        encoder.outputFormatting = backwardsCompatible
-            ? backwardsCompatibleOutputFormatting
-            : outputFormatting
+        encoder.keyEncodingStrategy = sdkEncoder.keyEncodingStrategy
+        encoder.dateEncodingStrategy = sdkEncoder.dateEncodingStrategy
+        encoder.dataEncodingStrategy = sdkEncoder.dataEncodingStrategy
+        encoder.nonConformingFloatEncodingStrategy = sdkEncoder.nonConformingFloatEncodingStrategy
+        encoder.userInfo = sdkEncoder.userInfo
+        var outputFormatting = sdkEncoder.outputFormatting
+        if !backwardsCompatible {
+            outputFormatting.update(with: .withoutEscapingSlashes)
+        }
+        encoder.outputFormatting = outputFormatting
 
         return try encoder.encode(self)
     }
 
 }
-
-private let backwardsCompatibleOutputFormatting: JSONEncoder.OutputFormatting = {
-    return [
-        .prettyPrinted,
-        .sortedKeys
-    ]
-}()
-
-private let outputFormatting: JSONEncoder.OutputFormatting = {
-    var result = backwardsCompatibleOutputFormatting
-    result.update(with: .withoutEscapingSlashes)
-
-    return result
-}()

--- a/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
+++ b/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
@@ -91,12 +91,12 @@ func verifySnapshot<Value, Format>(
 
 extension Snapshotting where Value == Encodable, Format == String {
 
-    /// Uses SDK's `JSONEncoder.prettyPrinted`, but with `JSONEncoder.OutputFormatting.withoutEscapingSlashes`.
+    /// Uses a copy of the SDK's `JSONEncoder.prettyPrinted`, but with `JSONEncoder.OutputFormatting.withoutEscapingSlashes`.
     static var formattedJson: Snapshotting {
         return self.formattedJson(backwardsCompatible: false)
     }
 
-    /// Uses SDK's `JSONEncoder.prettyPrinted`
+    /// Uses a copy of the SDK's `JSONEncoder.prettyPrinted`
     static var backwardsCompatibleFormattedJson: Snapshotting {
         return self.formattedJson(backwardsCompatible: true)
     }


### PR DESCRIPTION
### Motivation
The snapshot tests were using a different JSON encoding strategy than the SDK, in particular, for dates.
As an example, the `CustomerInfo` snapshot tests were mapping dates differently to what the SDK does (which maps them to its ISO8601 format) E.g. 
```JSON
"purchase_date" : -326323164
```
vs
```JSON
 "purchase_date" : "1990-08-30T02:40:36Z"
```

These tests should encode objects with a format as similar as possible to the actual encoding format used in the SDK.

### Description
With this PR:
* The snapshots now use the ISO8601 date format
* Encoding objects in unit tests now uses a `JSONEncoder` that copies the properties from the SDK's `JSONEncoder.prettyPrinted`