### PR TITLE
Add Bottom Sheet View

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1135,6 +1135,7 @@
 		FD43D2FC2C41864000077235 /* TimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD43D2FA2C4185B700077235 /* TimeInterval+Extensions.swift */; };
 		FD43D2FE2C41867600077235 /* TimeInterval+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD43D2FD2C41867600077235 /* TimeInterval+ExtensionsTests.swift */; };
 		FD6186542D1393FA007843DA /* MockCustomerCenterStoreKitUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6186532D1393FA007843DA /* MockCustomerCenterStoreKitUtilities.swift */; };
+		FD9BCEBC2DC946C400408A5D /* ButtonSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9BCEBB2DC946C400408A5D /* ButtonSheetView.swift */; };
 		FD9F982D2BE28A7F0091A5BF /* MockNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B515526D44B2300BD2BD7 /* MockNotificationCenter.swift */; };
 		FDAADFCB2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAADFCA2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift */; };
 		FDAADFCC2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAADFCA2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift */; };
@@ -2471,6 +2472,7 @@
 		FD43D2FA2C4185B700077235 /* TimeInterval+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Extensions.swift"; sourceTree = "<group>"; };
 		FD43D2FD2C41867600077235 /* TimeInterval+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		FD6186532D1393FA007843DA /* MockCustomerCenterStoreKitUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCustomerCenterStoreKitUtilities.swift; sourceTree = "<group>"; };
+		FD9BCEBB2DC946C400408A5D /* ButtonSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonSheetView.swift; sourceTree = "<group>"; };
 		FDAADFCA2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAllTransactionsProvider.swift; sourceTree = "<group>"; };
 		FDAADFCE2BE2B84500BD1659 /* StoreKit2ObserverModePurchaseDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2ObserverModePurchaseDetector.swift; sourceTree = "<group>"; };
 		FDAADFD22BE2B99900BD1659 /* MockStoreKit2ObserverModePurchaseDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreKit2ObserverModePurchaseDetector.swift; sourceTree = "<group>"; };
@@ -4714,6 +4716,7 @@
 			children = (
 				7707A94F2CAD9775006E0313 /* ButtonComponentView.swift */,
 				7707A94D2CAD94D2006E0313 /* ButtonComponentViewModel.swift */,
+				FD9BCEBB2DC946C400408A5D /* ButtonSheetView.swift */,
 			);
 			path = Button;
 			sourceTree = "<group>";
@@ -7017,6 +7020,7 @@
 				887A60852C1D037000E1A461 /* FitToAspectRatio.swift in Sources */,
 				353756652C382C2800A1B8D6 /* CustomerCenterConfigTestData.swift in Sources */,
 				2C4C36132C6FBA8B00AE959B /* CompatibilityTopBarTrailing.swift in Sources */,
+				FD9BCEBC2DC946C400408A5D /* ButtonSheetView.swift in Sources */,
 				3546355C2C391F38001D7E85 /* FeedbackSurveyViewModel.swift in Sources */,
 				353756692C382C2800A1B8D6 /* CustomerCenterViewState.swift in Sources */,
 				7783607B2CCA88E4000785B8 /* StickyFooterComponentView.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1135,7 +1135,7 @@
 		FD43D2FC2C41864000077235 /* TimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD43D2FA2C4185B700077235 /* TimeInterval+Extensions.swift */; };
 		FD43D2FE2C41867600077235 /* TimeInterval+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD43D2FD2C41867600077235 /* TimeInterval+ExtensionsTests.swift */; };
 		FD6186542D1393FA007843DA /* MockCustomerCenterStoreKitUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6186532D1393FA007843DA /* MockCustomerCenterStoreKitUtilities.swift */; };
-		FD9BCEBC2DC946C400408A5D /* ButtonSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9BCEBB2DC946C400408A5D /* ButtonSheetView.swift */; };
+		FD9BCEBC2DC946C400408A5D /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9BCEBB2DC946C400408A5D /* BottomSheetView.swift */; };
 		FD9F982D2BE28A7F0091A5BF /* MockNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B515526D44B2300BD2BD7 /* MockNotificationCenter.swift */; };
 		FDAADFCB2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAADFCA2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift */; };
 		FDAADFCC2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAADFCA2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift */; };
@@ -2472,7 +2472,7 @@
 		FD43D2FA2C4185B700077235 /* TimeInterval+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Extensions.swift"; sourceTree = "<group>"; };
 		FD43D2FD2C41867600077235 /* TimeInterval+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		FD6186532D1393FA007843DA /* MockCustomerCenterStoreKitUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCustomerCenterStoreKitUtilities.swift; sourceTree = "<group>"; };
-		FD9BCEBB2DC946C400408A5D /* ButtonSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonSheetView.swift; sourceTree = "<group>"; };
+		FD9BCEBB2DC946C400408A5D /* BottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
 		FDAADFCA2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAllTransactionsProvider.swift; sourceTree = "<group>"; };
 		FDAADFCE2BE2B84500BD1659 /* StoreKit2ObserverModePurchaseDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2ObserverModePurchaseDetector.swift; sourceTree = "<group>"; };
 		FDAADFD22BE2B99900BD1659 /* MockStoreKit2ObserverModePurchaseDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreKit2ObserverModePurchaseDetector.swift; sourceTree = "<group>"; };
@@ -4716,7 +4716,7 @@
 			children = (
 				7707A94F2CAD9775006E0313 /* ButtonComponentView.swift */,
 				7707A94D2CAD94D2006E0313 /* ButtonComponentViewModel.swift */,
-				FD9BCEBB2DC946C400408A5D /* ButtonSheetView.swift */,
+				FD9BCEBB2DC946C400408A5D /* BottomSheetView.swift */,
 			);
 			path = Button;
 			sourceTree = "<group>";
@@ -7020,7 +7020,7 @@
 				887A60852C1D037000E1A461 /* FitToAspectRatio.swift in Sources */,
 				353756652C382C2800A1B8D6 /* CustomerCenterConfigTestData.swift in Sources */,
 				2C4C36132C6FBA8B00AE959B /* CompatibilityTopBarTrailing.swift in Sources */,
-				FD9BCEBC2DC946C400408A5D /* ButtonSheetView.swift in Sources */,
+				FD9BCEBC2DC946C400408A5D /* BottomSheetView.swift in Sources */,
 				3546355C2C391F38001D7E85 /* FeedbackSurveyViewModel.swift in Sources */,
 				353756692C382C2800A1B8D6 /* CustomerCenterViewState.swift in Sources */,
 				7783607B2CCA88E4000785B8 /* StickyFooterComponentView.swift in Sources */,

--- a/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
@@ -54,6 +54,9 @@ struct BottomSheetView<Content: View>: View {
     var body: some View {
         ScrollView(.vertical) {
             content
+                .safeAreaInset(edge: .bottom, spacing: 0) {
+                    EmptyView()
+                }
         }
         .frame(maxWidth: .infinity, maxHeight: height)
         .background(backgroundColor)

--- a/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
@@ -88,13 +88,21 @@ struct BottomSheetConfig: Sendable {
     ///   - tapOutsideToDismiss: A Boolean value that determines whether tapping outside the sheet
     ///     dismisses it. Defaults to `true`.
     init(
-        backgroundColor: Color = Color(UIColor.systemBackground),
+        backgroundColor: Color = Self.systemBackgroundColor,
         screenHeightPercentage: CGFloat = 0.33333,
         tapOutsideToDismiss: Bool = true
     ) {
         self.backgroundColor = backgroundColor
         self.screenHeightPercentage = screenHeightPercentage
         self.tapOutsideToDismiss = tapOutsideToDismiss
+    }
+
+    private static var systemBackgroundColor: Color {
+        #if os(watchOS)
+        Color.black
+        #else
+        return Color(UIColor.systemBackground)
+        #endif
     }
 }
 
@@ -206,7 +214,7 @@ extension View {
                         config: BottomSheetConfig(
                             backgroundColor: Color.blue,
                             screenHeightPercentage: 0.5,
-                            tapOutsideToDismiss: false
+                            tapOutsideToDismiss: true
                         )
                     ) {
                         VStack(spacing: 20) {

--- a/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
@@ -7,7 +7,7 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  ButtonSheet.swift
+//  BottomSheetView.swift
 //
 //  Created by Will Taylor on 5/5/25.
 
@@ -20,7 +20,7 @@ import SwiftUI
 /// This view is designed to be used as a bottom sheet that slides up from the bottom of the screen.
 /// It provides a scrollable container for its content with a fixed height and customizable background color.
 ///
-/// - Note: This view is typically used in conjunction with ``ButtonSheetOverlayModifier`` to present
+/// - Note: This view is typically used in conjunction with ``BottomSheetOverlayModifier`` to present
 ///   content in a sheet-like interface.
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -155,7 +155,6 @@ struct BottomSheetOverlayModifier<SheetContent: View>: ViewModifier {
                         }
                 }
             )
-
             .animation(.spring(duration: 0.25), value: isPresented.wrappedValue)
         }
     }
@@ -171,7 +170,7 @@ extension View {
     ///
     /// - Parameters:
     ///   - isPresented: A binding to a Boolean value that determines whether to present the sheet.
-    ///   - buttonConfig: The configuration for the sheet. Defaults to a configuration with
+    ///   - config: The configuration for the sheet. Defaults to a configuration with
     ///     system background color and one-third screen height.
     ///   - content: A closure that returns the content of the sheet.
     ///

--- a/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
@@ -166,7 +166,7 @@ struct BottomSheetOverlayModifier<SheetContent: View>: ViewModifier {
                         }
                 }
             )
-            .animation(.spring(duration: 0.25), value: isPresented.wrappedValue)
+            .animation(.spring(duration: 0.35), value: isPresented.wrappedValue)
         }
     }
 }

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonSheetView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonSheetView.swift
@@ -1,0 +1,220 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ButtonSheet.swift
+//
+//  Created by Will Taylor on 5/5/25.
+
+import SwiftUI
+
+/// A view that presents content in a sheet-like interface with customizable height and background.
+///
+/// This view is designed to be used as a bottom sheet that slides up from the bottom of the screen.
+/// It provides a scrollable container for its content with a fixed height and customizable background color.
+///
+/// - Note: This view is typically used in conjunction with ``ButtonSheetOverlayModifier`` to present
+///   content in a sheet-like interface.
+struct ButtonSheetView<Content: View>: View {
+
+    /// The background color of the sheet.
+    let backgroundColor: Color
+
+    /// The height of the sheet.
+    let height: CGFloat
+
+    /// The content to be displayed within the sheet.
+    let content: Content
+
+    /// Creates a new sheet view with the specified parameters.
+    ///
+    /// - Parameters:
+    ///   - backgroundColor: The background color of the sheet.
+    ///   - height: The height of the sheet.
+    ///   - content: A view builder closure that creates the content of the sheet.
+    init(
+        backgroundColor: Color,
+        height: CGFloat,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.backgroundColor = backgroundColor
+        self.height = height
+        self.content = content()
+    }
+
+    var body: some View {
+        ScrollView(.vertical) {
+            content
+        }
+        .frame(maxWidth: .infinity, maxHeight: height)
+        .background(backgroundColor)
+    }
+}
+
+/// Configuration options for presenting a sheet view.
+///
+/// Use this type to customize the appearance and behavior of a sheet view.
+/// You can specify the background color, height percentage relative to the screen,
+/// and whether tapping outside the sheet should dismiss it.
+struct ButtonSheetConfig: Sendable {
+
+    /// The background color of the sheet.
+    let backgroundColor: Color
+
+    /// The height of the sheet as a percentage of the screen height.
+    ///
+    /// This value should be between 0 and 1, where 1 represents 100% of the screen height.
+    let screenHeightPercentage: CGFloat
+
+    /// A Boolean value that determines whether tapping outside the sheet dismisses it.
+    let tapOutsideToDismiss: Bool
+
+    /// Creates a new sheet configuration with the specified parameters.
+    ///
+    /// - Parameters:
+    ///   - backgroundColor: The background color of the sheet. Defaults to the system background color.
+    ///   - screenHeightPercentage: The height of the sheet as a percentage of the screen height.
+    ///     Defaults to 0.33333 (one-third of the screen height).
+    ///   - tapOutsideToDismiss: A Boolean value that determines whether tapping outside the sheet
+    ///     dismisses it. Defaults to `true`.
+    init(
+        backgroundColor: Color = Color(UIColor.systemBackground),
+        screenHeightPercentage: CGFloat = 0.33333,
+        tapOutsideToDismiss: Bool = true
+    ) {
+        self.backgroundColor = backgroundColor
+        self.screenHeightPercentage = screenHeightPercentage
+        self.tapOutsideToDismiss = tapOutsideToDismiss
+    }
+}
+
+/// A view modifier that presents content in a sheet-like interface.
+///
+/// This modifier handles the presentation and dismissal of a sheet view, including
+/// the animation and tap-to-dismiss behavior.
+struct ButtonSheetOverlayModifier<SheetContent: View>: ViewModifier {
+    /// A binding to a Boolean value that determines whether the sheet is presented.
+    let isPresented: Binding<Bool>
+
+    /// The configuration for the sheet.
+    let buttonConfig: ButtonSheetConfig
+
+    /// A closure that creates the content of the sheet.
+    let sheetContent: () -> SheetContent
+
+    @State private var sheetHeight: CGFloat = 0
+
+    func body(content: Content) -> some View {
+        if #available(iOS 14.0, *) {
+            modifierBody(content: content)
+                .ignoresSafeArea()
+        } else {
+            // .ignoresSafeArea() is not available in iOS <14,
+            // so we use .edgesIgnoringSafeArea instead
+            modifierBody(content: content)
+                .edgesIgnoringSafeArea(.all)
+        }
+    }
+
+    @ViewBuilder
+    private func modifierBody(
+        content: Content
+    ) -> some View {
+        ZStack {
+            content
+            // Invisible tap area that covers the screen
+            if isPresented.wrappedValue && buttonConfig.tapOutsideToDismiss {
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        isPresented.wrappedValue = false
+                    }
+            }
+
+            // Sheet content
+            VStack {
+                Spacer()
+                if isPresented.wrappedValue {
+                    ButtonSheetView(
+                        backgroundColor: buttonConfig.backgroundColor,
+                        height: self.sheetHeight
+                    ) {
+                        sheetContent()
+                    }
+                    .transition(.move(edge: .bottom))
+                }
+            }
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .onAppear {
+                            self.sheetHeight = proxy.size.height * buttonConfig.screenHeightPercentage
+                        }
+                }
+            )
+
+            .animation(.spring(duration: 0.25), value: isPresented.wrappedValue)
+        }
+    }
+}
+
+extension View {
+    /// Presents a sheet view when a binding to a Boolean value is true.
+    ///
+    /// Use this modifier to present a sheet view that slides up from the bottom of the screen.
+    /// The sheet can be dismissed by setting the binding to `false` or by tapping outside
+    /// the sheet (if `tapOutsideToDismiss` is enabled in the configuration).
+    ///
+    /// - Parameters:
+    ///   - isPresented: A binding to a Boolean value that determines whether to present the sheet.
+    ///   - buttonConfig: The configuration for the sheet. Defaults to a configuration with
+    ///     system background color and one-third screen height.
+    ///   - content: A closure that returns the content of the sheet.
+    ///
+    /// - Returns: A view that presents the sheet when `isPresented` is true.
+    func buttonSheet<Content: View>(
+        isPresented: Binding<Bool>,
+        buttonConfig: ButtonSheetConfig = ButtonSheetConfig(),
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        modifier(ButtonSheetOverlayModifier(
+            isPresented: isPresented,
+            buttonConfig: buttonConfig,
+            sheetContent: content
+        ))
+    }
+}
+
+#Preview {
+    struct Preview: View {
+        @State private var isPresented = false
+
+        var body: some View {
+            ZStack {
+                Color.gray.opacity(0.2)
+
+                VStack {
+                    Button("Show Sheet") {
+                        isPresented.toggle()
+                    }
+                    .buttonSheet(isPresented: $isPresented) {
+                        VStack(spacing: 20) {
+                            Text("Sheet Content")
+                                .font(.title)
+                            Text("This is a simple sheet preview")
+                        }
+                        .padding()
+                    }
+                }
+            }
+            .edgesIgnoringSafeArea(.all)
+        }
+    }
+
+    return Preview()
+}


### PR DESCRIPTION
This PR adds a bottom sheet view that can be used as a modifier on a view (like a button) to show a sheet.

### Demo

https://github.com/user-attachments/assets/1c46b2df-a7a1-4264-8d78-5a57f57a82b4

### Usage
You can display the sheet with the following view modifier:
```swift
.bottomSheet(isPresented: $isPresented) {
   // Content
   VStack(spacing: 20) {
      Text("Sheet Content")
         .font(.title)
      Text("This is a simple sheet preview")
   }
   .padding()
}
```

You can also customize the sheet's appearance and behavior with by providing a `BottomSheetConfig` object:

```swift
.bottomSheet(
    isPresented: $isPresented,
    config: BottomSheetConfig(
        backgroundColor: Color.blue,
        screenHeightPercentage: 0.5,
        tapOutsideToDismiss: false
    )
) {
    VStack(spacing: 20) {
        Text("Sheet Content")
            .font(.title)
        Text("This is a simple sheet preview")
    }
    .padding()
}
```