### PR TITLE
Introduce SubscriptionDetailViewModel & BaseManageSubscriptionViewModel

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -746,6 +746,8 @@
 		57BB070E28D27A2B007F5DF0 /* CachingProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BB070D28D27A2B007F5DF0 /* CachingProductsManager.swift */; };
 		57BB071628D282A4007F5DF0 /* CachingProductsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BB071528D282A4007F5DF0 /* CachingProductsManagerTests.swift */; };
 		57BB08642DD3BE37007493E1 /* BaseManageSubscriptionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BB08632DD3BE2D007493E1 /* BaseManageSubscriptionViewModelTests.swift */; };
+		57BB08662DD3D9B0007493E1 /* SubscriptionDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BB08652DD3D9AC007493E1 /* SubscriptionDetailViewModel.swift */; };
+		57BB08682DD3D9EC007493E1 /* SubscriptionDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BB08672DD3D9EA007493E1 /* SubscriptionDetailViewModelTests.swift */; };
 		57BD50AA27692B7500211D6D /* StoreKitError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */; };
 		57BF87592967880C00424254 /* MockCachingTrialOrIntroPriceEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BF87582967880C00424254 /* MockCachingTrialOrIntroPriceEligibilityChecker.swift */; };
 		57C0BB6929F840BD00827807 /* FrameworkDisambiguation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C0BB6829F840BD00827807 /* FrameworkDisambiguation.swift */; };
@@ -2119,6 +2121,8 @@
 		57BB070D28D27A2B007F5DF0 /* CachingProductsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingProductsManager.swift; sourceTree = "<group>"; };
 		57BB071528D282A4007F5DF0 /* CachingProductsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingProductsManagerTests.swift; sourceTree = "<group>"; };
 		57BB08632DD3BE2D007493E1 /* BaseManageSubscriptionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseManageSubscriptionViewModelTests.swift; sourceTree = "<group>"; };
+		57BB08652DD3D9AC007493E1 /* SubscriptionDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionDetailViewModel.swift; sourceTree = "<group>"; };
+		57BB08672DD3D9EA007493E1 /* SubscriptionDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionDetailViewModelTests.swift; sourceTree = "<group>"; };
 		57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitError+Extensions.swift"; sourceTree = "<group>"; };
 		57BF87582967880C00424254 /* MockCachingTrialOrIntroPriceEligibilityChecker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockCachingTrialOrIntroPriceEligibilityChecker.swift; sourceTree = "<group>"; };
 		57C0BB6829F840BD00827807 /* FrameworkDisambiguation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkDisambiguation.swift; sourceTree = "<group>"; };
@@ -3836,6 +3840,7 @@
 		3537565A2C382C2800A1B8D6 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				57BB08652DD3D9AC007493E1 /* SubscriptionDetailViewModel.swift */,
 				57FE3A592DD3BD9700868DEF /* BaseManageSubscriptionViewModel.swift */,
 				35724B402D96DB1700332612 /* RestorePurchasesAlertViewModel.swift */,
 				5767D0462D5B505A003D423C /* ManageSubscriptions */,
@@ -3988,6 +3993,7 @@
 		3544DA6B2C2C848E00704E9D /* CustomerCenter */ = {
 			isa = PBXGroup;
 			children = (
+				57BB08672DD3D9EA007493E1 /* SubscriptionDetailViewModelTests.swift */,
 				57BB08632DD3BE2D007493E1 /* BaseManageSubscriptionViewModelTests.swift */,
 				577782B42D91829D00F97EB4 /* CustomerCenterActionWrapperTests.swift */,
 				FD6186522D1393E2007843DA /* Mocks */,
@@ -7031,6 +7037,7 @@
 				0354AA4D2D4029C300F9E330 /* TabControlComponentView.swift in Sources */,
 				35724B412D96DB2000332612 /* RestorePurchasesAlertViewModel.swift in Sources */,
 				887A60C22C1D037000E1A461 /* ErrorDisplay.swift in Sources */,
+				57BB08662DD3D9B0007493E1 /* SubscriptionDetailViewModel.swift in Sources */,
 				887A60692C1D037000E1A461 /* IntroEligibilityViewModel.swift in Sources */,
 				2C2AEB0F2CA64E0E00A50F38 /* Template1Preview.swift in Sources */,
 				88A543E32C37A4970039C6A5 /* Template7View.swift in Sources */,
@@ -7176,6 +7183,7 @@
 				887A63312C1D177800E1A461 /* AvailabilityChecks.swift in Sources */,
 				887A63322C1D177800E1A461 /* CurrentTestCaseTracker.swift in Sources */,
 				887A63332C1D177800E1A461 /* DataExtensions.swift in Sources */,
+				57BB08682DD3D9EC007493E1 /* SubscriptionDetailViewModelTests.swift in Sources */,
 				887A63342C1D177800E1A461 /* ImageSnapshot.swift in Sources */,
 				1E2F911B2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift in Sources */,
 				887A63352C1D177800E1A461 /* OSVersionEquivalent.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -745,6 +745,7 @@
 		57BA943128330ACA00CD5FC5 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BA943028330ACA00CD5FC5 /* ConfigurationTests.swift */; };
 		57BB070E28D27A2B007F5DF0 /* CachingProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BB070D28D27A2B007F5DF0 /* CachingProductsManager.swift */; };
 		57BB071628D282A4007F5DF0 /* CachingProductsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BB071528D282A4007F5DF0 /* CachingProductsManagerTests.swift */; };
+		57BB08642DD3BE37007493E1 /* BaseManageSubscriptionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BB08632DD3BE2D007493E1 /* BaseManageSubscriptionViewModelTests.swift */; };
 		57BD50AA27692B7500211D6D /* StoreKitError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */; };
 		57BF87592967880C00424254 /* MockCachingTrialOrIntroPriceEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BF87582967880C00424254 /* MockCachingTrialOrIntroPriceEligibilityChecker.swift */; };
 		57C0BB6929F840BD00827807 /* FrameworkDisambiguation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C0BB6829F840BD00827807 /* FrameworkDisambiguation.swift */; };
@@ -837,6 +838,7 @@
 		57FDAABA284937A0009A48F1 /* SandboxEnvironmentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAAB9284937A0009A48F1 /* SandboxEnvironmentDetector.swift */; };
 		57FDAABE28493A29009A48F1 /* SandboxEnvironmentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAABD28493A29009A48F1 /* SandboxEnvironmentDetectorTests.swift */; };
 		57FDAAC028493C13009A48F1 /* MockSandboxEnvironmentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAABF28493C13009A48F1 /* MockSandboxEnvironmentDetector.swift */; };
+		57FE3A5A2DD3BDA800868DEF /* BaseManageSubscriptionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FE3A592DD3BD9700868DEF /* BaseManageSubscriptionViewModel.swift */; };
 		57FFD2512922DBED00A9A878 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
 		57FFD2522922DBED00A9A878 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
 		6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECF627761D375C8431EB866 /* StoreProduct.swift */; };
@@ -2116,6 +2118,7 @@
 		57BA943028330ACA00CD5FC5 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		57BB070D28D27A2B007F5DF0 /* CachingProductsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingProductsManager.swift; sourceTree = "<group>"; };
 		57BB071528D282A4007F5DF0 /* CachingProductsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingProductsManagerTests.swift; sourceTree = "<group>"; };
+		57BB08632DD3BE2D007493E1 /* BaseManageSubscriptionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseManageSubscriptionViewModelTests.swift; sourceTree = "<group>"; };
 		57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitError+Extensions.swift"; sourceTree = "<group>"; };
 		57BF87582967880C00424254 /* MockCachingTrialOrIntroPriceEligibilityChecker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockCachingTrialOrIntroPriceEligibilityChecker.swift; sourceTree = "<group>"; };
 		57C0BB6829F840BD00827807 /* FrameworkDisambiguation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkDisambiguation.swift; sourceTree = "<group>"; };
@@ -2180,6 +2183,7 @@
 		57FDAAB9284937A0009A48F1 /* SandboxEnvironmentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxEnvironmentDetector.swift; sourceTree = "<group>"; };
 		57FDAABD28493A29009A48F1 /* SandboxEnvironmentDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxEnvironmentDetectorTests.swift; sourceTree = "<group>"; };
 		57FDAABF28493C13009A48F1 /* MockSandboxEnvironmentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSandboxEnvironmentDetector.swift; sourceTree = "<group>"; };
+		57FE3A592DD3BD9700868DEF /* BaseManageSubscriptionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseManageSubscriptionViewModel.swift; sourceTree = "<group>"; };
 		57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreTransaction.swift; sourceTree = "<group>"; };
 		752F94912DD21A1300ED7DFE /* CustomerCenterConfigData+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerCenterConfigData+Mock.swift"; sourceTree = "<group>"; };
 		75425E0E2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentsDataTests.swift; sourceTree = "<group>"; };
@@ -3832,6 +3836,7 @@
 		3537565A2C382C2800A1B8D6 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				57FE3A592DD3BD9700868DEF /* BaseManageSubscriptionViewModel.swift */,
 				35724B402D96DB1700332612 /* RestorePurchasesAlertViewModel.swift */,
 				5767D0462D5B505A003D423C /* ManageSubscriptions */,
 				574BA2672D3E762E009B8EA6 /* PurchaseHistory */,
@@ -3983,6 +3988,7 @@
 		3544DA6B2C2C848E00704E9D /* CustomerCenter */ = {
 			isa = PBXGroup;
 			children = (
+				57BB08632DD3BE2D007493E1 /* BaseManageSubscriptionViewModelTests.swift */,
 				577782B42D91829D00F97EB4 /* CustomerCenterActionWrapperTests.swift */,
 				FD6186522D1393E2007843DA /* Mocks */,
 				35A99C822CCB95950074AB41 /* SubscriptionInformationFixtures.swift */,
@@ -7054,6 +7060,7 @@
 				887A60682C1D037000E1A461 /* TemplateError.swift in Sources */,
 				887A60792C1D037000E1A461 /* UserInterfaceIdiom.swift in Sources */,
 				03C06FCC2D479C7C00600693 /* CarouselComponentViewModel.swift in Sources */,
+				57FE3A5A2DD3BDA800868DEF /* BaseManageSubscriptionViewModel.swift in Sources */,
 				35D41B432D403556000621C7 /* Store+Localization.swift in Sources */,
 				887A60742C1D037000E1A461 /* Strings.swift in Sources */,
 				57233AA32D3F976500488B00 /* CustomerCenterLocalizationStrings.swift in Sources */,
@@ -7175,6 +7182,7 @@
 				887A63362C1D177800E1A461 /* SnapshotTesting+Extensions.swift in Sources */,
 				887A63372C1D177800E1A461 /* TestCase.swift in Sources */,
 				3544DA6F2C2C848E00704E9D /* ManageSubscriptionsViewModelTests.swift in Sources */,
+				57BB08642DD3BE37007493E1 /* BaseManageSubscriptionViewModelTests.swift in Sources */,
 				887A63382C1D177800E1A461 /* PurchaseHandlerTests.swift in Sources */,
 				887A63392C1D177800E1A461 /* OtherPaywallViewTests.swift in Sources */,
 				356523AA2CF885D300B6E3EA /* MockCustomerCenterPurchases.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -1,0 +1,332 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  BaseManageSubscriptionViewModel.swift
+//
+//  Created by Facundo Menzella on 5/5/25.
+
+import Foundation
+@_spi(Internal) import RevenueCat
+import SwiftUI
+
+#if os(iOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@MainActor
+class BaseManageSubscriptionViewModel: ObservableObject {
+
+    let screen: CustomerCenterConfigData.Screen
+
+    var relevantPathsForPurchase: [CustomerCenterConfigData.HelpPath] {
+        paths.relevantPahts(for: purchaseInformation)
+    }
+
+    @Published
+    var showAllPurchases = false
+
+    @Published
+    var showRestoreAlert: Bool = false
+
+    @Published
+    var restoreAlertType: RestorePurchasesAlertViewModel.AlertType
+
+    @Published
+    var feedbackSurveyData: FeedbackSurveyData?
+
+    @Published
+    var loadingPath: CustomerCenterConfigData.HelpPath?
+
+    @Published
+    var promotionalOfferData: PromotionalOfferData?
+
+    @Published
+    var inAppBrowserURL: IdentifiableURL?
+
+    let actionWrapper: CustomerCenterActionWrapper
+
+    @Published
+    var purchaseInformation: PurchaseInformation?
+
+    @Published
+    private(set) var refundRequestStatus: RefundRequestStatus?
+
+    private var error: Error?
+    private let loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType
+    private let paths: [CustomerCenterConfigData.HelpPath]
+    private(set) var purchasesProvider: CustomerCenterPurchasesType
+
+    init(
+        screen: CustomerCenterConfigData.Screen,
+        actionWrapper: CustomerCenterActionWrapper,
+        purchaseInformation: PurchaseInformation? = nil,
+        refundRequestStatus: RefundRequestStatus? = nil,
+        purchasesProvider: CustomerCenterPurchasesType,
+        loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType? = nil) {
+            self.screen = screen
+            self.paths = screen.supportedPaths
+            self.purchaseInformation = purchaseInformation
+            self.purchasesProvider = purchasesProvider
+            self.refundRequestStatus = refundRequestStatus
+            self.actionWrapper = actionWrapper
+            self.loadPromotionalOfferUseCase = loadPromotionalOfferUseCase
+            ?? LoadPromotionalOfferUseCase(purchasesProvider: purchasesProvider)
+            self.restoreAlertType = .loading
+        }
+
+#if os(iOS) || targetEnvironment(macCatalyst)
+    func handleHelpPath(_ path: CustomerCenterConfigData.HelpPath, wihtActiveProductId: String? = nil) async {
+        // Convert the path to an appropriate action using the extension
+        if let action = path.asAction() {
+            // Send the action through the action wrapper
+            self.actionWrapper.handleAction(.buttonTapped(action: action))
+        }
+
+        switch path.detail {
+        case let .feedbackSurvey(feedbackSurvey):
+            self.feedbackSurveyData = FeedbackSurveyData(
+                configuration: feedbackSurvey,
+                path: path) { [weak self] in
+                    Task {
+                        await self?.onPathSelected(path: path)
+                    }
+                }
+
+        case let .promotionalOffer(promotionalOffer) where purchaseInformation?.store == .appStore:
+            if promotionalOffer.eligible {
+                self.loadingPath = path
+                let result = await loadPromotionalOfferUseCase.execute(promoOfferDetails: promotionalOffer)
+                switch result {
+                case .success(let promotionalOfferData):
+                    self.promotionalOfferData = promotionalOfferData
+                case .failure:
+                    await self.onPathSelected(path: path)
+                    self.loadingPath = nil
+                }
+            } else {
+                Logger.debug(Strings.promo_offer_not_eligible_for_product(
+                    promotionalOffer.iosOfferId, wihtActiveProductId ?? ""
+                ))
+                await self.onPathSelected(path: path)
+            }
+
+        default:
+            await self.onPathSelected(path: path)
+        }
+    }
+
+    func onDismissInAppBrowser() {
+        self.inAppBrowserURL = nil
+    }
+
+#endif
+
+}
+
+// MARK: - Promotional Offer Sheet Dismissal Handling
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension BaseManageSubscriptionViewModel {
+
+    /// Function responsible for handling the user's action on the PromotionalOfferView
+    func handleDismissPromotionalOfferView(_ userAction: PromotionalOfferViewAction) async {
+        switch userAction {
+        case .successfullyRedeemedPromotionalOffer:
+            self.actionWrapper.handleAction(.promotionalOfferSuccess)
+        case .declinePromotionalOffer, .promotionalCodeRedemptionFailed:
+            break
+        }
+
+        // Clear the promotional offer data to dismiss the sheet
+        self.promotionalOfferData = nil
+
+        if userAction.shouldTerminateCurrentPathFlow {
+            self.loadingPath = nil
+        } else {
+            if let loadingPath = loadingPath {
+                await self.onPathSelected(path: loadingPath)
+                self.loadingPath = nil
+            }
+        }
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private extension BaseManageSubscriptionViewModel {
+
+#if os(iOS) || targetEnvironment(macCatalyst)
+    // swiftlint:disable:next cyclomatic_complexity
+    private func onPathSelected(path: CustomerCenterConfigData.HelpPath) async {
+        switch path.type {
+        case .missingPurchase:
+            self.showRestoreAlert = true
+
+        case .refundRequest:
+            guard let purchaseInformation = self.purchaseInformation else { return }
+            let productId = purchaseInformation.productIdentifier
+            do {
+                self.actionWrapper.handleAction(.refundRequestStarted(productId))
+
+                let status = try await self.purchasesProvider.beginRefundRequest(forProduct: productId)
+                self.refundRequestStatus = status
+                self.actionWrapper.handleAction(.refundRequestCompleted(productId, status))
+            } catch {
+                self.refundRequestStatus = .error
+                self.actionWrapper.handleAction(.refundRequestCompleted(productId, .error))
+            }
+
+        case .cancel where purchaseInformation?.store != .appStore:
+            if let url = purchaseInformation?.managementURL {
+                self.inAppBrowserURL = IdentifiableURL(url: url)
+            }
+
+        case .changePlans, .cancel:
+            self.actionWrapper.handleAction(.showingManageSubscriptions)
+
+        case .customUrl:
+            guard let url = path.url,
+                  let openMethod = path.openMethod else {
+                Logger.warning("Found a custom URL path without a URL or open method. Ignoring tap.")
+                return
+            }
+            switch openMethod {
+            case .external,
+                _ where !url.isWebLink:
+                URLUtilities.openURLIfNotAppExtension(url)
+            case .inApp:
+                self.inAppBrowserURL = .init(url: url)
+            @unknown default:
+                Logger.warning(Strings.could_not_determine_type_of_custom_url)
+                URLUtilities.openURLIfNotAppExtension(url)
+            }
+
+        default:
+            break
+        }
+    }
+#endif
+
+}
+
+private extension CustomerCenterConfigData.Screen {
+
+    var supportedPaths: [CustomerCenterConfigData.HelpPath] {
+        return self.paths.filter { path in
+            return path.type != .unknown
+        }
+    }
+
+}
+
+private extension Array<CustomerCenterConfigData.HelpPath> {
+    func relevantPahts(
+        for purchaseInformation: PurchaseInformation?
+    ) -> [CustomerCenterConfigData.HelpPath] {
+        guard let purchaseInformation else {
+            return self
+        }
+
+        return filter {
+            let isNonAppStorePurchase = purchaseInformation.store != .appStore
+            let isAppStoreOnlyPath = $0.type.isAppStoreOnly
+
+            let isCancel = $0.type == .cancel
+            // if it's cancel, it cannot be a lifetime subscription
+            let isEligibleCancel = !purchaseInformation.isLifetime && !purchaseInformation.isCancelled
+
+            // if it's refundRequest, it cannot be free  nor within trial period
+            let isRefund = $0.type == .refundRequest
+            let isRefundEligible = purchaseInformation.price != .free
+                                    && !purchaseInformation.isTrial
+                                    && !purchaseInformation.isCancelled
+
+            // if it has a refundDuration, check it's still valid
+            let refundWindowIsValid = $0.refundWindowDuration?.isWithin(purchaseInformation) ?? true
+
+            // skip AppStore only paths if the purchase is not from App Store
+            if isNonAppStorePurchase && isAppStoreOnlyPath {
+                return false
+            }
+
+            // don't show cancel if there's no URL
+            if isCancel && isNonAppStorePurchase && purchaseInformation.managementURL == nil {
+                 return false
+            }
+
+            return (!isCancel || isEligibleCancel) &&
+                    (!isRefund || isRefundEligible) &&
+                    refundWindowIsValid
+        }
+    }
+}
+
+private extension CustomerCenterConfigData.HelpPath.PathType {
+
+    var isAppStoreOnly: Bool {
+        switch self {
+        case .cancel, .customUrl:
+            return false
+
+        case .changePlans, .refundRequest, .missingPurchase, .unknown:
+            return true
+
+        @unknown default:
+            return false
+        }
+    }
+}
+
+private extension CustomerCenterConfigData.HelpPath.RefundWindowDuration {
+    func isWithin(_ purchaseInformation: PurchaseInformation) -> Bool {
+        switch self {
+        case .forever:
+            return true
+
+        case let .duration(duration):
+            return duration.isWithin(
+                from: purchaseInformation.latestPurchaseDate,
+                now: purchaseInformation.customerInfoRequestedDate
+            )
+
+        @unknown default:
+            return true
+        }
+    }
+}
+
+private extension ISODuration {
+    func isWithin(from startDate: Date?, now: Date) -> Bool {
+        guard let startDate else {
+            return true
+        }
+
+        var dateComponents = DateComponents()
+        dateComponents.year = self.years
+        dateComponents.month = self.months
+        dateComponents.weekOfYear = self.weeks
+        dateComponents.day = self.days
+        dateComponents.hour = self.hours
+        dateComponents.minute = self.minutes
+        dateComponents.second = self.seconds
+
+        let calendar = Calendar.current
+        let endDate = calendar.date(byAdding: dateComponents, to: startDate) ?? startDate
+
+        return startDate < endDate && now <= endDate
+    }
+}
+
+#endif

--- a/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ManageSubscriptions/ManageSubscriptionsViewModel.swift
@@ -53,15 +53,6 @@ final class ManageSubscriptionsViewModel: ObservableObject {
     @Published
     var inAppBrowserURL: IdentifiableURL?
 
-    @Published
-    var state: CustomerCenterViewState {
-        didSet {
-            if case let .error(stateError) = state {
-                self.error = stateError
-            }
-        }
-    }
-
     let actionWrapper: CustomerCenterActionWrapper
 
     @Published
@@ -90,7 +81,6 @@ final class ManageSubscriptionsViewModel: ObservableObject {
             self.actionWrapper = actionWrapper
             self.loadPromotionalOfferUseCase = loadPromotionalOfferUseCase
             ?? LoadPromotionalOfferUseCase(purchasesProvider: purchasesProvider)
-            self.state = .success
             self.restoreAlertType = .loading
         }
 

--- a/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
@@ -1,0 +1,74 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SubscriptionDetailViewModel.swift
+//
+//
+//  Created by Facundo Menzella on 3/5/25.
+//
+
+import Foundation
+@_spi(Internal) import RevenueCat
+import SwiftUI
+
+#if os(iOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@MainActor
+final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
+
+    let showPurchaseHistory: Bool
+
+    var shouldShowContactSupport: Bool {
+        purchaseInformation?.store != .appStore
+    }
+
+    init(
+        screen: CustomerCenterConfigData.Screen,
+        showPurchaseHistory: Bool,
+        actionWrapper: CustomerCenterActionWrapper,
+        purchaseInformation: PurchaseInformation? = nil,
+        refundRequestStatus: RefundRequestStatus? = nil,
+        purchasesProvider: CustomerCenterPurchasesType,
+        loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType? = nil) {
+        self.showPurchaseHistory = showPurchaseHistory
+
+        super.init(
+            screen: screen,
+            actionWrapper: actionWrapper,
+            purchaseInformation: purchaseInformation,
+            refundRequestStatus: refundRequestStatus,
+            purchasesProvider: purchasesProvider,
+            loadPromotionalOfferUseCase: loadPromotionalOfferUseCase
+        )
+    }
+
+    // Previews
+    convenience init(
+        screen: CustomerCenterConfigData.Screen,
+        showPurchaseHistory: Bool,
+        purchaseInformation: PurchaseInformation? = nil,
+        refundRequestStatus: RefundRequestStatus? = nil
+    ) {
+        self.init(
+            screen: screen,
+            showPurchaseHistory: showPurchaseHistory,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchaseInformation,
+            refundRequestStatus: refundRequestStatus,
+            purchasesProvider: CustomerCenterPurchases(),
+            loadPromotionalOfferUseCase: nil
+        )
+    }
+}
+
+#endif

--- a/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
@@ -1,0 +1,567 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+// ManageSubscriptionsViewModelTests.swift
+//
+//
+//  Created by Cesar de la Vega on 11/6/24.
+//
+
+// swiftlint:disable file_length type_body_length function_body_length
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import StoreKit
+import XCTest
+
+#if os(iOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@MainActor
+final class BaseManageSubscriptionViewModelTests: TestCase {
+
+    private let error = TestError(message: "An error occurred")
+
+    private struct TestError: Error, Equatable {
+        let message: String
+        var localizedDescription: String {
+            return message
+        }
+    }
+
+    func testInitialState() {
+        let viewModel =
+        BaseManageSubscriptionViewModel(
+            screen: ManageSubscriptionsViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: nil,
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        expect(viewModel.purchaseInformation).to(beNil())
+        expect(viewModel.refundRequestStatus).to(beNil())
+        expect(viewModel.screen).toNot(beNil())
+        expect(viewModel.showRestoreAlert) == false
+    }
+
+    func testNonAppStoreFiltersAppStoreOnlyPaths() {
+        let purchase = PurchaseInformation.mockNonLifetime(store: .playStore)
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: ManageSubscriptionsViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchase,
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        expect(viewModel.relevantPathsForPurchase.count) == 1
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .cancel })).to(beTrue())
+    }
+
+    func testNonAppStoreFiltersAppStoreOnlyPathsAndCancelIfNoURL() {
+        let purchase = PurchaseInformation.mockNonLifetime(store: .playStore, managementURL: nil)
+
+        let viewModel = ManageSubscriptionsViewModel(
+            screen: ManageSubscriptionsViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchase,
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        expect(viewModel.relevantPathsForPurchase.count) == 0
+    }
+
+    func testLifetimeSubscriptionDoesNotShowCancel() {
+        let purchase = PurchaseInformation.mockLifetime()
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: ManageSubscriptionsViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchase,
+            purchasesProvider: MockCustomerCenterPurchases())
+
+        expect(viewModel.relevantPathsForPurchase.count) == 3
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .cancel })).to(beFalse())
+    }
+
+    func testCancelledDoesNotShowCancelAndRefund() {
+        let purchase = PurchaseInformation.mockNonLifetime(
+            isCancelled: true
+        )
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: ManageSubscriptionsViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchase,
+            purchasesProvider: MockCustomerCenterPurchases())
+
+        expect(viewModel.relevantPathsForPurchase.count) == 2
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .cancel })).to(beFalse())
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .refundRequest })).to(beFalse())
+    }
+
+    func testShowsRefundIfRefundWindowIsForever() {
+        let purchase = PurchaseInformation.mockNonLifetime()
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: ManageSubscriptionsViewModelTests.managementScreen(refundWindowDuration: .forever),
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchase,
+            purchasesProvider: MockCustomerCenterPurchases())
+
+        expect(viewModel.relevantPathsForPurchase.count) == 4
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .refundRequest })).to(beTrue())
+    }
+
+    func testDoesNotShowRefundIfPurchaseOutsideRefundWindow() {
+        let latestPurchaseDate = Date()
+        let oneDay = ISODuration(
+            years: 0,
+            months: 0,
+            weeks: 0,
+            days: 1,
+            hours: 0,
+            minutes: 0,
+            seconds: 0
+        )
+
+        let twoDays: TimeInterval = 2 * 24 * 60 * 60
+        let purchase = PurchaseInformation.mockNonLifetime(
+            latestPurchaseDate: latestPurchaseDate,
+            customerInfoRequestedDate: latestPurchaseDate.addingTimeInterval(twoDays))
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: ManageSubscriptionsViewModelTests.managementScreen(refundWindowDuration: .duration(oneDay)),
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchase,
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        expect(viewModel.relevantPathsForPurchase.count) == 3
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .refundRequest })).to(beFalse())
+    }
+
+    func testDoesNotShowRefundIfPurchaseIsFree() {
+        let latestPurchaseDate = Date()
+        let twoDays: TimeInterval = 2 * 24 * 60 * 60
+        let purchase = PurchaseInformation.mockNonLifetime(
+            price: .free,
+            latestPurchaseDate: latestPurchaseDate,
+            customerInfoRequestedDate: latestPurchaseDate.addingTimeInterval(twoDays))
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: ManageSubscriptionsViewModelTests.managementScreen(refundWindowDuration: .forever),
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchase,
+            purchasesProvider: MockCustomerCenterPurchases())
+
+        expect(viewModel.relevantPathsForPurchase.count) == 3
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .refundRequest })).to(beFalse())
+    }
+
+    func testDoesNotShowRefundIfPurchaseIsWithinTrial() {
+        let latestPurchaseDate = Date()
+        let twoDays: TimeInterval = 2 * 24 * 60 * 60
+        let purchase = PurchaseInformation.mockNonLifetime(
+            price: .paid(""), // just to prove price is ignored if is in trial
+            isTrial: true,
+            latestPurchaseDate: latestPurchaseDate,
+            customerInfoRequestedDate: latestPurchaseDate.addingTimeInterval(twoDays))
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: ManageSubscriptionsViewModelTests.managementScreen(refundWindowDuration: .forever),
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchase,
+            purchasesProvider: MockCustomerCenterPurchases())
+
+        expect(viewModel.relevantPathsForPurchase.count) == 3
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .refundRequest })).to(beFalse())
+    }
+
+    func testShowsRefundIfPurchaseOutsideRefundWindow() {
+        let latestPurchaseDate = Date()
+        let oneDay = ISODuration(
+            years: 0,
+            months: 0,
+            weeks: 0,
+            days: 3,
+            hours: 0,
+            minutes: 0,
+            seconds: 0
+        )
+
+        let twoDays: TimeInterval = 2 * 24 * 60 * 60
+        let purchase = PurchaseInformation.mockNonLifetime(
+            latestPurchaseDate: latestPurchaseDate,
+            customerInfoRequestedDate: latestPurchaseDate.addingTimeInterval(twoDays))
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: ManageSubscriptionsViewModelTests.managementScreen(refundWindowDuration: .duration(oneDay)),
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchase,
+            purchasesProvider: MockCustomerCenterPurchases())
+
+        expect(viewModel.relevantPathsForPurchase.count) == 4
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .refundRequest })).to(beTrue())
+    }
+
+    func testStateChangeToError() {
+        let viewModel =
+        BaseManageSubscriptionViewModel(
+            screen: ManageSubscriptionsViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: nil,
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        viewModel.state = CustomerCenterViewState.error(error)
+
+        switch viewModel.state {
+        case .error(let stateError):
+            expect(stateError as? TestError) == error
+        default:
+            fail("Expected state to be .error")
+        }
+    }
+
+    func testLoadsPromotionalOffer() async throws {
+        let offerIdentifierInJSON = "rc_refund_offer"
+        let (viewModel, loadPromotionalOfferUseCase) = try await setupPromotionalOfferTest(
+            offerIdentifierInJSON: offerIdentifierInJSON,
+            offerIdentifierInProduct: offerIdentifierInJSON
+        )
+
+        try await verifyPromotionalOfferLoading(viewModel: viewModel,
+                                                loadPromotionalOfferUseCase: loadPromotionalOfferUseCase,
+                                                expectedOfferIdentifierInJSON: offerIdentifierInJSON)
+    }
+
+    func testLoadsPromotionalOfferWithSuffix() async throws {
+        let offerIdentifierInJSON = "rc_refund_offer"
+        let offerIdentifierInProduct = "monthly_rc_refund_offer"
+        let (viewModel, loadPromotionalOfferUseCase) = try await setupPromotionalOfferTest(
+            offerIdentifierInJSON: offerIdentifierInJSON,
+            offerIdentifierInProduct: offerIdentifierInProduct
+        )
+
+        try await verifyPromotionalOfferLoading(viewModel: viewModel,
+                                                loadPromotionalOfferUseCase: loadPromotionalOfferUseCase,
+                                                expectedOfferIdentifierInJSON: offerIdentifierInJSON,
+                                                expectedOfferIdentifierInProduct: offerIdentifierInProduct)
+    }
+
+    func testDoesNotLoadPromotionalOfferIfNotEligible() async throws {
+        let productIdOne = "com.revenuecat.product1"
+        let productIdTwo = "com.revenuecat.product2"
+        let purchaseDate = "2022-04-12T00:03:28Z"
+        let expirationDateFirst = "2062-04-12T00:03:35Z"
+        let expirationDateSecond = "2062-05-12T00:03:35Z"
+        let offerIdentifier = "offer_id"
+
+        // Test both possible subscription array orders
+        let subscriptionOrders = [
+            [(id: productIdOne, exp: expirationDateFirst),
+             (id: productIdTwo, exp: expirationDateSecond)],
+            [(id: productIdTwo, exp: expirationDateSecond),
+             (id: productIdOne, exp: expirationDateFirst)]
+        ]
+
+        for subscriptions in subscriptionOrders {
+            let product = PurchaseInformationFixtures.product(
+                id: productIdOne,
+                title: "yearly",
+                duration: .year,
+                price: Decimal(29.99),
+                offerIdentifier: offerIdentifier
+            )
+            let products = [
+                product,
+                PurchaseInformationFixtures.product(
+                    id: productIdTwo,
+                    title: "monthly",
+                    duration: .month,
+                    price: Decimal(2.99)
+                )
+            ]
+
+            let customerInfo = CustomerInfoFixtures.customerInfo(
+                subscriptions: subscriptions.map { subscription in
+                    CustomerInfoFixtures.Subscription(
+                        id: subscription.id,
+                        store: "app_store",
+                        purchaseDate: purchaseDate,
+                        expirationDate: subscription.exp
+                    )
+                },
+                entitlements: [
+                    CustomerInfoFixtures.Entitlement(
+                        entitlementId: "premium",
+                        productId: productIdOne,
+                        purchaseDate: purchaseDate,
+                        expirationDate: expirationDateFirst
+                    )
+                ]
+            )
+
+            let promoOfferDetails = CustomerCenterConfigData.HelpPath.PromotionalOffer(
+                iosOfferId: offerIdentifier,
+                eligible: false,
+                title: "Wait",
+                subtitle: "Here's an offer for you",
+                productMapping: [
+                    "product_id": "offer_id"
+                ]
+            )
+            let loadPromotionalOfferUseCase = MockLoadPromotionalOfferUseCase()
+            loadPromotionalOfferUseCase.mockedProduct = product
+            loadPromotionalOfferUseCase.mockedPromoOfferDetails = promoOfferDetails
+            let signedData = PromotionalOffer.SignedData(
+                identifier: "id",
+                keyIdentifier: "key_i",
+                nonce: UUID(),
+                signature: "a signature",
+                timestamp: 1234
+            )
+            let discount = MockStoreProductDiscount(
+                offerIdentifier: offerIdentifier,
+                currencyCode: "usd",
+                price: 1,
+                localizedPriceString: "$1.00",
+                paymentMode: .payAsYouGo,
+                subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .month),
+                numberOfPeriods: 1,
+                type: .introductory
+            )
+
+            loadPromotionalOfferUseCase.mockedPromotionalOffer = PromotionalOffer(
+                discount: discount,
+                signedData: signedData
+            )
+
+            let viewModel = ManageSubscriptionsViewModel(
+                screen: PurchaseInformationFixtures.screenWithIneligiblePromo,
+                actionWrapper: CustomerCenterActionWrapper(),
+                purchaseInformation: nil,
+                purchasesProvider: MockCustomerCenterPurchases(
+                    customerInfo: customerInfo,
+                    products: products
+                ),
+                loadPromotionalOfferUseCase: loadPromotionalOfferUseCase)
+
+            let screen = try XCTUnwrap(viewModel.screen)
+            expect(viewModel.state) == .success
+
+            let pathWithPromotionalOffer = try XCTUnwrap(screen.paths.first { path in
+                if case .promotionalOffer = path.detail {
+                    return true
+                }
+                return false
+            })
+
+            expect(loadPromotionalOfferUseCase.offerToLoadPromoFor).to(beNil())
+
+            await viewModel.handleHelpPath(pathWithPromotionalOffer)
+
+            expect(loadPromotionalOfferUseCase.offerToLoadPromoFor).to(beNil())
+        }
+    }
+
+    // Helper methods
+    private func setupPromotionalOfferTest(offerIdentifierInJSON: String,
+                                           offerIdentifierInProduct: String
+    ) async throws -> (ManageSubscriptionsViewModel, MockLoadPromotionalOfferUseCase) {
+        let productIdOne = "com.revenuecat.product1"
+        let productIdTwo = "com.revenuecat.product2"
+        let purchaseDate = "2022-04-12T00:03:28Z"
+        let expirationDateFirst = "2062-04-12T00:03:35Z"
+        let expirationDateSecond = "2062-05-12T00:03:35Z"
+
+        let product = PurchaseInformationFixtures.product(id: productIdOne,
+                                                          title: "yearly",
+                                                          duration: .year,
+                                                          price: Decimal(29.99),
+                                                          offerIdentifier: offerIdentifierInProduct)
+        let products = [
+            product,
+            PurchaseInformationFixtures.product(id: productIdTwo, title: "monthly", duration: .month, price: 2.99)
+        ]
+
+        // Test both possible subscription array orders
+        let subscriptionOrders = [
+            [(id: productIdOne, exp: expirationDateFirst),
+             (id: productIdTwo, exp: expirationDateSecond)],
+            [(id: productIdTwo, exp: expirationDateSecond),
+             (id: productIdOne, exp: expirationDateFirst)]
+        ]
+
+        let customerInfo = CustomerInfoFixtures.customerInfo(
+            subscriptions: subscriptionOrders[0].map { subscription in
+                CustomerInfoFixtures.Subscription(
+                    id: subscription.id,
+                    store: "app_store",
+                    purchaseDate: purchaseDate,
+                    expirationDate: subscription.exp
+                )
+            },
+            entitlements: [
+                CustomerInfoFixtures.Entitlement(
+                    entitlementId: "premium",
+                    productId: productIdOne,
+                    purchaseDate: purchaseDate,
+                    expirationDate: expirationDateFirst
+                )
+            ]
+        )
+
+        let promoOfferDetails =
+        CustomerCenterConfigData.HelpPath.PromotionalOffer(iosOfferId: offerIdentifierInJSON,
+                                                           eligible: true,
+                                                           title: "Wait",
+                                                           subtitle: "Here's an offer for you",
+                                                           productMapping: [
+                                                            "product_id": "offer_id"
+                                                           ])
+        let loadPromotionalOfferUseCase = MockLoadPromotionalOfferUseCase()
+        loadPromotionalOfferUseCase.mockedProduct = product
+        loadPromotionalOfferUseCase.mockedPromoOfferDetails = promoOfferDetails
+        let signedData = PromotionalOffer.SignedData(identifier: "id",
+                                                     keyIdentifier: "key_i",
+                                                     nonce: UUID(),
+                                                     signature: "a signature",
+                                                     timestamp: 1234)
+        let discount = MockStoreProductDiscount(offerIdentifier: offerIdentifierInProduct,
+                                                currencyCode: "usd",
+                                                price: 1,
+                                                localizedPriceString: "$1.00",
+                                                paymentMode: .payAsYouGo,
+                                                subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .month),
+                                                numberOfPeriods: 1,
+                                                type: .introductory)
+
+        loadPromotionalOfferUseCase.mockedPromotionalOffer = PromotionalOffer(discount: discount,
+                                                                              signedData: signedData)
+
+        let screen = PurchaseInformationFixtures.screenWithPromo(offerID: offerIdentifierInJSON)
+        let viewModel = ManageSubscriptionsViewModel(screen: screen,
+                                                     actionWrapper: CustomerCenterActionWrapper(),
+                                                     purchaseInformation: nil,
+                                                     purchasesProvider: MockCustomerCenterPurchases(
+                                                        customerInfo: customerInfo,
+                                                        products: products
+                                                     ),
+                                                     loadPromotionalOfferUseCase: loadPromotionalOfferUseCase)
+
+        return (viewModel, loadPromotionalOfferUseCase)
+    }
+
+    private func verifyPromotionalOfferLoading(viewModel: ManageSubscriptionsViewModel,
+                                               loadPromotionalOfferUseCase: MockLoadPromotionalOfferUseCase,
+                                               expectedOfferIdentifierInJSON: String,
+                                               expectedOfferIdentifierInProduct: String? = nil) async throws {
+        let screen = try XCTUnwrap(viewModel.screen)
+        expect(viewModel.state) == .success
+
+        let pathWithPromotionalOffer = try XCTUnwrap(screen.paths.first { path in
+            if case .promotionalOffer = path.detail {
+                return true
+            }
+            return false
+        })
+
+        expect(loadPromotionalOfferUseCase.offerToLoadPromoFor).to(beNil())
+
+        await viewModel.handleHelpPath(pathWithPromotionalOffer)
+
+        let loadingPath = try XCTUnwrap(viewModel.loadingPath)
+        expect(loadingPath.id) == pathWithPromotionalOffer.id
+
+        expect(loadPromotionalOfferUseCase.offerToLoadPromoFor?.iosOfferId) == expectedOfferIdentifierInJSON
+
+        if let expectedOfferIdentifierInProduct = expectedOfferIdentifierInProduct {
+            expect(
+                loadPromotionalOfferUseCase.mockedPromotionalOffer?.discount.offerIdentifier
+            ) == expectedOfferIdentifierInProduct
+        }
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension ManageSubscriptionsViewModelTests {
+
+    static let `default`: CustomerCenterConfigData.Screen =
+    CustomerCenterConfigData.default.screens[.management]!
+
+    static func managementScreen(
+        refundWindowDuration: CustomerCenterConfigData.HelpPath.RefundWindowDuration
+    ) -> CustomerCenterConfigData.Screen {
+        CustomerCenterConfigData.mock(
+            lastPublishedAppVersion: "1.0.0",
+            refundWindowDuration: refundWindowDuration).screens[.management]!
+    }
+
+}
+
+private extension PurchaseInformation {
+    static func mockLifetime(
+        customerInfoRequestedDate: Date = Date(),
+        store: Store = .appStore
+    ) -> PurchaseInformation {
+        PurchaseInformation(
+            title: "",
+            durationTitle: "",
+            explanation: .lifetime,
+            price: .paid(""),
+            expirationOrRenewal: PurchaseInformation.ExpirationOrRenewal(label: .expires, date: .date("")),
+            productIdentifier: "",
+            store: store,
+            isLifetime: true,
+            isTrial: false,
+            isCancelled: false,
+            latestPurchaseDate: nil,
+            customerInfoRequestedDate: customerInfoRequestedDate,
+            managementURL: URL(string: "https://www.revenuecat.com")!
+        )
+    }
+
+    static func mockNonLifetime(
+        store: Store = .appStore,
+        price: PurchaseInformation.PriceDetails = .paid("5"),
+        isTrial: Bool = false,
+        isCancelled: Bool = false,
+        latestPurchaseDate: Date = Date(),
+        customerInfoRequestedDate: Date = Date(),
+        managementURL: URL? = URL(string: "https://www.revenuecat.com")!
+    ) -> PurchaseInformation {
+        PurchaseInformation(
+            title: "",
+            durationTitle: "",
+            explanation: .earliestExpiration,
+            price: price,
+            expirationOrRenewal: PurchaseInformation.ExpirationOrRenewal(
+                label: .expires,
+                date: .date("")
+            ),
+            productIdentifier: "",
+            store: store,
+            isLifetime: false,
+            isTrial: isTrial,
+            isCancelled: isCancelled,
+            latestPurchaseDate: latestPurchaseDate,
+            customerInfoRequestedDate: customerInfoRequestedDate,
+            managementURL: managementURL
+        )
+    }
+}
+
+#endif

--- a/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
@@ -215,25 +215,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
         expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .refundRequest })).to(beTrue())
     }
 
-    func testStateChangeToError() {
-        let viewModel =
-        BaseManageSubscriptionViewModel(
-            screen: ManageSubscriptionsViewModelTests.default,
-            actionWrapper: CustomerCenterActionWrapper(),
-            purchaseInformation: nil,
-            purchasesProvider: MockCustomerCenterPurchases()
-        )
-
-        viewModel.state = CustomerCenterViewState.error(error)
-
-        switch viewModel.state {
-        case .error(let stateError):
-            expect(stateError as? TestError) == error
-        default:
-            fail("Expected state to be .error")
-        }
-    }
-
     func testLoadsPromotionalOffer() async throws {
         let offerIdentifierInJSON = "rc_refund_offer"
         let (viewModel, loadPromotionalOfferUseCase) = try await setupPromotionalOfferTest(
@@ -359,7 +340,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
                 loadPromotionalOfferUseCase: loadPromotionalOfferUseCase)
 
             let screen = try XCTUnwrap(viewModel.screen)
-            expect(viewModel.state) == .success
 
             let pathWithPromotionalOffer = try XCTUnwrap(screen.paths.first { path in
                 if case .promotionalOffer = path.detail {
@@ -469,7 +449,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
                                                expectedOfferIdentifierInJSON: String,
                                                expectedOfferIdentifierInProduct: String? = nil) async throws {
         let screen = try XCTUnwrap(viewModel.screen)
-        expect(viewModel.state) == .success
 
         let pathWithPromotionalOffer = try XCTUnwrap(screen.paths.first { path in
             if case .promotionalOffer = path.detail {

--- a/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ManageSubscriptionsViewModelTests.swift
@@ -46,7 +46,6 @@ final class ManageSubscriptionsViewModelTests: TestCase {
                                      purchaseInformation: nil,
                                      purchasesProvider: MockCustomerCenterPurchases())
 
-        expect(viewModel.state) == CustomerCenterViewState.success
         expect(viewModel.purchaseInformation).to(beNil())
         expect(viewModel.refundRequestStatus).to(beNil())
         expect(viewModel.screen).toNot(beNil())
@@ -211,23 +210,6 @@ final class ManageSubscriptionsViewModelTests: TestCase {
         expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .refundRequest })).to(beTrue())
     }
 
-    func testStateChangeToError() {
-        let viewModel =
-        ManageSubscriptionsViewModel(screen: ManageSubscriptionsViewModelTests.default,
-                                     actionWrapper: CustomerCenterActionWrapper(),
-                                     purchaseInformation: nil,
-                                     purchasesProvider: MockCustomerCenterPurchases())
-
-        viewModel.state = CustomerCenterViewState.error(error)
-
-        switch viewModel.state {
-        case .error(let stateError):
-            expect(stateError as? TestError) == error
-        default:
-            fail("Expected state to be .error")
-        }
-    }
-
     func testLoadsPromotionalOffer() async throws {
         let offerIdentifierInJSON = "rc_refund_offer"
         let (viewModel, loadPromotionalOfferUseCase) = try await setupPromotionalOfferTest(
@@ -353,7 +335,6 @@ final class ManageSubscriptionsViewModelTests: TestCase {
                 loadPromotionalOfferUseCase: loadPromotionalOfferUseCase)
 
             let screen = try XCTUnwrap(viewModel.screen)
-            expect(viewModel.state) == .success
 
             let pathWithPromotionalOffer = try XCTUnwrap(screen.paths.first { path in
                 if case .promotionalOffer = path.detail {
@@ -463,7 +444,6 @@ final class ManageSubscriptionsViewModelTests: TestCase {
                                                expectedOfferIdentifierInJSON: String,
                                                expectedOfferIdentifierInProduct: String? = nil) async throws {
         let screen = try XCTUnwrap(viewModel.screen)
-        expect(viewModel.state) == .success
 
         let pathWithPromotionalOffer = try XCTUnwrap(screen.paths.first { path in
             if case .promotionalOffer = path.detail {

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
@@ -1,0 +1,61 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SubscriptionDetailViewModelTests.swift
+//
+//  Created by Facundo Menzella on 13/5/25.
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import StoreKit
+import XCTest
+
+#if os(iOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@MainActor
+final class SubscriptionDetailViewModelTests: TestCase {
+
+    func testShouldShowContactSupport() {
+        let viewModelAppStore = SubscriptionDetailViewModel(
+            screen: CustomerCenterConfigData.default.screens[.management]!,
+            showPurchaseHistory: false,
+            purchaseInformation: .yearlyExpiring(store: .appStore)
+        )
+
+        expect(viewModelAppStore.shouldShowContactSupport).to(beFalse())
+
+        let otherStores = [
+            Store.macAppStore,
+            .playStore,
+            .stripe,
+            .promotional,
+            .unknownStore,
+            .amazon,
+            .rcBilling,
+            .external
+        ]
+
+        otherStores.forEach {
+            let viewModelOther = SubscriptionDetailViewModel(
+                screen: CustomerCenterConfigData.default.screens[.management]!,
+                showPurchaseHistory: false,
+                purchaseInformation: .yearlyExpiring(store: $0)
+            )
+
+            expect(viewModelOther.shouldShowContactSupport).to(beTrue())
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
### Motivation
We want to display a list of active subscriptions in Customer Center. 

### Description
To avoid opening a huge PR, I'm splitting it into smaller pieces. This PR contains:
- `BaseManageSubscriptionViewModel` that's pretty much the existing `ManageSubscriptionViewModel`
- `SubscriptionDetailViewModel` that will be the new subscription detail screen

### Upcoming
- `SubscriptionListViewModel` to handle the list, that will also inherit `BaseManageSubscriptionViewModel`


> I've duplicated the tests from `ManageSubscriptionViewModel` to `BaseManageSubscriptionViewModel` to make sure the logic works. Once finished, I'll delete the old code in one PR
