### PR TITLE
feat: Introduce fade transition for loop animated CarouselView

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -141,6 +141,7 @@ private struct CarouselView<Content: View>: View {
     /// Used to keep the drag position for better animations
     @State private var dragOffset: CGFloat = 0
 
+    /// Used to animate opacity for the loop transition
     @State private var opacity: CGFloat = 1.0
 
     // MARK: - Init
@@ -195,7 +196,7 @@ private struct CarouselView<Content: View>: View {
                         originalCount: self.originalCount,
                         pageControl: pageControl,
                         currentIndex: self.$index,
-                        animationDuration: 0.5
+                        animationDuration: autoPlayTimerDuration.map { $0 / 5 }
                     )
             }
 
@@ -484,7 +485,7 @@ struct PageControlView: View {
     @Binding var currentIndex: Int
 
     // Half of whatever the fade animation is
-    let animationDuration: CGFloat
+    let animationDuration: CGFloat?
 
     @State private var localCurrentIndex: Int = 0
 
@@ -516,9 +517,20 @@ struct PageControlView: View {
             .shadow(shadow: pageControl.shadow, shape: pageControl.shape?.toInsettableShape())
             .padding(self.pageControl.margin)
             .onChangeOf(self.currentIndex) { newValue in
-                withAnimation(.easeInOut(duration: animationDuration)) {
-                    self.localCurrentIndex = newValue % originalCount
+                if let animationDuration {
+                    withAnimation(.easeInOut(duration: animationDuration)) {
+                        self.localCurrentIndex = newValue % originalCount
+                    }
+                } else {
+                    withAnimation {
+                        guard originalCount > 0 else {
+                            self.localCurrentIndex = 0
+                            return
+                        }
+                        self.localCurrentIndex = newValue % originalCount
+                    }
                 }
+
             }
         }
     }

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -200,7 +200,7 @@ private struct CarouselView<Content: View>: View {
                     originalCount: self.originalCount,
                     pageControl: pageControl,
                     currentIndex: self.$index,
-                    animationDuration: autoPlayTimerDuration.map { $0 / 2 }
+                    animationDuration: fadeDuration.map { $0 / 2 }
                 )
             }
 
@@ -246,7 +246,7 @@ private struct CarouselView<Content: View>: View {
                     originalCount: self.originalCount,
                     pageControl: pageControl,
                     currentIndex: self.$index,
-                    animationDuration: autoPlayTimerDuration.map { $0 / 2 }
+                    animationDuration: fadeDuration.map { $0 / 2 }
                 )
             }
         }

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -197,11 +197,11 @@ private struct CarouselView<Content: View>: View {
             // If top page control
             if let pageControl = self.pageControl, pageControl.position == .top {
                 PageControlView(
-                        originalCount: self.originalCount,
-                        pageControl: pageControl,
-                        currentIndex: self.$index,
-                        animationDuration: autoPlayTimerDuration.map { $0 / 5 }
-                    )
+                    originalCount: self.originalCount,
+                    pageControl: pageControl,
+                    currentIndex: self.$index,
+                    animationDuration: autoPlayTimerDuration.map { $0 / 5 }
+                )
             }
 
             // Main horizontal “strip” of pages:

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -142,7 +142,7 @@ private struct CarouselView<Content: View>: View {
     @State private var dragOffset: CGFloat = 0
 
     @State private var opacity: CGFloat = 1.0
-    @State private var indicatorOpacity: CGFloat = 1.0
+
     // MARK: - Init
 
     init(
@@ -195,7 +195,6 @@ private struct CarouselView<Content: View>: View {
                         originalCount: self.originalCount,
                         pageControl: pageControl,
                         currentIndex: self.$index,
-                        opacity: self.indicatorOpacity,
                         animationDuration: 0.5
                     )
             }
@@ -240,7 +239,6 @@ private struct CarouselView<Content: View>: View {
                     originalCount: self.originalCount,
                     pageControl: pageControl,
                     currentIndex: self.$index,
-                    opacity: self.indicatorOpacity,
                     animationDuration: 0.5
                 )
             }
@@ -318,7 +316,6 @@ private struct CarouselView<Content: View>: View {
             // Fade out both slide + indicator
             withAnimation(.easeInOut(duration: fadeDuration)) {
                 opacity = 0
-                indicatorOpacity = 0
             }
 
             DispatchQueue.main.asyncAfter(deadline: .now() + fadeDuration) {
@@ -331,7 +328,6 @@ private struct CarouselView<Content: View>: View {
                 // Fade in both slide + indicator
                 withAnimation(.easeInOut(duration: fadeDuration)) {
                     opacity = 1
-                    indicatorOpacity = 1
                 }
             }
         }
@@ -452,9 +448,8 @@ struct PageControlView: View {
     let originalCount: Int
     let pageControl: DisplayablePageControl
     @Binding var currentIndex: Int
-    var opacity: CGFloat
     let animationDuration: CGFloat // Half of whatever the fade animation is
-    
+
     @State private var localCurrentIndex: Int = 0
 
     var activeIndicator: DisplayablePageControlIndicator {
@@ -477,8 +472,6 @@ struct PageControlView: View {
                         )
                 }
             }
-//            .opacity(opacity)
-            .animation(.easeInOut(duration: 1.0), value: opacity)
             .padding(self.pageControl.padding)
             .shape(border: pageControl.border,
                    shape: pageControl.shape,

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -200,7 +200,7 @@ private struct CarouselView<Content: View>: View {
                     originalCount: self.originalCount,
                     pageControl: pageControl,
                     currentIndex: self.$index,
-                    animationDuration: autoPlayTimerDuration.map { $0 / 5 }
+                    animationDuration: autoPlayTimerDuration.map { $0 / 2 }
                 )
             }
 
@@ -246,7 +246,7 @@ private struct CarouselView<Content: View>: View {
                     originalCount: self.originalCount,
                     pageControl: pageControl,
                     currentIndex: self.$index,
-                    animationDuration: autoPlayTimerDuration.map { $0 / 5 }
+                    animationDuration: autoPlayTimerDuration.map { $0 / 2 }
                 )
             }
         }

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -141,6 +141,8 @@ private struct CarouselView<Content: View>: View {
     /// Used to keep the drag position for better animations
     @State private var dragOffset: CGFloat = 0
 
+    @State private var opacity: CGFloat = 1.0
+
     // MARK: - Init
 
     init(
@@ -205,10 +207,12 @@ private struct CarouselView<Content: View>: View {
             }
             .frame(width: self.width, alignment: .leading)
             .offset(x: xOffset(in: self.width) + dragOffset) // Apply drag offset
+            .opacity(opacity)
             // Animate only final snaps (or auto transitions), not real-time dragging
-            .animation(.easeInOut(duration: self.transitionTime), value: index)
+//            .animation(.easeInOut(duration: self.transitionTime), value: index)
             .gesture(
                 DragGesture()
+
                     .onChanged({ _ in
                         pauseAutoPlay(for: 10)
                     })
@@ -306,7 +310,14 @@ private struct CarouselView<Content: View>: View {
                 return
             }
 
-            withAnimation(.easeInOut(duration: Double(msTransitionTime) / 1000)) {
+            let slideDuration: Double = Double(msTransitionTime) / 1000
+            let fadeDuration: Double = Double(msTransitionTime) / 4000
+
+            withAnimation(.easeInOut(duration: fadeDuration)) {
+                opacity = 0
+            }
+
+            withAnimation(.easeInOut(duration: slideDuration).delay(fadeDuration)) {
                 index += 1
                 if loop {
                     expandDataIfNeeded()
@@ -314,6 +325,10 @@ private struct CarouselView<Content: View>: View {
                 } else {
                     index = min(index, data.count - 1)
                 }
+            }
+
+            withAnimation(.easeInOut(duration: fadeDuration).delay(slideDuration)) {
+                opacity = 1
             }
         }
     }
@@ -663,7 +678,7 @@ struct CarouselComponentView_Previews: PreviewProvider {
                         pagePeek: 20,
                         initialPageIndex: 1,
                         loop: true,
-                        autoAdvance: .init(msTimePerPage: 1000, msTransitionTime: 500),
+                        autoAdvance: .init(msTimePerPage: 1500, msTransitionTime: 1000),
                         pageControl: .init(
                             position: .bottom,
                             padding: PaywallComponent.Padding(top: 0, bottom: 0, leading: 0, trailing: 0),

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -242,7 +242,7 @@ private struct CarouselView<Content: View>: View {
                     originalCount: self.originalCount,
                     pageControl: pageControl,
                     currentIndex: self.$index,
-                    animationDuration: 0.5
+                    animationDuration: autoPlayTimerDuration.map { $0 / 5 }
                 )
             }
         }

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -489,7 +489,8 @@ struct PageControlView: View {
     let pageControl: DisplayablePageControl
     @Binding var currentIndex: Int
 
-    // Half of whatever the fade animation is
+    /// Used for fade transition
+    /// - Note: This needs to be half of whatever the fade duration is
     let animationDuration: CGFloat?
 
     @State private var localCurrentIndex: Int = 0

--- a/Sources/Paywalls/Components/PaywallCarouselComponent.swift
+++ b/Sources/Paywalls/Components/PaywallCarouselComponent.swift
@@ -22,12 +22,18 @@ public extension PaywallComponent {
 
             public let msTimePerPage: Int
             public let msTransitionTime: Int
+            public let transitionType: AutoAdvanceTransitionType
 
-            public init(msTimePerPage: Int, msTransitionTime: Int) {
+            public init(msTimePerPage: Int, msTransitionTime: Int, transitionType: AutoAdvanceTransitionType) {
                 self.msTimePerPage = msTimePerPage
                 self.msTransitionTime = msTransitionTime
+                self.transitionType = transitionType
             }
 
+        }
+
+        public enum AutoAdvanceTransitionType: PaywallComponentBase {
+            case fade
         }
 
         public struct PageControl: PaywallComponentBase {

--- a/Sources/Paywalls/Components/PaywallCarouselComponent.swift
+++ b/Sources/Paywalls/Components/PaywallCarouselComponent.swift
@@ -22,9 +22,9 @@ public extension PaywallComponent {
 
             public let msTimePerPage: Int
             public let msTransitionTime: Int
-            public let transitionType: AutoAdvanceTransitionType
+            public let transitionType: AutoAdvanceTransitionType?
 
-            public init(msTimePerPage: Int, msTransitionTime: Int, transitionType: AutoAdvanceTransitionType) {
+            public init(msTimePerPage: Int, msTransitionTime: Int, transitionType: AutoAdvanceTransitionType?) {
                 self.msTimePerPage = msTimePerPage
                 self.msTransitionTime = msTransitionTime
                 self.transitionType = transitionType
@@ -33,7 +33,7 @@ public extension PaywallComponent {
         }
 
         public enum AutoAdvanceTransitionType: PaywallComponentBase {
-            case fade
+            case fade, slide
         }
 
         public struct PageControl: PaywallComponentBase {


### PR DESCRIPTION
### Motivation
We want to add support for these type of animations. 

### Description
In order to not break previous implementations, we're adding a few if / else here and there.

We can't use modern `withAnimation:complete` API so we had to go the old way. We animate the opacity, and simply don't animate the offset if the fade transition is turned on.


https://github.com/user-attachments/assets/04125683-beb3-4415-bb7b-de0693a7cbb2



Excellent team work @ajpallares @hiddevdploeg @polpielladev 🚀 
