### PR TITLE
[Diagnostics] add `apple_transaction_queue_received` event

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -56,6 +56,7 @@ struct DiagnosticsEvent: Codable, Equatable {
         case restorePurchasesStarted = "restore_purchases_started"
         case restorePurchasesResult = "restore_purchases_result"
         case applePresentCodeRedemptionSheetRequest = "apple_present_code_redemption_sheet_request"
+        case appleTransactionQueueReceived = "apple_transaction_queue_received"
     }
 
     enum PurchaseResult: String, Codable, Equatable {

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -119,6 +119,12 @@ protocol DiagnosticsTrackerType {
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func trackApplePresentCodeRedemptionSheetRequest()
 
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func trackAppleTransactionQueueReceived(productId: String?,
+                                            paymentDiscountId: String?,
+                                            transactionState: String,
+                                            errorMessage: String?)
+
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -344,6 +350,19 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
 
     func trackApplePresentCodeRedemptionSheetRequest() {
         self.trackEvent(name: .applePresentCodeRedemptionSheetRequest, properties: .empty)
+    }
+
+    func trackAppleTransactionQueueReceived(productId: String?,
+                                            paymentDiscountId: String?,
+                                            transactionState: String,
+                                            errorMessage: String?) {
+        self.trackEvent(name: .appleTransactionQueueReceived,
+                        properties: DiagnosticsEvent.Properties(
+                            errorMessage: errorMessage,
+                            skErrorDescription: transactionState,
+                            productId: productId,
+                            promotionalOfferId: paymentDiscountId
+                        ))
     }
 
 }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -355,7 +355,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             : .left(.init(
                 operationDispatcher: operationDispatcher,
                 observerMode: observerMode,
-                sandboxEnvironmentDetector: systemInfo
+                sandboxEnvironmentDetector: systemInfo,
+                diagnosticsTracker: diagnosticsTracker
             ))
 
         let offeringsFactory = OfferingsFactory()

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -66,15 +66,18 @@ class StoreKit1Wrapper: NSObject {
     private let operationDispatcher: OperationDispatcher
     private let observerMode: Bool
     private let sandboxEnvironmentDetector: SandboxEnvironmentDetector
+    private let diagnosticsTracker: DiagnosticsTrackerType?
 
     init(paymentQueue: SKPaymentQueue = .default(),
          operationDispatcher: OperationDispatcher = .default,
          observerMode: Bool,
-         sandboxEnvironmentDetector: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector.default) {
+         sandboxEnvironmentDetector: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector.default,
+         diagnosticsTracker: DiagnosticsTrackerType?) {
         self.paymentQueue = paymentQueue
         self.operationDispatcher = operationDispatcher
         self.observerMode = observerMode
         self.sandboxEnvironmentDetector = sandboxEnvironmentDetector
+        self.diagnosticsTracker = diagnosticsTracker
 
         super.init()
 
@@ -186,6 +189,8 @@ extension StoreKit1Wrapper: SKPaymentTransactionObserver {
             ))
         }
 
+        self.trackTransactionQueueReceivedIfNeeded(transactions)
+
         self.operationDispatcher.dispatchOnWorkerThread {
             for transaction in transactions {
                 Logger.debug(Strings.purchase.paymentqueue_updated_transaction(self, transaction))
@@ -246,6 +251,20 @@ extension StoreKit1Wrapper: SKPaymentTransactionObserver {
     /// Receiving this many or more will produce a warning.
     private static let highTransactionCountThreshold: Int = 100
 
+    private func trackTransactionQueueReceivedIfNeeded(_ transactions: [SKPaymentTransaction]) {
+        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *),
+              let diagnosticsTracker = self.diagnosticsTracker else { return }
+
+        transactions.forEach { transaction in
+            diagnosticsTracker.trackAppleTransactionQueueReceived(
+                productId: transaction.payment.productIdentifier,
+                paymentDiscountId: transaction.payment.paymentDiscount?.identifier,
+                transactionState: transaction.transactionState.diagnosticsName,
+                errorMessage: transaction.error?.localizedDescription
+            )
+        }
+    }
+
 }
 
 extension StoreKit1Wrapper: SKPaymentQueueDelegate {
@@ -262,3 +281,23 @@ extension StoreKit1Wrapper: SKPaymentQueueDelegate {
 // @unchecked because:
 // - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
 extension StoreKit1Wrapper: @unchecked Sendable {}
+
+fileprivate extension SKPaymentTransactionState {
+
+    var diagnosticsName: String {
+        switch self {
+        case .purchasing:
+            return "PURCHASING"
+        case .purchased:
+            return "PURCHASED"
+        case .failed:
+            return "FAILED"
+        case .restored:
+            return "RESTORED"
+        case .deferred:
+            return "DEFERRED"
+        @unknown default:
+            return "UNKNOWN (RAW VALUE: \(self.rawValue))"
+        }
+    }
+}

--- a/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
@@ -421,12 +421,37 @@ class DiagnosticsTrackerTests: TestCase {
 
     // MARK: - Present Code Redemption Sheet Request
 
-    func testApplePresentCodeRedemptionSheetRequest() async {
+    func testTrackingApplePresentCodeRedemptionSheetRequest() async throws {
         self.tracker.trackApplePresentCodeRedemptionSheetRequest()
+
         let entries = await self.handler.getEntries()
         Self.expectEventArrayWithoutId(entries, [
             .init(name: .applePresentCodeRedemptionSheetRequest,
                   properties: .empty,
+                  timestamp: Self.eventTimestamp1,
+                  appSessionId: SystemInfo.appSessionID)
+        ])
+    }
+
+    // MARK: - Transaction Queue Received
+
+    func testTrackingAppleTransactionQueueReceived() async throws {
+        self.tracker.trackAppleTransactionQueueReceived(
+            productId: "test.product",
+            paymentDiscountId: "discount_123",
+            transactionState: "purchased",
+            errorMessage: "error message"
+        )
+
+        let entries = await self.handler.getEntries()
+        Self.expectEventArrayWithoutId(entries, [
+            .init(name: .appleTransactionQueueReceived,
+                  properties: DiagnosticsEvent.Properties(
+                    errorMessage: "error message",
+                    skErrorDescription: "purchased",
+                    productId: "test.product",
+                    promotionalOfferId: "discount_123"
+                  ),
                   timestamp: Self.eventTimestamp1,
                   appSessionId: SystemInfo.appSessionID)
         ])

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -297,4 +297,20 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
     func trackApplePresentCodeRedemptionSheetRequest() {
         self.trackedApplePresentCodeRedemptionSheetRequestCalls.modify { $0 += 1 }
     }
+
+    let trackedAppleTransactionQueueReceivedParams: Atomic<[
+        (productId: String?,
+         paymentDiscountId: String?,
+         transactionState: String,
+         errorMessage: String?)
+    ]> = .init([])
+    func trackAppleTransactionQueueReceived(productId: String?,
+                                            paymentDiscountId: String?,
+                                            transactionState: String,
+                                            errorMessage: String?) {
+        self.trackedAppleTransactionQueueReceivedParams.modify {
+            $0.append((productId, paymentDiscountId, transactionState, errorMessage))
+        }
+    }
+
 }

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -120,13 +120,13 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
         self.trackedProductsRequestParams.modify {
             $0.append(
                 (wasSuccessful,
-                storeKitVersion,
-                errorMessage,
-                errorCode,
-                storeKitErrorDescription,
-                requestedProductIds,
-                notFoundProductIds,
-                responseTime)
+                 storeKitVersion,
+                 errorMessage,
+                 errorCode,
+                 storeKitErrorDescription,
+                 requestedProductIds,
+                 notFoundProductIds,
+                 responseTime)
             )
         }
     }

--- a/Tests/UnitTests/Mocks/MockStoreKit1Wrapper.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit1Wrapper.swift
@@ -8,7 +8,7 @@ import StoreKit
 
 class MockStoreKit1Wrapper: StoreKit1Wrapper {
     init(observerMode: Bool = false) {
-        super.init(observerMode: observerMode)
+        super.init(observerMode: observerMode, diagnosticsTracker: nil)
     }
 
     var payment: SKPayment?

--- a/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
@@ -30,7 +30,8 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
         self.wrapper = StoreKit1Wrapper(paymentQueue: self.paymentQueue,
                                         operationDispatcher: self.operationDispatcher,
                                         observerMode: false,
-                                        sandboxEnvironmentDetector: self.sandboxEnvironmentDetector)
+                                        sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
+                                        diagnosticsTracker: nil)
         self.wrapper.delegate = self
     }
 

--- a/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
@@ -18,6 +18,15 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
     private var paymentQueue: MockPaymentQueue!
     private var sandboxEnvironmentDetector: MockSandboxEnvironmentDetector!
 
+    var diagnosticsTracker: DiagnosticsTrackerType?
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var mockDiagnosticsTracker: MockDiagnosticsTracker {
+        get throws {
+            return try XCTUnwrap(self.diagnosticsTracker as? MockDiagnosticsTracker)
+        }
+    }
+
     private var wrapper: StoreKit1Wrapper!
 
     override func setUp() {
@@ -27,11 +36,17 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
         self.paymentQueue = .init()
         self.sandboxEnvironmentDetector = .init(isSandbox: true)
 
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            self.diagnosticsTracker = MockDiagnosticsTracker()
+        } else {
+            self.diagnosticsTracker = nil
+        }
+
         self.wrapper = StoreKit1Wrapper(paymentQueue: self.paymentQueue,
                                         operationDispatcher: self.operationDispatcher,
                                         observerMode: false,
                                         sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
-                                        diagnosticsTracker: nil)
+                                        diagnosticsTracker: self.diagnosticsTracker)
         self.wrapper.delegate = self
     }
 
@@ -330,6 +345,76 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
     }
 #endif
 
+}
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+extension StoreKit1WrapperTests {
+
+    func testDoesNotTrackDiagnosticsWhenTransactionsUpdatedAreEmpty() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        wrapper?.paymentQueue(paymentQueue, updatedTransactions: [])
+
+        let mockDiagnosticsTracker = try XCTUnwrap(self.mockDiagnosticsTracker)
+        expect(mockDiagnosticsTracker.trackedAppleTransactionQueueReceivedParams.value).to(beEmpty())
+    }
+
+    func testTracksDiagnosticsWhenTransactionsAreUpdated() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let product0 = MockSK1Product(mockProductIdentifier: "product_id_0",
+                                      mockSubscriptionGroupIdentifier: "group_0")
+        let payment0 = SKPayment(product: product0)
+        wrapper?.add(payment0)
+
+        let transaction0 = MockTransaction()
+        transaction0.mockState = .purchasing
+        transaction0.mockPayment = payment0
+
+        let product1 = MockSK1Product(mockProductIdentifier: "product_id_1",
+                                      mockSubscriptionGroupIdentifier: "group_1")
+        let payment1 = SKPayment(product: product1)
+        wrapper?.add(payment1)
+
+        let transaction1 = MockTransaction()
+        transaction1.mockState = .restored
+        transaction1.mockPayment = payment1
+
+        let product2 = MockSK1Product(mockProductIdentifier: "product_id_2",
+                                      mockSubscriptionGroupIdentifier: "group_2")
+        let payment2 = SKPayment(product: product2)
+        wrapper?.add(payment2)
+
+        let transaction2 = MockTransaction()
+        transaction2.mockState = .failed
+        transaction2.mockPayment = payment2
+
+        let error2 = NSError(domain: SKErrorDomain, code: SKError.paymentNotAllowed.rawValue)
+        transaction2.mockError = error2
+
+        wrapper?.paymentQueue(paymentQueue, updatedTransactions: [transaction0, transaction1, transaction2])
+
+        let mockDiagnosticsTracker = try XCTUnwrap(self.mockDiagnosticsTracker)
+        expect(mockDiagnosticsTracker.trackedAppleTransactionQueueReceivedParams.value.count) == 3
+
+        let params0 = mockDiagnosticsTracker.trackedAppleTransactionQueueReceivedParams.value[0]
+        expect(params0.productId) == "product_id_0"
+        expect(params0.paymentDiscountId) == nil
+        expect(params0.transactionState) == "PURCHASING"
+        expect(params0.errorMessage) == nil
+
+        let params1 = mockDiagnosticsTracker.trackedAppleTransactionQueueReceivedParams.value[1]
+        expect(params1.productId) == "product_id_1"
+        expect(params1.paymentDiscountId) == nil
+        expect(params1.transactionState) == "RESTORED"
+        expect(params1.errorMessage) == nil
+
+        let params2 = mockDiagnosticsTracker.trackedAppleTransactionQueueReceivedParams.value[2]
+        expect(params2.productId) == "product_id_2"
+        expect(params2.paymentDiscountId) == nil
+        expect(params2.transactionState) == "FAILED"
+        expect(params2.errorMessage) == error2.localizedDescription
+    }
 }
 
 private extension StoreKit1WrapperTests {


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Description
This PR implements the `apple_transaction_queue_received` diagnostics events