### PR TITLE
Fix for Chinese locale scripts that aren't supported in iOS 15

### DIFF
--- a/RevenueCatUI/Templates/V2/Localizations/LocaleExtensions.swift
+++ b/RevenueCatUI/Templates/V2/Localizations/LocaleExtensions.swift
@@ -44,10 +44,10 @@ extension Locale {
         if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, visionOS 1.0, *) {
             return self.language.script?.identifier
         } else {
-            return self.scriptCode
+            return self.scriptCode ?? self.fallbackScriptForiOS15
         }
         #else
-        return self.scriptCode
+        return self.scriptCode ?? self.fallbackScriptForiOS15
         #endif
     }
 
@@ -98,6 +98,21 @@ extension Locale {
     /// - Returns: the same locale as `self` but removing its region.
     private var removingRegion: Self? {
         return self.rc_languageCode.map(Locale.init(identifier:))
+    }
+
+    /// iOS 15 returns a nil scrippCode for these locale identifiers so hardcoding fallbacks
+    private var fallbackScriptForiOS15: String? {
+        let map: [String: String] = [
+            "zh": "Hans",
+            "zh_CN": "Hans",
+            "zh_SG": "Hans",
+            "zh_MY": "Hans",
+            "zh_TW": "Hant",
+            "zh_HK": "Hant",
+            "zh_MO": "Hant"
+        ]
+
+        return map[self.identifier]
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Localizations/LocaleFinder.swift
+++ b/RevenueCatUI/Templates/V2/Localizations/LocaleFinder.swift
@@ -13,6 +13,16 @@
 
 import Foundation
 
+fileprivate let iOS15ScriptMapping: [String: String] = [
+    "zh": "zh-Hans",
+    "zh-CN": "zh-Hans-CN",
+    "zh-SG": "zh-Hans-SG",
+    "zh-MY": "zh-Hans-MY",
+    "zh-TW": "zh-Hant-TW",
+    "zh-HK": "zh-Hant-HK",
+    "zh-MO": "zh-Hant-MO"
+]
+
 extension Dictionary where Key == String {
 
     func findLocale(_ locale: Locale) -> Value? {


### PR DESCRIPTION
### Motivation

Tests were failing in iOS 15 when trying to get the `Locale`'s `scriptCode` (it was always returning nil)

### Description

Hardcoding script code for the locales that we know for iOS 15 back support
