### PR TITLE
chore: `EventsManagerIntegrationTests` working as expected

### DIFF
--- a/BackendIntegrationTests/BackendIntegrationTests-All-CI.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-All-CI.xctestplan
@@ -37,9 +37,6 @@
   },
   "testTargets" : [
     {
-      "skippedTests" : [
-         "EventsManagerIntegrationTests"
-       ],
       "target" : {
         "containerPath" : "container:RevenueCat.xcodeproj",
         "identifier" : "2DE20B6B264087FB004C597D",

--- a/BackendIntegrationTests/BackendIntegrationTests-All.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-All.xctestplan
@@ -33,9 +33,6 @@
   },
   "testTargets" : [
     {
-      "skippedTests" : [
-        "EventsManagerIntegrationTests"
-      ],
       "target" : {
         "containerPath" : "container:RevenueCat.xcodeproj",
         "identifier" : "2DE20B6B264087FB004C597D",

--- a/BackendIntegrationTests/BackendIntegrationTests-CustomEntitlements.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-CustomEntitlements.xctestplan
@@ -37,9 +37,6 @@
   },
   "testTargets" : [
     {
-      "skippedTests" : [
-         "EventsManagerIntegrationTests"
-       ],
       "target" : {
         "containerPath" : "container:RevenueCat.xcodeproj",
         "identifier" : "4F6BEE042A27B02400CD9322",

--- a/BackendIntegrationTests/BackendIntegrationTests-Offline.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-Offline.xctestplan
@@ -45,6 +45,7 @@
         "DisabledSignatureVerificationIntegrationTests",
         "DynamicModeSignatureVerificationIntegrationTests",
         "EnforcedSignatureVerificationIntegrationTests",
+	"EventsManagerIntegrationTests",
         "InformationalSignatureVerificationIntegrationTests",
         "LoadShedderSignatureVerificationWithoutHeaderHashIntegrationTests",
         "LoadShedderStoreKit1IntegrationTests",

--- a/BackendIntegrationTests/BackendIntegrationTests-Offline.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-Offline.xctestplan
@@ -45,7 +45,6 @@
         "DisabledSignatureVerificationIntegrationTests",
         "DynamicModeSignatureVerificationIntegrationTests",
         "EnforcedSignatureVerificationIntegrationTests",
-        "EventsManagerIntegrationTests", 
         "InformationalSignatureVerificationIntegrationTests",
         "LoadShedderSignatureVerificationWithoutHeaderHashIntegrationTests",
         "LoadShedderStoreKit1IntegrationTests",

--- a/BackendIntegrationTests/BackendIntegrationTests-Other.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-Other.xctestplan
@@ -43,7 +43,6 @@
         "LoadShedderStoreKit1IntegrationTests",
         "LoadShedderStoreKit2IntegrationTests",
         "LoadShedderStoreKit2JWSIntegrationTests",
-	"EventsManagerIntegrationTests",
         "OfflineStoreKit1IntegrationTests",
         "OfflineStoreKit2IntegrationTests",
         "OfflineStoreKit2JWSIntegrationTests",

--- a/BackendIntegrationTests/BackendIntegrationTests-SK1.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-SK1.xctestplan
@@ -46,7 +46,6 @@
         "DisabledSignatureVerificationIntegrationTests",
         "DynamicModeSignatureVerificationIntegrationTests",
         "EnforcedSignatureVerificationIntegrationTests",
-	"EventsManagerIntegrationTests",
         "InformationalSignatureVerificationIntegrationTests",
         "LoadShedderSignatureVerificationWithoutHeaderHashIntegrationTests",
         "LoadShedderStoreKit2IntegrationTests",

--- a/BackendIntegrationTests/BackendIntegrationTests-SK2.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-SK2.xctestplan
@@ -46,7 +46,6 @@
         "DisabledSignatureVerificationIntegrationTests",
         "DynamicModeSignatureVerificationIntegrationTests",
         "EnforcedSignatureVerificationIntegrationTests",
-	"EventsManagerIntegrationTests",
         "InformationalSignatureVerificationIntegrationTests",
         "LoadShedderSignatureVerificationWithoutHeaderHashIntegrationTests",
         "LoadShedderStoreKit1IntegrationTests",

--- a/BackendIntegrationTests/BackendIntegrationTests-Shedder.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-Shedder.xctestplan
@@ -46,7 +46,6 @@
         "DisabledSignatureVerificationIntegrationTests",
         "DynamicModeSignatureVerificationIntegrationTests",
         "EnforcedSignatureVerificationIntegrationTests",
-	"EventsManagerIntegrationTests",
         "InformationalSignatureVerificationIntegrationTests",
         "OfflineStoreKit1IntegrationTests",
         "OfflineStoreKit2IntegrationTests",

--- a/Tests/BackendIntegrationTests/EventsManagerIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/EventsManagerIntegrationTests.swift
@@ -76,16 +76,20 @@ final class EventsManagerIntegrationTests: BaseBackendIntegrationTests {
                 )
             )
         )
+        // give background task a chance to run
+        await Task.yield()
 
-        try await flushAndVerify(eventsCount: 2, trackingIsAsync: true)
+        try await self.logger.verifyMessageIsEventuallyLogged(
+            "Storing event:",
+            expectedCount: 2,
+            timeout: .seconds(3),
+            pollInterval: .seconds(1)
+        )
+
+        try await flushAndVerify(eventsCount: 2)
     }
 
-    private func flushAndVerify(eventsCount: Int, trackingIsAsync: Bool = false) async throws {
-        if trackingIsAsync {
-            // tracking customer center is async
-            try await Task.sleep(nanoseconds: 1_000_000_000)
-        }
-
+    private func flushAndVerify(eventsCount: Int) async throws {
         _ = try await Purchases.shared.flushPaywallEvents(count: 2)
 
         self.logger.verifyMessageWasLogged(

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -128,7 +128,7 @@ extension TestLogHandler {
     }
 
     func verifyMessageIsEventuallyLogged(
-        _ message: String,
+        _ message: CustomStringConvertible,
         level: LogLevel? = nil,
         expectedCount: Int? = nil,
         timeout: DispatchTimeInterval = AsyncDefaults.timeout,


### PR DESCRIPTION
### Motivation
We need to be sure events are working as expected =)

### Description
I've tweaked the test to just call Purchases api. The only caveat is that the tracking for customer center async, and the one for paywalls is not, so I had to add an arbitrary sleep. Once this is merged, I can go with https://github.com/RevenueCat/purchases-ios/pull/4837

This will enable further refactors for PaywallEventsManager, like renaming it to support `FeatureEvent`
Test is only ignored in the offline test plan
