### PR TITLE
[Paywalls] Extend the padding by border.width amount in components that support both

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -72,7 +72,7 @@ struct CarouselComponentView: View {
                 }
                 // Style the carousel
                 .size(style.size)
-                .padding(style.padding)
+                .padding(style.padding.extend(by: style.border?.width ?? 0))
                 .shape(border: style.border,
                        shape: style.shape,
                        background: style.backgroundStyle,

--- a/RevenueCatUI/Templates/V2/Components/Icon/IconComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Icon/IconComponentView.swift
@@ -51,7 +51,7 @@ struct IconComponentView: View {
                 ) { (image, size) in
                     self.renderImage(image, size, with: style)
                 }
-                .padding(style.padding)
+                .padding(style.padding.extend(by: style.iconBackgroundBorder?.width ?? 0))
                 .shape(border: style.iconBackgroundBorder,
                        shape: style.iconBackgroundShape,
                        background: style.iconBackgroundStyle,

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -56,12 +56,11 @@ struct ImageComponentView: View {
                 }
                 .size(style.size)
                 .clipped()
+                .padding(style.padding.extend(by: style.border?.width ?? 0))
                 .shape(border: style.border,
                        shape: style.shape)
                 .shadow(shadow: style.shadow,
                         shape: style.shape?.toInsettableShape())
-                .padding(style.padding)
-                // WIP: Add border still
                 .padding(style.margin)
             }
         }

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -117,7 +117,7 @@ struct StackComponentView: View {
             }
         }
         .hidden(if: self.showActivityIndicatorOverContent)
-        .padding(style.padding)
+        .padding(style.padding.extend(by: style.border?.width ?? 0))
         .padding(additionalPadding)
         .applyIf(self.showActivityIndicatorOverContent, apply: { view in
             view.progressOverlay(for: style.backgroundStyle)

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentTypeTransformers.swift
@@ -229,6 +229,20 @@ extension PaywallComponent.Padding {
 
 }
 
+extension EdgeInsets {
+    func extend(by amount: CGFloat) -> EdgeInsets {
+        if amount == 0 {
+            return self
+        }
+        return .init(
+            top: self.top + amount,
+            leading: self.leading + amount,
+            bottom: self.bottom + amount,
+            trailing: self.trailing + amount
+        )
+    }
+}
+
 extension PaywallComponent.FitMode {
     var contentMode: ContentMode {
         switch self {


### PR DESCRIPTION
Affected components: Carousel, Image, Icon and Stack.

Additionally, this PR fixes an issue with image padding which was being applied *after* the border, causing it to act as if it was additional margin.