### PR TITLE
Fix Magic Weather SwiftUI compilation error

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Helpers/Extensions.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Helpers/Extensions.swift
@@ -25,7 +25,7 @@ extension Package {
     }
 }
 
-extension SubscriptionPeriod {
+extension RevenueCat.SubscriptionPeriod {
     var durationTitle: String {
         switch self.unit {
         case .day: return "day"


### PR DESCRIPTION
### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
The Magic Weather SwiftUI example app has a compilation error.
The extension on `SubscriptionPeriod` is ambiguous due to a name clash between `StoreKit.SubscriptionPeriod` and `RevenueCatSubscriptionPeriod`.

### Description
Applying these changes will specify the namespace, therefore fix the issue.
