### PR TITLE
Fix some flaky tests

### DIFF
--- a/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionListenerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionListenerTests.swift
@@ -317,6 +317,7 @@ private extension StoreKit2TransactionListenerBaseTests {
         expect(self.delegate.invokedTransactionUpdated) == false
     }
 
+    @available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *)
     func waitForTransactionUpdated(
         file: FileString = #fileID,
         line: UInt = #line
@@ -399,7 +400,7 @@ class StoreKit2TransactionListenerDiagnosticsTests: StoreKit2TransactionListener
 
         try await self.waitForTransactionUpdated()
 
-        expect(self.mockDiagnosticsTracker.trackedAppleTransactionUpdateReceivedParams.value).to(haveCount(1))
+        expect(self.mockDiagnosticsTracker.trackedAppleTransactionUpdateReceivedParams.value).toNot(beEmpty())
         let params = self.mockDiagnosticsTracker.trackedAppleTransactionUpdateReceivedParams.value[0]
         expect(params.productId) == Self.productID
         expect(params.environment) == "xcode"

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -522,7 +522,8 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(
             Self.create(
                 purchasesAreCompletedBy: .revenueCat,
-                dangerousSettings: .init(customEntitlementComputation: true)
+                dangerousSettings: .init(customEntitlementComputation: true),
+                appUserID: "MockUserID"
             ).offlineCustomerInfoEnabled
         ) == false
     }
@@ -569,12 +570,14 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
   private static func create(
       purchasesAreCompletedBy: PurchasesAreCompletedBy,
-      dangerousSettings: DangerousSettings = .init()
+      dangerousSettings: DangerousSettings = .init(),
+      appUserID: String? = nil
   ) -> Purchases {
         return Purchases.configure(
             with: .init(withAPIKey: "")
                 .with(purchasesAreCompletedBy: purchasesAreCompletedBy, storeKitVersion: .storeKit1)
                 .with(dangerousSettings: dangerousSettings)
+                .with(appUserID: appUserID)
         )
     }
 


### PR DESCRIPTION
### Motivation
Flaky tests

### Description
This PR fixes the flakiness of 2 unit tests that fail regularly:
1. `StoreKit2TransactionListenerDiagnosticsTests`'s `testTracksDiagnosticsForRenewals()`: which was expecting exactly 1 transaction diagnostics event, but due to the `testSession.timeRate` being set to `.oneRenewalEveryTwoSeconds`, more than one renewal can happen during the test. I've relaxed the condition to expect at least 1 transaction diagnostics event with the expected parameters.
2. `PurchasesConfiguringTests`'s `testOfflineCustomerInfoDisabledForCustomEntitlementsComputation()` was crashing due sometimes due to the SDK being configured for Customer Entitlements Computation without an App User ID (see these lines https://github.com/RevenueCat/purchases-ios/blob/fd893d2a34460525c6c48891018fe76797acef89/Sources/Purchasing/Purchases/Purchases.swift#L657-L660).
As a result, this test was only passing if another test setting the `appUserId` had been executed before.

There are still many more flaky tests to fix, but... baby steps