### PR TITLE
Update fastlane plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 4ee857918d749a48393c3eaef2d78eb4f6b873e9
+  revision: 05ef0952ecb3b92398a0185a3f74019abd0c1d95
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri
@@ -269,11 +269,11 @@ GEM
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    logger (1.6.5)
+    logger (1.6.6)
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0107)
+    mime-types-data (3.2025.0304)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
@@ -288,6 +288,8 @@ GEM
     nkf (0.2.0)
     nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
     octokit (9.2.0)
       faraday (>= 1, < 3)


### PR DESCRIPTION
This updates the fastlane plugin to the latest version. I'm not sure why dependabot is not picking these automatically, and I didn't find anything after a cursory glance, so decided to just update it manually for now.