### PR TITLE
[Paywalls v2] fixes crash when getting invalid URL from paywall components localization

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
@@ -13,7 +13,7 @@
 //
 
 import Foundation
-import RevenueCat
+@_spi(Internal) import RevenueCat
 
 #if !os(macOS) && !os(tvOS) // For Paywalls V2
 
@@ -113,12 +113,12 @@ class ButtonComponentViewModel {
 fileprivate extension PaywallComponent.LocalizationDictionary {
 
     func urlFromLid(_ urlLid: String) throws -> URL {
-        let urlString = try string(key: urlLid)
-        let url = URL(string: urlString)
-        if url == nil {
+        do {
+            return try url(key: urlLid)
+        } catch {
             Logger.error(Strings.paywall_invalid_url(urlLid))
+            throw error
         }
-        return url!
     }
 
 }

--- a/Sources/Paywalls/Components/Common/PaywallComponentLocalization.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentLocalization.swift
@@ -34,6 +34,16 @@ extension PaywallComponent.LocalizationDictionary {
         return value
     }
 
+    @_spi(Internal) public func url(key: String) throws -> URL {
+        let string = try self.string(key: key)
+        guard let url = URL(string: string) else {
+            throw LocalizationValidationError.invalidUrl(
+                "Invalid URL localization for property with id: \"\(key)\": \"\(string)\""
+            )
+        }
+        return url
+    }
+
 }
 
 enum LocalizationValidationError: Error {


### PR DESCRIPTION
This code would produce a runtime crash when getting a `nil` url

```
func urlFromLid(_ urlLid: String) throws -> URL {
    let urlString = try string(key: urlLid)
    let url = URL(string: urlString)
    if url == nil {
        Logger.error(Strings.paywall_invalid_url(urlLid))
    }
    return url! // <-- Crash here
}
```
