### PR TITLE
fix: Use ObservedObject instead of StateObject

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -31,7 +31,7 @@ import RevenueCat
     private lazy var currentAppVersion: String? = currentVersionFetcher()
 
     @Published
-    private(set) var purchaseInformation: PurchaseInformation?
+    var purchaseInformation: PurchaseInformation?
 
     @Published
     private(set) var appIsLatestVersion: Bool = defaultAppIsLatestVersion

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
@@ -64,8 +64,8 @@ final class ManageSubscriptionsViewModel: ObservableObject {
 
     let actionWrapper: CustomerCenterActionWrapper
 
-    @Published
-    private(set) var purchaseInformation: PurchaseInformation?
+    @Binding
+    var purchaseInformation: PurchaseInformation?
 
     @Published
     private(set) var refundRequestStatus: RefundRequestStatus?
@@ -78,13 +78,13 @@ final class ManageSubscriptionsViewModel: ObservableObject {
     init(
         screen: CustomerCenterConfigData.Screen,
         actionWrapper: CustomerCenterActionWrapper,
-        purchaseInformation: PurchaseInformation? = nil,
+        purchaseInformation: Binding<PurchaseInformation?>,
         refundRequestStatus: RefundRequestStatus? = nil,
         purchasesProvider: CustomerCenterPurchasesType,
         loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType? = nil) {
             self.screen = screen
             self.paths = screen.filteredPaths
-            self.purchaseInformation = purchaseInformation
+            self._purchaseInformation = purchaseInformation
             self.purchasesProvider = purchasesProvider
             self.refundRequestStatus = refundRequestStatus
             self.actionWrapper = actionWrapper

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -218,7 +218,7 @@ private extension CustomerCenterView {
                 } else {
                     ManageSubscriptionsView(
                         screen: screen,
-                        purchaseInformation: purchaseInformation,
+                        purchaseInformation: $viewModel.purchaseInformation,
                         purchasesProvider: self.viewModel.purchasesProvider,
                         actionWrapper: self.viewModel.actionWrapper)
                 }
@@ -231,7 +231,7 @@ private extension CustomerCenterView {
         } else {
             if let screen = configuration.screens[.noActive] {
                 ManageSubscriptionsView(screen: screen,
-                                        purchaseInformation: nil,
+                                        purchaseInformation: $viewModel.purchaseInformation,
                                         purchasesProvider: self.viewModel.purchasesProvider,
                                         actionWrapper: self.viewModel.actionWrapper)
             } else {

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -39,6 +39,9 @@ struct ManageSubscriptionsView: View {
     @Environment(\.navigationOptions)
     var navigationOptions
 
+    @Binding
+    var purchaseInformation: PurchaseInformation?
+
     @StateObject
     private var viewModel: ManageSubscriptionsViewModel
 
@@ -46,16 +49,22 @@ struct ManageSubscriptionsView: View {
          purchaseInformation: Binding<PurchaseInformation?>,
          purchasesProvider: CustomerCenterPurchasesType,
          actionWrapper: CustomerCenterActionWrapper) {
-        let viewModel = ManageSubscriptionsViewModel(
-            screen: screen,
-            actionWrapper: actionWrapper,
+        self.init(
             purchaseInformation: purchaseInformation,
-            purchasesProvider: purchasesProvider)
-        self.init(viewModel: viewModel)
+            viewModel: ManageSubscriptionsViewModel(
+                screen: screen,
+                actionWrapper: actionWrapper,
+                purchaseInformation: purchaseInformation,
+                purchasesProvider: purchasesProvider
+            )
+        )
     }
 
-    fileprivate init(viewModel: ManageSubscriptionsViewModel) {
-        self._viewModel = .init(wrappedValue: viewModel)
+    fileprivate init(
+        purchaseInformation: Binding<PurchaseInformation?>,
+        viewModel: ManageSubscriptionsViewModel) {
+            self._purchaseInformation = purchaseInformation
+            self._viewModel = .init(wrappedValue: viewModel)
     }
 
     var body: some View {
@@ -106,7 +115,6 @@ struct ManageSubscriptionsView: View {
             }, content: { inAppBrowserURL in
                 SafariView(url: inAppBrowserURL.url)
             })
-
     }
 
     @ViewBuilder
@@ -170,73 +178,73 @@ struct ManageSubscriptionsView: View {
 
 }
 
-#if DEBUG
- @available(iOS 15.0, *)
- @available(macOS, unavailable)
- @available(tvOS, unavailable)
- @available(watchOS, unavailable)
- struct ManageSubscriptionsView_Previews: PreviewProvider {
-
-    // swiftlint:disable force_unwrapping line_length
-    static var previews: some View {
-        ForEach(ColorScheme.allCases, id: \.self) { colorScheme in
-            CompatibilityNavigationStack {
-                let viewModelMonthlyRenewing = ManageSubscriptionsViewModel(
-                    screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
-                    actionWrapper: CustomerCenterActionWrapper(),
-                    purchaseInformation: .init(get: { CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing }, set: { _ in}),
-                    refundRequestStatus: .success,
-                    purchasesProvider: CustomerCenterPurchases())
-                ManageSubscriptionsView(viewModel: viewModelMonthlyRenewing)
-                .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
-                .environment(\.appearance, CustomerCenterConfigTestData.customerCenterData.appearance)
-            }
-            .preferredColorScheme(colorScheme)
-            .previewDisplayName("Monthly renewing - \(colorScheme)")
-
-            CompatibilityNavigationStack {
-                let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
-                    screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
-                    actionWrapper: CustomerCenterActionWrapper(),
-                    purchaseInformation: .init(get: { CustomerCenterConfigTestData.subscriptionInformationYearlyExpiring }, set: { _ in}),
-                    purchasesProvider: CustomerCenterPurchases())
-                ManageSubscriptionsView(viewModel: viewModelYearlyExpiring)
-                .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
-                .environment(\.appearance, CustomerCenterConfigTestData.customerCenterData.appearance)
-            }
-            .preferredColorScheme(colorScheme)
-            .previewDisplayName("Yearly expiring - \(colorScheme)")
-
-            CompatibilityNavigationStack {
-                let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
-                    screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
-                    actionWrapper: CustomerCenterActionWrapper(),
-                    purchaseInformation: .init(get: { CustomerCenterConfigTestData.subscriptionInformationFree }, set: { _ in}),
-                    purchasesProvider: CustomerCenterPurchases())
-                ManageSubscriptionsView(viewModel: viewModelYearlyExpiring)
-                .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
-                .environment(\.appearance, CustomerCenterConfigTestData.customerCenterData.appearance)
-            }
-            .preferredColorScheme(colorScheme)
-            .previewDisplayName("Free subscription - \(colorScheme)")
-
-            CompatibilityNavigationStack {
-                let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
-                    screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
-                    actionWrapper: CustomerCenterActionWrapper(),
-                    purchaseInformation: .init(get: { CustomerCenterConfigTestData.consumable }, set: { _ in}),
-                    purchasesProvider: CustomerCenterPurchases())
-                ManageSubscriptionsView(viewModel: viewModelYearlyExpiring)
-                .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
-                .environment(\.appearance, CustomerCenterConfigTestData.customerCenterData.appearance)
-            }
-            .preferredColorScheme(colorScheme)
-            .previewDisplayName("Consumable - \(colorScheme)")
-        }
-    }
-
- }
-
-#endif
+// #if DEBUG
+// @available(iOS 15.0, *)
+// @available(macOS, unavailable)
+// @available(tvOS, unavailable)
+// @available(watchOS, unavailable)
+// struct ManageSubscriptionsView_Previews: PreviewProvider {
+//
+//    // swiftlint:disable force_unwrapping line_length
+//    static var previews: some View {
+//        ForEach(ColorScheme.allCases, id: \.self) { colorScheme in
+//            CompatibilityNavigationStack {
+//                let viewModelMonthlyRenewing = ManageSubscriptionsViewModel(
+//                    screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
+//                    actionWrapper: CustomerCenterActionWrapper(),
+//                    purchaseInformation: .init(get: { CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing }, set: { _ in}),
+//                    refundRequestStatus: .success,
+//                    purchasesProvider: CustomerCenterPurchases())
+//                ManageSubscriptionsView(viewModel: viewModelMonthlyRenewing)
+//                .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
+//                .environment(\.appearance, CustomerCenterConfigTestData.customerCenterData.appearance)
+//            }
+//            .preferredColorScheme(colorScheme)
+//            .previewDisplayName("Monthly renewing - \(colorScheme)")
+//
+//            CompatibilityNavigationStack {
+//                let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
+//                    screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
+//                    actionWrapper: CustomerCenterActionWrapper(),
+//                    purchaseInformation: .init(get: { CustomerCenterConfigTestData.subscriptionInformationYearlyExpiring }, set: { _ in}),
+//                    purchasesProvider: CustomerCenterPurchases())
+//                ManageSubscriptionsView(viewModel: viewModelYearlyExpiring)
+//                .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
+//                .environment(\.appearance, CustomerCenterConfigTestData.customerCenterData.appearance)
+//            }
+//            .preferredColorScheme(colorScheme)
+//            .previewDisplayName("Yearly expiring - \(colorScheme)")
+//
+//            CompatibilityNavigationStack {
+//                let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
+//                    screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
+//                    actionWrapper: CustomerCenterActionWrapper(),
+//                    purchaseInformation: .init(get: { CustomerCenterConfigTestData.subscriptionInformationFree }, set: { _ in}),
+//                    purchasesProvider: CustomerCenterPurchases())
+//                ManageSubscriptionsView(viewModel: viewModelYearlyExpiring)
+//                .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
+//                .environment(\.appearance, CustomerCenterConfigTestData.customerCenterData.appearance)
+//            }
+//            .preferredColorScheme(colorScheme)
+//            .previewDisplayName("Free subscription - \(colorScheme)")
+//
+//            CompatibilityNavigationStack {
+//                let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
+//                    screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
+//                    actionWrapper: CustomerCenterActionWrapper(),
+//                    purchaseInformation: .init(get: { CustomerCenterConfigTestData.consumable }, set: { _ in}),
+//                    purchasesProvider: CustomerCenterPurchases())
+//                ManageSubscriptionsView(viewModel: viewModelYearlyExpiring)
+//                .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
+//                .environment(\.appearance, CustomerCenterConfigTestData.customerCenterData.appearance)
+//            }
+//            .preferredColorScheme(colorScheme)
+//            .previewDisplayName("Consumable - \(colorScheme)")
+//        }
+//    }
+//
+// }
+//
+// #endif
 
 #endif

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -39,11 +39,11 @@ struct ManageSubscriptionsView: View {
     @Environment(\.navigationOptions)
     var navigationOptions
 
-    @ObservedObject
+    @StateObject
     private var viewModel: ManageSubscriptionsViewModel
 
     init(screen: CustomerCenterConfigData.Screen,
-         purchaseInformation: PurchaseInformation?,
+         purchaseInformation: Binding<PurchaseInformation?>,
          purchasesProvider: CustomerCenterPurchasesType,
          actionWrapper: CustomerCenterActionWrapper) {
         let viewModel = ManageSubscriptionsViewModel(
@@ -55,7 +55,7 @@ struct ManageSubscriptionsView: View {
     }
 
     fileprivate init(viewModel: ManageSubscriptionsViewModel) {
-        self.viewModel = viewModel
+        self._viewModel = .init(wrappedValue: viewModel)
     }
 
     var body: some View {
@@ -177,14 +177,14 @@ struct ManageSubscriptionsView: View {
  @available(watchOS, unavailable)
  struct ManageSubscriptionsView_Previews: PreviewProvider {
 
-    // swiftlint:disable force_unwrapping
+    // swiftlint:disable force_unwrapping line_length
     static var previews: some View {
         ForEach(ColorScheme.allCases, id: \.self) { colorScheme in
             CompatibilityNavigationStack {
                 let viewModelMonthlyRenewing = ManageSubscriptionsViewModel(
                     screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
                     actionWrapper: CustomerCenterActionWrapper(),
-                    purchaseInformation: CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing,
+                    purchaseInformation: .init(get: { CustomerCenterConfigTestData.subscriptionInformationMonthlyRenewing }, set: { _ in}),
                     refundRequestStatus: .success,
                     purchasesProvider: CustomerCenterPurchases())
                 ManageSubscriptionsView(viewModel: viewModelMonthlyRenewing)
@@ -198,7 +198,7 @@ struct ManageSubscriptionsView: View {
                 let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
                     screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
                     actionWrapper: CustomerCenterActionWrapper(),
-                    purchaseInformation: CustomerCenterConfigTestData.subscriptionInformationYearlyExpiring,
+                    purchaseInformation: .init(get: { CustomerCenterConfigTestData.subscriptionInformationYearlyExpiring }, set: { _ in}),
                     purchasesProvider: CustomerCenterPurchases())
                 ManageSubscriptionsView(viewModel: viewModelYearlyExpiring)
                 .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
@@ -211,7 +211,7 @@ struct ManageSubscriptionsView: View {
                 let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
                     screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
                     actionWrapper: CustomerCenterActionWrapper(),
-                    purchaseInformation: CustomerCenterConfigTestData.subscriptionInformationFree,
+                    purchaseInformation: .init(get: { CustomerCenterConfigTestData.subscriptionInformationFree }, set: { _ in}),
                     purchasesProvider: CustomerCenterPurchases())
                 ManageSubscriptionsView(viewModel: viewModelYearlyExpiring)
                 .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)
@@ -224,7 +224,7 @@ struct ManageSubscriptionsView: View {
                 let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
                     screen: CustomerCenterConfigTestData.customerCenterData.screens[.management]!,
                     actionWrapper: CustomerCenterActionWrapper(),
-                    purchaseInformation: CustomerCenterConfigTestData.consumable,
+                    purchaseInformation: .init(get: { CustomerCenterConfigTestData.consumable }, set: { _ in}),
                     purchasesProvider: CustomerCenterPurchases())
                 ManageSubscriptionsView(viewModel: viewModelYearlyExpiring)
                 .environment(\.localization, CustomerCenterConfigTestData.customerCenterData.localization)

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -39,7 +39,7 @@ struct ManageSubscriptionsView: View {
     @Environment(\.navigationOptions)
     var navigationOptions
 
-    @StateObject
+    @ObservedObject
     private var viewModel: ManageSubscriptionsViewModel
 
     init(screen: CustomerCenterConfigData.Screen,
@@ -55,7 +55,7 @@ struct ManageSubscriptionsView: View {
     }
 
     fileprivate init(viewModel: ManageSubscriptionsViewModel) {
-        self._viewModel = .init(wrappedValue: viewModel)
+        self.viewModel = viewModel
     }
 
     var body: some View {


### PR DESCRIPTION
### Motivation
While working on https://github.com/RevenueCat/purchases-ios/pull/5035 I've noticed `ManageSubscriptionsView` wasn't updating accordingly when purchasesInformation was updated (cancelled)

### Description
This fixes the issue, and will refresh then screen whenever `PurchaseInformation` is updated.
