### PR TITLE
Fix crash in SwiftUI previews

### DIFF
--- a/RevenueCatUI/Templates/V2/Previews/PreviewMock.swift
+++ b/RevenueCatUI/Templates/V2/Previews/PreviewMock.swift
@@ -82,6 +82,7 @@ struct PreviewRequiredEnvironmentProperties: ViewModifier {
     func body(content: Content) -> some View {
         content
             .environmentObject(IntroOfferEligibilityContext(introEligibilityChecker: .default()))
+            .environmentObject(PurchaseHandler.default())
             .environmentObject(self.packageContext ?? Self.defaultPackageContext)
             .environment(\.screenCondition, screenCondition)
             .environment(\.componentViewState, componentViewState)


### PR DESCRIPTION
### Motivation
The `PurchaseButtonComponentView`s in `PurchaseButtonComponentView_Previews` were missing the `packageContext` `environmentObject`, what is making the SwiftUI preview crash and Snapshot tests fail

### Description
This PR adds the `packageContext` `environmentObject` to the `PurchaseButtonComponentView`s in `PurchaseButtonComponentView_Previews`