### PR TITLE
[Diagnostics] add `apple_purchase_intent_received` event

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -44,6 +44,7 @@ struct DiagnosticsEvent: Codable, Equatable {
         case enteredOfflineEntitlementsMode = "entered_offline_entitlements_mode"
         case errorEnteringOfflineEntitlementsMode = "error_entering_offline_entitlements_mode"
         case applePurchaseAttempt = "apple_purchase_attempt"
+        case applePurchaseIntentReceived = "apple_purchase_intent_received"
         case maxDiagnosticsSyncRetriesReached = "max_diagnostics_sync_retries_reached"
         case getOfferingsStarted = "get_offerings_started"
         case getOfferingsResult = "get_offerings_result"
@@ -90,6 +91,8 @@ struct DiagnosticsEvent: Codable, Equatable {
         let productId: String?
         let productType: String?
         let promotionalOfferId: String?
+        let offerId: String?
+        let offerType: String?
         let winBackOfferApplied: Bool?
         let purchaseResult: PurchaseResult?
         let cacheStatus: CacheStatus?
@@ -114,6 +117,8 @@ struct DiagnosticsEvent: Codable, Equatable {
              productId: String? = nil,
              productType: StoreProduct.ProductType? = nil,
              promotionalOfferId: String? = nil,
+             offerId: String? = nil,
+             offerType: String? = nil,
              winBackOfferApplied: Bool? = nil,
              purchaseResult: PurchaseResult? = nil,
              cacheStatus: CacheStatus? = nil,
@@ -137,6 +142,8 @@ struct DiagnosticsEvent: Codable, Equatable {
             self.productId = productId
             self.productType = productType?.diagnosticsName
             self.promotionalOfferId = promotionalOfferId
+            self.offerId = offerId
+            self.offerType = offerType
             self.winBackOfferApplied = winBackOfferApplied
             self.purchaseResult = purchaseResult
             self.cacheStatus = cacheStatus

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -55,6 +55,11 @@ protocol DiagnosticsTrackerType {
                               responseTime: TimeInterval)
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func trackPurchaseIntentReceived(productId: String,
+                                     offerId: String?,
+                                     offerType: String?)
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func trackMaxDiagnosticsSyncRetriesReached()
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -231,6 +236,17 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                             promotionalOfferId: promotionalOfferId,
                             winBackOfferApplied: winBackOfferApplied,
                             purchaseResult: purchaseResult
+                        ))
+    }
+
+    func trackPurchaseIntentReceived(productId: String,
+                                     offerId: String?,
+                                     offerType: String?) {
+        self.trackEvent(name: .applePurchaseIntentReceived,
+                        properties: DiagnosticsEvent.Properties(
+                            productId: productId,
+                            offerId: offerId,
+                            offerType: offerType
                         ))
     }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1206,7 +1206,6 @@ private extension PurchasesOrchestrator {
         }
     }
 
-
     @available(iOS 16.4, macOS 14.4, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1206,6 +1206,28 @@ private extension PurchasesOrchestrator {
         }
     }
 
+
+    @available(iOS 16.4, macOS 14.4, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(visionOS, unavailable)
+    func trackApplePurchaseIntentReceivedIfNeeded(purchaseIntent: StoreKit.PurchaseIntent) {
+        let offerId: String?
+        let offerType: String?
+
+        if #available(iOSApplicationExtension 18.0, *) {
+            offerId = purchaseIntent.offer?.id
+            offerType = purchaseIntent.offer?.type.rawValue
+        } else {
+            offerId = nil
+            offerType = nil
+        }
+
+        self.diagnosticsTracker?.trackPurchaseIntentReceived(productId: purchaseIntent.product.id,
+                                                             offerId: offerId,
+                                                             offerType: offerType)
+    }
+
     /// - Parameter restored: whether the transaction state was `.restored` instead of `.purchased`.
     private func purchaseSource(
         for productIdentifier: String,
@@ -1300,6 +1322,8 @@ extension PurchasesOrchestrator: StoreKit2PurchaseIntentListenerDelegate {
 
         guard let purchaseIntent = purchaseIntent.purchaseIntent else { return }
         let storeProduct = StoreProduct(sk2Product: purchaseIntent.product)
+
+        self.trackApplePurchaseIntentReceivedIfNeeded(purchaseIntent: purchaseIntent)
 
         delegate?.readyForPromotedProduct(storeProduct) { completion in
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1214,7 +1214,7 @@ private extension PurchasesOrchestrator {
         let offerId: String?
         let offerType: String?
 
-        if #available(iOSApplicationExtension 18.0, *) {
+        if #available(iOS 18.0, macOS 15.0, *) {
             offerId = purchaseIntent.offer?.id
             offerType = purchaseIntent.offer?.type.rawValue
         } else {

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1210,7 +1210,7 @@ private extension PurchasesOrchestrator {
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     @available(visionOS, unavailable)
-    func trackApplePurchaseIntentReceivedIfNeeded(purchaseIntent: StoreKit.PurchaseIntent) {
+    func trackApplePurchaseIntentReceivedIfNeeded(purchaseIntent: any StoreKit2PurchaseIntentType) {
         let offerId: String?
         let offerType: String?
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1206,6 +1206,8 @@ private extension PurchasesOrchestrator {
         }
     }
 
+    #if compiler(>=5.10) && !os(tvOS) && !os(watchOS) && !os(visionOS)
+
     @available(iOS 16.4, macOS 14.4, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
@@ -1226,6 +1228,8 @@ private extension PurchasesOrchestrator {
                                                              offerId: offerId,
                                                              offerType: offerType)
     }
+
+    #endif
 
     /// - Parameter restored: whether the transaction state was `.restored` instead of `.purchased`.
     private func purchaseSource(
@@ -1317,7 +1321,7 @@ extension PurchasesOrchestrator: StoreKit2PurchaseIntentListenerDelegate {
         // stop the compiler from checking availability in the functions.
         // We also need to ensure that we're on Xcode >= 15.3, since that is when
         // PurchaseIntents were first made available on macOS.
-        #if !os(tvOS) && !os(watchOS) && compiler(>=5.10)
+        #if compiler(>=5.10) && !os(tvOS) && !os(watchOS) && !os(visionOS)
 
         guard let purchaseIntent = purchaseIntent.purchaseIntent else { return }
         let storeProduct = StoreProduct(sk2Product: purchaseIntent.product)
@@ -1328,7 +1332,7 @@ extension PurchasesOrchestrator: StoreKit2PurchaseIntentListenerDelegate {
 
             var attemptedToPurchaseWithASubscriptionOffer = false
 
-            if #available(iOS 18.0, macOS 15.0, visionOS 2.0, *) {
+            if #available(iOS 18.0, macOS 15.0, *) {
                 #if compiler(>=6.0)
                 if let offer = purchaseIntent.offer {
                     switch offer.type {

--- a/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
@@ -60,7 +60,7 @@ actor StoreKit2PurchaseIntentListener: StoreKit2PurchaseIntentListenerType {
 
     init(delegate: StoreKit2PurchaseIntentListenerDelegate? = nil) {
 
-        #if compiler(>=5.10)
+        #if compiler(>=5.10) && !os(tvOS) && !os(watchOS) && !os(visionOS)
         let storePurchaseIntentSequence = StoreKit.PurchaseIntent.intents.map { purchaseIntent in
             return StorePurchaseIntent(purchaseIntent: purchaseIntent)
         }.toAsyncStream()
@@ -124,7 +124,7 @@ actor StoreKit2PurchaseIntentListener: StoreKit2PurchaseIntentListenerType {
 @available(visionOS, unavailable)
 struct StorePurchaseIntent: Sendable, Equatable {
 
-    #if compiler(>=5.10)
+    #if compiler(>=5.10) && !os(tvOS) && !os(watchOS) && !os(visionOS)
     init(purchaseIntent: (any StoreKit2PurchaseIntentType)?) {
         self.purchaseIntent = purchaseIntent
     }
@@ -134,7 +134,7 @@ struct StorePurchaseIntent: Sendable, Equatable {
 
     // PurchaseIntents became available on macOS starting in macOS 14.4, which isn't available
     // until Xcode 15.3, which shipped with version 5.10 of the Swift compiler
-    #if compiler(>=5.10)
+    #if compiler(>=5.10) && !os(tvOS) && !os(watchOS) && !os(visionOS)
     @available(iOS 16.4, macOS 14.4, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
@@ -143,13 +143,15 @@ struct StorePurchaseIntent: Sendable, Equatable {
     #endif
 
     static func == (lhs: StorePurchaseIntent, rhs: StorePurchaseIntent) -> Bool {
-    #if compiler(>=5.10)
+    #if compiler(>=5.10) && !os(tvOS) && !os(watchOS) && !os(visionOS)
         return lhs.purchaseIntent?.id == rhs.purchaseIntent?.id
     #else
         return true
     #endif
     }
 }
+
+#if compiler(>=5.10) && !os(tvOS) && !os(watchOS) && !os(visionOS)
 
 @available(iOS 16.4, macOS 14.4, *)
 @available(tvOS, unavailable)
@@ -160,18 +162,12 @@ protocol StoreKit2PurchaseIntentType: Equatable, Identifiable, Sendable {
     var product: StoreKit.Product { get }
 
     @available(iOS 18.0, macOS 15.0, *)
-    @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
-    @available(visionOS, unavailable)
     var offer: StoreKit.Product.SubscriptionOffer? { get }
 
     var id: StoreKit.Product.ID { get }
 }
 
-#if compiler(>=5.10)
 @available(iOS 16.4, macOS 14.4, *)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
-@available(visionOS, unavailable)
 extension StoreKit.PurchaseIntent: StoreKit2PurchaseIntentType { }
+
 #endif

--- a/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
@@ -125,7 +125,7 @@ actor StoreKit2PurchaseIntentListener: StoreKit2PurchaseIntentListenerType {
 struct StorePurchaseIntent: Sendable, Equatable {
 
     #if compiler(>=5.10)
-    init(purchaseIntent: PurchaseIntent?) {
+    init(purchaseIntent: (any StoreKit2PurchaseIntentType)?) {
         self.purchaseIntent = purchaseIntent
     }
     #else
@@ -139,6 +139,39 @@ struct StorePurchaseIntent: Sendable, Equatable {
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     @available(visionOS, unavailable)
-    let purchaseIntent: PurchaseIntent?
+    let purchaseIntent: (any StoreKit2PurchaseIntentType)?
     #endif
+
+    static func == (lhs: StorePurchaseIntent, rhs: StorePurchaseIntent) -> Bool {
+    #if compiler(>=5.10)
+        return lhs.purchaseIntent?.id == rhs.purchaseIntent?.id
+    #else
+        return true
+    #endif
+    }
 }
+
+@available(iOS 16.4, macOS 14.4, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@available(visionOS, unavailable)
+protocol StoreKit2PurchaseIntentType: Equatable, Identifiable, Sendable {
+
+    var product: StoreKit.Product { get }
+
+    @available(iOS 18.0, macOS 15.0, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(visionOS, unavailable)
+    var offer: StoreKit.Product.SubscriptionOffer? { get }
+
+    var id: StoreKit.Product.ID { get }
+}
+
+#if compiler(>=5.10)
+@available(iOS 16.4, macOS 14.4, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@available(visionOS, unavailable)
+extension StoreKit.PurchaseIntent: StoreKit2PurchaseIntentType { }
+#endif

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorCommonTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorCommonTests.swift
@@ -531,7 +531,7 @@ final class MockStoreKit2PurchaseIntent: StoreKit2PurchaseIntentType {
 @available(visionOS, unavailable)
 extension PurchasesOrchestratorTrackingTests {
 
-    func test() async throws {
+    func testTracksPurchaseIntentReceived() async throws {
         try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         let sk2Product = try await self.fetchSk2Product()

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorCommonTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorCommonTests.swift
@@ -500,7 +500,7 @@ class PurchasesOrchestratorTrackingTests: BasePurchasesOrchestratorTests {
 
 }
 
-#if !os(tvOS) && !os(watchOS) && compiler(>=5.10)
+#if compiler(>=5.10) && !os(tvOS) && !os(watchOS) && !os(visionOS)
 
 // MARK: - Purchase Intent Received events
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorCommonTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorCommonTests.swift
@@ -547,7 +547,6 @@ extension PurchasesOrchestratorTrackingTests {
         expect(params.productId) == sk2Product.id
         expect(params.offerId) == nil
         expect(params.offerType) == nil
-
     }
 
 }

--- a/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
@@ -459,6 +459,25 @@ class DiagnosticsTrackerTests: TestCase {
         ])
     }
 
+    // MARK: - Purchase Intent Received
+
+    func testTrackingApplePurchaseIntentReceived() async {
+        self.tracker.trackPurchaseIntentReceived(productId: "product_id",
+                                                 offerId: "offer_id",
+                                                 offerType: "offer_type")
+        let entries = await self.handler.getEntries()
+        Self.expectEventArrayWithoutId(entries, [
+            .init(name: .restorePurchasesResult,
+                  properties: DiagnosticsEvent.Properties(
+                    productId: "product_id",
+                    offerId: "offer_id",
+                    offerType: "offer_type"
+                  ),
+                  timestamp: Self.eventTimestamp1,
+                  appSessionId: SystemInfo.appSessionID)
+        ])
+    }
+
     // MARK: - empty diagnostics file when too big
 
     func testTrackingEventClearsDiagnosticsFileIfTooBig() async throws {

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -97,6 +97,19 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
         }
     }
 
+    let trackedPurchaseIntentReceivedParams: Atomic<[
+        (productId: String,
+         offerId: String?,
+         offerType: String?)
+    ]> = .init([])
+    func trackPurchaseIntentReceived(productId: String,
+                                     offerId: String?,
+                                     offerType: String?) {
+        self.trackedPurchaseIntentReceivedParams.modify {
+            $0.append((productId, offerId, offerType))
+        }
+    }
+
     let trackedProductsRequestParams: Atomic<[
         // swiftlint:disable:next large_tuple
         (wasSuccessful: Bool,


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Description
This PR implements the apple_purchase_intent_received` diagnostics events

### Notes
This is a duplicated PR of #4888 which was merged too soon by mistake