### PR TITLE
[Diagnostics] add `max_diagnostics_sync_retries_reached` event

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -41,6 +41,7 @@ struct DiagnosticsEvent: Codable, Equatable {
         case customerInfoVerificationResult = "customer_info_verification_result"
         case maxEventsStoredLimitReached = "max_events_stored_limit_reached"
         case applePurchaseAttempt = "apple_purchase_attempt"
+        case maxDiagnosticsSyncRetriesReached = "max_diagnostics_sync_retries_reached"
     }
 
     enum PurchaseResult: String, Codable, Equatable {

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -54,6 +54,8 @@ protocol DiagnosticsTrackerType {
                               purchaseResult: DiagnosticsEvent.PurchaseResult?,
                               responseTime: TimeInterval)
 
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func trackMaxDiagnosticsSyncRetriesReached()
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -179,6 +181,12 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
         )
     }
 
+    func trackMaxDiagnosticsSyncRetriesReached() {
+        self.track(DiagnosticsEvent(name: .maxEventsStoredLimitReached,
+                                    properties: .empty,
+                                    timestamp: self.dateProvider.now(),
+                                    appSessionId: self.appSessionID))
+    }
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/Sources/Diagnostics/Networking/DiagnosticsSynchronizer.swift
+++ b/Sources/Diagnostics/Networking/DiagnosticsSynchronizer.swift
@@ -25,6 +25,7 @@ actor DiagnosticsSynchronizer: DiagnosticsSynchronizerType {
 
     private let internalAPI: InternalAPI
     private let handler: DiagnosticsFileHandlerType
+    private let tracker: DiagnosticsTrackerType?
     private let userDefaults: SynchronizedUserDefaults
 
     private var syncInProgress = false
@@ -32,10 +33,12 @@ actor DiagnosticsSynchronizer: DiagnosticsSynchronizerType {
     init(
         internalAPI: InternalAPI,
         handler: DiagnosticsFileHandlerType,
+        tracker: DiagnosticsTrackerType?,
         userDefaults: SynchronizedUserDefaults
     ) {
         self.internalAPI = internalAPI
         self.handler = handler
+        self.tracker = tracker
         self.userDefaults = userDefaults
     }
 
@@ -79,6 +82,7 @@ actor DiagnosticsSynchronizer: DiagnosticsSynchronizerType {
                 if currentSyncRetries >= Self.maxSyncRetries {
                     Logger.error(Strings.diagnostics.failed_diagnostics_sync_more_than_max_retries)
                     await self.handler.emptyDiagnosticsFile()
+                    self.tracker?.trackMaxDiagnosticsSyncRetriesReached()
                     self.clearSyncRetries()
                 } else {
                     self.increaseSyncRetries(currentRetries: currentSyncRetries)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -485,6 +485,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                         let synchronizedUserDefaults = SynchronizedUserDefaults(userDefaults: userDefaults)
                         diagnosticsSynchronizer = DiagnosticsSynchronizer(internalAPI: backend.internalAPI,
                                                                           handler: diagnosticsFileHandler,
+                                                                          tracker: diagnosticsTracker,
                                                                           userDefaults: synchronizedUserDefaults)
                     } else {
                         Logger.error(Strings.diagnostics.could_not_create_diagnostics_tracker)

--- a/Tests/UnitTests/Diagnostics/DiagnosticsSynchronizerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsSynchronizerTests.swift
@@ -139,7 +139,7 @@ class DiagnosticsSynchronizerTests: TestCase {
 
         let cacheKey = "com.revenuecat.diagnostics.number_sync_retries"
 
-        let expectedError: NetworkError = .errorResponse(.defaultResponse, .invalidRequest)
+        let expectedError: NetworkError = .errorResponse(.defaultResponse, .internalServerError)
 
         self.api.stubbedPostDiagnosticsEventsCompletionResult = .networkError(expectedError)
 

--- a/Tests/UnitTests/Diagnostics/DiagnosticsSynchronizerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsSynchronizerTests.swift
@@ -22,6 +22,7 @@ class DiagnosticsSynchronizerTests: TestCase {
     fileprivate var api: MockInternalAPI!
     fileprivate var fileHandler: FileHandler!
     fileprivate var handler: DiagnosticsFileHandler!
+    fileprivate var tracker: MockDiagnosticsTracker!
     fileprivate var synchronizer: DiagnosticsSynchronizer!
     fileprivate var userDefaults: MockUserDefaults!
 
@@ -33,9 +34,11 @@ class DiagnosticsSynchronizerTests: TestCase {
         self.api = .init()
         self.fileHandler = try Self.createWithTemporaryFile()
         self.handler = .init(self.fileHandler)
+        self.tracker = MockDiagnosticsTracker()
         self.userDefaults = .init()
         self.synchronizer = .init(internalAPI: self.api,
                                   handler: self.handler,
+                                  tracker: self.tracker,
                                   userDefaults: .init(userDefaults: self.userDefaults))
     }
 
@@ -134,6 +137,28 @@ class DiagnosticsSynchronizerTests: TestCase {
                                            expectedCount: 1)
     }
 
+    func testNoRetryIfFailedEventIsConsideredSuccessfulSync() async throws {
+        _ = await self.storeEvent()
+
+        let cacheKey = "com.revenuecat.diagnostics.number_sync_retries"
+
+        let expectedError: NetworkError = .errorResponse(.defaultResponse, .invalidRequest)
+
+        self.api.stubbedPostDiagnosticsEventsCompletionResult = .networkError(expectedError)
+
+        self.userDefaults.mockValues = [cacheKey: 1]
+
+        do {
+            try await self.synchronizer.syncDiagnosticsIfNeeded()
+
+            fail("Should have errored")
+        } catch {
+            await self.verifyEmptyStore()
+            expect(self.userDefaults.removeObjectForKeyCalledValues) == [cacheKey]
+            expect(self.userDefaults.mockValues[cacheKey]).to(beNil())
+        }
+    }
+
     func testClearsDiagnosticsFileAndRetriesIfMaxRetriesReached() async throws {
         _ = await self.storeEvent()
 
@@ -153,6 +178,22 @@ class DiagnosticsSynchronizerTests: TestCase {
             await self.verifyEmptyStore()
             expect(self.userDefaults.removeObjectForKeyCalledValues) == [cacheKey]
         }
+    }
+
+    func testSendsTrackMaxDiagnosticsSyncRetriesReachedIfMaxRetriesReached() async throws {
+        _ = await self.storeEvent()
+
+        let cacheKey = "com.revenuecat.diagnostics.number_sync_retries"
+
+        let expectedError: NetworkError = .errorResponse(.defaultResponse, .internalServerError)
+
+        self.api.stubbedPostDiagnosticsEventsCompletionResult = .networkError(expectedError)
+
+        self.userDefaults.mockValues = [cacheKey: 3]
+
+        try? await self.synchronizer.syncDiagnosticsIfNeeded()
+
+        expect(self.tracker.trackedMaxDiagnosticsSyncRetriesReachedCalls.value) == 1
     }
 
     func testMultipleErrorsEventuallyClearDiagnosticsFileAndRetriesIfMaxRetriesReached() async throws {

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -131,4 +131,8 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
         }
     }
 
+    let trackedMaxDiagnosticsSyncRetriesReachedCalls: Atomic<Int> = .init(0)
+    func trackMaxDiagnosticsSyncRetriesReached() {
+        trackedMaxDiagnosticsSyncRetriesReachedCalls.modify { $0 += 1 }
+    }
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Description
This PR implements the `max_diagnostics_sync_retries_reached` diagnostics event