### PR TITLE
feat: Refresh customer center and purchases after restore

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -128,10 +128,13 @@ import RevenueCat
             self.actionWrapper.handleAction(.restoreCompleted(customerInfo))
 
             let hasPurchases = !customerInfo.activeSubscriptions.isEmpty || !customerInfo.nonSubscriptions.isEmpty
+
+            self.state = .notLoaded
+            await self.loadScreen()
+
             return hasPurchases ? .purchasesRecovered : .purchasesNotFound
         } catch {
             self.actionWrapper.handleAction(.restoreFailed(error))
-
             return .purchasesNotFound
         }
     }


### PR DESCRIPTION
### Motivation
We need to keep up-to-date customer center after a successful restore

### Description
This PR just reloads the Customer Center after the restore works. I think we should not leave the screen in an inconsistent state, so if the restore works, but the load screen fails it will error out.

> There's room for a better UI effect, but this does the trick for now
