### PR TITLE
[Diagnostics] add `clearing_diagnostics_after_failed_sync` event

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -40,6 +40,7 @@ struct DiagnosticsEvent: Codable, Equatable {
         case appleProductsRequest = "apple_products_request"
         case customerInfoVerificationResult = "customer_info_verification_result"
         case maxEventsStoredLimitReached = "max_events_stored_limit_reached"
+        case clearingDiagnosticsAfterFailedSync = "clearing_diagnostics_after_failed_sync"
         case applePurchaseAttempt = "apple_purchase_attempt"
         case maxDiagnosticsSyncRetriesReached = "max_diagnostics_sync_retries_reached"
     }

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -56,6 +56,9 @@ protocol DiagnosticsTrackerType {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func trackMaxDiagnosticsSyncRetriesReached()
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func trackClearingDiagnosticsAfterFailedSync()
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -183,6 +186,13 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
 
     func trackMaxDiagnosticsSyncRetriesReached() {
         self.track(DiagnosticsEvent(name: .maxEventsStoredLimitReached,
+                                    properties: .empty,
+                                    timestamp: self.dateProvider.now(),
+                                    appSessionId: self.appSessionID))
+    }
+
+    func trackClearingDiagnosticsAfterFailedSync() {
+        self.track(DiagnosticsEvent(name: .clearingDiagnosticsAfterFailedSync,
                                     properties: .empty,
                                     timestamp: self.dateProvider.now(),
                                     appSessionId: self.appSessionID))

--- a/Sources/Diagnostics/Networking/DiagnosticsSynchronizer.swift
+++ b/Sources/Diagnostics/Networking/DiagnosticsSynchronizer.swift
@@ -75,6 +75,7 @@ actor DiagnosticsSynchronizer: DiagnosticsSynchronizerType {
             if let backendError = error as? BackendError,
                backendError.successfullySynced {
                 await self.handler.cleanSentDiagnostics(diagnosticsSentCount: count)
+                self.tracker?.trackClearingDiagnosticsAfterFailedSync()
                 self.clearSyncRetries()
             } else {
                 let currentSyncRetries = self.getCurrentSyncRetries()

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -135,4 +135,9 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
     func trackMaxDiagnosticsSyncRetriesReached() {
         trackedMaxDiagnosticsSyncRetriesReachedCalls.modify { $0 += 1 }
     }
+
+    let trackedClearingDiagnosticsAfterFailedSyncCalls: Atomic<Int> = .init(0)
+    func trackClearingDiagnosticsAfterFailedSync() {
+        trackedClearingDiagnosticsAfterFailedSyncCalls.modify { $0 += 1 }
+    }
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Description
This PR implements the `clearing_diagnostics_after_failed_sync` diagnostics event