### PR TITLE
Fix Paywalls v2 Text component to not localized from bundle but support markdown

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -129,6 +129,7 @@ struct TextComponentView_Previews: PreviewProvider {
                 localizationProvider: .init(
                     locale: Locale.current,
                     localizedStrings: [
+                        // swiftlint:disable:next line_length
                         "id_1": .string("Hello, world\n**bold**\n_italic_ \n`code`\n[RevenueCat](https://revenuecat.com)")
                     ]
                 ),

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -74,7 +74,9 @@ private struct NonLocalizedMarkdownText: View {
     let fontWeight: Font.Weight
 
     var markdownText: AttributedString? {
-        return try? AttributedString(markdown: self.text)
+        return try? AttributedString(
+            markdown: self.text.replacingOccurrences(of: "\n", with: "  \n")
+        )
     }
 
     var body: some View {
@@ -127,7 +129,7 @@ struct TextComponentView_Previews: PreviewProvider {
                 localizationProvider: .init(
                     locale: Locale.current,
                     localizedStrings: [
-                        "id_1": .string("Hello, world **bold** _italic_ `code` [RevenueCat](https://revenuecat.com)")
+                        "id_1": .string("Hello, world\n**bold**\n_italic_ \n`code`\n[RevenueCat](https://revenuecat.com)")
                     ]
                 ),
                 uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
@@ -148,7 +150,7 @@ struct TextComponentView_Previews: PreviewProvider {
                 localizationProvider: .init(
                     locale: Locale.current,
                     localizedStrings: [
-                        "id_1": .string("Hello, world **bold _italic `code [RevenueCat](https://revenuecat.com")
+                        "id_1": .string("Hello, world\n**bold\n_italic\n`code \n[RevenueCat](https://revenuecat.com")
                     ]
                 ),
                 uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -75,6 +75,8 @@ private struct NonLocalizedMarkdownText: View {
 
     var markdownText: AttributedString? {
         return try? AttributedString(
+            // AttributedString allegedly uses CommonMark hard line breaks
+            // which is two or more spaces before line break
             markdown: self.text.replacingOccurrences(of: "\n", with: "  \n")
         )
     }

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -141,6 +141,27 @@ struct TextComponentView_Previews: PreviewProvider {
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Markdown")
 
+        // Markdown - Invalid
+        TextComponentView(
+            // swiftlint:disable:next force_try
+            viewModel: try! .init(
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("Hello, world **bold _italic `code [RevenueCat](https://revenuecat.com")
+                    ]
+                ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                component: .init(
+                    text: "id_1",
+                    color: .init(light: .hex("#000000"))
+                )
+            )
+        )
+        .previewRequiredEnvironmentProperties()
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Markdown - Invalid")
+
         // Custom Font
         VStack {
             TextComponentView(

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -50,9 +50,7 @@ struct TextComponentView: View {
             )
         ) { style in
             if style.visible {
-                Text(verbatim: style.text)
-                    .font(style.font)
-                    .fontWeight(style.fontWeight)
+                NonLocalizedMarkdownText(text: style.text, font: style.font, fontWeight: style.fontWeight)
                     .fixedSize(horizontal: false, vertical: true)
                     .multilineTextAlignment(style.textAlignment)
                     .foregroundColorScheme(style.color)
@@ -65,6 +63,33 @@ struct TextComponentView: View {
         }
     }
 
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+/// Parses markdown using AttributedString and does not use bundle assets for localization
+private struct NonLocalizedMarkdownText: View {
+
+    let text: String
+    let font: Font
+    let fontWeight: Font.Weight
+
+    var markdownText: AttributedString? {
+        return try? AttributedString(markdown: self.text)
+    }
+
+    var body: some View {
+        Group {
+            if let markdownText = self.markdownText {
+                Text(markdownText)
+                    .font(self.font)
+                    .fontWeight(self.fontWeight)
+            } else {
+                Text(verbatim: self.text)
+                    .font(self.font)
+                    .fontWeight(self.fontWeight)
+            }
+        }
+    }
 }
 
 #if DEBUG
@@ -94,6 +119,27 @@ struct TextComponentView_Previews: PreviewProvider {
         .previewRequiredEnvironmentProperties()
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Default")
+
+        // Markdown
+        TextComponentView(
+            // swiftlint:disable:next force_try
+            viewModel: try! .init(
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("Hello, world **bold** _italic_ `code` [RevenueCat](https://revenuecat.com)")
+                    ]
+                ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                component: .init(
+                    text: "id_1",
+                    color: .init(light: .hex("#000000"))
+                )
+            )
+        )
+        .previewRequiredEnvironmentProperties()
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Markdown")
 
         // Custom Font
         VStack {


### PR DESCRIPTION
### Motivation

Fixes #4986

### Description

- Manually attempts to parse text with `AttributedString(markdown:)` and sets that into `Text`
  - This prevents attempting to look up localized strings from bundle
- Falls back to using `Text(verbatim:)`
  - If markdown failed to parse, probably more important to not localize

| Markdown | Invalid Markdown |
|--------|--------|
| <img width="631" alt="Screenshot 2025-04-14 at 11 51 27 AM" src="https://github.com/user-attachments/assets/0d0f9e5f-a8c3-4453-895b-12ba0f70b988" /> | <img width="635" alt="Screenshot 2025-04-14 at 11 51 34 AM" src="https://github.com/user-attachments/assets/9a0cf197-8694-4d12-8d20-6bd136a40f80" /> | 