### PR TITLE
fix: Wrap viewmodel binding into another binding

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -157,7 +157,12 @@ private extension CustomerCenterView {
                 }
             }
         }
-        .manageSubscriptionsSheet(isPresented: $viewModel.manageSubscriptionsSheet)
+        // This is needed because `CustomerCenterViewModel` is isolated to @MainActor
+        // A bigger refactor is needed, but its already throwing a warning. 
+        .manageSubscriptionsSheet(isPresented: .init(
+            get: { viewModel.manageSubscriptionsSheet },
+            set: { manage in DispatchQueue.main.async { viewModel.manageSubscriptionsSheet = manage } })
+        )
         .modifier(CustomerCenterActionViewModifier(actionWrapper: viewModel.actionWrapper))
         .onCustomerCenterPromotionalOfferSuccess {
             Task {


### PR DESCRIPTION
### Motivation
We're getting this warning:

```
\CustomerCenterViewModel.manageSubscriptionsSheet is isolated to the main actor. Accessing it via Binding from a different actor will cause undefined behaviors, and potential data races; This warning will become a runtime crash in a future version of SwiftUI.
Publishing changes from background threads is not allowed; make sure to publish values from the main thread (via operators like receive(on:)) on model updates.
Publishing changes from background threads is not allowed; make sure to publish values from the main thread (via operators like receive(on:)) on model updates.
```


### Description
I missed that the SwiftUI extension is marked as `non isolated`, and it's causing this warning when displaying the manage subscriptions view.  This wraps the binding that comes from the `Published` property, into another binding that dispatches the setter to the main queue.

#### Thoughts
I am thinking that most probably `CustomerCenterViewModel` shouldn't be wrapped as `MainActor`. However, I think this wrapper can't be avoided, because the `Published` property would produce a different warning.