### PR TITLE
[Diagnostics] add `entered_offline_entitlements_mode` event

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -41,6 +41,7 @@ struct DiagnosticsEvent: Codable, Equatable {
         case customerInfoVerificationResult = "customer_info_verification_result"
         case maxEventsStoredLimitReached = "max_events_stored_limit_reached"
         case clearingDiagnosticsAfterFailedSync = "clearing_diagnostics_after_failed_sync"
+        case enteredOfflineEntitlementsMode = "entered_offline_entitlements_mode"
         case applePurchaseAttempt = "apple_purchase_attempt"
         case maxDiagnosticsSyncRetriesReached = "max_diagnostics_sync_retries_reached"
     }

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -59,6 +59,9 @@ protocol DiagnosticsTrackerType {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func trackClearingDiagnosticsAfterFailedSync()
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func trackEnteredOfflineEntitlementsMode()
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -193,6 +196,13 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
 
     func trackClearingDiagnosticsAfterFailedSync() {
         self.track(DiagnosticsEvent(name: .clearingDiagnosticsAfterFailedSync,
+                                    properties: .empty,
+                                    timestamp: self.dateProvider.now(),
+                                    appSessionId: self.appSessionID))
+    }
+
+    func trackEnteredOfflineEntitlementsMode() {
+        self.track(DiagnosticsEvent(name: .enteredOfflineEntitlementsMode,
                                     properties: .empty,
                                     timestamp: self.dateProvider.now(),
                                     appSessionId: self.appSessionID))

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -341,6 +341,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             offlineCustomerInfoCreator: .createIfAvailable(
                 with: purchasedProductsFetcher,
                 productEntitlementMappingFetcher: deviceCache,
+                tracker: diagnosticsTracker,
                 observerMode: observerMode
             ),
             diagnosticsTracker: diagnosticsTracker

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -140,4 +140,9 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
     func trackClearingDiagnosticsAfterFailedSync() {
         trackedClearingDiagnosticsAfterFailedSyncCalls.modify { $0 += 1 }
     }
+
+    let trackedEnteredOfflineEntitlementsModeCalls: Atomic<Int> = .init(0)
+    func trackEnteredOfflineEntitlementsMode() {
+        trackedEnteredOfflineEntitlementsModeCalls.modify { $0 += 1 }
+    }
 }

--- a/Tests/UnitTests/Mocks/MockOfflineCustomerInfoCreator.swift
+++ b/Tests/UnitTests/Mocks/MockOfflineCustomerInfoCreator.swift
@@ -19,6 +19,7 @@ class MockOfflineCustomerInfoCreator: OfflineCustomerInfoCreator {
         super.init(
             purchasedProductsFetcher: MockPurchasedProductsFetcher(),
             productEntitlementMappingFetcher: MockProductEntitlementMappingFetcher(),
+            tracker: nil,
             creator: { CustomerInfo(from: $0, mapping: $1, userID: $2) }
         )
     }

--- a/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
+++ b/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
@@ -363,6 +363,7 @@ private extension BaseCustomerInfoResponseHandlerTests {
             offlineCreator: .init(
                 purchasedProductsFetcher: self.fetcher,
                 productEntitlementMappingFetcher: MappingFetcher(productEntitlementMapping: mapping),
+                tracker: nil,
                 creator: { self.factory.create(products: $0, mapping: $1, userID: $2) }
             ),
             userID: self.userID,


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Description
This PR implements the `entered_offline_entitlements_mode` diagnostics event
