### PR TITLE
[Diagnostics]: add `NOT_CHECKED` value to `cache_status` parameter of `get_offerings_result` event

### DIFF
--- a/Sources/Caching/CacheStatus.swift
+++ b/Sources/Caching/CacheStatus.swift
@@ -15,4 +15,5 @@ enum CacheStatus: String, Codable {
     case stale = "STALE"
     case notFound = "NOT_FOUND"
     case valid = "VALID"
+    case notChecked = "NOT_CHECKED"
 }

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -654,6 +654,35 @@ extension OfferingsManagerTests {
         expect(params.responseTime) >= 0
     }
 
+    func testOfferingsTracksOfferingsResultEventCorrectlyWhenFetchCurrent() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        // given
+        // swiftlint:disable:next force_cast
+        let mockDiagnosticsTracker = self.mockDiagnosticsTracker as! MockDiagnosticsTracker
+
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
+
+        // when
+        _ = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID, fetchCurrent: true) {
+                completed($0)
+            }
+        }
+
+        // then
+        expect(mockDiagnosticsTracker.trackedOfferingsStartedCount.value) == 1
+        expect(mockDiagnosticsTracker.trackedOfferingsResultParams.value.count) == 1
+        let params = try XCTUnwrap(mockDiagnosticsTracker.trackedOfferingsResultParams.value.first)
+        expect(params.requestedProductIds) == ["monthly_freetrial"]
+        expect(params.notFoundProductIds) == []
+        expect(params.errorMessage) == nil
+        expect(params.errorCode) == nil
+        expect(params.verificationResult) == nil
+        expect(params.cacheStatus) == .notChecked
+        expect(params.responseTime) >= 0
+    }
+
     func testOfferingsDoesNotTrackEventsIfDiagnosticsTrackingDisabled() throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 


### PR DESCRIPTION
This PR adds the `NOT_CHECKED` cache status value to the `get_offerings_result` diagnostics event when the offerings are fetch from the network regardless of the cache status