### PR TITLE
Fix Backwards compatibility errors introduced by new `testSDKHealthCheck` implementation

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -548,6 +548,7 @@
 		537B4B382DA9744B00CEFF4C /* SDKHealthStatus+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B362DA9744B00CEFF4C /* SDKHealthStatus+Icon.swift */; };
 		537B4B392DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B352DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift */; };
 		537B4B3A2DA9744B00CEFF4C /* ProductStatus+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B342DA9744B00CEFF4C /* ProductStatus+Icon.swift */; };
+		537BA85B2DBBFAF200C93327 /* SDKHealthError+CustomNSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537BA85A2DBBFAE700C93327 /* SDKHealthError+CustomNSError.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
 		57045B3C29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */; };
@@ -1913,6 +1914,7 @@
 		537B4B342DA9744B00CEFF4C /* ProductStatus+Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductStatus+Icon.swift"; sourceTree = "<group>"; };
 		537B4B352DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthCheckStatus+Icon.swift"; sourceTree = "<group>"; };
 		537B4B362DA9744B00CEFF4C /* SDKHealthStatus+Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthStatus+Icon.swift"; sourceTree = "<group>"; };
+		537BA85A2DBBFAE700C93327 /* SDKHealthError+CustomNSError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthError+CustomNSError.swift"; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
 		57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProductEntitlementMappingOperation.swift; sourceTree = "<group>"; };
 		57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingCallback.swift; sourceTree = "<group>"; };
@@ -4093,6 +4095,7 @@
 				A5F0104D2717B3150090732D /* BeginRefundRequestHelper.swift */,
 				35E840C5270FB47C00899AE2 /* ManageSubscriptionsHelper.swift */,
 				578C5F2B28DB82DD00A56F02 /* PurchasesDiagnostics.swift */,
+				537BA85A2DBBFAE700C93327 /* SDKHealthError+CustomNSError.swift */,
 				57F2C60B29784C11009EE527 /* SwiftVersionCheck.swift */,
 				57C0BB6829F840BD00827807 /* FrameworkDisambiguation.swift */,
 				4FE6669E2A2F95A1004EEAFC /* PaywallExtensions.swift */,
@@ -6442,6 +6445,7 @@
 				88AD01132C740CF400AA1F2B /* PaywallTextComponent.swift in Sources */,
 				B37815492857F1E7000A7B93 /* BackendConfiguration.swift in Sources */,
 				57045B3C29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift in Sources */,
+				537BA85B2DBBFAF200C93327 /* SDKHealthError+CustomNSError.swift in Sources */,
 				4FBBD4E62A620573001CBA21 /* PaywallColor.swift in Sources */,
 				B35042C626CDD3B100905B95 /* PurchasesDelegate.swift in Sources */,
 				0313FD41268A506400168386 /* DateProvider.swift in Sources */,

--- a/Sources/Support/DebugUI/DebugContentViews.swift
+++ b/Sources/Support/DebugUI/DebugContentViews.swift
@@ -451,7 +451,7 @@ private struct DebugPackageView: View {
 
 @available(iOS 16.0, macOS 13.0, *)
 private struct DebugStatusDetailsView: View {
-    let errors: [PurchasesDiagnostics.Error]
+    let errors: [PurchasesDiagnostics.SDKHealthError]
 
     var body: some View {
         List {

--- a/Sources/Support/DebugUI/DebugViewModel.swift
+++ b/Sources/Support/DebugUI/DebugViewModel.swift
@@ -161,7 +161,7 @@ extension DebugViewModel {
         }
     }
 
-    var errorsToExpandOn: [PurchasesDiagnostics.Error] {
+    var errorsToExpandOn: [PurchasesDiagnostics.SDKHealthError] {
         switch self.diagnosticsResult {
         case .loading: return []
         case let .loaded(healthReport):

--- a/Sources/Support/DebugUI/ProductStatus+Icon.swift
+++ b/Sources/Support/DebugUI/ProductStatus+Icon.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Pol Piella on 4/10/25.
 
+#if DEBUG
 import SwiftUI
 
 @available(iOS 16.0, macOS 13.0, *)
@@ -32,3 +33,4 @@ extension PurchasesDiagnostics.ProductStatus {
         }
     }
 }
+#endif

--- a/Sources/Support/DebugUI/SDKHealthCheckStatus+Icon.swift
+++ b/Sources/Support/DebugUI/SDKHealthCheckStatus+Icon.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Pol Piella on 4/10/25.
 
+#if DEBUG
 import SwiftUI
 
 @available(iOS 16.0, macOS 13.0, *)
@@ -29,3 +30,4 @@ extension PurchasesDiagnostics.SDKHealthCheckStatus {
         }
     }
 }
+#endif

--- a/Sources/Support/DebugUI/SDKHealthStatus+Icon.swift
+++ b/Sources/Support/DebugUI/SDKHealthStatus+Icon.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Pol Piella on 4/10/25.
 
+#if DEBUG
 import SwiftUI
 
 @available(iOS 16.0, macOS 13.0, *)
@@ -29,3 +30,4 @@ extension PurchasesDiagnostics.SDKHealthStatus {
 
     }
 }
+#endif

--- a/Sources/Support/HealthReport+Validate.swift
+++ b/Sources/Support/HealthReport+Validate.swift
@@ -62,7 +62,7 @@ extension HealthReport {
         )
     }
 
-    func error(from check: HealthCheck) -> PurchasesDiagnostics.Error {
+    func error(from check: HealthCheck) -> PurchasesDiagnostics.SDKHealthError {
         switch check.name {
         case .apiKey: return .invalidAPIKey
         case .bundleId: return createBundleIdError(from: check)
@@ -72,14 +72,14 @@ extension HealthReport {
         }
     }
 
-    private func createBundleIdError(from check: HealthCheck) -> PurchasesDiagnostics.Error {
+    private func createBundleIdError(from check: HealthCheck) -> PurchasesDiagnostics.SDKHealthError {
         guard case let .bundleId(payload) = check.details else {
             return .invalidBundleId(nil)
         }
         return .invalidBundleId(.init(appBundleId: payload.appBundleId, sdkBundleId: payload.sdkBundleId))
     }
 
-    private func createProductsError(from check: HealthCheck) -> PurchasesDiagnostics.Error {
+    private func createProductsError(from check: HealthCheck) -> PurchasesDiagnostics.SDKHealthError {
         guard case let .products(payload) = check.details else {
             return .invalidProducts([])
         }
@@ -87,7 +87,7 @@ extension HealthReport {
         return .invalidProducts(payload.products.map(createProductPayload))
     }
 
-    private func createOfferingsError(from check: HealthCheck) -> PurchasesDiagnostics.Error {
+    private func createOfferingsError(from check: HealthCheck) -> PurchasesDiagnostics.SDKHealthError {
         guard case let .offeringsProducts(payload) = check.details else {
             return .offeringConfiguration([])
         }

--- a/Sources/Support/HealthReport+Validate.swift
+++ b/Sources/Support/HealthReport+Validate.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Pol Piella on 4/10/25.
 
+#if DEBUG
 extension HealthReport {
     func validate() -> PurchasesDiagnostics.SDKHealthReport {
         guard let firstFailedCheck = self.checks.first(where: { $0.status == .failed }) else {
@@ -190,3 +191,4 @@ extension HealthReport {
         }
     }
 }
+#endif

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -201,11 +201,11 @@ extension PurchasesDiagnostics {
         case unhealthy(PurchasesDiagnostics.SDKHealthError)
     }
 
+    /// Perform tests to ensure SDK is configured correctly.
+    /// - `Throws`: ``PurchasesDiagnostics/Error`` if any step fails
     @available(*, deprecated, message: """
     Use the `PurchasesDiagnostics.shared.checkSDKHealth()` method instead.
     """)
-    /// Perform tests to ensure SDK is configured correctly.
-    /// - `Throws`: ``PurchasesDiagnostics/Error`` if any step fails
     @objc(testSDKHealthWithCompletion:)
     public func testSDKHealth() async throws {
         do {
@@ -325,67 +325,6 @@ private extension PurchasesDiagnostics {
 
         default:
             return Error.unknown(error)
-        }
-    }
-
-}
-
-extension PurchasesDiagnostics.SDKHealthError : CustomNSError {
-
-    // swiftlint:disable:next missing_docs
-    public var errorUserInfo: [String: Any] {
-        return [
-            NSUnderlyingErrorKey: self.underlyingError as NSError? ?? NSNull(),
-            NSLocalizedDescriptionKey: self.localizedDescription
-        ]
-    }
-
-    var localizedDescription: String {
-        switch self {
-        case .notAuthorizedToMakePayments: return "The person is not authorized to make payments on this device"
-        case let .unknown(error): return "Unknown error: \(error.localizedDescription)"
-        case .invalidAPIKey: return "API key is not valid"
-        case .noOfferings: return "No offerings configured"
-        case let .offeringConfiguration(payload):
-            guard let offendingOffering = payload.first(where: { $0.status == .failed }) else {
-                return "Default offering is not configured correctly"
-            }
-
-            let offeringIdentifier = offendingOffering.identifier
-            let offendingPackageCount = offendingOffering.packages.filter({ $0.status != .valid }).count
-            let noPackages = "Offering '\(offeringIdentifier)' has no packages"
-            let packagesNotReady = """
-            Offering '\(offeringIdentifier)' uses \(offendingPackageCount) products \
-            that are not ready in App Store Connect
-            """
-
-            return offendingOffering.packages.isEmpty ? noPackages : packagesNotReady
-        case let .invalidBundleId(payload):
-            guard let payload else {
-                return "Bundle ID in your app does not match the Bundle ID in the RevenueCat Website"
-            }
-            let sdkBundleId = payload.sdkBundleId
-            let appBundleId = payload.appBundleId
-            return "Bundle ID in your app '\(sdkBundleId)' does not match the RevenueCat app Bundle ID '\(appBundleId)'"
-        case let .invalidProducts(products):
-            if products.isEmpty {
-                return "Your app has no products"
-            }
-
-            return "You must have at least one product approved in App Store Connect"
-        }
-    }
-
-    private var underlyingError: Swift.Error? {
-        switch self {
-        case let .unknown(error): return error
-        case .invalidAPIKey,
-                .offeringConfiguration,
-                .noOfferings,
-                .invalidBundleId,
-                .invalidProducts,
-                .notAuthorizedToMakePayments:
-            return nil
         }
     }
 

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -137,6 +137,7 @@ extension PurchasesDiagnostics {
 
     }
 
+    /// An error that represents a problem in the SDK's configuration
     public enum SDKHealthError: Swift.Error {
         /// API key is invalid
         case invalidAPIKey

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -233,7 +233,7 @@ extension PurchasesDiagnostics {
     #if DEBUG
     /// Performs a full SDK configuration health check and throws an error if the configuration is not valid.
     /// - Important: This method can not be invoked in production builds.
-    /// - Throws: The specific configuration issue that needs to be solved.
+    /// - Throws: ``SDKHealthError`` indicating the specific configuration issue that needs to be solved.
     public func checkSDKHealth() async throws {
         switch await self.healthReport().status {
         case let .unhealthy(error): throw error

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -43,8 +43,8 @@ public final class PurchasesDiagnostics: NSObject, Sendable {
     public static let `default`: PurchasesDiagnostics = .init(purchases: Purchases.shared)
 }
 
+#if DEBUG
 extension PurchasesDiagnostics {
-
     /// Enum representing the status of a product in the store
     public enum ProductStatus: Sendable {
         /// Product is configured correctly in App Store Connect
@@ -117,26 +117,6 @@ extension PurchasesDiagnostics {
         public let productTitle: String?
     }
 
-    /// An error that represents a failing step in ``PurchasesDiagnostics``
-    public enum Error: Swift.Error {
-
-        /// Connection to the API failed
-        case failedConnectingToAPI(Swift.Error)
-
-        /// API key is invalid
-        case invalidAPIKey
-
-        /// Fetching offerings failed due to the underlying error
-        case failedFetchingOfferings(Swift.Error)
-
-        /// Failure performing a signed request
-        case failedMakingSignedRequest(Swift.Error)
-
-        /// Any other not identifier error. You can check the undelying error for details.
-        case unknown(Swift.Error)
-
-    }
-
     /// An error that represents a problem in the SDK's configuration
     public enum SDKHealthError: Swift.Error {
         /// API key is invalid
@@ -161,9 +141,6 @@ extension PurchasesDiagnostics {
         case unknown(Swift.Error)
     }
 
-}
-
-extension PurchasesDiagnostics {
     /// A report that encapsulates the result of the SDK configuration health check.
     /// Use this to programmatically inspect the SDK's health status after calling `healthReport()`.
     public struct SDKHealthReport: Sendable {
@@ -200,6 +177,34 @@ extension PurchasesDiagnostics {
         /// SDK configuration is not valid and has issues that must be resolved
         case unhealthy(PurchasesDiagnostics.SDKHealthError)
     }
+}
+#endif
+
+extension PurchasesDiagnostics {
+
+    /// An error that represents a failing step in ``PurchasesDiagnostics``
+    public enum Error: Swift.Error {
+
+        /// Connection to the API failed
+        case failedConnectingToAPI(Swift.Error)
+
+        /// API key is invalid
+        case invalidAPIKey
+
+        /// Fetching offerings failed due to the underlying error
+        case failedFetchingOfferings(Swift.Error)
+
+        /// Failure performing a signed request
+        case failedMakingSignedRequest(Swift.Error)
+
+        /// Any other not identifier error. You can check the undelying error for details.
+        case unknown(Swift.Error)
+
+    }
+
+}
+
+extension PurchasesDiagnostics {
 
     /// Checks if the SDK is configured correctly.
     /// - Important: This method is intended solely for debugging configuration issues with the SDK implementation.

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -201,8 +201,10 @@ extension PurchasesDiagnostics {
         case unhealthy(PurchasesDiagnostics.SDKHealthError)
     }
 
-    /// Perform tests to ensure SDK is configured correctly.
-    /// - `Throws`: ``PurchasesDiagnostics/Error`` if any step fails
+    /// Checks if the SDK is configured correctly.
+    /// - Important: This method is intended solely for debugging configuration issues with the SDK implementation.
+    /// It should not be invoked in production builds.
+    /// - Throws: ``PurchasesDiagnostics/Error`` if any step fails
     @available(*, deprecated, message: """
     Use the `PurchasesDiagnostics.shared.checkSDKHealth()` method instead.
     """)
@@ -225,8 +227,7 @@ extension PurchasesDiagnostics {
 
     #if DEBUG
     /// Performs a full SDK configuration health check and throws an error if the configuration is not valid.
-    /// - Important: This method is intended solely for debugging configuration issues with the SDK implementation.
-    /// It should not be invoked in production builds.
+    /// - Important: This method can not be invoked in production builds.
     /// - Throws: The specific configuration issue that needs to be solved.
     public func checkSDKHealth() async throws {
         switch await self.healthReport().status {

--- a/Sources/Support/SDKHealthError+CustomNSError.swift
+++ b/Sources/Support/SDKHealthError+CustomNSError.swift
@@ -11,6 +11,8 @@
 //
 //  Created by Pol Piella Abadia on 25/04/2025.
 
+import Foundation
+
 extension PurchasesDiagnostics.SDKHealthError: CustomNSError {
 
     // swiftlint:disable:next missing_docs

--- a/Sources/Support/SDKHealthError+CustomNSError.swift
+++ b/Sources/Support/SDKHealthError+CustomNSError.swift
@@ -13,6 +13,7 @@
 
 import Foundation
 
+#if DEBUG
 extension PurchasesDiagnostics.SDKHealthError: CustomNSError {
 
     // swiftlint:disable:next missing_docs
@@ -73,3 +74,4 @@ extension PurchasesDiagnostics.SDKHealthError: CustomNSError {
     }
 
 }
+#endif

--- a/Sources/Support/SDKHealthError+CustomNSError.swift
+++ b/Sources/Support/SDKHealthError+CustomNSError.swift
@@ -1,0 +1,73 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SDKHealthError+CustomNSError.swift
+//
+//  Created by Pol Piella Abadia on 25/04/2025.
+
+extension PurchasesDiagnostics.SDKHealthError: CustomNSError {
+
+    // swiftlint:disable:next missing_docs
+    public var errorUserInfo: [String: Any] {
+        return [
+            NSUnderlyingErrorKey: self.underlyingError as NSError? ?? NSNull(),
+            NSLocalizedDescriptionKey: self.localizedDescription
+        ]
+    }
+
+    var localizedDescription: String {
+        switch self {
+        case .notAuthorizedToMakePayments: return "The person is not authorized to make payments on this device"
+        case let .unknown(error): return "Unknown error: \(error.localizedDescription)"
+        case .invalidAPIKey: return "API key is not valid"
+        case .noOfferings: return "No offerings configured"
+        case let .offeringConfiguration(payload):
+            guard let offendingOffering = payload.first(where: { $0.status == .failed }) else {
+                return "Default offering is not configured correctly"
+            }
+
+            let offeringIdentifier = offendingOffering.identifier
+            let offendingPackageCount = offendingOffering.packages.filter({ $0.status != .valid }).count
+            let noPackages = "Offering '\(offeringIdentifier)' has no packages"
+            let packagesNotReady = """
+            Offering '\(offeringIdentifier)' uses \(offendingPackageCount) products \
+            that are not ready in App Store Connect
+            """
+
+            return offendingOffering.packages.isEmpty ? noPackages : packagesNotReady
+        case let .invalidBundleId(payload):
+            guard let payload else {
+                return "Bundle ID in your app does not match the Bundle ID in the RevenueCat Website"
+            }
+            let sdkBundleId = payload.sdkBundleId
+            let appBundleId = payload.appBundleId
+            return "Bundle ID in your app '\(sdkBundleId)' does not match the RevenueCat app Bundle ID '\(appBundleId)'"
+        case let .invalidProducts(products):
+            if products.isEmpty {
+                return "Your app has no products"
+            }
+
+            return "You must have at least one product approved in App Store Connect"
+        }
+    }
+
+    private var underlyingError: Swift.Error? {
+        switch self {
+        case let .unknown(error): return error
+        case .invalidAPIKey,
+                .offeringConfiguration,
+                .noOfferings,
+                .invalidBundleId,
+                .invalidProducts,
+                .notAuthorizedToMakePayments:
+            return nil
+        }
+    }
+
+}


### PR DESCRIPTION
We recently introduced breaking changes to the `PurchasesDiagnostics` API through the `testSDKHealthCheck` method. We have decided to instead make the changes backwards compatible and instead deprecate the existing method. 

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids
