### PR TITLE
fix: diagnostics parameter key name

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -47,7 +47,7 @@ struct DiagnosticsEvent: Codable, Equatable {
         let errorMessage: String?
         let errorCode: Int?
         let skErrorDescription: String?
-        let eTagHit: Bool?
+        let etagHit: Bool?
         let requestedProductIds: Set<String>?
         let notFoundProductIds: Set<String>?
         let productId: String?
@@ -65,7 +65,7 @@ struct DiagnosticsEvent: Codable, Equatable {
              errorMessage: String? = nil,
              errorCode: Int? = nil,
              skErrorDescription: String? = nil,
-             eTagHit: Bool? = nil,
+             etagHit: Bool? = nil,
              requestedProductIds: Set<String>? = nil,
              notFoundProductIds: Set<String>? = nil,
              productId: String? = nil,
@@ -82,7 +82,7 @@ struct DiagnosticsEvent: Codable, Equatable {
             self.errorMessage = errorMessage
             self.errorCode = errorCode
             self.skErrorDescription = skErrorDescription
-            self.eTagHit = eTagHit
+            self.etagHit = etagHit
             self.requestedProductIds = requestedProductIds
             self.notFoundProductIds = notFoundProductIds
             self.productId = productId

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -134,7 +134,7 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                     successful: wasSuccessful,
                     responseCode: responseCode,
                     backendErrorCode: backendErrorCode,
-                    eTagHit: resultOrigin == .cache
+                    etagHit: resultOrigin == .cache
                 ),
                 timestamp: self.dateProvider.now()
             )

--- a/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
@@ -128,7 +128,7 @@ class DiagnosticsTrackerTests: TestCase {
                     successful: true,
                     responseCode: 200,
                     backendErrorCode: 7121,
-                    eTagHit: true
+                    etagHit: true
                   ),
                   timestamp: Self.eventTimestamp1)
         ]

--- a/Tests/UnitTests/Networking/Requests/DiagnosticsEventEncodingTests.swift
+++ b/Tests/UnitTests/Networking/Requests/DiagnosticsEventEncodingTests.swift
@@ -33,7 +33,7 @@ class DiagnosticsEventEncodingTests: TestCase {
            errorMessage: "OK",
            errorCode: 1,
            skErrorDescription: "test_skErrorDescription",
-           eTagHit: false,
+           etagHit: false,
 
            // Do not use more than 1 elements in sets for snapshot testing
            // as the order of elements is not defined

--- a/Tests/UnitTests/Networking/Requests/__Snapshots__/DiagnosticsEventEncodingTests/testEncoding.1.json
+++ b/Tests/UnitTests/Networking/Requests/__Snapshots__/DiagnosticsEventEncodingTests/testEncoding.1.json
@@ -2,10 +2,10 @@
   "name" : "http_request_performed",
   "properties" : {
     "backend_error_code" : 500,
-    "etag_hit" : false,
     "endpoint_name" : "log_in",
     "error_code" : 1,
     "error_message" : "OK",
+    "etag_hit" : false,
     "not_found_product_ids" : [
       "test_product_id2"
     ],

--- a/Tests/UnitTests/Networking/Requests/__Snapshots__/DiagnosticsEventEncodingTests/testEncoding.1.json
+++ b/Tests/UnitTests/Networking/Requests/__Snapshots__/DiagnosticsEventEncodingTests/testEncoding.1.json
@@ -2,7 +2,7 @@
   "name" : "http_request_performed",
   "properties" : {
     "backend_error_code" : 500,
-    "e_tag_hit" : false,
+    "etag_hit" : false,
     "endpoint_name" : "log_in",
     "error_code" : 1,
     "error_message" : "OK",


### PR DESCRIPTION
### Description
This PR fixes the Diagnostics JSON field name for the `eTagHit` parameter. 

It was being sent as `e_tag_hit`, whereas it should be `etag_hit`. 