### PR TITLE
[Paywalls v2] Fixes blank lines not showing up

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -157,7 +157,12 @@ private extension CustomerCenterView {
                 }
             }
         }
-        .manageSubscriptionsSheet(isPresented: $viewModel.manageSubscriptionsSheet)
+        // This is needed because `CustomerCenterViewModel` is isolated to @MainActor
+        // A bigger refactor is needed, but its already throwing a warning. 
+        .manageSubscriptionsSheet(isPresented: .init(
+            get: { viewModel.manageSubscriptionsSheet },
+            set: { manage in DispatchQueue.main.async { viewModel.manageSubscriptionsSheet = manage } })
+        )
         .modifier(CustomerCenterActionViewModifier(actionWrapper: viewModel.actionWrapper))
         .onCustomerCenterPromotionalOfferSuccess {
             Task {

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -78,7 +78,7 @@ private struct NonLocalizedMarkdownText: View {
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             return try? AttributedString(
                 markdown: self.text,
-                // We want to only processing inline markdown, preserving line feeds in the original text.
+                // We want to only process inline markdown, preserving line feeds in the original text.
                 options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnly)
             )
         } else {

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -77,9 +77,9 @@ private struct NonLocalizedMarkdownText: View {
         #if swift(>=5.7)
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             return try? AttributedString(
-                // AttributedString allegedly uses CommonMark hard line breaks
-                // which is two or more spaces before line break
-                markdown: self.text.replacingOccurrences(of: "\n", with: "  \n")
+                markdown: self.text,
+                // We want to preserve whitespace and linefeeds in the original text.
+                options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace)
             )
         } else {
             return nil
@@ -186,6 +186,28 @@ struct TextComponentView_Previews: PreviewProvider {
         .previewRequiredEnvironmentProperties()
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Markdown - Invalid")
+
+        // Blank line
+        TextComponentView(
+            // swiftlint:disable:next force_try
+            viewModel: try! .init(
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        // swiftlint:disable:next line_length
+                        "id_1": .string("Before blank line.\n\nAfter blank line.")
+                    ]
+                ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                component: .init(
+                    text: "id_1",
+                    color: .init(light: .hex("#000000"))
+                )
+            )
+        )
+        .previewRequiredEnvironmentProperties()
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Blank line")
 
         // Custom Font
         VStack {

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -78,7 +78,7 @@ private struct NonLocalizedMarkdownText: View {
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             return try? AttributedString(
                 markdown: self.text,
-                // We want to preserve whitespace and linefeeds in the original text, only processing inline markdown.
+                // We want to only processing inline markdown, preserving line feeds in the original text.
                 options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnly)
             )
         } else {

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -78,8 +78,8 @@ private struct NonLocalizedMarkdownText: View {
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             return try? AttributedString(
                 markdown: self.text,
-                // We want to preserve whitespace and linefeeds in the original text.
-                options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+                // We want to preserve whitespace and linefeeds in the original text, only processing inline markdown.
+                options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnly)
             )
         } else {
             return nil
@@ -194,7 +194,6 @@ struct TextComponentView_Previews: PreviewProvider {
                 localizationProvider: .init(
                     locale: Locale.current,
                     localizedStrings: [
-                        // swiftlint:disable:next line_length
                         "id_1": .string("Before blank line.\n\nAfter blank line.")
                     ]
                 ),

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -194,6 +194,7 @@ struct TextComponentView_Previews: PreviewProvider {
                 localizationProvider: .init(
                     locale: Locale.current,
                     localizedStrings: [
+                        // swiftlint:disable:next line_length
                         "id_1": .string("Before blank line.\n\nAfter blank line.")
                     ]
                 ),

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -194,7 +194,6 @@ struct TextComponentView_Previews: PreviewProvider {
                 localizationProvider: .init(
                     locale: Locale.current,
                     localizedStrings: [
-                        // swiftlint:disable:next line_length
                         "id_1": .string("Before blank line.\n\nAfter blank line.")
                     ]
                 ),


### PR DESCRIPTION
Quick follow-up to #4990 which seems to have resulted in ignoring blank lines.

## Bug
Blank lines are ignored.

## Cause
`AttributedString` seems to ignore `\n\n`, or even `  \n  \n`. 

## Fix
Using `InterpretedSyntax.inlineOnly`. I tried `InterpretedSyntax.inlineOnlyPreservingWhitespace` as well, and both seem to fix it. I went with the former as that seemed closer to what we had, but would be totally fine with the latter as well.