### PR TITLE
Fix unit tests: make `presentCodeRedemptionSheet()` test only run on iOS

### DIFF
--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDiagnosticsTrackingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDiagnosticsTrackingTests.swift
@@ -24,7 +24,7 @@ class PurchasesDiagnosticsTrackingTests: BasePurchasesTests {
         self.setupPurchases()
     }
 
-    #if os(iOS)
+    #if os(iOS) || os(visionOS)
     @available(iOS 15.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDiagnosticsTrackingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDiagnosticsTrackingTests.swift
@@ -24,6 +24,7 @@ class PurchasesDiagnosticsTrackingTests: BasePurchasesTests {
         self.setupPurchases()
     }
 
+    #if os(iOS)
     @available(iOS 15.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
@@ -34,4 +35,5 @@ class PurchasesDiagnosticsTrackingTests: BasePurchasesTests {
 
         expect(try self.mockDiagnosticsTracker.trackedApplePresentCodeRedemptionSheetRequestCalls.value) == 1
     }
+    #endif
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDiagnosticsTrackingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDiagnosticsTrackingTests.swift
@@ -31,6 +31,8 @@ class PurchasesDiagnosticsTrackingTests: BasePurchasesTests {
     @available(macOS, unavailable)
     @available(macCatalyst, unavailable)
     func testPresentCodeRedepmtionSheetTracksDiagnostics() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
         self.purchases.presentCodeRedemptionSheet()
 
         expect(try self.mockDiagnosticsTracker.trackedApplePresentCodeRedemptionSheetRequestCalls.value) == 1


### PR DESCRIPTION
### Motivation
Unit tests were failing in targets that are not iOS due to the unit test for `presentCodeRedemptionSheet()` added in #4893. 

### Description
This PR fixes the issue by making the unit test for `presentCodeRedemptionSheet()` only run on iOS