### PR TITLE
Support closing paywall if purchasing through Web Paywall Link URL with an `inapp` method

### DIFF
--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -284,6 +284,12 @@ class CustomerInfoManager {
         }
     }
 
+    func clearCustomerInfoCacheTimestamp(forAppUserID appUserID: String) {
+        self.modifyData {
+            $0.deviceCache.clearCustomerInfoCacheTimestamp(appUserID: appUserID)
+        }
+    }
+
     func setLastSentCustomerInfo(_ info: CustomerInfo) {
         self.modifyData {
             $0.lastSentCustomerInfo = info

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1112,6 +1112,10 @@ public extension Purchases {
         self.customerInfoManager.clearCustomerInfoCache(forAppUserID: appUserID)
     }
 
+    @objc func markCustomerInfoCacheAsStale() {
+        self.customerInfoManager.clearCustomerInfoCacheTimestamp(forAppUserID: appUserID)
+    }
+
     @objc func syncPurchases(completion: ((CustomerInfo?, PublicError?) -> Void)?) {
         self.purchasesOrchestrator.syncPurchases { @Sendable in
             completion?($0.value, $0.error?.asPublicError)


### PR DESCRIPTION
### Description
This adds some extra logic so, if we open a URL that is a WPL, we will:
- Mark the CustomerInfo cache as stale, so it will be fetched from network next time it's requested.
- After closing an `inapp` WPL URL, we will fetch CustomerInfo and ask to close the paywall (no `onPurchaseCompleted` callback called currently).