### PR TITLE
Only preview `RestorePurchasesAlert` on iOS

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
@@ -267,8 +267,6 @@ extension View {
 
 }
 
-#endif
-
 #if DEBUG
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable)
@@ -306,4 +304,6 @@ private struct PreviewContainer: View {
             }
     }
 }
+#endif
+
 #endif


### PR DESCRIPTION
#4922 broke watchOS tests because we were building the previews on wathOS