### PR TITLE
[Diagnostics] Add sync purchases tracking (part 1)

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -51,6 +51,8 @@ struct DiagnosticsEvent: Codable, Equatable {
         case getProductsResult = "get_products_result"
         case getCustomerInfoStarted = "get_customer_info_started"
         case getCustomerInfoResult = "get_customer_info_result"
+        case syncPurchasesStarted = "sync_purchases_started"
+        case syncPurchasesResult = "sync_purchases_result"
     }
 
     enum PurchaseResult: String, Codable, Equatable {

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -99,6 +99,15 @@ protocol DiagnosticsTrackerType {
                                     errorMessage: String?,
                                     errorCode: Int?,
                                     responseTime: TimeInterval)
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func trackSyncPurchasesStarted()
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func trackSyncPurchasesResult(errorMessage: String?,
+                                  errorCode: Int?,
+                                  responseTime: TimeInterval)
+
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -134,13 +143,8 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
             return
         }
 
-        let event = DiagnosticsEvent(
-            name: .customerInfoVerificationResult,
-            properties: DiagnosticsEvent.Properties(verificationResult: verificationResult.name),
-            timestamp: self.dateProvider.now(),
-            appSessionId: self.appSessionID
-        )
-        self.track(event)
+        self.trackEvent(name: .customerInfoVerificationResult,
+                        properties: DiagnosticsEvent.Properties(verificationResult: verificationResult.name))
     }
 
     func trackProductsRequest(wasSuccessful: Bool,
@@ -151,21 +155,17 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                               requestedProductIds: Set<String>,
                               notFoundProductIds: Set<String>,
                               responseTime: TimeInterval) {
-        self.track(
-            DiagnosticsEvent(name: .appleProductsRequest,
-                             properties: DiagnosticsEvent.Properties(
-                                responseTime: responseTime,
-                                storeKitVersion: storeKitVersion,
-                                successful: wasSuccessful,
-                                errorMessage: errorMessage,
-                                errorCode: errorCode,
-                                skErrorDescription: storeKitErrorDescription,
-                                requestedProductIds: requestedProductIds,
-                                notFoundProductIds: notFoundProductIds
-                             ),
-                             timestamp: self.dateProvider.now(),
-                             appSessionId: self.appSessionID)
-        )
+        self.trackEvent(name: .appleProductsRequest,
+                        properties: DiagnosticsEvent.Properties(
+                            responseTime: responseTime,
+                            storeKitVersion: storeKitVersion,
+                            successful: wasSuccessful,
+                            errorMessage: errorMessage,
+                            errorCode: errorCode,
+                            skErrorDescription: storeKitErrorDescription,
+                            requestedProductIds: requestedProductIds,
+                            notFoundProductIds: notFoundProductIds
+                        ))
     }
 
     func trackHttpRequestPerformed(endpointName: String,
@@ -176,23 +176,17 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                                    resultOrigin: HTTPResponseOrigin?,
                                    verificationResult: VerificationResult,
                                    isRetry: Bool) {
-        self.track(
-            DiagnosticsEvent(
-                name: .httpRequestPerformed,
-                properties: DiagnosticsEvent.Properties(
-                    verificationResult: verificationResult.name,
-                    endpointName: endpointName,
-                    responseTime: responseTime,
-                    successful: wasSuccessful,
-                    responseCode: responseCode,
-                    backendErrorCode: backendErrorCode,
-                    etagHit: resultOrigin == .cache,
-                    isRetry: isRetry
-                ),
-                timestamp: self.dateProvider.now(),
-                appSessionId: self.appSessionID
-            )
-        )
+        self.trackEvent(name: .httpRequestPerformed,
+                        properties: DiagnosticsEvent.Properties(
+                            verificationResult: verificationResult.name,
+                            endpointName: endpointName,
+                            responseTime: responseTime,
+                            successful: wasSuccessful,
+                            responseCode: responseCode,
+                            backendErrorCode: backendErrorCode,
+                            etagHit: resultOrigin == .cache,
+                            isRetry: isRetry
+                        ))
     }
 
     func trackPurchaseRequest(wasSuccessful: Bool,
@@ -205,64 +199,44 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                               winBackOfferApplied: Bool,
                               purchaseResult: DiagnosticsEvent.PurchaseResult?,
                               responseTime: TimeInterval) {
-        self.track(
-            DiagnosticsEvent(name: .applePurchaseAttempt,
-                             properties: DiagnosticsEvent.Properties(
-                                responseTime: responseTime,
-                                storeKitVersion: storeKitVersion,
-                                successful: wasSuccessful,
-                                errorMessage: errorMessage,
-                                errorCode: errorCode,
-                                skErrorDescription: storeKitErrorDescription,
-                                productId: productId,
-                                promotionalOfferId: promotionalOfferId,
-                                winBackOfferApplied: winBackOfferApplied,
-                                purchaseResult: purchaseResult
-                             ),
-                             timestamp: self.dateProvider.now(),
-                             appSessionId: self.appSessionID)
-        )
+        self.trackEvent(name: .applePurchaseAttempt,
+                        properties: DiagnosticsEvent.Properties(
+                            responseTime: responseTime,
+                            storeKitVersion: storeKitVersion,
+                            successful: wasSuccessful,
+                            errorMessage: errorMessage,
+                            errorCode: errorCode,
+                            skErrorDescription: storeKitErrorDescription,
+                            productId: productId,
+                            promotionalOfferId: promotionalOfferId,
+                            winBackOfferApplied: winBackOfferApplied,
+                            purchaseResult: purchaseResult
+                        ))
     }
 
     func trackMaxDiagnosticsSyncRetriesReached() {
-        self.track(DiagnosticsEvent(name: .maxEventsStoredLimitReached,
-                                    properties: .empty,
-                                    timestamp: self.dateProvider.now(),
-                                    appSessionId: self.appSessionID))
+        self.trackEvent(name: .maxEventsStoredLimitReached, properties: .empty)
     }
 
     func trackClearingDiagnosticsAfterFailedSync() {
-        self.track(DiagnosticsEvent(name: .clearingDiagnosticsAfterFailedSync,
-                                    properties: .empty,
-                                    timestamp: self.dateProvider.now(),
-                                    appSessionId: self.appSessionID))
+        self.trackEvent(name: .clearingDiagnosticsAfterFailedSync, properties: .empty)
     }
 
     func trackEnteredOfflineEntitlementsMode() {
-        self.track(DiagnosticsEvent(name: .enteredOfflineEntitlementsMode,
-                                    properties: .empty,
-                                    timestamp: self.dateProvider.now(),
-                                    appSessionId: self.appSessionID))
+        self.trackEvent(name: .enteredOfflineEntitlementsMode, properties: .empty)
     }
 
     func trackErrorEnteringOfflineEntitlementsMode(reason: DiagnosticsEvent.OfflineEntitlementsModeErrorReason,
                                                    errorMessage: String) {
-        self.track(DiagnosticsEvent(name: .errorEnteringOfflineEntitlementsMode,
-                                    properties: DiagnosticsEvent.Properties(
-                                        offlineEntitlementErrorReason: reason,
-                                        errorMessage: errorMessage
-                                    ),
-                                    timestamp: self.dateProvider.now(),
-                                    appSessionId: self.appSessionID))
+        self.trackEvent(name: .errorEnteringOfflineEntitlementsMode,
+                        properties: DiagnosticsEvent.Properties(
+                            offlineEntitlementErrorReason: reason,
+                            errorMessage: errorMessage
+                        ))
     }
 
     func trackOfferingsStarted() {
-        self.track(
-            DiagnosticsEvent(name: .getOfferingsStarted,
-                             properties: .empty,
-                             timestamp: self.dateProvider.now(),
-                             appSessionId: self.appSessionID)
-        )
+        self.trackEvent(name: .getOfferingsStarted, properties: .empty)
     }
 
     func trackOfferingsResult(requestedProductIds: Set<String>?,
@@ -272,31 +246,23 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                               verificationResult: VerificationResult?,
                               cacheStatus: CacheStatus,
                               responseTime: TimeInterval) {
-        self.track(
-            DiagnosticsEvent(name: .getOfferingsResult,
-                             properties: DiagnosticsEvent.Properties(
-                                verificationResult: verificationResult?.name,
-                                responseTime: responseTime,
-                                errorMessage: errorMessage,
-                                errorCode: errorCode,
-                                requestedProductIds: requestedProductIds,
-                                notFoundProductIds: notFoundProductIds,
-                                cacheStatus: cacheStatus
-                             ),
-                             timestamp: self.dateProvider.now(),
-                             appSessionId: self.appSessionID)
-        )
+        self.trackEvent(name: .getOfferingsResult,
+                        properties: DiagnosticsEvent.Properties(
+                            verificationResult: verificationResult?.name,
+                            responseTime: responseTime,
+                            errorMessage: errorMessage,
+                            errorCode: errorCode,
+                            requestedProductIds: requestedProductIds,
+                            notFoundProductIds: notFoundProductIds,
+                            cacheStatus: cacheStatus
+                        ))
     }
 
     func trackProductsStarted(requestedProductIds: Set<String>) {
-        self.track(
-            DiagnosticsEvent(name: .getProductsStarted,
-                             properties: DiagnosticsEvent.Properties(
-                                requestedProductIds: requestedProductIds
-                             ),
-                             timestamp: self.dateProvider.now(),
-                             appSessionId: self.appSessionID)
-        )
+        self.trackEvent(name: .getProductsResult,
+                        properties: DiagnosticsEvent.Properties(
+                            requestedProductIds: requestedProductIds
+                        ))
     }
 
     func trackProductsResult(requestedProductIds: Set<String>,
@@ -304,27 +270,18 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                              errorMessage: String?,
                              errorCode: Int?,
                              responseTime: TimeInterval) {
-        self.track(
-            DiagnosticsEvent(name: .getProductsResult,
-                             properties: DiagnosticsEvent.Properties(
-                                responseTime: responseTime,
-                                errorMessage: errorMessage,
-                                errorCode: errorCode,
-                                requestedProductIds: requestedProductIds,
-                                notFoundProductIds: notFoundProductIds
-                             ),
-                             timestamp: self.dateProvider.now(),
-                             appSessionId: self.appSessionID)
-        )
+        self.trackEvent(name: .getProductsResult,
+                        properties: DiagnosticsEvent.Properties(
+                            responseTime: responseTime,
+                            errorMessage: errorMessage,
+                            errorCode: errorCode,
+                            requestedProductIds: requestedProductIds,
+                            notFoundProductIds: notFoundProductIds
+                        ))
     }
 
     func trackGetCustomerInfoStarted() {
-        self.track(
-            DiagnosticsEvent(name: .getCustomerInfoStarted,
-                             properties: .empty,
-                             timestamp: self.dateProvider.now(),
-                             appSessionId: self.appSessionID)
-        )
+        self.trackEvent(name: .getCustomerInfoStarted, properties: .empty)
     }
 
     func trackGetCustomerInfoResult(cacheFetchPolicy: CacheFetchPolicy,
@@ -333,24 +290,44 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                                     errorMessage: String?,
                                     errorCode: Int?,
                                     responseTime: TimeInterval) {
-        self.track(
-            DiagnosticsEvent(name: .getCustomerInfoResult,
-                             properties: DiagnosticsEvent.Properties(
-                                verificationResult: verificationResult?.name,
-                                responseTime: responseTime,
-                                errorMessage: errorMessage,
-                                errorCode: errorCode,
-                                cacheFetchPolicy: cacheFetchPolicy,
-                                hadUnsyncedPurchasesBefore: hadUnsyncedPurchasesBefore
-                             ),
-                             timestamp: self.dateProvider.now(),
-                             appSessionId: self.appSessionID)
-        )
+        self.trackEvent(name: .getCustomerInfoResult,
+                        properties: DiagnosticsEvent.Properties(
+                            verificationResult: verificationResult?.name,
+                            responseTime: responseTime,
+                            errorMessage: errorMessage,
+                            errorCode: errorCode,
+                            cacheFetchPolicy: cacheFetchPolicy,
+                            hadUnsyncedPurchasesBefore: hadUnsyncedPurchasesBefore
+                        ))
+    }
+
+    func trackSyncPurchasesStarted() {
+        self.trackEvent(name: .syncPurchasesStarted, properties: .empty)
+    }
+
+    func trackSyncPurchasesResult(errorMessage: String?,
+                                  errorCode: Int?,
+                                  responseTime: TimeInterval) {
+        self.trackEvent(name: .syncPurchasesResult,
+                        properties: DiagnosticsEvent.Properties(
+                            responseTime: responseTime,
+                            errorMessage: errorMessage,
+                            errorCode: errorCode
+                        ))
     }
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 private extension DiagnosticsTracker {
+
+    func trackEvent(name: DiagnosticsEvent.EventName, properties: DiagnosticsEvent.Properties) {
+        self.track(
+            DiagnosticsEvent(name: name,
+                             properties: properties,
+                             timestamp: self.dateProvider.now(),
+                             appSessionId: self.appSessionID)
+        )
+    }
 
     func clearDiagnosticsFileIfTooBig() async {
         if await self.diagnosticsFileHandler.isDiagnosticsFileTooBig() {

--- a/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
@@ -359,6 +359,36 @@ class DiagnosticsTrackerTests: TestCase {
         ])
     }
 
+    // MARK: - Sync Purchases
+
+    func testTrackingSyncPurchasesStarted() async {
+        self.tracker.trackSyncPurchasesStarted()
+        let entries = await self.handler.getEntries()
+        Self.expectEventArrayWithoutId(entries, [
+            .init(name: .syncPurchasesStarted,
+                  properties: .empty,
+                  timestamp: Self.eventTimestamp1,
+                  appSessionId: SystemInfo.appSessionID)
+        ])
+    }
+
+    func testTrackingSyncPurchasesResult() async {
+        self.tracker.trackSyncPurchasesResult(errorMessage: "an error msg",
+                                              errorCode: 20,
+                                              responseTime: 100.1)
+        let entries = await self.handler.getEntries()
+        Self.expectEventArrayWithoutId(entries, [
+            .init(name: .syncPurchasesResult,
+                  properties: DiagnosticsEvent.Properties(
+                    responseTime: 100.1,
+                    errorMessage: "an error msg",
+                    errorCode: 20
+                  ),
+                  timestamp: Self.eventTimestamp1,
+                  appSessionId: SystemInfo.appSessionID)
+        ])
+    }
+
     // MARK: - empty diagnostics file when too big
 
     func testTrackingEventClearsDiagnosticsFileIfTooBig() async throws {

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -256,4 +256,22 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
             )
         }
     }
+
+    let trackedSyncPurchasesStartedCalls: Atomic<Int> = .init(0)
+    func trackSyncPurchasesStarted() {
+        self.trackedSyncPurchasesStartedCalls.modify { $0 += 1 }
+    }
+
+    let trackedSyncPurchasesResult: Atomic<[
+        (errorMessage: String?,
+         errorCode: Int?,
+         responseTime: TimeInterval)
+    ]> = .init([])
+    func trackSyncPurchasesResult(errorMessage: String?,
+                                  errorCode: Int?,
+                                  responseTime: TimeInterval) {
+        self.trackedSyncPurchasesResult.modify {
+            $0.append((errorMessage, errorCode, responseTime))
+        }
+    }
 }


### PR DESCRIPTION
### Description
This PR:
- Adds the `sync_purchases_started` and `sync_purchases_result` events to `DiagnosticsTracker` (currently unused, will be in a follow-up PR).
- Refactors the code inside the `DiagnosticsTracker` to avoid some repetition