### PR TITLE
fix: Unify finding active transaction for customer center

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -716,6 +716,7 @@
 		57ACB12428174B9F000DCC9F /* CustomerInfo+TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ACB12328174B9F000DCC9F /* CustomerInfo+TestExtensions.swift */; };
 		57ACB12528174B9F000DCC9F /* CustomerInfo+TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ACB12328174B9F000DCC9F /* CustomerInfo+TestExtensions.swift */; };
 		57ACB13728184CF1000DCC9F /* DecoderExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ACB13628184CF1000DCC9F /* DecoderExtensionTests.swift */; };
+		57B179D32DAE4C9A009A5CFE /* CustomerInfo+ActiveTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B179D22DAE4C94009A5CFE /* CustomerInfo+ActiveTransaction.swift */; };
 		57BA943128330ACA00CD5FC5 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BA943028330ACA00CD5FC5 /* ConfigurationTests.swift */; };
 		57BB070E28D27A2B007F5DF0 /* CachingProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BB070D28D27A2B007F5DF0 /* CachingProductsManager.swift */; };
 		57BB071628D282A4007F5DF0 /* CachingProductsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BB071528D282A4007F5DF0 /* CachingProductsManagerTests.swift */; };
@@ -2063,6 +2064,7 @@
 		57AC4C1B2770F56200DDE30F /* SK1StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreProduct.swift; sourceTree = "<group>"; };
 		57ACB12328174B9F000DCC9F /* CustomerInfo+TestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+TestExtensions.swift"; sourceTree = "<group>"; };
 		57ACB13628184CF1000DCC9F /* DecoderExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderExtensionTests.swift; sourceTree = "<group>"; };
+		57B179D22DAE4C94009A5CFE /* CustomerInfo+ActiveTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+ActiveTransaction.swift"; sourceTree = "<group>"; };
 		57B530E52858F3FD00FA4E37 /* SwiftStyleGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SwiftStyleGuide.swift; path = Contributing/SwiftStyleGuide.swift; sourceTree = "<group>"; };
 		57BA943028330ACA00CD5FC5 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		57BB070D28D27A2B007F5DF0 /* CachingProductsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingProductsManager.swift; sourceTree = "<group>"; };
@@ -4019,6 +4021,7 @@
 		35D41B412D40354A000621C7 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				57B179D22DAE4C94009A5CFE /* CustomerInfo+ActiveTransaction.swift */,
 				57CD17262D9D830F00B4B667 /* CustomerCenterConfigDataSupport+URL.swift */,
 				35D41B422D403550000621C7 /* Store+Localization.swift */,
 			);
@@ -7005,6 +7008,7 @@
 				35C200B12C39254100B9778B /* FeedbackSurveyView.swift in Sources */,
 				35F249CC2C493DCC0058993A /* CustomerCenterPurchasesType.swift in Sources */,
 				887A60672C1D037000E1A461 /* PaywallError.swift in Sources */,
+				57B179D32DAE4C9A009A5CFE /* CustomerInfo+ActiveTransaction.swift in Sources */,
 				2C74574B2CEA6B80004ACE52 /* LocalizationProvider.swift in Sources */,
 				77BA1AB12CCBAB80009BF0EA /* RootViewModel.swift in Sources */,
 				4D21041E2CF548790095D254 /* GradientView.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
+++ b/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
@@ -43,7 +43,11 @@ class LoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
         do {
             let customerInfo = try await self.purchasesProvider.customerInfo(fetchPolicy: .default)
 
-            let subscribedProduct = try await getActiveSubscription(customerInfo)
+            guard let activeTransaction = customerInfo.findActiveTransaction() else {
+                return .failure(CustomerCenterError.couldNotFindOfferForActiveProducts)
+            }
+
+            let subscribedProduct = try await getActiveSubscription(activeTransaction.productIdentifier)
             let discount = try findDiscount(for: subscribedProduct,
                                             productIdentifier: subscribedProduct.productIdentifier,
                                             promoOfferDetails: promoOfferDetails)
@@ -71,9 +75,8 @@ class LoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
 @available(watchOS, unavailable)
 private extension LoadPromotionalOfferUseCase {
 
-    private func getActiveSubscription(_ customerInfo: CustomerInfo) async throws -> StoreProduct {
-        guard let productIdentifier = customerInfo.earliestExpiringAppStoreEntitlement()?.productIdentifier,
-              let subscribedProduct = await self.purchasesProvider.products([productIdentifier]).first else {
+    private func getActiveSubscription(_ productId: String) async throws -> StoreProduct {
+        guard let subscribedProduct = await self.purchasesProvider.products([productId]).first else {
             Logger.warning(Strings.could_not_offer_for_any_active_subscriptions)
             throw CustomerCenterError.couldNotFindSubscriptionInformation
         }

--- a/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
+++ b/RevenueCatUI/CustomerCenter/Data/LoadPromotionalOfferUseCase.swift
@@ -43,7 +43,7 @@ class LoadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType {
         do {
             let customerInfo = try await self.purchasesProvider.customerInfo(fetchPolicy: .default)
 
-            guard let activeTransaction = customerInfo.findActiveTransaction() else {
+            guard let activeTransaction = customerInfo.earliestExpiringTransaction() else {
                 return .failure(CustomerCenterError.couldNotFindOfferForActiveProducts)
             }
 

--- a/RevenueCatUI/CustomerCenter/Extensions/CustomerInfo+ActiveTransaction.swift
+++ b/RevenueCatUI/CustomerCenter/Extensions/CustomerInfo+ActiveTransaction.swift
@@ -1,0 +1,43 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerInfo+ActiveTransaction.swift
+//
+//  Created by Facundo Menzella on 14/4/25.
+
+import RevenueCat
+
+extension CustomerInfo {
+
+    func findActiveTransaction() -> Transaction? {
+        let activeSubscriptions = subscriptionsByProductIdentifier.values
+            .filter(\.isActive)
+            .sorted(by: {
+                guard let date1 = $0.expiresDate, let date2 = $1.expiresDate else {
+                    return $0.expiresDate != nil
+                }
+                return date1 < date2
+            })
+
+        let (activeAppleSubscriptions, otherActiveSubscriptions) = (
+            activeSubscriptions.filter { $0.store == .appStore },
+            activeSubscriptions.filter { $0.store != .appStore }
+        )
+
+        let (appleNonSubscriptions, otherNonSubscriptions) = (
+            nonSubscriptions.filter { $0.store == .appStore },
+            nonSubscriptions.filter { $0.store != .appStore }
+        )
+
+        return activeAppleSubscriptions.first ??
+        appleNonSubscriptions.first ??
+        otherActiveSubscriptions.first ??
+        otherNonSubscriptions.first
+    }
+}

--- a/RevenueCatUI/CustomerCenter/Extensions/CustomerInfo+ActiveTransaction.swift
+++ b/RevenueCatUI/CustomerCenter/Extensions/CustomerInfo+ActiveTransaction.swift
@@ -15,7 +15,20 @@ import RevenueCat
 
 extension CustomerInfo {
 
-    func findActiveTransaction() -> Transaction? {
+    /// Returns the earliest expiring `Transaction`.
+    ///
+    /// The logic prioritizes active App Store subscriptions first, followed by:
+    /// 1. Active App Store subscriptions
+    /// 2. Non-subscription App Store transactions
+    /// 3. Active subscriptions from other stores
+    /// 4. Non-subscription transactions from other stores
+    ///
+    /// Within each group, transactions are sorted by their expiration date in ascending order.
+    ///
+    /// - Note: This is a **temporary** implementation and should eventually be replaced by
+    ///         backend-side logic for consistency and accuracy.
+    ///
+    func earliestExpiringTransaction() -> Transaction? {
         let activeSubscriptions = subscriptionsByProductIdentifier.values
             .filter(\.isActive)
             .sorted(by: {

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -168,7 +168,7 @@ private extension CustomerCenterViewModel {
             return
         }
 
-        guard let activeTransaction = findActiveTransaction(customerInfo: customerInfo) else {
+        guard let activeTransaction = customerInfo.findActiveTransaction() else {
             Logger.warning(Strings.could_not_find_subscription_information)
             self.purchaseInformation = nil
             throw CustomerCenterError.couldNotFindSubscriptionInformation

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -168,7 +168,7 @@ private extension CustomerCenterViewModel {
             return
         }
 
-        guard let activeTransaction = customerInfo.findActiveTransaction() else {
+        guard let activeTransaction = customerInfo.earliestExpiringTransaction() else {
             Logger.warning(Strings.could_not_find_subscription_information)
             self.purchaseInformation = nil
             throw CustomerCenterError.couldNotFindSubscriptionInformation
@@ -192,32 +192,6 @@ private extension CustomerCenterViewModel {
                 URLUtilities.openURLIfNotAppExtension(url)
             }
         }
-    }
-
-    func findActiveTransaction(customerInfo: CustomerInfo) -> Transaction? {
-        let activeSubscriptions = customerInfo.subscriptionsByProductIdentifier.values
-            .filter(\.isActive)
-            .sorted(by: {
-                guard let date1 = $0.expiresDate, let date2 = $1.expiresDate else {
-                    return $0.expiresDate != nil
-                }
-                return date1 < date2
-            })
-
-        let (activeAppleSubscriptions, otherActiveSubscriptions) = (
-            activeSubscriptions.filter { $0.store == .appStore },
-            activeSubscriptions.filter { $0.store != .appStore }
-        )
-
-        let (appleNonSubscriptions, otherNonSubscriptions) = (
-            customerInfo.nonSubscriptions.filter { $0.store == .appStore },
-            customerInfo.nonSubscriptions.filter { $0.store != .appStore }
-        )
-
-        return activeAppleSubscriptions.first ??
-        appleNonSubscriptions.first ??
-        otherActiveSubscriptions.first ??
-        otherNonSubscriptions.first
     }
 
     func createPurchaseInformation(for transaction: Transaction,


### PR DESCRIPTION
### Motivation
We've noticed that we have two different logics to find the active transaction. 
Entitlements are optional, so we shouldn't rely on those to find it. 

### Description
The correct way was in CustomerCenterViewModel, so I've extracted that into an extension.
