### PR TITLE
Fix possible memory leaks with diagnostics completion blocks

### DIFF
--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -59,13 +59,13 @@ class OfferingsManager {
             let cacheStatus = self.deviceCache.offeringsCacheStatus(isAppBackgrounded: isAppBackgrounded)
 
             let completionFromNetworkWithTracking: @MainActor @Sendable (Result<OfferingsResultData, Error>) -> Void =
-            { result in
-                self.trackGetOfferingsResultIfNeeded(trackDiagnostics: trackDiagnostics,
-                                                     startTime: startTime,
-                                                     cacheStatus: .notFound,
-                                                     error: result.error,
-                                                     requestedProductIds: result.value?.requestedProductIds,
-                                                     notFoundProductIds: result.value?.notFoundProductIds)
+            { [weak self] result in
+                self?.trackGetOfferingsResultIfNeeded(trackDiagnostics: trackDiagnostics,
+                                                      startTime: startTime,
+                                                      cacheStatus: .notFound,
+                                                      error: result.error,
+                                                      requestedProductIds: result.value?.requestedProductIds,
+                                                      notFoundProductIds: result.value?.notFoundProductIds)
                 completion?(result.map(\.offerings))
             }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1403,10 +1403,10 @@ private extension PurchasesOrchestrator {
             Logger.warn(Strings.purchase.restorepurchases_called_with_allow_sharing_appstore_account_false)
         }
 
-        let completionWithTracking: (@Sendable (Result<CustomerInfo, PurchasesError>) -> Void) = { result in
-            self.trackSyncOrRestorePurchasesResultIfNeeded(receiptRefreshPolicy,
-                                                           startTime: startTime,
-                                                           error: result.error)
+        let completionWithTracking: (@Sendable (Result<CustomerInfo, PurchasesError>) -> Void) = { [weak self] result in
+            self?.trackSyncOrRestorePurchasesResultIfNeeded(receiptRefreshPolicy,
+                                                            startTime: startTime,
+                                                            error: result.error)
             completion?(result)
         }
 


### PR DESCRIPTION
### Description
We were not doing `weak self` in the completion blocks for diagnostics. This fixes that. The chances of a leak here are small, considering these classes are usually singletons (unless the SDK is configured multiple times), but better to do it correctly.