### PR TITLE
fix build issue in iOS 15

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1138,7 +1138,7 @@ private extension PurchasesOrchestrator {
     func trackPurchaseResultIfNeeded(trackDiagnostics: Bool,
                                      productId: String,
                                      productType: StoreProduct.ProductType,
-                                     verificationResult: RevenueCat.VerificationResult?,
+                                     verificationResult: VerificationResult?,
                                      error: PublicError?,
                                      startTime: Date) {
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *), trackDiagnostics,


### PR DESCRIPTION
### Motivation
I wanted to try and cover errors with `VerificationResult` similar to the conflict solved in #4814. But it looks like not only it's not needed but also it breaks compilation in iOS 15.

### Description
This PR removes the `RevenueCat` from `RevenueCat.VerificationInfo`