### PR TITLE
Compute active subscriptions for CustomerCenter

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -181,6 +181,9 @@ private extension CustomerCenterViewModel {
         }
 
         guard let activeTransaction = customerInfo.earliestExpiringTransaction() else {
+            self.activePurchase = nil
+            self.activePurchases = []
+
             Logger.warning(Strings.could_not_find_subscription_information)
             throw CustomerCenterError.couldNotFindSubscriptionInformation
         }

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -74,14 +74,14 @@ import RevenueCat
     }
 
     var hasPurchases: Bool {
-        !activePurchases.isEmpty || purchaseInformation != nil
+        !activePurchases.isEmpty || activePurchase != nil
     }
 
     @Published
     var activePurchases: [PurchaseInformation] = []
 
     @Published
-    var purchaseInformation: PurchaseInformation?
+    var activePurchase: PurchaseInformation?
 
     private let currentVersionFetcher: CurrentVersionFetcher
 
@@ -121,7 +121,7 @@ import RevenueCat
         configuration: CustomerCenterConfigData
     ) {
         self.init(actionWrapper: CustomerCenterActionWrapper(legacyActionHandler: nil))
-        self.purchaseInformation = purchaseInformation
+        self.activePurchase = purchaseInformation
         self.configuration = configuration
         self.state = .success
     }
@@ -171,11 +171,11 @@ import RevenueCat
 private extension CustomerCenterViewModel {
 
     func loadPurchaseInformation(customerInfo: CustomerInfo) async throws {
-        let hasActiveProducts =  !customerInfo.activeSubscriptions.isEmpty ||
-            !customerInfo.nonSubscriptions.isEmpty
+        let hasActiveProducts =  !customerInfo.activeSubscriptions.isEmpty || !customerInfo.nonSubscriptions.isEmpty
 
         if !hasActiveProducts {
             self.activePurchases = []
+            self.activePurchase = nil
             self.state = .success
             return
         }
@@ -209,12 +209,12 @@ private extension CustomerCenterViewModel {
             let entitlement = customerInfo.entitlements.all.values
                 .first(where: { $0.productIdentifier == activeTransaction.productIdentifier })
 
-            self.purchaseInformation = try await createPurchaseInformation(
+            self.activePurchase = try await createPurchaseInformation(
                 for: activeTransaction,
                 entitlement: entitlement,
                 customerInfo: customerInfo
             )
-        } else if activePurchases.isEmpty {
+        } else if activePurchases.isEmpty && activePurchase == nil {
             Logger.warning(Strings.could_not_find_subscription_information)
             throw CustomerCenterError.couldNotFindSubscriptionInformation
         }

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -192,7 +192,7 @@ private extension CustomerCenterViewModel {
         let entitlement = customerInfo.entitlements.all.values
             .first(where: { $0.productIdentifier == activeTransaction.productIdentifier })
 
-        self.activePurchase = try await createPurchaseInformation(
+        self.activePurchase = await createPurchaseInformation(
             for: activeTransaction,
             entitlement: entitlement,
             customerInfo: customerInfo
@@ -212,10 +212,11 @@ private extension CustomerCenterViewModel {
             let entitlement = customerInfo.entitlements.all.values
                 .first(where: { $0.productIdentifier == subscription.productIdentifier })
 
-            let purchaseInfo = try await createPurchaseInformation(
+            let purchaseInfo = await createPurchaseInformation(
                 for: subscription,
                 entitlement: entitlement,
-                customerInfo: customerInfo)
+                customerInfo: customerInfo
+            )
 
             activePurchases.append(purchaseInfo)
         }
@@ -235,7 +236,7 @@ private extension CustomerCenterViewModel {
 
     func createPurchaseInformation(for transaction: RevenueCatUI.Transaction,
                                    entitlement: EntitlementInfo?,
-                                   customerInfo: CustomerInfo) async throws -> PurchaseInformation {
+                                   customerInfo: CustomerInfo) async -> PurchaseInformation {
         if transaction.store == .appStore {
             if let product = await purchasesProvider.products([transaction.productIdentifier]).first {
                 return await PurchaseInformation.purchaseInformationUsingRenewalInfo(

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -202,7 +202,7 @@ private extension CustomerCenterView {
 
     @ViewBuilder
     func destinationContent(configuration: CustomerCenterConfigData) -> some View {
-        if let purchaseInformation = viewModel.purchaseInformation {
+        if let purchaseInformation = viewModel.activePurchase {
             if purchaseInformation.store == .appStore,
                let screen = configuration.screens[.management] {
                 if let onUpdateAppClick = viewModel.onUpdateAppClick,
@@ -218,7 +218,7 @@ private extension CustomerCenterView {
                 } else {
                     ManageSubscriptionsView(
                         screen: screen,
-                        purchaseInformation: $viewModel.purchaseInformation,
+                        purchaseInformation: $viewModel.activePurchase,
                         purchasesProvider: self.viewModel.purchasesProvider,
                         actionWrapper: self.viewModel.actionWrapper)
                 }
@@ -231,7 +231,7 @@ private extension CustomerCenterView {
         } else {
             if let screen = configuration.screens[.noActive] {
                 ManageSubscriptionsView(screen: screen,
-                                        purchaseInformation: $viewModel.purchaseInformation,
+                                        purchaseInformation: $viewModel.activePurchase,
                                         purchasesProvider: self.viewModel.purchasesProvider,
                                         actionWrapper: self.viewModel.actionWrapper)
             } else {

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -43,7 +43,7 @@ final class CustomerCenterViewModelTests: TestCase {
         let viewModel = CustomerCenterViewModel(actionWrapper: CustomerCenterActionWrapper())
 
         expect(viewModel.state) == .notLoaded
-        expect(viewModel.purchaseInformation).to(beNil())
+        expect(viewModel.activePurchase).to(beNil())
         expect(viewModel.activePurchases).to(beEmpty())
         expect(viewModel.state) == .notLoaded
     }
@@ -101,7 +101,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadScreen()
 
-        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        let purchaseInformation = try XCTUnwrap(viewModel.activePurchase)
         expect(viewModel.activePurchases.count) == 1
         expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
 
@@ -121,7 +121,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadScreen()
 
-        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        let purchaseInformation = try XCTUnwrap(viewModel.activePurchase)
         expect(viewModel.activePurchases.count) == 1
         expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
 
@@ -141,7 +141,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadScreen()
 
-        expect(viewModel.purchaseInformation).to(beNil())
+        expect(viewModel.activePurchase).to(beNil())
         expect(viewModel.activePurchases).to(beEmpty())
         expect(viewModel.state) == .success
     }
@@ -156,7 +156,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadScreen()
 
-        expect(viewModel.purchaseInformation).to(beNil())
+        expect(viewModel.activePurchase).to(beNil())
         expect(viewModel.activePurchases).to(beEmpty())
         switch viewModel.state {
         case .error(let stateError):
@@ -206,7 +206,7 @@ final class CustomerCenterViewModelTests: TestCase {
         // Assert
         expect(viewModel.state) == .success
 
-        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        let purchaseInformation = try XCTUnwrap(viewModel.activePurchase)
         expect(viewModel.activePurchases.count) == 1
         expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
 
@@ -256,7 +256,7 @@ final class CustomerCenterViewModelTests: TestCase {
         // Assert
         expect(viewModel.state) == .success
 
-        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        let purchaseInformation = try XCTUnwrap(viewModel.activePurchase)
         expect(viewModel.activePurchases.count) == 1
         expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
 
@@ -339,7 +339,7 @@ final class CustomerCenterViewModelTests: TestCase {
             // Assert
             expect(viewModel.state) == .success
 
-            let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+            let purchaseInformation = try XCTUnwrap(viewModel.activePurchase)
             expect(viewModel.activePurchases.count) == 2
             expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
 
@@ -431,7 +431,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
             expect(viewModel.state) == .success
 
-            let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+            let purchaseInformation = try XCTUnwrap(viewModel.activePurchase)
             expect(viewModel.activePurchases.count) == 2
             expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
 
@@ -485,7 +485,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         expect(viewModel.state) == .success
 
-        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        let purchaseInformation = try XCTUnwrap(viewModel.activePurchase)
         expect(viewModel.activePurchases.count) == 0
 
         expect(purchaseInformation.title) == "lifetime"
@@ -563,7 +563,7 @@ final class CustomerCenterViewModelTests: TestCase {
             // Assert
             expect(viewModel.state) == .success
 
-            let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+            let purchaseInformation = try XCTUnwrap(viewModel.activePurchase)
             expect(viewModel.activePurchases.count) == 2
             expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
 
@@ -649,7 +649,7 @@ final class CustomerCenterViewModelTests: TestCase {
             // Assert
             expect(viewModel.state) == .success
 
-            let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+            let purchaseInformation = try XCTUnwrap(viewModel.activePurchase)
             expect(viewModel.activePurchases.count) == 2
             expect(viewModel.activePurchases.last?.productIdentifier) == purchaseInformation.productIdentifier
 
@@ -702,7 +702,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         expect(viewModel.state) == .success
 
-        let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        let purchaseInformation = try XCTUnwrap(viewModel.activePurchase)
         expect(viewModel.activePurchases.count) == 1
         expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
 
@@ -727,7 +727,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadScreen()
 
-        expect(viewModel.purchaseInformation).to(beNil())
+        expect(viewModel.activePurchase).to(beNil())
         expect(viewModel.state) == .success
     }
 
@@ -738,7 +738,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadScreen()
 
-        expect(viewModel.purchaseInformation).to(beNil())
+        expect(viewModel.activePurchase).to(beNil())
         expect(viewModel.activePurchases).to(beEmpty())
 
         expect(viewModel.state) == .error(error)
@@ -893,7 +893,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadScreen()
 
-        expect(viewModel.purchaseInformation).toNot(beNil())
+        expect(viewModel.activePurchase).toNot(beNil())
         expect(mockStoreKitUtilities.renewalPriceFromRenewalInfoCallCount).to(equal(2))
     }
 
@@ -913,7 +913,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadScreen()
 
-        expect(viewModel.purchaseInformation?.price).to(equal(.paid("$5.00")))
+        expect(viewModel.activePurchase?.price).to(equal(.paid("$5.00")))
         expect(mockStoreKitUtilities.renewalPriceFromRenewalInfoCallCount).to(equal(2))
     }
 
@@ -947,9 +947,9 @@ final class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.state) == .success
 
         // Wait for state to change to success
-        expect(viewModel.purchaseInformation).toNot(beNil())
-        expect(viewModel.purchaseInformation?.expirationOrRenewal?.label).to(equal(.expires))
-        expect(viewModel.purchaseInformation?.expirationOrRenewal?.date).to(equal(.never))
+        expect(viewModel.activePurchase).toNot(beNil())
+        expect(viewModel.activePurchase?.expirationOrRenewal?.label).to(equal(.expires))
+        expect(viewModel.activePurchase?.expirationOrRenewal?.date).to(equal(.never))
 
         // Verify screen was reloaded
         expect(viewModel.configuration).toNot(beNil())

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -44,6 +44,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         expect(viewModel.state) == .notLoaded
         expect(viewModel.purchaseInformation).to(beNil())
+        expect(viewModel.activePurchases).to(beEmpty())
         expect(viewModel.state) == .notLoaded
     }
 
@@ -58,6 +59,8 @@ final class CustomerCenterViewModelTests: TestCase {
         default:
             fail("Expected state to be .error")
         }
+
+        expect(viewModel.activePurchases).to(beEmpty())
     }
 
     func testIsLoaded() {
@@ -99,6 +102,9 @@ final class CustomerCenterViewModelTests: TestCase {
         await viewModel.loadScreen()
 
         let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        expect(viewModel.activePurchases.count) == 1
+        expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
+
         expect(purchaseInformation.store) == .appStore
         expect(viewModel.state) == .success
     }
@@ -116,6 +122,9 @@ final class CustomerCenterViewModelTests: TestCase {
         await viewModel.loadScreen()
 
         let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        expect(viewModel.activePurchases.count) == 1
+        expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
+
         expect(purchaseInformation.store) == .playStore
         expect(viewModel.state) == .success
     }
@@ -133,6 +142,7 @@ final class CustomerCenterViewModelTests: TestCase {
         await viewModel.loadScreen()
 
         expect(viewModel.purchaseInformation).to(beNil())
+        expect(viewModel.activePurchases).to(beEmpty())
         expect(viewModel.state) == .success
     }
 
@@ -147,6 +157,7 @@ final class CustomerCenterViewModelTests: TestCase {
         await viewModel.loadScreen()
 
         expect(viewModel.purchaseInformation).to(beNil())
+        expect(viewModel.activePurchases).to(beEmpty())
         switch viewModel.state {
         case .error(let stateError):
             expect(stateError as? TestError) == error
@@ -196,6 +207,9 @@ final class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.state) == .success
 
         let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        expect(viewModel.activePurchases.count) == 1
+        expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
+
         expect(purchaseInformation.title) == "title"
         expect(purchaseInformation.durationTitle) == "1 month"
 
@@ -243,6 +257,9 @@ final class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.state) == .success
 
         let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        expect(viewModel.activePurchases.count) == 1
+        expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
+
         expect(purchaseInformation.title) == "title"
         expect(purchaseInformation.durationTitle) == "1 month"
 
@@ -323,6 +340,9 @@ final class CustomerCenterViewModelTests: TestCase {
             expect(viewModel.state) == .success
 
             let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+            expect(viewModel.activePurchases.count) == 2
+            expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
+
             // Should always show yearly subscription since it expires first
             expect(purchaseInformation.title) == yearlyProduct.title
             expect(purchaseInformation.durationTitle) == yearlyProduct.duration
@@ -412,6 +432,9 @@ final class CustomerCenterViewModelTests: TestCase {
             expect(viewModel.state) == .success
 
             let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+            expect(viewModel.activePurchases.count) == 2
+            expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
+
             expect(purchaseInformation.title) == "monthly"
             expect(purchaseInformation.durationTitle) == "1 month"
             expect(purchaseInformation.price) == .paid("$2.99")
@@ -463,6 +486,8 @@ final class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.state) == .success
 
         let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        expect(viewModel.activePurchases.count) == 0
+
         expect(purchaseInformation.title) == "lifetime"
         expect(purchaseInformation.durationTitle).to(beNil())
         expect(purchaseInformation.price) == .paid("$29.99")
@@ -539,6 +564,9 @@ final class CustomerCenterViewModelTests: TestCase {
             expect(viewModel.state) == .success
 
             let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+            expect(viewModel.activePurchases.count) == 2
+            expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
+
             // Should always show yearly subscription since it expires first
             expect(purchaseInformation.title) == yearlyProduct.title
             expect(purchaseInformation.durationTitle) == yearlyProduct.duration
@@ -622,6 +650,9 @@ final class CustomerCenterViewModelTests: TestCase {
             expect(viewModel.state) == .success
 
             let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+            expect(viewModel.activePurchases.count) == 2
+            expect(viewModel.activePurchases.last?.productIdentifier) == purchaseInformation.productIdentifier
+
             // We expect to see the monthly one, because the yearly one is a Google subscription
             expect(purchaseInformation.title) == appleProduct.title
             expect(purchaseInformation.durationTitle) == appleProduct.duration
@@ -672,6 +703,9 @@ final class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.state) == .success
 
         let purchaseInformation = try XCTUnwrap(viewModel.purchaseInformation)
+        expect(viewModel.activePurchases.count) == 1
+        expect(viewModel.activePurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
+
         expect(purchaseInformation.title).to(beNil())
         expect(purchaseInformation.durationTitle).to(beNil())
         expect(purchaseInformation.explanation) == .earliestRenewal
@@ -705,6 +739,8 @@ final class CustomerCenterViewModelTests: TestCase {
         await viewModel.loadScreen()
 
         expect(viewModel.purchaseInformation).to(beNil())
+        expect(viewModel.activePurchases).to(beEmpty())
+
         expect(viewModel.state) == .error(error)
     }
 
@@ -858,7 +894,7 @@ final class CustomerCenterViewModelTests: TestCase {
         await viewModel.loadScreen()
 
         expect(viewModel.purchaseInformation).toNot(beNil())
-        expect(mockStoreKitUtilities.renewalPriceFromRenewalInfoCallCount).to(equal(1))
+        expect(mockStoreKitUtilities.renewalPriceFromRenewalInfoCallCount).to(equal(2))
     }
 
     func testPurchaseInformationUsesInfoFromRenewalInfoWhenAvailable() async {
@@ -878,7 +914,7 @@ final class CustomerCenterViewModelTests: TestCase {
         await viewModel.loadScreen()
 
         expect(viewModel.purchaseInformation?.price).to(equal(.paid("$5.00")))
-        expect(mockStoreKitUtilities.renewalPriceFromRenewalInfoCallCount).to(equal(1))
+        expect(mockStoreKitUtilities.renewalPriceFromRenewalInfoCallCount).to(equal(2))
     }
 
     func testOnDismissRestorePurchasesAlertReloadsScreen() async {


### PR DESCRIPTION
### Motivation
We want to show the whole list of active subscriptions, instead of just one purchase with the earliest expiry date.

### Description
Compute array of active subscriptions as it was done [here](https://github.com/RevenueCat/purchases-ios/pull/5050) before reverting the whole feature.
In order to not break the functionality, I've computed the array and left the code for the active subscription still there. I'll remove that part once I introduce the views.

Note that purchases that are not subscriptions are not in the `activeSubscriptions` array.

### Next
Introduce views, and integrate with CustomerCenter
