### PR TITLE
fix compilation issues in older versions of Xcode

### DIFF
--- a/Sources/Support/DebugUI/ProductStatus+Icon.swift
+++ b/Sources/Support/DebugUI/ProductStatus+Icon.swift
@@ -18,16 +18,16 @@ extension PurchasesDiagnostics.ProductStatus {
     var icon: some View {
         switch self {
         case .valid:
-            Image(systemName: "checkmark.circle.fill")
+            return Image(systemName: "checkmark.circle.fill")
                 .foregroundColor(.green)
         case .couldNotCheck, .unknown:
-            Image(systemName: "questionmark.circle.fill")
+            return Image(systemName: "questionmark.circle.fill")
                 .foregroundColor(.gray)
         case .notFound:
-            Image(systemName: "xmark.circle.fill")
+            return Image(systemName: "xmark.circle.fill")
                 .foregroundColor(.red)
         case .actionInProgress, .needsAction:
-            Image(systemName: "exclamationmark.triangle.fill")
+            return Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundColor(.yellow)
         }
     }

--- a/Sources/Support/DebugUI/SDKHealthCheckStatus+Icon.swift
+++ b/Sources/Support/DebugUI/SDKHealthCheckStatus+Icon.swift
@@ -18,13 +18,13 @@ extension PurchasesDiagnostics.SDKHealthCheckStatus {
     var icon: some View {
         switch self {
         case .passed:
-            Image(systemName: "checkmark.circle.fill")
+            return Image(systemName: "checkmark.circle.fill")
                 .foregroundColor(.green)
         case .failed:
-            Image(systemName: "xmark.circle.fill")
+            return Image(systemName: "xmark.circle.fill")
                 .foregroundColor(.red)
         case .warning:
-            Image(systemName: "exclamationmark.triangle.fill")
+            return Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundColor(.yellow)
         }
     }

--- a/Sources/Support/DebugUI/SDKHealthStatus+Icon.swift
+++ b/Sources/Support/DebugUI/SDKHealthStatus+Icon.swift
@@ -18,10 +18,10 @@ extension PurchasesDiagnostics.SDKHealthStatus {
     var icon: some View {
         switch self {
         case let .healthy(warnings):
-            Image(systemName: warnings.count > 0 ? "checkmark.circle.badge.questionmark.fill" : "checkmark.circle.fill")
+            return Image(systemName: warnings.count > 0 ? "checkmark.circle.badge.questionmark.fill" : "checkmark.circle.fill")
                 .foregroundColor(.green)
         case .unhealthy:
-            Image(systemName: "xmark.circle.fill")
+            return Image(systemName: "xmark.circle.fill")
                 .foregroundColor(.red)
         }
 

--- a/Sources/Support/DebugUI/SDKHealthStatus+Icon.swift
+++ b/Sources/Support/DebugUI/SDKHealthStatus+Icon.swift
@@ -18,7 +18,9 @@ extension PurchasesDiagnostics.SDKHealthStatus {
     var icon: some View {
         switch self {
         case let .healthy(warnings):
-            return Image(systemName: warnings.count > 0 ? "checkmark.circle.badge.questionmark.fill" : "checkmark.circle.fill")
+            return Image(systemName: warnings.count > 0
+                         ? "checkmark.circle.badge.questionmark.fill"
+                         : "checkmark.circle.fill")
                 .foregroundColor(.green)
         case .unhealthy:
             return Image(systemName: "xmark.circle.fill")

--- a/Sources/Support/HealthReport+Validate.swift
+++ b/Sources/Support/HealthReport+Validate.swift
@@ -181,12 +181,12 @@ extension HealthReport {
 
     private func status(from productCheckStatus: ProductStatus) -> PurchasesDiagnostics.ProductStatus {
         switch productCheckStatus {
-        case .valid: .valid
-        case .couldNotCheck: .couldNotCheck
-        case .notFound: .notFound
-        case .actionInProgress: .actionInProgress
-        case .needsAction: .needsAction
-        case .unknown: .unknown
+        case .valid: return .valid
+        case .couldNotCheck: return .couldNotCheck
+        case .notFound: return .notFound
+        case .actionInProgress: return .actionInProgress
+        case .needsAction: return .needsAction
+        case .unknown: return .unknown
         }
     }
 }


### PR DESCRIPTION
### Description

The builds are failing on CI when using Xcode 14. This is due to some code recently added that uses some newer features of Swift that are not available in Xcode 14.