### PR TITLE
Revert "Make Paywalls v2 Text use verbatim"

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -50,7 +50,7 @@ struct TextComponentView: View {
             )
         ) { style in
             if style.visible {
-                Text(verbatim: style.text)
+                Text(.init(style.text))
                     .font(style.font)
                     .fontWeight(style.fontWeight)
                     .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
Reverts RevenueCat/purchases-ios#4975

Using `verbatim` doesn't apply markdown. Also need to figure out why snapshot tests didn't fail with this one.