### PR TITLE
[DO NOT MERGE] Add log when detecting use of StoreKit Configuration file

### DIFF
--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -95,6 +95,8 @@ enum StoreKitStrings {
 
     case skunknown_purchase_result(String)
 
+    case skconfig_file_detected
+
 }
 
 extension StoreKitStrings: LogMessage {
@@ -225,6 +227,10 @@ extension StoreKitStrings: LogMessage {
 
         case let .skunknown_purchase_result(name):
             return "Unrecognized Product.PurchaseResult: \(name)"
+
+        case .skconfig_file_detected:
+            return "Using StoreKit Configuration file. Running in Xcode's local test environment. " +
+            "In-app purchases are simulated and not connected to App Store or Sandbox. Use for local testing only."
         }
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -337,6 +337,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             diagnosticsTracker: diagnosticsTracker
         )
         let transactionFetcher = StoreKit2TransactionFetcher(diagnosticsTracker: diagnosticsTracker)
+        transactionFetcher.logIfUsingStoreKitFile()
 
         let backend = Backend(
             apiKey: apiKey,

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
@@ -155,6 +155,19 @@ final class StoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
             }
         }
     }
+
+    /// Logs a message if the app is using StoreKit file.
+    func logIfUsingStoreKitFile() {
+        guard #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) else {
+            return
+        }
+        Task {
+            if let appTransaction = await self.appTransaction,
+               appTransaction.environment == .xcode {
+                Logger.info(Strings.storeKit.skconfig_file_detected)
+            }
+        }
+    }
 }
 
 // MARK: -


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Description
Adds an info log when the SDK detects that a StoreKit Configuration file is being used

### Notes
Because the implementation relies on `StoreKit.AppTransaction.shared`, which requires authentication in the App Store to be accessed. This means that it may prompt for the Apple credentials login.