### PR TITLE
[Diagnostics] add `host` parameter to `http_request_performed` event

### DIFF
--- a/Sources/Diagnostics/DiagnosticsEvent.swift
+++ b/Sources/Diagnostics/DiagnosticsEvent.swift
@@ -81,6 +81,7 @@ struct DiagnosticsEvent: Codable, Equatable {
     struct Properties: Codable, Equatable {
         let verificationResult: String?
         let endpointName: String?
+        let host: String?
         let responseTimeMillis: Int?
         let storeKitVersion: String?
         let successful: Bool?
@@ -119,6 +120,7 @@ struct DiagnosticsEvent: Codable, Equatable {
 
         init(verificationResult: String? = nil,
              endpointName: String? = nil,
+             host: String? = nil,
              responseTime: TimeInterval? = nil,
              storeKitVersion: StoreKitVersion? = nil,
              successful: Bool? = nil,
@@ -156,6 +158,7 @@ struct DiagnosticsEvent: Codable, Equatable {
              reason: String? = nil) {
             self.verificationResult = verificationResult
             self.endpointName = endpointName
+            self.host = host
             self.responseTimeMillis = responseTime.map { Int($0 * 1000) }
             self.storeKitVersion = storeKitVersion.map { "store_kit_\($0.debugDescription)" }
             self.successful = successful

--- a/Sources/Diagnostics/DiagnosticsTracker.swift
+++ b/Sources/Diagnostics/DiagnosticsTracker.swift
@@ -37,6 +37,7 @@ protocol DiagnosticsTrackerType: Sendable {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func trackHttpRequestPerformed(endpointName: String,
+                                   host: String?,
                                    responseTime: TimeInterval,
                                    wasSuccessful: Bool,
                                    responseCode: Int,
@@ -235,6 +236,7 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
     }
 
     func trackHttpRequestPerformed(endpointName: String,
+                                   host: String?,
                                    responseTime: TimeInterval,
                                    wasSuccessful: Bool,
                                    responseCode: Int,
@@ -246,6 +248,7 @@ final class DiagnosticsTracker: DiagnosticsTrackerType, Sendable {
                         properties: DiagnosticsEvent.Properties(
                             verificationResult: verificationResult.name,
                             endpointName: endpointName,
+                            host: host,
                             responseTime: responseTime,
                             successful: wasSuccessful,
                             responseCode: responseCode,

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -506,6 +506,7 @@ private extension HTTPClient {
         }
 
         self.trackHttpRequestPerformedIfNeeded(request: request,
+                                               host: urlRequest.url?.host,
                                                requestStartTime: requestStartTime,
                                                result: response)
 
@@ -598,6 +599,7 @@ private extension HTTPClient {
     }
 
     private func trackHttpRequestPerformedIfNeeded(request: Request,
+                                                   host: String?,
                                                    requestStartTime: Date,
                                                    result: Result<VerifiedHTTPResponse<Data>, NetworkError>?) {
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
@@ -609,6 +611,7 @@ private extension HTTPClient {
                 let httpStatusCode = response.httpStatusCode.rawValue
                 let verificationResult = response.verificationResult
                 diagnosticsTracker.trackHttpRequestPerformed(endpointName: requestPathName,
+                                                             host: host,
                                                              responseTime: responseTime,
                                                              wasSuccessful: true,
                                                              responseCode: httpStatusCode,
@@ -624,6 +627,7 @@ private extension HTTPClient {
                     backendErrorCode = errorResponse.code.rawValue
                 }
                 diagnosticsTracker.trackHttpRequestPerformed(endpointName: requestPathName,
+                                                             host: host,
                                                              responseTime: responseTime,
                                                              wasSuccessful: false,
                                                              responseCode: responseCode,

--- a/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
+++ b/Tests/UnitTests/Diagnostics/DiagnosticsTrackerTests.swift
@@ -125,6 +125,7 @@ class DiagnosticsTrackerTests: TestCase {
 
     func testTracksHttpRequestPerformedWithExpectedParameters() async {
         self.tracker.trackHttpRequestPerformed(endpointName: "mock_endpoint",
+                                               host: "api.revenuecat.com",
                                                responseTime: 50,
                                                wasSuccessful: true,
                                                responseCode: 200,

--- a/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
+++ b/Tests/UnitTests/Mocks/MockDiagnosticsTracker.swift
@@ -32,10 +32,11 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
 
     let trackedHttpRequestPerformedParams: Atomic<[
         // swiftlint:disable:next large_tuple
-        (String, TimeInterval, Bool, Int, Int?, HTTPResponseOrigin?, VerificationResult, Bool)
+        (String, String?, TimeInterval, Bool, Int, Int?, HTTPResponseOrigin?, VerificationResult, Bool)
     ]> = .init([])
     // swiftlint:disable:next function_parameter_count
     func trackHttpRequestPerformed(endpointName: String,
+                                   host: String?,
                                    responseTime: TimeInterval,
                                    wasSuccessful: Bool,
                                    responseCode: Int,
@@ -46,6 +47,7 @@ final class MockDiagnosticsTracker: DiagnosticsTrackerType, Sendable {
         self.trackedHttpRequestPerformedParams.modify {
             $0.append(
                 (endpointName,
+                 host,
                  responseTime,
                  wasSuccessful,
                  responseCode,

--- a/Tests/UnitTests/Networking/Requests/DiagnosticsEventEncodingTests.swift
+++ b/Tests/UnitTests/Networking/Requests/DiagnosticsEventEncodingTests.swift
@@ -26,6 +26,7 @@ class DiagnosticsEventEncodingTests: TestCase {
         properties: DiagnosticsEvent.Properties(
             verificationResult: "FAILED",
             endpointName: HTTPRequest.Path.logIn.name,
+            host: "api.revenuecat.com",
             responseTime: 3,
             storeKitVersion: .storeKit1,
             successful: true,

--- a/Tests/UnitTests/Networking/Requests/__Snapshots__/DiagnosticsEventEncodingTests/testEncoding.1.json
+++ b/Tests/UnitTests/Networking/Requests/__Snapshots__/DiagnosticsEventEncodingTests/testEncoding.1.json
@@ -9,6 +9,7 @@
     "error_message" : "OK",
     "etag_hit" : false,
     "fetch_policy" : "CACHED_OR_FETCHED",
+    "host" : "api.revenuecat.com",
     "is_retry" : true,
     "not_found_product_ids" : [
       "test_product_id2"


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Description
Adds a new `host` parameter to the existing`http_request_performed` diagnostics event, which can be useful with the new logic for retry requests using fallback hosts when receiving a server-down response