### PR TITLE
Fix build issue of PaywallsTester app in visionOS

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomerCenterUIKitView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomerCenterUIKitView.swift
@@ -5,7 +5,7 @@
 //  Created by Will Taylor on 12/6/24.
 //
 
-#if !os(watchOS)
+#if canImport(UIKit) && os(iOS)
 
 import SwiftUI
 import RevenueCat

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/OfferingsList.swift
@@ -68,7 +68,7 @@ struct OfferingsList: View {
                 Text("No data available.")
             }
         case .error(let error):
-        #if !os(watchOS)
+            #if os(iOS)
             CompatibilityContentUnavailableView("Error loading paywalls", systemImage: "exclamationmark.triangle.fill", description: Text(error.localizedDescription))
             #else
             ContentUnavailableView("Error loading paywalls", systemImage: "exclamationmark.triangle.fill", description: Text(error.localizedDescription))
@@ -138,7 +138,7 @@ struct OfferingsList: View {
 
     private func noPaywallsListItem() -> some View {
         VStack {
-            #if !os(watchOS)
+            #if canImport(UIKit) && os(iOS)
             CompatibilityContentUnavailableView("No configured paywalls",
                                                          systemImage: "exclamationmark.triangle.fill")
             #else

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -73,7 +73,7 @@ struct SamplePaywallsList: View {
                 )
             )
 
-        #if !os(watchOS)
+        #if os(iOS)
         case let .customPaywall(mode):
             CustomPaywall(customerInfo: Self.loader.customerInfo,
                           condensed: mode == .condensedFooter)
@@ -105,7 +105,7 @@ struct SamplePaywallsList: View {
                 introEligibility: Self.introEligibility
             ))
         #endif
-        #if !os(watchOS)
+        #if canImport(UIKit) && os(iOS)
         case .customerCenterSheet,
                 .customerCenterFullScreen,
                 .customerCenterNavigationView:


### PR DESCRIPTION
### Description
PaywallsTester app was failing to build in visionOS due to some wrong `#if` conditions that were only checking for `watchOS` (I forgot to consider visionOS when removing the preprocessor script in #4969)

Now, the `#if` conditions for showing some of the RevenueCatUI views are exactly the same as RevenueCatUI