### PR TITLE
Change Parsing of VirtualCurrencyInfo.balance from amount to balance

### DIFF
--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -107,7 +107,7 @@ extension CustomerInfoResponse {
 
     #if ENABLE_VIRTUAL_CURRENCIES
     internal struct VirtualCurrencyInfo {
-        let amount: Int64
+        let balance: Int64
     }
     #endif
 

--- a/Sources/Purchasing/VirtualCurrencyInfo.swift
+++ b/Sources/Purchasing/VirtualCurrencyInfo.swift
@@ -30,7 +30,7 @@ public final class VirtualCurrencyInfo: NSObject {
     @objc public let balance: Int64
 
     init(with virtualCurrencyInfo: CustomerInfoResponse.VirtualCurrencyInfo) {
-        self.balance = virtualCurrencyInfo.amount
+        self.balance = virtualCurrencyInfo.balance
     }
 }
 

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -902,7 +902,7 @@ class BasicCustomerInfoTests: TestCase {
                 "subscriptions": {},
                 "virtual_currencies": {
                   "COIN": {
-                    "amount": 200
+                    "balance": 200
                   }
                 }
               }
@@ -936,10 +936,10 @@ class BasicCustomerInfoTests: TestCase {
                 "subscriptions": {},
                 "virtual_currencies": {
                   "COIN1": {
-                    "amount": 200
+                    "balance": 200
                   },
                   "COIN2": {
-                    "amount": 500
+                    "balance": 500
                   }
                 }
               }


### PR DESCRIPTION
We recently changed the key that the backend returns containing the virtual currency balance in CustomerInfo from `amount` to `balance`. This PR switches the SDK from looking for `amount` to `balance`. This update is purely internal and doesn't affect the public API.

#### Old Response Format
```
// CustomerInfo
{
  // ...
  "subscriber": {
    // ...
    "virtual_currencies": {
      "WIL": {
        "amount": 100
      }
    }
  }
}
```

#### New Response Format
```
// CustomerInfo
{
  // ...
  "subscriber": {
    // ...
    "virtual_currencies": {
      "WIL": {
        "balance": 100
      }
    }
  }
}
```

### Testing
For testing, I've:
- Updated the automated CustomerInfo parsing tests
- Tested the change manually