### PR TITLE
chore: Make StoreProductDiscountType @__spi public

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -815,6 +815,7 @@
 		57F3C10529B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F3C10429B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift */; };
 		57F3C10C29B7EAE90004FD7E /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357D16038F07915D7825D /* MockUserDefaults.swift */; };
 		57F7DAAB2D9E906200855622 /* RuntimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F7DAAA2D9E906100855622 /* RuntimeUtils.swift */; };
+		57F9726B2DC3EF9500C6E540 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F9726A2DC3EF9500C6E540 /* MockStoreProductDiscount.swift */; };
 		57FD7B1528DA4037009CA4E4 /* PurchasesType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FD7B1428DA4037009CA4E4 /* PurchasesType.swift */; };
 		57FDAA962846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAA952846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift */; };
 		57FDAA9A2846C2BD009A48F1 /* PurchasesDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAA992846C2BD009A48F1 /* PurchasesDelegateTests.swift */; };
@@ -2145,6 +2146,7 @@
 		57F2C60B29784C11009EE527 /* SwiftVersionCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftVersionCheck.swift; sourceTree = "<group>"; };
 		57F3C10429B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+ActiveDates.swift"; sourceTree = "<group>"; };
 		57F7DAAA2D9E906100855622 /* RuntimeUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeUtils.swift; sourceTree = "<group>"; };
+		57F9726A2DC3EF9500C6E540 /* MockStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreProductDiscount.swift; sourceTree = "<group>"; };
 		57FD7B1428DA4037009CA4E4 /* PurchasesType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesType.swift; sourceTree = "<group>"; };
 		57FDAA952846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesTransactionHandlingTests.swift; sourceTree = "<group>"; };
 		57FDAA992846C2BD009A48F1 /* PurchasesDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesDelegateTests.swift; sourceTree = "<group>"; };
@@ -5351,6 +5353,7 @@
 		FD6186522D1393E2007843DA /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				57F9726A2DC3EF9500C6E540 /* MockStoreProductDiscount.swift */,
 				35617C772D5A45F900612B7A /* MockLoadPromotionalOfferUseCase.swift */,
 				356523A92CF885CE00B6E3EA /* MockCustomerCenterPurchases.swift */,
 				FD6186532D1393FA007843DA /* MockCustomerCenterStoreKitUtilities.swift */,
@@ -7148,6 +7151,7 @@
 				887A63402C1D177800E1A461 /* Template5ViewTests.swift in Sources */,
 				35617C782D5A460400612B7A /* MockLoadPromotionalOfferUseCase.swift in Sources */,
 				887A63412C1D177800E1A461 /* BaseSnapshotTest.swift in Sources */,
+				57F9726B2DC3EF9500C6E540 /* MockStoreProductDiscount.swift in Sources */,
 				887A63422C1D177800E1A461 /* ImageLoaderTests.swift in Sources */,
 				887A63432C1D177800E1A461 /* LocalizationTests.swift in Sources */,
 				030890842D2B77E70069677B /* VariableHandlerV2Tests.swift in Sources */,

--- a/RevenueCatUI/Helpers/StoreProductDiscount+Extensions.swift
+++ b/RevenueCatUI/Helpers/StoreProductDiscount+Extensions.swift
@@ -12,9 +12,30 @@
 //  Created by Cesar de la Vega on 25/9/24.
 
 import Foundation
-import RevenueCat
+@_spi(Internal) import RevenueCat
 
-extension StoreProductDiscount {
+@_spi(Internal) extension StoreProductDiscountType {
+
+    var discountedPeriodsWithUnit: String {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .full
+        var components = DateComponents()
+
+        switch self.subscriptionPeriod.unit {
+        case .day:
+            components.day = self.numberOfPeriods
+        case .week:
+            components.weekOfMonth = self.numberOfPeriods
+        case .month:
+            components.month = self.numberOfPeriods
+        case .year:
+            components.year = self.numberOfPeriods
+        default:
+            return "\(self.numberOfPeriods)"
+        }
+
+        return formatter.string(from: components) ?? "\(self.numberOfPeriods)"
+    }
 
     func localizedPricePerPeriodByPaymentMode(_ locale: Locale) -> String {
         let discountDuration = self.subscriptionPeriod.durationTitle
@@ -39,30 +60,8 @@ extension StoreProductDiscount {
         }
     }
 
-    var discountedPeriodsWithUnit: String {
-        let formatter = DateComponentsFormatter()
-        formatter.unitsStyle = .full
-        var components = DateComponents()
-
-        switch self.subscriptionPeriod.unit {
-        case .day:
-            components.day = self.numberOfPeriods
-        case .week:
-            components.weekOfMonth = self.numberOfPeriods
-        case .month:
-            components.month = self.numberOfPeriods
-        case .year:
-            components.year = self.numberOfPeriods
-        default:
-            return "\(self.numberOfPeriods)"
-        }
-
-        return formatter.string(from: components) ?? "\(self.numberOfPeriods)"
-    }
-
     func localizedPricePerPeriod(_ locale: Locale) -> String {
         let unit = Localization.abbreviatedUnitLocalizedString(for: self.subscriptionPeriod, locale: locale)
         return "\(self.localizedPriceString)/\(unit)"
     }
-
 }

--- a/Sources/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -175,7 +175,7 @@ extension StoreProductDiscount {
 }
 
 /// The details of an introductory offer or a promotional offer for an auto-renewable subscription.
-internal protocol StoreProductDiscountType: Sendable {
+@_spi(Internal) public protocol StoreProductDiscountType: Sendable {
 
     // Note: this is only `nil` for SK1 products.
     // It can become `String` once it's not longer supported.

--- a/Sources/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -27,7 +27,7 @@ public typealias SK2ProductDiscount = StoreKit.Product.SubscriptionOffer
 /// and provides access to their properties.
 /// Information about a subscription offer that you configured in App Store Connect.
 @objc(RCStoreProductDiscount)
-public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
+public final class StoreProductDiscount: NSObject {
 
     /// The payment mode for a `StoreProductDiscount`
     /// Indicates how the product discount price is charged.
@@ -114,6 +114,9 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
     }
 
 }
+
+@_spi(Internal) extension StoreProductDiscount: StoreProductDiscountType { }
+
 extension StoreProductDiscount {
     // swiftlint:disable:next missing_docs
     @_spi(Internal) public func promotionalOffer(withSignedDataIdentifier identifier: String,

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProductDiscount.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProductDiscount.swift
@@ -47,13 +47,13 @@ public struct TestStoreProductDiscount {
 
 }
 
-extension TestStoreProductDiscount: StoreProductDiscountType {
+@_spi(Internal) extension TestStoreProductDiscount: StoreProductDiscountType {
 
-    var offerIdentifier: String? {
+    @_spi(Internal) public var offerIdentifier: String? {
         return self.identifier
     }
 
-    var currencyCode: String? {
+    @_spi(Internal) public var currencyCode: String? {
         // Test currency defaults to current locale
         return Locale.current.rc_currencyCode
     }

--- a/Tests/RevenueCatUITests/CustomerCenter/FeedbackSurveyViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/FeedbackSurveyViewModelTests.swift
@@ -487,16 +487,4 @@ private extension FeedbackSurveyViewModelTests {
 
 }
 
-private struct MockStoreProductDiscount: StoreProductDiscountType {
-
-    let offerIdentifier: String?
-    let currencyCode: String?
-    let price: Decimal
-    let localizedPriceString: String
-    let paymentMode: StoreProductDiscount.PaymentMode
-    let subscriptionPeriod: SubscriptionPeriod
-    let numberOfPeriods: Int
-    let type: StoreProductDiscount.DiscountType
-}
-
 #endif

--- a/Tests/RevenueCatUITests/CustomerCenter/FeedbackSurveyViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/FeedbackSurveyViewModelTests.swift
@@ -14,7 +14,7 @@
 // swiftlint:disable type_body_length file_length
 
 import Nimble
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 @testable import RevenueCatUI
 import XCTest
 
@@ -497,7 +497,6 @@ private struct MockStoreProductDiscount: StoreProductDiscountType {
     let subscriptionPeriod: SubscriptionPeriod
     let numberOfPeriods: Int
     let type: StoreProductDiscount.DiscountType
-
 }
 
 #endif

--- a/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
@@ -461,19 +461,6 @@ private extension ManageSubscriptionsViewModelTests {
 
 }
 
-private struct MockStoreProductDiscount: StoreProductDiscountType {
-
-    let offerIdentifier: String?
-    let currencyCode: String?
-    let price: Decimal
-    let localizedPriceString: String
-    let paymentMode: StoreProductDiscount.PaymentMode
-    let subscriptionPeriod: RevenueCat.SubscriptionPeriod
-    let numberOfPeriods: Int
-    let type: StoreProductDiscount.DiscountType
-
-}
-
 private extension PurchaseInformation {
     static func mockLifetime(
         customerInfoRequestedDate: Date = Date()

--- a/Tests/RevenueCatUITests/CustomerCenter/Mocks/MockStoreProductDiscount.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/Mocks/MockStoreProductDiscount.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockStoreProductDiscount.swift
+//
+//  Created by Facundo Menzella on 1/5/25.
+
+import Foundation
+@_spi(Internal) @testable import RevenueCat
+
+struct MockStoreProductDiscount {
+
+    let offerIdentifier: String?
+    let currencyCode: String?
+    let price: Decimal
+    let localizedPriceString: String
+    let paymentMode: StoreProductDiscount.PaymentMode
+    let subscriptionPeriod: SubscriptionPeriod
+    let numberOfPeriods: Int
+    let type: StoreProductDiscount.DiscountType
+}
+
+@_spi(Internal) extension MockStoreProductDiscount: StoreProductDiscountType {}

--- a/Tests/UnitTests/Mocks/MockStoreProductDiscount.swift
+++ b/Tests/UnitTests/Mocks/MockStoreProductDiscount.swift
@@ -11,9 +11,9 @@
 //
 //  Created by Nacho Soto on 1/17/22.
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
-struct MockStoreProductDiscount: StoreProductDiscountType {
+struct MockStoreProductDiscount {
 
     let offerIdentifier: String?
     let currencyCode: String?
@@ -25,3 +25,5 @@ struct MockStoreProductDiscount: StoreProductDiscountType {
     let type: StoreProductDiscount.DiscountType
 
 }
+
+@_spi(Internal) extension MockStoreProductDiscount: StoreProductDiscountType { }

--- a/Tests/UnitTests/Purchasing/ProductRequestDataExtensions.swift
+++ b/Tests/UnitTests/Purchasing/ProductRequestDataExtensions.swift
@@ -4,7 +4,7 @@
 //
 
 import Foundation
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 extension ProductRequestData {
 


### PR DESCRIPTION
### Motivation
While working on the new billing information for Customer Center subscriptions, I realised I need this protocol in `RevenueCatUI`

### Description
Internally expose `StoreProductDiscountType` using `@_spi`
