### PR TITLE
Add new APIs to CustomEntitlementsComputationMode SDK

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		1E568B512ACC6A8300D3C12F /* StoreMessageTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E568B502ACC6A8300D3C12F /* StoreMessageTypeTests.swift */; };
 		1E5F8F6E2C4515430041EECD /* View+PresentCustomerCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E5F8F6D2C4515430041EECD /* View+PresentCustomerCenter.swift */; };
 		1E5F8F782C46BBD90041EECD /* CustomerCenterAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E5F8F772C46BBD90041EECD /* CustomerCenterAction.swift */; };
+		1E72C4962DA632D5009226C9 /* ConfigurationInCustomEntitlementsComputation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E72C4952DA632D5009226C9 /* ConfigurationInCustomEntitlementsComputation.swift */; };
 		1E8A60422CDBD75A0034ACF3 /* WebPurchaseRedemption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E8A60412CDBD75A0034ACF3 /* WebPurchaseRedemption.swift */; };
 		1E8A607F2CDCE5EC0034ACF3 /* View+OnRedeemWebPurchaseAttempt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E8A607E2CDCE5EC0034ACF3 /* View+OnRedeemWebPurchaseAttempt.swift */; };
 		1E98EC092CDE567100A751C0 /* URL+WebPurchaseRedemption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E98EC082CDE567100A751C0 /* URL+WebPurchaseRedemption.swift */; };
@@ -1358,6 +1359,7 @@
 		1E568B502ACC6A8300D3C12F /* StoreMessageTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessageTypeTests.swift; sourceTree = "<group>"; };
 		1E5F8F6D2C4515430041EECD /* View+PresentCustomerCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+PresentCustomerCenter.swift"; sourceTree = "<group>"; };
 		1E5F8F772C46BBD90041EECD /* CustomerCenterAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterAction.swift; sourceTree = "<group>"; };
+		1E72C4952DA632D5009226C9 /* ConfigurationInCustomEntitlementsComputation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationInCustomEntitlementsComputation.swift; sourceTree = "<group>"; };
 		1E8A60412CDBD75A0034ACF3 /* WebPurchaseRedemption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPurchaseRedemption.swift; sourceTree = "<group>"; };
 		1E8A607E2CDCE5EC0034ACF3 /* View+OnRedeemWebPurchaseAttempt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+OnRedeemWebPurchaseAttempt.swift"; sourceTree = "<group>"; };
 		1E98EC082CDE567100A751C0 /* URL+WebPurchaseRedemption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+WebPurchaseRedemption.swift"; sourceTree = "<group>"; };
@@ -3875,6 +3877,7 @@
 				006E105DDA8D0D0FA32D690C /* StoreKit2 */,
 				2D1015DC275A57DB0086173F /* StoreKitAbstractions */,
 				B325543B2825C81800DA62EA /* Configuration.swift */,
+				1E72C4952DA632D5009226C9 /* ConfigurationInCustomEntitlementsComputation.swift */,
 				B32B750026868C1D005647BF /* EntitlementInfo.swift */,
 				B3AA6235268A81C700894871 /* EntitlementInfos.swift */,
 				B3DF6A4F269524080030D57C /* IntroEligibility.swift */,
@@ -6375,6 +6378,7 @@
 				F5BE44432698581100254A30 /* AttributionTypeFactory.swift in Sources */,
 				4FA4C8DA2A168956007D2803 /* OfflineCustomerInfoCreator.swift in Sources */,
 				2D971CC12744364C0093F35F /* SKError+Extensions.swift in Sources */,
+				1E72C4962DA632D5009226C9 /* ConfigurationInCustomEntitlementsComputation.swift in Sources */,
 				1E473B682AC43254008B07F9 /* StoreMessageType.swift in Sources */,
 				57F2C60C29784C11009EE527 /* SwiftVersionCheck.swift in Sources */,
 				57EAE527274324C60060EB74 /* Lock.swift in Sources */,

--- a/Sources/Misc/StoreKitVersion.swift
+++ b/Sources/Misc/StoreKitVersion.swift
@@ -35,6 +35,13 @@ public extension StoreKitVersion {
     /// Let RevenueCat use the most appropiate version of StoreKit
     static let `default` = Self.storeKit2
 
+    #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
+    /// Let RevenueCat use the most appropiate version of StoreKit
+    static let defaultForCustomEntitlementComputation = Self.storeKit1
+
+    #endif
+
 }
 
 extension StoreKitVersion: CustomDebugStringConvertible {

--- a/Sources/Purchasing/ConfigurationInCustomEntitlementsComputation.swift
+++ b/Sources/Purchasing/ConfigurationInCustomEntitlementsComputation.swift
@@ -1,0 +1,229 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Configuration.swift
+//
+//  Created by Joshua Liebowitz on 5/6/22.
+
+import Foundation
+
+#if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
+// swiftlint:disable type_name
+/**
+ * ``ConfigurationInCustomEntitlementsComputation`` can be used when configuring the ``Purchases`` instance.
+ * It is not required to be used, but highly recommended. This class follows a builder pattern.
+ *
+ * To configure your `Purchases` instance using this object, follow these steps.
+ *
+ * **Steps:**
+ * 1. Call ``ConfigurationInCustomEntitlementsComputation/builder(withAPIKey:)``
+ *  To obtain a ``ConfigurationInCustomEntitlementsComputation/Builder`` object.
+ * 2. Set this builder's properties using the "`with(`" functions.
+ * 3. Call ``ConfigurationInCustomEntitlementsComputation/Builder/build()`` to obtain the
+ *  `ConfigurationInCustomEntitlementsComputation` object.
+ * 4. Pass the `ConfigurationInCustomEntitlementsComputation` object into
+ *  ``Purchases/configureInCustomEntitlementsComputationMode(with:)``.
+ *
+ * ```swift
+ * let configuration = ConfigurationInCustomEntitlementsComputation.Builder(withAPIKey: "MyKey",
+ *                                                                          appUserID: "SomeAppUserID).build()
+ *  Purchases.configure(with: configuration)
+ * ```
+ */
+public final class ConfigurationInCustomEntitlementsComputation: NSObject {
+
+    static let storeKitRequestTimeoutDefault: TimeInterval = 30
+    static let networkTimeoutDefault: TimeInterval = 60
+
+    let apiKey: String
+    let appUserID: String?
+    internal let observerMode: Bool
+    internal let userDefaults: UserDefaults?
+    let storeKitVersion: StoreKitVersion
+    internal let dangerousSettings: DangerousSettings?
+    internal let networkTimeout: TimeInterval
+    internal let storeKit1Timeout: TimeInterval
+    internal let platformInfo: Purchases.PlatformInfo?
+    internal let responseVerificationMode: Signing.ResponseVerificationMode
+    let showStoreMessagesAutomatically: Bool
+    internal let diagnosticsEnabled: Bool
+
+    private init(with builder: Builder) {
+        Self.verify(apiKey: builder.apiKey)
+
+        self.apiKey = builder.apiKey
+        self.appUserID = builder.appUserID
+        self.observerMode = builder.observerMode
+        self.userDefaults = builder.userDefaults
+        self.storeKitVersion = builder.storeKitVersion
+        self.dangerousSettings = builder.dangerousSettings
+        self.storeKit1Timeout = builder.storeKit1Timeout
+        self.networkTimeout = builder.networkTimeout
+        self.platformInfo = builder.platformInfo
+        self.responseVerificationMode = builder.responseVerificationMode
+        self.showStoreMessagesAutomatically = builder.showStoreMessagesAutomatically
+        self.diagnosticsEnabled = builder.diagnosticsEnabled
+    }
+
+    /// Factory method for the ``Configuration/Builder`` object that is required to create a `Configuration`
+    @objc public static func builder(withAPIKey apiKey: String, appUserID: String) -> Builder {
+        return Builder(withAPIKey: apiKey, appUserID: appUserID)
+    }
+
+    /// The Builder for ```ConfigurationInCustomEntitlementsComputation```.
+    public class Builder: NSObject {
+
+        private static let minimumTimeout: TimeInterval = 5
+
+        private(set) var apiKey: String
+        private(set) var appUserID: String?
+        internal var observerMode: Bool {
+            switch purchasesAreCompletedBy {
+            case .revenueCat:
+                return false
+            case .myApp:
+                return true
+            }
+        }
+        private(set) internal var purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat
+        private(set) internal var userDefaults: UserDefaults?
+        private(set) internal var dangerousSettings: DangerousSettings? = DangerousSettings(
+            customEntitlementComputation: true
+        )
+        private(set) internal var networkTimeout = Configuration.networkTimeoutDefault
+        private(set) internal var storeKit1Timeout = Configuration.storeKitRequestTimeoutDefault
+        private(set) internal var platformInfo: Purchases.PlatformInfo?
+        private(set) internal var responseVerificationMode: Signing.ResponseVerificationMode = .default
+        private(set) var showStoreMessagesAutomatically: Bool = true
+        private(set) internal var diagnosticsEnabled: Bool = false
+        private(set) var storeKitVersion: StoreKitVersion = .defaultForCustomEntitlementComputation
+
+        /**
+         * Create a new builder with your API key.
+         * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
+         */
+        @objc public init(withAPIKey apiKey: String, appUserID: String) {
+            self.apiKey = apiKey
+            self.appUserID = appUserID
+        }
+
+        /// Update your API key.
+        @objc public func with(apiKey: String) -> Builder {
+            self.apiKey = apiKey
+            return self
+        }
+
+        /**
+         * Set an `appUserID`.
+         * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
+         * purchases and subscriptions across devices. Pass `nil` or an empty string if you want ``Purchases``
+         * to generate this for you.
+         *
+         * - Note: Best practice is to use a salted hash of your unique app user ids.
+         *
+         * - Important: Set this property if you have your own user identifiers that you manage.
+         */
+        @_disfavoredOverload
+        @objc public func with(appUserID: String?) -> Builder {
+            self.appUserID = appUserID
+            return self
+        }
+
+        @available(*, deprecated, message: """
+        The appUserID passed to configure is a constant string known at compile time.
+        This is likely a programmer error. This ID is used to identify the current user.
+        See https://docs.revenuecat.com/docs/user-ids for more information.
+        """)
+        // swiftlint:disable:next missing_docs
+        public func with(appUserID: StaticString) -> ConfigurationInCustomEntitlementsComputation.Builder {
+            Logger.warn(Strings.identity.logging_in_with_static_string)
+            return self.with(appUserID: "\(appUserID)")
+        }
+
+        /// Set `showStoreMessagesAutomatically`. Enabled by default.
+        /// If enabled, if the user has billing issues, has yet to accept a price increase consent, is eligible for a
+        /// win-back offer, or there are other messages from StoreKit, they will be displayed automatically when
+        /// the app is initialized.
+        ///
+        /// If you want to disable this behavior so that you can customize when these messages are shown, make sure
+        /// you configure the SDK as early as possible in the app's lifetime, otherwise messages will be displayed
+        /// automatically.
+        /// Then use the ``Purchases/showStoreMessages(for:)`` method to display the messages.
+        /// More information:  https://rev.cat/storekit-message
+        /// - Important: Set this property only if you're using Swift. If you're using ObjC, you won't be able to call
+        /// the related methods
+        @objc public func with(showStoreMessagesAutomatically: Bool) -> Builder {
+            self.showStoreMessagesAutomatically = showStoreMessagesAutomatically
+            return self
+        }
+
+        /// Set ``StoreKitVersion``.
+        ///
+        /// Defaults to ``StoreKitVersion/default`` which lets the SDK select
+        /// the most appropriate version of StoreKit. Currently defaults to StoreKit 2.
+        ///
+        /// - Note: StoreKit 2 is only available on iOS 15+. StoreKit 1 will be used for previous iOS versions
+        /// regardless of this setting.
+        ///
+        /// ### Related Symbols
+        /// - ``StoreKitVersion``
+        @objc public func with(storeKitVersion version: StoreKitVersion) -> Builder {
+            self.storeKitVersion = version
+            return self
+        }
+
+        /// Generate a ``Configuration`` object given the values configured by this builder.
+        @objc public func build() -> ConfigurationInCustomEntitlementsComputation {
+            return ConfigurationInCustomEntitlementsComputation(with: self)
+        }
+
+    }
+
+}
+
+// swiftlint:enable type_name
+
+// MARK: - API Key Validation
+
+// Visible for testing
+extension ConfigurationInCustomEntitlementsComputation {
+
+    enum APIKeyValidationResult {
+        case validApplePlatform
+        case otherPlatforms
+        case legacy
+    }
+
+    static func validate(apiKey: String) -> APIKeyValidationResult {
+        if applePlatformKeyPrefixes.contains(where: { prefix in apiKey.hasPrefix(prefix) }) {
+            // Apple key format: "apple_CtDdmbdWBySmqJeeQUTyrNxETUVkajsJ"
+            return .validApplePlatform
+        } else if apiKey.contains("_") {
+            // Other platforms format: "otherplatform_CtDdmbdWBySmqJeeQUTyrNxETUVkajsJ"
+            return .otherPlatforms
+        } else {
+            // Legacy key format: "CtDdmbdWBySmqJeeQUTyrNxETUVkajsJ"
+            return .legacy
+        }
+    }
+
+    fileprivate static func verify(apiKey: String) {
+        switch self.validate(apiKey: apiKey) {
+        case .validApplePlatform: break
+        case .legacy: Logger.debug(Strings.configure.legacyAPIKey)
+        case .otherPlatforms: Logger.error(Strings.configure.invalidAPIKey)
+        }
+    }
+
+    private static let applePlatformKeyPrefixes: Set<String> = ["appl_", "mac_"]
+
+}
+
+#endif

--- a/Sources/Purchasing/Purchases/PurchaseParams.swift
+++ b/Sources/Purchasing/Purchases/PurchaseParams.swift
@@ -13,8 +13,6 @@
 
 import Foundation
 
-#if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-
 /**
  * ``PurchaseParams`` can be used to add configuration options when making a purchase.
  * This class follows the builder pattern.
@@ -34,24 +32,39 @@ import Foundation
     let package: Package?
     let product: StoreProduct?
     let promotionalOffer: PromotionalOffer?
+
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
     let winBackOffer: WinBackOffer?
     let metadata: [String: String]?
 
+    #endif
+
     private init(with builder: Builder) {
         self.promotionalOffer = builder.promotionalOffer
-        self.metadata = builder.metadata
         self.product = builder.product
         self.package = builder.package
+
+        #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
         self.winBackOffer = builder.winBackOffer
+        self.metadata = builder.metadata
+
+        #endif
     }
 
     /// The Builder for ```PurchaseParams```.
     @objc(RCPurchaseParamsBuilder) public class Builder: NSObject {
         private(set) var promotionalOffer: PromotionalOffer?
-        private(set) var metadata: [String: String]?
         private(set) var package: Package?
         private(set) var product: StoreProduct?
+
+        #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
         private(set) var winBackOffer: WinBackOffer?
+        private(set) var metadata: [String: String]?
+
+        #endif
 
         /**
          * Create a new builder with a ``Package``.
@@ -83,6 +96,8 @@ import Foundation
             return self
         }
 
+        #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
         #if ENABLE_TRANSACTION_METADATA
         /**
          * Set `metadata`.
@@ -109,11 +124,11 @@ import Foundation
             return self
         }
 
+        #endif
+
         /// Generate a ``Configuration`` object given the values configured by this builder.
         @objc public func build() -> PurchaseParams {
             return PurchaseParams(with: self)
         }
     }
 }
-
-#endif

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1052,8 +1052,6 @@ public extension Purchases {
         return try await self.restorePurchasesAsync()
     }
 
-    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-
     @objc(purchaseWithParams:completion:)
     func purchase(_ params: PurchaseParams, completion: @escaping PurchaseCompletedBlock) {
         purchasesOrchestrator.purchase(params: params, trackDiagnostics: true, completion: completion)
@@ -1062,6 +1060,8 @@ public extension Purchases {
     func purchase(_ params: PurchaseParams) async throws -> PurchaseResultData {
         return try await purchaseAsync(params)
     }
+
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     @objc func invalidateCustomerInfoCache() {
         self.customerInfoManager.clearCustomerInfoCache(forAppUserID: appUserID)
@@ -1163,8 +1163,6 @@ public extension Purchases {
     }
 #endif
 
-    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-
     @objc(getPromotionalOfferForProductDiscount:withProduct:withCompletion:)
     func getPromotionalOffer(forProductDiscount discount: StoreProductDiscount,
                              product: StoreProduct,
@@ -1183,8 +1181,6 @@ public extension Purchases {
     func eligiblePromotionalOffers(forProduct product: StoreProduct) async -> [PromotionalOffer] {
         return await eligiblePromotionalOffersAsync(forProduct: product)
     }
-
-    #endif
 
 #if os(iOS) || os(macOS) || VISION_OS
 
@@ -1330,6 +1326,8 @@ public extension Purchases {
 
 public extension Purchases {
 
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
     /**
      * Configures an instance of the Purchases SDK with a specified ``Configuration``.
      *
@@ -1398,8 +1396,6 @@ public extension Purchases {
     @discardableResult static func configure(with builder: Configuration.Builder) -> Purchases {
         return Self.configure(with: builder.build())
     }
-
-    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     /**
      * Configures an instance of the Purchases SDK with a specified API key.
@@ -1560,11 +1556,50 @@ public extension Purchases {
     @objc(configureInCustomEntitlementsModeWithApiKey:appUserID:)
     @discardableResult static func configureInCustomEntitlementsComputationMode(apiKey: String,
                                                                                 appUserID: String) -> Purchases {
-        Self.configure(
-            with: .builder(withAPIKey: apiKey)
-                .with(appUserID: appUserID)
-                .with(dangerousSettings: DangerousSettings(customEntitlementComputation: true))
-                .build())
+        Self.configureInCustomEntitlementsComputationMode(
+            with: .builder(withAPIKey: apiKey, appUserID: appUserID).build())
+    }
+
+    /**
+     * Configures an instance of the Purchases SDK with a specified ``ConfigurationInCustomEntitlementsComputation``.
+     *
+     * The instance will be set as a singleton.
+     * You should access the singleton instance using ``Purchases/shared``
+     *
+     * - Parameter configuration: The ``Configuration`` object you wish to use to configure ``Purchases``
+     *
+     * - Returns: An instantiated ``Purchases`` object that has been set as a singleton.
+     *
+     * - Important: See ``Configuration/Builder`` for more information about configurable properties.
+     *
+     * ### Example
+     *
+     * ```swift
+     *  Purchases.configureInCustomEntitlementComputationMode(
+     *      with: Configuration.Builder(withAPIKey: Constants.apiKey)
+     *               .with(purchasesAreCompletedBy: .revenueCat)
+     *               .with(appUserID: "<app_user_id>")
+     *               .build()
+     *      )
+     * ```
+     *
+     */
+    @discardableResult static func configureInCustomEntitlementsComputationMode(
+        with configuration: ConfigurationInCustomEntitlementsComputation
+    ) -> Purchases {
+        configure(withAPIKey: configuration.apiKey,
+                  appUserID: configuration.appUserID,
+                  observerMode: configuration.observerMode,
+                  userDefaults: configuration.userDefaults,
+                  platformInfo: configuration.platformInfo,
+                  responseVerificationMode: configuration.responseVerificationMode,
+                  storeKitVersion: configuration.storeKitVersion,
+                  storeKitTimeout: configuration.storeKit1Timeout,
+                  networkTimeout: configuration.networkTimeout,
+                  dangerousSettings: configuration.dangerousSettings,
+                  showStoreMessagesAutomatically: configuration.showStoreMessagesAutomatically,
+                  diagnosticsEnabled: configuration.diagnosticsEnabled
+        )
     }
 
     #endif

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -391,7 +391,6 @@ final class PurchasesOrchestrator {
         }
     }
 
-    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     func purchase(params: PurchaseParams, trackDiagnostics: Bool, completion: @escaping PurchaseCompletedBlock) {
         var product = params.product
         if product == nil {
@@ -402,15 +401,26 @@ final class PurchasesOrchestrator {
             fatalError("Missing product in PurchaseParams")
         }
 
+        #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
+        let winBackOffer = params.winBackOffer
+        let metadata = params.metadata
+
+        #else
+
+        let winBackOffer: WinBackOffer? = nil
+        let metadata: [String: String]? = nil
+
+        #endif
+
         purchase(product: product,
                  package: params.package,
                  promotionalOffer: params.promotionalOffer?.signedData,
-                 winBackOffer: params.winBackOffer,
-                 metadata: params.metadata,
+                 winBackOffer: winBackOffer,
+                 metadata: metadata,
                  trackDiagnostics: trackDiagnostics,
                  completion: completion)
     }
-    #endif
 
     func purchase(product: StoreProduct,
                   package: Package?,


### PR DESCRIPTION
### Description
This adds some new APIs to our `CustomEntitlementsComputationMode` SDK:
- A new `ConfigurationInCustomEntitlementsComputationMode` builder to configure the SDK, including the option to select storeKit versions
- A new `configureInCustomEntitlementsComputationMode` that takes a `ConfigurationInCustomEntitlementsComputationMode` parameter
- Exposes methods to obtain `PromotionalOffer` from a product/discount
- Exposes purchase method that takes a `PurchaseParams` that accepts a `PromotionalOffer`.