### PR TITLE
[Diagnostics] Fix cache fetch policy key not matching specs

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -100,7 +100,7 @@ struct DiagnosticsEvent: Codable, Equatable {
         let winBackOfferApplied: Bool?
         let purchaseResult: PurchaseResult?
         let cacheStatus: CacheStatus?
-        let cacheFetchPolicy: String?
+        let fetchPolicy: String?
         let hadUnsyncedPurchasesBefore: Bool?
         let isRetry: Bool?
         let eligibilityUnknownCount: Int?
@@ -175,7 +175,7 @@ struct DiagnosticsEvent: Codable, Equatable {
             self.winBackOfferApplied = winBackOfferApplied
             self.purchaseResult = purchaseResult
             self.cacheStatus = cacheStatus
-            self.cacheFetchPolicy = cacheFetchPolicy.map { $0.diagnosticsName }
+            self.fetchPolicy = cacheFetchPolicy.map { $0.diagnosticsName }
             self.hadUnsyncedPurchasesBefore = hadUnsyncedPurchasesBefore
             self.isRetry = isRetry
             self.eligibilityUnknownCount = eligibilityUnknownCount

--- a/Tests/UnitTests/Networking/Requests/DiagnosticsEventEncodingTests.swift
+++ b/Tests/UnitTests/Networking/Requests/DiagnosticsEventEncodingTests.swift
@@ -45,6 +45,7 @@ class DiagnosticsEventEncodingTests: TestCase {
             promotionalOfferId: "promotionalOfferId",
             winBackOfferApplied: false,
             purchaseResult: .userCancelled,
+            cacheFetchPolicy: .cachedOrFetched,
             isRetry: true
         ),
         timestamp: dateFormatter.date(from: "2022-03-08T17:42:58Z")!,

--- a/Tests/UnitTests/Networking/Requests/__Snapshots__/DiagnosticsEventEncodingTests/testEncoding.1.json
+++ b/Tests/UnitTests/Networking/Requests/__Snapshots__/DiagnosticsEventEncodingTests/testEncoding.1.json
@@ -8,6 +8,7 @@
     "error_code" : 1,
     "error_message" : "OK",
     "etag_hit" : false,
+    "fetch_policy" : "CACHED_OR_FETCHED",
     "is_retry" : true,
     "not_found_product_ids" : [
       "test_product_id2"


### PR DESCRIPTION
### Description
We were naming the key for the cache fetch policy as `cache_fetch_policy`, but we expected `fetch_policy`. This fixes the property name moving forward