### PR TITLE
Make Paywalls v2 Text use verbatim

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -50,7 +50,7 @@ struct TextComponentView: View {
             )
         ) { style in
             if style.visible {
-                Text(.init(style.text))
+                Text(verbatim: style.text)
                     .font(style.font)
                     .fontWeight(style.fontWeight)
                     .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
### Motivation

The `TextViewComponent` component could end up using localized values in the developer's app

### Description

Have the `TextViewComponent` use the `Text(verbatim:)` constructor so it doesn't attempt to localize anything

(This was _intended_ when developing this but was not done correctly)

| Before | After (with fix) |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-09 at 09 47 34](https://github.com/user-attachments/assets/b46dba30-17e1-41fe-9f46-cb86a157b78f) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-09 at 09 47 01](https://github.com/user-attachments/assets/b9f72e75-adce-4286-bc1a-bbcecc70332b) | 
