### PR TITLE
[Diagnostics] Add sync and restore purchases events

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -53,6 +53,8 @@ struct DiagnosticsEvent: Codable, Equatable {
         case getCustomerInfoResult = "get_customer_info_result"
         case syncPurchasesStarted = "sync_purchases_started"
         case syncPurchasesResult = "sync_purchases_result"
+        case restorePurchasesStarted = "restore_purchases_started"
+        case restorePurchasesResult = "restore_purchases_result"
     }
 
     enum PurchaseResult: String, Codable, Equatable {

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -108,6 +108,14 @@ protocol DiagnosticsTrackerType {
                                   errorCode: Int?,
                                   responseTime: TimeInterval)
 
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func trackRestorePurchasesStarted()
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func trackRestorePurchasesResult(errorMessage: String?,
+                                     errorCode: Int?,
+                                     responseTime: TimeInterval)
+
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -315,6 +323,22 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                             errorCode: errorCode
                         ))
     }
+
+    func trackRestorePurchasesStarted() {
+        self.trackEvent(name: .restorePurchasesStarted, properties: .empty)
+    }
+
+    func trackRestorePurchasesResult(errorMessage: String?,
+                                     errorCode: Int?,
+                                     responseTime: TimeInterval) {
+        self.trackEvent(name: .restorePurchasesResult,
+                        properties: DiagnosticsEvent.Properties(
+                            responseTime: responseTime,
+                            errorMessage: errorMessage,
+                            errorCode: errorCode
+                        ))
+    }
+
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
@@ -389,6 +389,36 @@ class DiagnosticsTrackerTests: TestCase {
         ])
     }
 
+    // MARK: - Restore Purchases
+
+    func testTrackingRestorePurchasesStarted() async {
+        self.tracker.trackRestorePurchasesStarted()
+        let entries = await self.handler.getEntries()
+        Self.expectEventArrayWithoutId(entries, [
+            .init(name: .restorePurchasesStarted,
+                  properties: .empty,
+                  timestamp: Self.eventTimestamp1,
+                  appSessionId: SystemInfo.appSessionID)
+        ])
+    }
+
+    func testTrackingRestorePurchasesResult() async {
+        self.tracker.trackRestorePurchasesResult(errorMessage: "an error msg",
+                                                 errorCode: 20,
+                                                 responseTime: 100.1)
+        let entries = await self.handler.getEntries()
+        Self.expectEventArrayWithoutId(entries, [
+            .init(name: .restorePurchasesResult,
+                  properties: DiagnosticsEvent.Properties(
+                    responseTime: 100.1,
+                    errorMessage: "an error msg",
+                    errorCode: 20
+                  ),
+                  timestamp: Self.eventTimestamp1,
+                  appSessionId: SystemInfo.appSessionID)
+        ])
+    }
+
     // MARK: - empty diagnostics file when too big
 
     func testTrackingEventClearsDiagnosticsFileIfTooBig() async throws {

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -262,7 +262,7 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
         self.trackedSyncPurchasesStartedCalls.modify { $0 += 1 }
     }
 
-    let trackedSyncPurchasesResult: Atomic<[
+    let trackedSyncPurchasesResultParams: Atomic<[
         (errorMessage: String?,
          errorCode: Int?,
          responseTime: TimeInterval)
@@ -270,7 +270,25 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
     func trackSyncPurchasesResult(errorMessage: String?,
                                   errorCode: Int?,
                                   responseTime: TimeInterval) {
-        self.trackedSyncPurchasesResult.modify {
+        self.trackedSyncPurchasesResultParams.modify {
+            $0.append((errorMessage, errorCode, responseTime))
+        }
+    }
+
+    let trackedRestorePurchasesStartedCalls: Atomic<Int> = .init(0)
+    func trackRestorePurchasesStarted() {
+        self.trackedRestorePurchasesStartedCalls.modify { $0 += 1 }
+    }
+
+    let trackedRestorePurchasesResultParams: Atomic<[
+        (errorMessage: String?,
+         errorCode: Int?,
+         responseTime: TimeInterval)
+    ]> = .init([])
+    func trackRestorePurchasesResult(errorMessage: String?,
+                                     errorCode: Int?,
+                                     responseTime: TimeInterval) {
+        self.trackedRestorePurchasesResultParams.modify {
             $0.append((errorMessage, errorCode, responseTime))
         }
     }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
@@ -274,3 +274,78 @@ class PurchasesRestoreNoSetupTests: BasePurchasesTests {
     }
 
 }
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+class PurchasesRestoreTrackingTests: BasePurchasesTests {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.setupPurchases()
+    }
+
+    func getMockDiagnosticsTracker() -> MockDiagnosticsTracker {
+        // swiftlint:disable:next force_cast
+        return self.diagnosticsTracker as! MockDiagnosticsTracker
+    }
+
+    func testRestoringPurchasesTracksRestoreStarted() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let customerInfo = try CustomerInfo(data: Self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(customerInfo)
+
+        _ = waitUntilValue { completed in
+            self.purchases.restorePurchases { (_, error) in
+                completed(error as NSError?)
+            }
+        }
+
+        let mockDiagnosticsTracker = self.getMockDiagnosticsTracker()
+        let callCount = mockDiagnosticsTracker.trackedRestorePurchasesStartedCalls.value
+        expect(callCount) == 1
+    }
+
+    func testRestoringPurchasesTracksRestoreResultSuccess() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let customerInfo = try CustomerInfo(data: Self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(customerInfo)
+
+        _ = waitUntilValue { completed in
+            self.purchases.restorePurchases { (_, error) in
+                completed(error as NSError?)
+            }
+        }
+
+        let mockDiagnosticsTracker = self.getMockDiagnosticsTracker()
+        let calls = mockDiagnosticsTracker.trackedRestorePurchasesResultParams.value
+        expect(calls.count) == 1
+        let callParams = calls[0]
+        expect(callParams.errorCode).to(beNil())
+        expect(callParams.errorMessage).to(beNil())
+        expect(callParams.responseTime).to(beGreaterThanOrEqualTo(0))
+    }
+
+    func testRestoringPurchasesTracksRestoreResultError() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let error: BackendError = .missingAppUserID()
+
+        self.backend.postReceiptResult = .failure(error)
+
+        _ = waitUntilValue { completed in
+            self.purchases.restorePurchases { (_, error) in
+                completed(error as NSError?)
+            }
+        }
+
+        let mockDiagnosticsTracker = self.getMockDiagnosticsTracker()
+        let calls = mockDiagnosticsTracker.trackedRestorePurchasesResultParams.value
+        expect(calls.count) == 1
+        let callParams = calls[0]
+        expect(callParams.errorCode) == ErrorCode.invalidAppUserIdError.rawValue
+        expect(callParams.errorMessage) == "The app user id is not valid."
+        expect(callParams.responseTime).to(beGreaterThanOrEqualTo(0))
+    }
+}

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncPurchasesTests.swift
@@ -183,3 +183,78 @@ class PurchasesSyncPurchasesAnonymousTests: BasePurchasesTests {
     }
 
 }
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+class PurchasesSyncPurchasesTrackingTests: BasePurchasesTests {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.setupPurchases()
+    }
+
+    func getMockDiagnosticsTracker() -> MockDiagnosticsTracker {
+        // swiftlint:disable:next force_cast
+        return self.diagnosticsTracker as! MockDiagnosticsTracker
+    }
+
+    func testSyncPurchasesTracksSyncStarted() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let customerInfo = try CustomerInfo(data: Self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(customerInfo)
+
+        _ = waitUntilValue { completed in
+            self.purchases.syncPurchases { (_, error) in
+                completed(error as NSError?)
+            }
+        }
+
+        let mockDiagnosticsTracker = self.getMockDiagnosticsTracker()
+        let callCount = mockDiagnosticsTracker.trackedSyncPurchasesStartedCalls.value
+        expect(callCount) == 1
+    }
+
+    func testSyncPurchasesTracksSyncResultSuccess() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let customerInfo = try CustomerInfo(data: Self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(customerInfo)
+
+        _ = waitUntilValue { completed in
+            self.purchases.syncPurchases { (_, error) in
+                completed(error as NSError?)
+            }
+        }
+
+        let mockDiagnosticsTracker = self.getMockDiagnosticsTracker()
+        let calls = mockDiagnosticsTracker.trackedSyncPurchasesResultParams.value
+        expect(calls.count) == 1
+        let callParams = calls[0]
+        expect(callParams.errorCode).to(beNil())
+        expect(callParams.errorMessage).to(beNil())
+        expect(callParams.responseTime).to(beGreaterThanOrEqualTo(0))
+    }
+
+    func testSyncPurchasesTracksSyncResultError() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let error: BackendError = .missingAppUserID()
+
+        self.backend.postReceiptResult = .failure(error)
+
+        _ = waitUntilValue { completed in
+            self.purchases.syncPurchases { (_, error) in
+                completed(error as NSError?)
+            }
+        }
+
+        let mockDiagnosticsTracker = self.getMockDiagnosticsTracker()
+        let calls = mockDiagnosticsTracker.trackedSyncPurchasesResultParams.value
+        expect(calls.count) == 1
+        let callParams = calls[0]
+        expect(callParams.errorCode) == ErrorCode.invalidAppUserIdError.rawValue
+        expect(callParams.errorMessage) == "The app user id is not valid."
+        expect(callParams.responseTime).to(beGreaterThanOrEqualTo(0))
+    }
+}


### PR DESCRIPTION
### Description
Follow-up to #4885.

 This PR adds 4 new events:
- `sync_purchases_started`
- `sync_purchases_result`
- `restore_purchases_started`
- `restore_purchases_result`

The cases of sync and restore are pretty similar right now in the code, so I shared most of the code paths. I decided against joining them in a single event since they are slightly different operations after all.