### PR TITLE
Remove Identifiable conformance from StoreKit2PurchaseIntentListenerType

### DIFF
--- a/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
@@ -164,6 +164,9 @@ protocol StoreKit2PurchaseIntentType: Equatable, Sendable {
     // the conformance is not available in earlier versions of iOS, and this will
     // cause a runtime crash when trying to typecast a StoreKit.PurchaseIntent
     // to a StoreKit2PurchaseIntentType in iOS 16.4..<18.0.
+    //
+    // See https://github.com/RevenueCat/purchases-ios/pull/4964
+    // and https://github.com/RevenueCat/purchases-ios/issues/4963 for more details.
 
     var product: StoreKit.Product { get }
 

--- a/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
@@ -159,6 +159,12 @@ struct StorePurchaseIntent: Sendable, Equatable {
 @available(visionOS, unavailable)
 protocol StoreKit2PurchaseIntentType: Equatable, Sendable {
 
+    // WARNING: **DO NOT** make this type conform to Identifiable!!!
+    // While StoreKit.PurchaseIntent conforms to Identifiable in iOS 18+,
+    // the conformance is not available in earlier versions of iOS, and this will
+    // cause a runtime crash when trying to typecast a StoreKit.PurchaseIntent
+    // to a StoreKit2PurchaseIntentType in iOS 16.4..<18.0.
+
     var product: StoreKit.Product { get }
 
     #if compiler(>=6.0)

--- a/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
@@ -157,7 +157,7 @@ struct StorePurchaseIntent: Sendable, Equatable {
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 @available(visionOS, unavailable)
-protocol StoreKit2PurchaseIntentType: Equatable, Identifiable, Sendable {
+protocol StoreKit2PurchaseIntentType: Equatable, Sendable {
 
     var product: StoreKit.Product { get }
 


### PR DESCRIPTION
### Description
Addresses this issue: https://github.com/RevenueCat/purchases-ios/issues/4963

This PR removes `StoreKit2PurchaseIntentListenerType`'s `Identifiable` conformance to prevent crashes on iOS 16 & 17 when a purchase intent is received.