### PR TITLE
Use Swift Int for VirtualCurrencyInfo.balance

### DIFF
--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -107,7 +107,7 @@ extension CustomerInfoResponse {
 
     #if ENABLE_VIRTUAL_CURRENCIES
     internal struct VirtualCurrencyInfo {
-        let balance: Int64
+        let balance: Int
     }
     #endif
 

--- a/Sources/Purchasing/VirtualCurrencyInfo.swift
+++ b/Sources/Purchasing/VirtualCurrencyInfo.swift
@@ -23,11 +23,8 @@ import Foundation
 @objc(RCVirtualCurrencyInfo)
 public final class VirtualCurrencyInfo: NSObject {
 
-    /// The current balance of the virtual currency.
-    ///
-    /// This property represents the amount of virtual currency currently available.
-    /// The balance is represented as an integer value.
-    @objc public let balance: Int64
+    /// The customer's current balance of the virtual currency.
+    @objc public let balance: Int
 
     init(with virtualCurrencyInfo: CustomerInfoResponse.VirtualCurrencyInfo) {
         self.balance = virtualCurrencyInfo.balance


### PR DESCRIPTION
We recently decided to limit the maximum value of a virtual currency's balance to be a 32-bit signed integer. With this new limitation in mind, there's no need to use an Int64 for `balance`, so this PR change this to be a generic Swift `Int` instead. This simplifies the API a bit since developers are generally more familiar with `Int`s than they are with `Int64`s.

Swift's `Int` is a 32-bit signed integer on 32-bit devices, and is a 64-bit signed integer on 64-bit devices [source](https://developer.apple.com/documentation/swift/int).

This is technically a breaking change, but since the virtual currency feature is still in beta, this is okay. 👍

NOTE: No changes to the API testers were required 👍