### PR TITLE
Update `customerInfo` from an `AsyncStream` instead of the `PurchasesDelegate` in the SwiftUI sample app

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Lifecycle/PurchasesDelegateHandler.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Lifecycle/PurchasesDelegateHandler.swift
@@ -19,20 +19,6 @@ class PurchasesDelegateHandler: NSObject, ObservableObject {
 }
 
 extension PurchasesDelegateHandler: PurchasesDelegate {
-    
-    /**
-     Whenever the `shared` instance of Purchases updates the CustomerInfo cache, this method will be called.
-    
-     - Note: CustomerInfo is not pushed to each Purchases client, it has to be fetched.
-     This delegate method is only called when the SDK updates its cache after an app launch, purchase, restore, or fetch. 
-     You still need to call `Purchases.shared.customerInfo` to fetch CustomerInfo regularly.
-     */
-    func purchases(_ purchases: Purchases, receivedUpdated customerInfo: CustomerInfo) {
-        
-        /// - Update our published customerInfo object
-        UserViewModel.shared.customerInfo = customerInfo
-    }
-
     /**
      - Note: this can be tested by opening a link like:
      itms-services://?action=purchaseIntent&bundleId=<BUNDLE_ID>&productIdentifier=<SKPRODUCT_ID>

--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/ViewModels/UserViewModel.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/ViewModels/UserViewModel.swift
@@ -13,7 +13,7 @@ import SwiftUI
 class UserViewModel: ObservableObject {
     static let shared = UserViewModel()
     
-    /* The latest CustomerInfo from RevenueCat. Updated by PurchasesDelegate whenever the Purchases SDK updates the cache */
+    /* The latest CustomerInfo from RevenueCat. Updated by the `customerInfoStream` in the initializer. */
     @Published var customerInfo: CustomerInfo? {
         didSet {
             subscriptionActive = customerInfo?.entitlements[Constants.entitlementID]?.isActive == true
@@ -25,6 +25,23 @@ class UserViewModel: ObservableObject {
     
     /* Set from the didSet method of customerInfo above, based on the entitlement set in Constants.swift */
     @Published var subscriptionActive: Bool = false
+    
+    /* Keep track of the task that listens for changes to the `customerInfoStream` so that it can be cancelled later on */
+    private var task = Task<Void, Never> {}
+    
+    private init() {
+        /* Listen to changes in the `customerInfo` object using an `AsyncStream` */
+        self.task = Task.detached {
+            for await customerInfo in Purchases.shared.customerInfoStream {
+                await MainActor.run { self.customerInfo = customerInfo }
+            }
+        }
+    }
+    
+    /* Stop listening for updates to the `customerInfoStream` based on  */
+    deinit {
+        task.cancel()
+    }
     
     /*
      How to login and identify your users with the Purchases SDK.

--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/ViewModels/UserViewModel.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/ViewModels/UserViewModel.swift
@@ -26,21 +26,13 @@ class UserViewModel: ObservableObject {
     /* Set from the didSet method of customerInfo above, based on the entitlement set in Constants.swift */
     @Published var subscriptionActive: Bool = false
     
-    /* Keep track of the task that listens for changes to the `customerInfoStream` so that it can be cancelled later on */
-    private var task = Task<Void, Never> {}
-    
     private init() {
         /* Listen to changes in the `customerInfo` object using an `AsyncStream` */
-        self.task = Task.detached {
-            for await customerInfo in Purchases.shared.customerInfoStream {
-                await MainActor.run { self.customerInfo = customerInfo }
+        Task {
+            for await newCustomerInfo in Purchases.shared.customerInfoStream {
+                customerInfo = newCustomerInfo
             }
         }
-    }
-    
-    /* Stop listening for updates to the `customerInfoStream` based on  */
-    deinit {
-        task.cancel()
     }
     
     /*

--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/ViewModels/UserViewModel.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/ViewModels/UserViewModel.swift
@@ -30,7 +30,7 @@ class UserViewModel: ObservableObject {
         /* Listen to changes in the `customerInfo` object using an `AsyncStream` */
         Task {
             for await newCustomerInfo in Purchases.shared.customerInfoStream {
-                customerInfo = newCustomerInfo
+                await MainActor.run { customerInfo = newCustomerInfo }
             }
         }
     }


### PR DESCRIPTION
Now that we are going to allow users to download the SwiftUI sample app from Onboarding, we should make sure that it uses the most up-to-date APIs.

One area for improvement that we noticed was updating the `CustomerInfo` object from an `AsyncStream` instead of the delegate.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids
