### PR TITLE
[Paywalls v2] add stroke support in carousel dots

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -448,13 +448,21 @@ struct PageControlView: View {
         if self.originalCount > 1 {
             HStack(spacing: self.pageControl.spacing) {
                 ForEach(0..<originalCount, id: \.self) { index in
-                    Capsule()
-                        .fill(localCurrentIndex == index ? activeIndicator.color : indicator.color)
-                        .frame(
-                            width: localCurrentIndex == index ? activeIndicator.width : indicator.width,
-                            height: localCurrentIndex == index ? activeIndicator.height : indicator.height
-                        )
-                        .animation(.easeInOut, value: self.localCurrentIndex)
+                    ZStack {
+                        Capsule()
+                            .fill(localCurrentIndex == index ? activeIndicator.color : indicator.color)
+                        Capsule()
+                            .strokeBorder(
+                                localCurrentIndex == index ? activeIndicator.strokeColor : indicator.strokeColor,
+                                style: StrokeStyle(lineWidth: localCurrentIndex == index ? activeIndicator.strokeWidth : indicator.strokeWidth),
+                                antialiased: false
+                            )
+                    }
+                    .frame(
+                        width: localCurrentIndex == index ? activeIndicator.width : indicator.width,
+                        height: localCurrentIndex == index ? activeIndicator.height : indicator.height
+                    )
+                    .animation(.easeInOut, value: self.localCurrentIndex)
                 }
             }
             .padding(self.pageControl.padding)

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -544,12 +544,16 @@ struct CarouselComponentView_Previews: PreviewProvider {
                             default: .init(
                                 width: 10,
                                 height: 10,
-                                color: PaywallComponent.ColorScheme(light: .hex("#aeaeae"))
+                                color: PaywallComponent.ColorScheme(light: .hex("#aeaeae")),
+                                strokeColor: PaywallComponent.ColorScheme(light: .hex("#000000")),
+                                strokeWidth: 0
                             ),
                             active: .init(
                                 width: 10,
                                 height: 10,
-                                color: PaywallComponent.ColorScheme(light: .hex("#000000"))
+                                color: PaywallComponent.ColorScheme(light: .hex("#000000")),
+                                strokeColor: PaywallComponent.ColorScheme(light: .hex("#FFFF00")),
+                                strokeWidth: 0
                             )
                         )
                     ),
@@ -617,12 +621,16 @@ struct CarouselComponentView_Previews: PreviewProvider {
                             default: .init(
                                 width: 10,
                                 height: 10,
-                                color: PaywallComponent.ColorScheme(light: .hex("#cccccc"))
+                                color: PaywallComponent.ColorScheme(light: .hex("#cccccc")),
+                                strokeColor: PaywallComponent.ColorScheme(light: .hex("#000000")),
+                                strokeWidth: 0
                             ),
                             active: .init(
                                 width: 10,
                                 height: 10,
-                                color: PaywallComponent.ColorScheme(light: .hex("#000000"))
+                                color: PaywallComponent.ColorScheme(light: .hex("#00000000")),
+                                strokeColor: PaywallComponent.ColorScheme(light: .hex("#000000")),
+                                strokeWidth: 1
                             )
                         )
                     ),
@@ -684,12 +692,16 @@ struct CarouselComponentView_Previews: PreviewProvider {
                             default: .init(
                                 width: 10,
                                 height: 10,
-                                color: PaywallComponent.ColorScheme(light: .hex("#4462e96e"))
+                                color: PaywallComponent.ColorScheme(light: .hex("#4462e96e")),
+                                strokeColor: PaywallComponent.ColorScheme(light: .hex("#000000")),
+                                strokeWidth: 0
                             ),
                             active: .init(
                                 width: 60,
                                 height: 20,
-                                color: PaywallComponent.ColorScheme(light: .hex("#4462e9"))
+                                color: PaywallComponent.ColorScheme(light: .hex("#4462e9")),
+                                strokeColor: PaywallComponent.ColorScheme(light: .hex("#000000")),
+                                strokeWidth: 0
                             )
                         )
                     ),

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
@@ -231,6 +231,8 @@ struct DisplayablePageControlIndicator {
     let width: CGFloat
     let height: CGFloat
     let color: Color
+    let strokeColor: Color
+    let strokeWidth: CGFloat
 
     let uiConfigProvider: UIConfigProvider
 
@@ -241,8 +243,10 @@ struct DisplayablePageControlIndicator {
         self.width = CGFloat(pageControlIndicator.width)
         self.height = CGFloat(pageControlIndicator.height)
         self.color = pageControlIndicator.color.asDisplayable(uiConfigProvider: uiConfigProvider).toDynamicColor()
+        self.strokeColor = pageControlIndicator.strokeColor.asDisplayable(uiConfigProvider: uiConfigProvider).toDynamicColor()
 
         self.uiConfigProvider = uiConfigProvider
+        self.strokeWidth = pageControlIndicator.strokeWidth
     }
 
 }

--- a/Sources/Paywalls/Components/PaywallCarouselComponent.swift
+++ b/Sources/Paywalls/Components/PaywallCarouselComponent.swift
@@ -86,11 +86,15 @@ public extension PaywallComponent {
             public let width: Int
             public let height: Int
             public let color: ColorScheme
+            public let strokeColor: ColorScheme
+            public let strokeWidth: CGFloat
 
-            public init(width: Int, height: Int, color: ColorScheme) {
+            public init(width: Int, height: Int, color: ColorScheme, strokeColor: ColorScheme?, strokeWidth: CGFloat) {
                 self.width = width
                 self.height = height
                 self.color = color
+                self.strokeColor = strokeColor ?? color
+                self.strokeWidth = strokeWidth
             }
 
         }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
To allow more customization in the paywalls, we're adding stroke properties to the page control in carousel components.

### Description

Added to `PaywallComponent.CarouselComponent.PageControlIndicator`:

```swift
public let strokeColor: ColorScheme
public let strokeWidth: CGFloat
```

<img width="338" alt="image" src="https://github.com/user-attachments/assets/eba1fe79-93c8-432b-8b47-0ef0754a57f0" />

