### PR TITLE
[Customer center] show manage subscriptions through purchases provider

### DIFF
--- a/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
+++ b/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
@@ -86,6 +86,10 @@ extension CustomerCenterPurchasesType {
 
     let isPresented: Binding<Bool>
 
+    @_spi(Internal) public init(isPresented: Binding<Bool>) {
+        self.isPresented = isPresented
+    }
+
     @_spi(Internal) public func body(content: Content) -> some View {
         content.manageSubscriptionsSheet(isPresented: isPresented)
     }

--- a/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
+++ b/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
@@ -95,4 +95,3 @@ extension CustomerCenterPurchasesType {
         content.manageSubscriptionsSheet(isPresented: isPresented)
     }
 }
-

--- a/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
+++ b/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
@@ -63,6 +63,7 @@ import SwiftUI
     func beginRefundRequest(forProduct productID: String) async throws -> RefundRequestStatus
     #endif
 
+    @MainActor
     func manageSubscriptionsSheetViewModifier(isPresented: Binding<Bool>) -> ManageSubscriptionSheetModifier
 }
 

--- a/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
+++ b/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
@@ -13,6 +13,8 @@
 
 import Foundation
 import RevenueCat
+import StoreKit
+import SwiftUI
 
 // swiftlint:disable missing_docs
 
@@ -60,4 +62,32 @@ import RevenueCat
     @Sendable
     func beginRefundRequest(forProduct productID: String) async throws -> RefundRequestStatus
     #endif
+
+    func manageSubscriptionsSheetViewModifier(isPresented: Binding<Bool>) -> ManageSubscriptionSheetModifier
 }
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension CustomerCenterPurchasesType {
+
+    func manageSubscriptionsSheetViewModifier(isPresented: Binding<Bool>) -> ManageSubscriptionSheetModifier {
+        ManageSubscriptionSheetModifier(isPresented: isPresented)
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@_spi(Internal) public struct ManageSubscriptionSheetModifier: ViewModifier {
+
+    let isPresented: Binding<Bool>
+
+    @_spi(Internal) public func body(content: Content) -> some View {
+        content.manageSubscriptionsSheet(isPresented: isPresented)
+    }
+}
+

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -158,11 +158,11 @@ private extension CustomerCenterView {
             }
         }
         // This is needed because `CustomerCenterViewModel` is isolated to @MainActor
-        // A bigger refactor is needed, but its already throwing a warning. 
-        .manageSubscriptionsSheet(isPresented: .init(
+        // A bigger refactor is needed, but its already throwing a warning.
+        .modifier(self.viewModel.purchasesProvider.manageSubscriptionsSheetViewModifier(isPresented: .init(
             get: { viewModel.manageSubscriptionsSheet },
-            set: { manage in DispatchQueue.main.async { viewModel.manageSubscriptionsSheet = manage } })
-        )
+            set: { manage in DispatchQueue.main.async { viewModel.manageSubscriptionsSheet = manage } }
+        )))
         .modifier(CustomerCenterActionViewModifier(actionWrapper: viewModel.actionWrapper))
         .onCustomerCenterPromotionalOfferSuccess {
             Task {


### PR DESCRIPTION
### Motivation
In order to have the Customer Center previews functionality in the RC app, we need all the interactions of the Customer Center with StoreKit to go though the `CustomerCenterPurchasesType`

### Description
This PR adds a method in `CustomerCenterPurchasesType` that wraps `View`'s `manageSubscriptionsSheet(isPresented:)` method in StoreKit. This way, the RC app can add its own logic to this use case.

Thanks @facumenzella for your help on this!