### PR TITLE
[Paywalls v2] Fixes decoding `TabControlType`

### DIFF
--- a/Sources/Paywalls/Components/PaywallTabsComponent.swift
+++ b/Sources/Paywalls/Components/PaywallTabsComponent.swift
@@ -121,6 +121,28 @@ public extension PaywallComponent {
             public enum TabControlType: Codable, Sendable, Hashable, Equatable {
                 case buttons
                 case toggle
+
+                public init(from decoder: Decoder) throws {
+                    let container = try decoder.singleValueContainer()
+                    let value = try container.decode(String.self)
+
+                    switch value {
+                    case "buttons": self = .buttons
+                    case "toggle": self = .toggle
+                    default: throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Invalid TabControlType: \(value)"
+                    )
+                    }
+                }
+
+                public func encode(to encoder: Encoder) throws {
+                    var container = encoder.singleValueContainer()
+                    switch self {
+                    case .buttons: try container.encode("buttons")
+                    case .toggle: try container.encode("toggle")
+                    }
+                }
             }
 
             public let type: TabControlType

--- a/Sources/Paywalls/Components/PaywallTabsComponent.swift
+++ b/Sources/Paywalls/Components/PaywallTabsComponent.swift
@@ -118,31 +118,9 @@ public extension PaywallComponent {
 
         final public class TabControl: Codable, Sendable, Hashable, Equatable {
 
-            public enum TabControlType: Codable, Sendable, Hashable, Equatable {
+            public enum TabControlType: String, Codable, Sendable, Hashable, Equatable {
                 case buttons
                 case toggle
-
-                public init(from decoder: Decoder) throws {
-                    let container = try decoder.singleValueContainer()
-                    let value = try container.decode(String.self)
-
-                    switch value {
-                    case "buttons": self = .buttons
-                    case "toggle": self = .toggle
-                    default: throw DecodingError.dataCorruptedError(
-                        in: container,
-                        debugDescription: "Invalid TabControlType: \(value)"
-                    )
-                    }
-                }
-
-                public func encode(to encoder: Encoder) throws {
-                    var container = encoder.singleValueContainer()
-                    switch self {
-                    case .buttons: try container.encode("buttons")
-                    case .toggle: try container.encode("toggle")
-                    }
-                }
             }
 
             public let type: TabControlType


### PR DESCRIPTION
## Bug
Decoding the `TabControlType` gave errors such as
```
Paywall V2 Error: [
    "componentsConfig": RevenueCat.PaywallComponentsData.EquatableError(
        description: "typeMismatch(
            Swift.Dictionary<Swift.String, Any>, 
            Swift.DecodingError.Context(
                codingPath: [
                    CodingKeys(stringValue: \"offerings\", intValue: nil), 
                    _CodingKey(stringValue: \"Index 45\", intValue: 45), 
                    CodingKeys(stringValue: \"paywallComponents\", intValue: nil), 
                    CodingKeys(stringValue: \"componentsConfig\", intValue: nil), 
                    CodingKeys(stringValue: \"base\", intValue: nil), 
                    CodingKeys(stringValue: \"stack\", intValue: nil), 
                    CodingKeys(stringValue: \"components\", intValue: nil), 
                    _CodingKey(stringValue: \"Index 2\", intValue: 2), 
                    CodingKeys(stringValue: \"control\", intValue: nil), 
                    CodingKeys(stringValue: \"type\", intValue: nil)
                ], 
                debugDescription: \"Expected to decode Dictionary<String, Any> but found a string instead.\", 
                underlyingError: nil
            )
        )"
    )
]
```

## Fix
This PR fixes that by manually decoding the `TabControlType` to a string.