### PR TITLE
Add expirationDate and renewalDate to PurchaseInformation

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigData+Mock.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigData+Mock.swift
@@ -138,7 +138,7 @@ extension CustomerCenterConfigData {
     @available(iOS 14.0, *)
     static let `default` = mock()
 
-    static let subscriptionInformationMonthlyRenewing: PurchaseInformation = .init(
+    static let subscriptionInformationMonthlyRenewing = PurchaseInformation(
         title: "Basic",
         durationTitle: "Monthly",
         explanation: .earliestRenewal,
@@ -152,10 +152,12 @@ extension CustomerCenterConfigData {
         isCancelled: false,
         latestPurchaseDate: nil,
         customerInfoRequestedDate: Date(),
-        managementURL: URL(string: "https://www.revenuecat.com")!
+        managementURL: URL(string: "https://www.revenuecat.com")!,
+        expirationDate: nil,
+        renewalDate: nil
     )
 
-    static let subscriptionInformationFree: PurchaseInformation = .init(
+    static let subscriptionInformationFree = PurchaseInformation(
         title: "Basic",
         durationTitle: "Monthly",
         explanation: .earliestRenewal,
@@ -169,29 +171,12 @@ extension CustomerCenterConfigData {
         isCancelled: false,
         latestPurchaseDate: nil,
         customerInfoRequestedDate: Date(),
-        managementURL: URL(string: "https://www.revenuecat.com")!
+        managementURL: URL(string: "https://www.revenuecat.com")!,
+        expirationDate: nil,
+        renewalDate: nil
     )
 
-    static func subscriptionInformationYearlyExpiring(store: Store = .appStore) -> PurchaseInformation {
-        PurchaseInformation(
-            title: "Basic",
-            durationTitle: "Yearly",
-            explanation: .earliestRenewal,
-            price: .paid("$49.99"),
-            expirationOrRenewal: .init(label: .expires,
-                                       date: .date("June 1st, 2024")),
-            productIdentifier: "product_id",
-            store: store,
-            isLifetime: false,
-            isTrial: false,
-            isCancelled: false,
-            latestPurchaseDate: nil,
-            customerInfoRequestedDate: Date(),
-            managementURL: URL(string: "https://www.revenuecat.com")!
-        )
-    }
-
-    static let consumable: PurchaseInformation = .init(
+    static let consumable = PurchaseInformation(
         title: "Basic",
         durationTitle: nil,
         explanation: .lifetime,
@@ -204,7 +189,9 @@ extension CustomerCenterConfigData {
         isCancelled: false,
         latestPurchaseDate: Date(),
         customerInfoRequestedDate: Date(),
-        managementURL: URL(string: "https://www.revenuecat.com")!
+        managementURL: URL(string: "https://www.revenuecat.com")!,
+        expirationDate: nil,
+        renewalDate: nil
     )
 
     static let standardAppearance = CustomerCenterConfigData.Appearance(

--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation+Mock.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation+Mock.swift
@@ -29,7 +29,9 @@ extension PurchaseInformation {
         isCancelled: false,
         latestPurchaseDate: nil,
         customerInfoRequestedDate: Date(),
-        managementURL: URL(string: "https://www.revenuecat.com")!
+        managementURL: URL(string: "https://www.revenuecat.com")!,
+        expirationDate: nil,
+        renewalDate: nil
     )
 
     static let subscriptionInformationFree = PurchaseInformation(
@@ -46,7 +48,9 @@ extension PurchaseInformation {
         isCancelled: false,
         latestPurchaseDate: nil,
         customerInfoRequestedDate: Date(),
-        managementURL: URL(string: "https://www.revenuecat.com")!
+        managementURL: URL(string: "https://www.revenuecat.com")!,
+        expirationDate: nil,
+        renewalDate: nil
     )
 
     static func yearlyExpiring(
@@ -70,7 +74,9 @@ extension PurchaseInformation {
             isCancelled: false,
             latestPurchaseDate: nil,
             customerInfoRequestedDate: Date(),
-            managementURL: URL(string: "https://www.revenuecat.com")!
+            managementURL: URL(string: "https://www.revenuecat.com")!,
+            expirationDate: nil,
+            renewalDate: nil
         )
     }
 
@@ -87,6 +93,8 @@ extension PurchaseInformation {
         isCancelled: false,
         latestPurchaseDate: Date(),
         customerInfoRequestedDate: Date(),
-        managementURL: URL(string: "https://www.revenuecat.com")!
+        managementURL: URL(string: "https://www.revenuecat.com")!,
+        expirationDate: nil,
+        renewalDate: nil
     )
 }

--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -79,6 +79,8 @@ struct PurchaseInformation {
     /// Product specific management URL
     let managementURL: URL?
 
+    private let dateFormatter: DateFormatter
+
     init(title: String,
          durationTitle: String?,
          explanation: Explanation,
@@ -91,9 +93,10 @@ struct PurchaseInformation {
          isCancelled: Bool,
          latestPurchaseDate: Date?,
          customerInfoRequestedDate: Date,
+         dateFormatter: DateFormatter = Self.defaultDateFormatter,
          managementURL: URL?,
-         expirationDate: Date?,
-         renewalDate: Date?
+         expirationDate: Date? = nil,
+         renewalDate: Date? = nil
     ) {
         self.title = title
         self.durationTitle = durationTitle
@@ -110,6 +113,7 @@ struct PurchaseInformation {
         self.managementURL = managementURL
         self.expirationDate = expirationDate
         self.renewalDate = renewalDate
+        self.dateFormatter = dateFormatter
     }
 
     // swiftlint:disable:next function_body_length
@@ -118,8 +122,10 @@ struct PurchaseInformation {
          transaction: Transaction,
          renewalPrice: PriceDetails? = nil,
          customerInfoRequestedDate: Date,
+         dateFormatter: DateFormatter = Self.defaultDateFormatter,
          managementURL: URL?
     ) {
+        self.dateFormatter = dateFormatter
         // Title and duration from product if available
         self.title = subscribedProduct?.localizedTitle
         self.durationTitle = subscribedProduct?.subscriptionPeriod?.durationTitle

--- a/RevenueCatUI/CustomerCenter/Extensions/CustomerInfo+ActiveTransaction.swift
+++ b/RevenueCatUI/CustomerCenter/Extensions/CustomerInfo+ActiveTransaction.swift
@@ -28,7 +28,7 @@ extension CustomerInfo {
     /// - Note: This is a **temporary** implementation and should eventually be replaced by
     ///         backend-side logic for consistency and accuracy.
     ///
-    func earliestExpiringTransaction() -> Transaction? {
+    func earliestExpiringTransaction() -> RevenueCatUI.Transaction? {
         let activeSubscriptions = subscriptionsByProductIdentifier.values
             .filter(\.isActive)
             .sorted(by: {

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -199,7 +199,7 @@ private extension CustomerCenterViewModel {
         }
     }
 
-    func createPurchaseInformation(for transaction: Transaction,
+    func createPurchaseInformation(for transaction: RevenueCatUI.Transaction,
                                    entitlement: EntitlementInfo?,
                                    customerInfo: CustomerInfo) async throws -> PurchaseInformation {
         if transaction.store == .appStore {

--- a/RevenueCatUI/CustomerCenter/Views/CompatibilityLabeledContent.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CompatibilityLabeledContent.swift
@@ -66,8 +66,8 @@ import SwiftUI
 @available(watchOS, unavailable)
 struct CompatibilityLabeledContent<Label: View, Content: View>: View {
 
-    let label: () -> Label
-    let content: () -> Content
+    @ViewBuilder let label: () -> Label
+    @ViewBuilder let content: () -> Content
 
     var body: some View {
         if #available(iOS 16.0, *) {

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -216,10 +216,10 @@ struct ManageSubscriptionsView: View {
                 let viewModelYearlyExpiring = ManageSubscriptionsViewModel(
                     screen: CustomerCenterConfigData.default.screens[.management]!,
                     actionWrapper: CustomerCenterActionWrapper(),
-                    purchaseInformation: CustomerCenterConfigData.subscriptionInformationYearlyExpiring(),
+                    purchaseInformation: .yearlyExpiring(),
                     purchasesProvider: CustomerCenterPurchases())
                 ManageSubscriptionsView(
-                    purchaseInformation: .constant(CustomerCenterConfigData.subscriptionInformationYearlyExpiring()),
+                    purchaseInformation: .constant(.yearlyExpiring()),
                     viewModel: viewModelYearlyExpiring)
                 .environment(\.localization, CustomerCenterConfigData.default.localization)
                 .environment(\.appearance, CustomerCenterConfigData.default.appearance)


### PR DESCRIPTION
### Motivation
After https://github.com/RevenueCat/purchases-ios/pull/5078, I am bringing back the subscription list.

### Description
Add `expirationDate` and `renewalDate` to `PurchaseInformation`. This will be used as part of the new billing information label for each subscription.
