### PR TITLE
Fixing fit mode on background property

### DIFF
--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -272,7 +272,8 @@ private struct LoadedPaywallsV2View: View {
             .frame(maxHeight: .infinity, alignment: .topLeading)
             .backgroundStyle(
                 self.paywallState.componentsConfig.background
-                    .asDisplayable(uiConfigProvider: uiConfigProvider).backgroundStyle
+                    .asDisplayable(uiConfigProvider: uiConfigProvider).backgroundStyle,
+                alignment: .top
             )
             .edgesIgnoringSafeArea(.bottom)
         }

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -181,7 +181,7 @@ struct BackgrounDStyle_Previews: PreviewProvider {
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Color - Dark (should be red because fallback)")
 
-        // Image - Light (should be pink cat)
+        // Image (Fill) - Light (should be pink cat)
         testContent
             .backgroundStyle(.image(.init(
                 light: .init(
@@ -200,9 +200,9 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                 )
             ), .fill))
             .previewLayout(.sizeThatFits)
-            .previewDisplayName("Image - Light (should be pink cat)")
+            .previewDisplayName("Image (Fill) - Light (should be pink cat)")
 
-        // Image - Dark (should be japan cats)
+        // Image (Fill) - Dark (should be japan cats)
         testContent
             .backgroundStyle(.image(.init(
                 light: .init(
@@ -223,6 +223,27 @@ struct BackgrounDStyle_Previews: PreviewProvider {
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Image - Dark (should be japan cats)")
+
+        // Image (Fit) - Light (should be pink cat)
+        testContent
+            .backgroundStyle(.image(.init(
+                light: .init(
+                    width: 750,
+                    height: 530,
+                    original: lightUrl,
+                    heic: lightUrl,
+                    heicLowRes: lightUrl
+                ),
+                dark: .init(
+                    width: 1024,
+                    height: 853,
+                    original: darkUrl,
+                    heic: darkUrl,
+                    heicLowRes: darkUrl
+                )
+            ), .fit))
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("Image (Fit) - Light (should be pink cat)")
 
         testContent
             .backgroundStyle(

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -19,7 +19,7 @@ import SwiftUI
 enum BackgroundStyle: Hashable {
 
     case color(DisplayableColorScheme)
-    case image(PaywallComponent.ThemeImageUrls)
+    case image(PaywallComponent.ThemeImageUrls, PaywallComponent.FitMode)
 
 }
 
@@ -30,11 +30,16 @@ struct BackgroundStyleModifier: ViewModifier {
     var colorScheme
 
     var backgroundStyle: BackgroundStyle?
+    var alignment: Alignment
 
     func body(content: Content) -> some View {
         if let backgroundStyle {
             content
-                .apply(backgroundStyle: backgroundStyle, colorScheme: colorScheme)
+                .apply(
+                    backgroundStyle: backgroundStyle,
+                    colorScheme: colorScheme,
+                    alignment: alignment
+                )
         } else {
             content
         }
@@ -48,7 +53,8 @@ fileprivate extension View {
     @ViewBuilder
     func apply(
         backgroundStyle: BackgroundStyle,
-        colorScheme: ColorScheme
+        colorScheme: ColorScheme,
+        alignment: Alignment
     ) -> some View {
         switch backgroundStyle {
         case .color(let color):
@@ -77,8 +83,8 @@ fileprivate extension View {
                     .edgesIgnoringSafeArea(.all)
                 }
             }
-        case .image(let imageInfo):
-            self.background {
+        case .image(let imageInfo, let fitMode):
+            self.background(alignment: alignment) {
                 RemoteImage(
                     url: imageInfo.light.heic,
                     lowResUrl: imageInfo.light.heicLowRes,
@@ -87,7 +93,7 @@ fileprivate extension View {
                 ) { (image, _) in
                     image
                         .resizable()
-                        .scaledToFill()
+                        .aspectRatio(contentMode: fitMode.contentMode)
                         .ignoresSafeArea()
                 }
                 .edgesIgnoringSafeArea(.all)
@@ -100,8 +106,8 @@ fileprivate extension View {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
-    func backgroundStyle(_ backgroundStyle: BackgroundStyle?) -> some View {
-        self.modifier(BackgroundStyleModifier(backgroundStyle: backgroundStyle))
+    func backgroundStyle(_ backgroundStyle: BackgroundStyle?, alignment: Alignment = .center) -> some View {
+        self.modifier(BackgroundStyleModifier(backgroundStyle: backgroundStyle, alignment: alignment))
     }
 
 }
@@ -112,8 +118,8 @@ extension BackgroundStyle {
         switch self {
         case .color(let value):
             return .color(value)
-        case .image(let value):
-            return .image(value)
+        case .image(let value, let fitMode):
+            return .image(value, fitMode)
         }
     }
 
@@ -192,7 +198,7 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                     heic: darkUrl,
                     heicLowRes: darkUrl
                 )
-            )))
+            ), .fill))
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Image - Light (should be pink cat)")
 
@@ -213,7 +219,7 @@ struct BackgrounDStyle_Previews: PreviewProvider {
                     heic: darkUrl,
                     heicLowRes: darkUrl
                 )
-            )))
+            ), .fill))
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
             .previewDisplayName("Image - Dark (should be japan cats)")

--- a/RevenueCatUI/Templates/V2/ViewHelpers/DisplayableColor.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/DisplayableColor.swift
@@ -23,8 +23,8 @@ extension PaywallComponent.Background {
         switch self {
         case .color(let color):
             return .color(color.asDisplayable(uiConfigProvider: uiConfigProvider))
-        case .image(let image):
-            return .image(image)
+        case .image(let image, let fitMode):
+            return .image(image, fitMode)
         }
     }
 

--- a/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
@@ -441,7 +441,7 @@ struct CornerBorder_Previews: PreviewProvider {
                     heic: lightUrl,
                     heicLowRes: lightUrl
                 )
-            )),
+            ), .fill),
             nil
         ]
 

--- a/Sources/Paywalls/Components/Common/Background.swift
+++ b/Sources/Paywalls/Components/Common/Background.swift
@@ -19,7 +19,7 @@ public extension PaywallComponent {
     enum Background: Codable, Sendable, Hashable {
 
         case color(ColorScheme)
-        case image(ThemeImageUrls)
+        case image(ThemeImageUrls, FitMode)
 
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
@@ -28,10 +28,10 @@ public extension PaywallComponent {
             case .color(let colorScheme):
                 try container.encode(BackgroundType.color.rawValue, forKey: .type)
                 try container.encode(colorScheme, forKey: .value)
-            case .image(let imageInfo):
+            case .image(let imageInfo, let fitMode):
                 try container.encode(BackgroundType.image.rawValue, forKey: .type)
                 try container.encode(imageInfo, forKey: .value)
-
+                try container.encode(fitMode, forKey: .fitMode)
             }
         }
 
@@ -45,7 +45,8 @@ public extension PaywallComponent {
                 self = .color(value)
             case .image:
                 let value = try container.decode(ThemeImageUrls.self, forKey: .value)
-                self = .image(value)
+                let fitMode = try container.decode(FitMode.self, forKey: .fitMode)
+                self = .image(value, fitMode)
             }
         }
 
@@ -54,6 +55,7 @@ public extension PaywallComponent {
 
             case type
             case value
+            case fitMode
 
         }
 


### PR DESCRIPTION
### Motivation

Fit mode was not being recognized on background image property

### Description

- Pass fit mode into the background view modifier and apply it
- Add optional alignment property for root paywall background to align background to top

| Fit | Fill |
|--------|--------|
| <img width="303" alt="Screenshot 2025-03-19 at 3 37 41 PM" src="https://github.com/user-attachments/assets/5d81e36e-7bbd-4658-8ba1-dc5a59c10700" /> | <img width="297" alt="Screenshot 2025-03-19 at 3 38 08 PM" src="https://github.com/user-attachments/assets/3bbb2df1-8895-4709-b3c6-b2f0601e2b90" /> | 