### PR TITLE
Allow custom url on purchase button

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		03C7305B2D35985900297FEC /* TextComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C7305A2D35985500297FEC /* TextComponentTests.swift */; };
 		03C730F32D35F14600297FEC /* PaywallV2CacheWarming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C730F22D35F13F00297FEC /* PaywallV2CacheWarming.swift */; };
 		03E37BEA2D30B32200CD9678 /* PaywallTabsComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E37BE92D30B32200CD9678 /* PaywallTabsComponent.swift */; };
+		03F0B6512DD5700D00E82199 /* LocalizationDictionaryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F0B6502DD5700D00E82199 /* LocalizationDictionaryExtensions.swift */; };
 		03F446212D2F73240046129A /* StackComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446202D2F73210046129A /* StackComponentTests.swift */; };
 		03F446242D2FE0C50046129A /* ShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446232D2FE0C10046129A /* ShapePropertyTests.swift */; };
 		03F446262D2FE1510046129A /* MaskShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */; };
@@ -1380,6 +1381,7 @@
 		03C7305A2D35985500297FEC /* TextComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextComponentTests.swift; sourceTree = "<group>"; };
 		03C730F22D35F13F00297FEC /* PaywallV2CacheWarming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallV2CacheWarming.swift; sourceTree = "<group>"; };
 		03E37BE92D30B32200CD9678 /* PaywallTabsComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallTabsComponent.swift; sourceTree = "<group>"; };
+		03F0B6502DD5700D00E82199 /* LocalizationDictionaryExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationDictionaryExtensions.swift; sourceTree = "<group>"; };
 		03F446202D2F73210046129A /* StackComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackComponentTests.swift; sourceTree = "<group>"; };
 		03F446232D2FE0C10046129A /* ShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapePropertyTests.swift; sourceTree = "<group>"; };
 		03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskShapePropertyTests.swift; sourceTree = "<group>"; };
@@ -2669,6 +2671,7 @@
 		030F91882D55C0FF0085103F /* Localizations */ = {
 			isa = PBXGroup;
 			children = (
+				03F0B6502DD5700D00E82199 /* LocalizationDictionaryExtensions.swift */,
 				030F918D2D5664410085103F /* LocaleExtensions.swift */,
 				030F91892D55C1AB0085103F /* LocaleFinder.swift */,
 			);
@@ -7082,6 +7085,7 @@
 				887A60852C1D037000E1A461 /* FitToAspectRatio.swift in Sources */,
 				FD9BCEBC2DC946C400408A5D /* BottomSheetView.swift in Sources */,
 				3546355C2C391F38001D7E85 /* FeedbackSurveyViewModel.swift in Sources */,
+				03F0B6512DD5700D00E82199 /* LocalizationDictionaryExtensions.swift in Sources */,
 				353756692C382C2800A1B8D6 /* CustomerCenterViewState.swift in Sources */,
 				7783607B2CCA88E4000785B8 /* StickyFooterComponentView.swift in Sources */,
 				887A608B2C1D037000E1A461 /* PurchaseHandler+TestData.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		03C730F32D35F14600297FEC /* PaywallV2CacheWarming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C730F22D35F13F00297FEC /* PaywallV2CacheWarming.swift */; };
 		03E37BEA2D30B32200CD9678 /* PaywallTabsComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E37BE92D30B32200CD9678 /* PaywallTabsComponent.swift */; };
 		03F0B6512DD5700D00E82199 /* LocalizationDictionaryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F0B6502DD5700D00E82199 /* LocalizationDictionaryExtensions.swift */; };
+		03F0B6712DD6364100E82199 /* NavigatetoURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F0B6702DD6363B00E82199 /* NavigatetoURL.swift */; };
 		03F446212D2F73240046129A /* StackComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446202D2F73210046129A /* StackComponentTests.swift */; };
 		03F446242D2FE0C50046129A /* ShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446232D2FE0C10046129A /* ShapePropertyTests.swift */; };
 		03F446262D2FE1510046129A /* MaskShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */; };
@@ -1382,6 +1383,7 @@
 		03C730F22D35F13F00297FEC /* PaywallV2CacheWarming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallV2CacheWarming.swift; sourceTree = "<group>"; };
 		03E37BE92D30B32200CD9678 /* PaywallTabsComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallTabsComponent.swift; sourceTree = "<group>"; };
 		03F0B6502DD5700D00E82199 /* LocalizationDictionaryExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationDictionaryExtensions.swift; sourceTree = "<group>"; };
+		03F0B6702DD6363B00E82199 /* NavigatetoURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigatetoURL.swift; sourceTree = "<group>"; };
 		03F446202D2F73210046129A /* StackComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackComponentTests.swift; sourceTree = "<group>"; };
 		03F446232D2FE0C10046129A /* ShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapePropertyTests.swift; sourceTree = "<group>"; };
 		03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskShapePropertyTests.swift; sourceTree = "<group>"; };
@@ -2803,6 +2805,7 @@
 		2C7457442CEA652B004ACE52 /* ViewHelpers */ = {
 			isa = PBXGroup;
 			children = (
+				03F0B6702DD6363B00E82199 /* NavigatetoURL.swift */,
 				030F93B22D5ED90B0085103F /* ProgressViewModifier.swift */,
 				2C7457872CEDF7AC004ACE52 /* BackgroundStyle.swift */,
 				77089F9D2CD39EC100848CD5 /* ShadowModifier.swift */,
@@ -7189,6 +7192,7 @@
 				88A543DF2C37A45B0039C6A5 /* TemplatePackageSetting.swift in Sources */,
 				3546355D2C391F38001D7E85 /* PromotionalOfferViewModel.swift in Sources */,
 				57CD17272D9D831600B4B667 /* CustomerCenterConfigDataSupport+URL.swift in Sources */,
+				03F0B6712DD6364100E82199 /* NavigatetoURL.swift in Sources */,
 				35F249CA2C493D970058993A /* LoadPromotionalOfferUseCase.swift in Sources */,
 				887A60762C1D037000E1A461 /* TemplateViewConfiguration+Extensions.swift in Sources */,
 				887A607A2C1D037000E1A461 /* Variables.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		038211972DCA730C003C02C3 /* PurchaseButtonInPackagePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038211962DCA730C003C02C3 /* PurchaseButtonInPackagePreview.swift */; };
 		038211982DCA730C003C02C3 /* ButtonWithFooterPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038211952DCA730C003C02C3 /* ButtonWithFooterPreview.swift */; };
 		038213602DCAF6BE003C02C3 /* OpenSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0382135F2DCAF6BE003C02C3 /* OpenSheet.swift */; };
+		038213DB2DD4979A003C02C3 /* PurchaseButtonComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038213DA2DD4979A003C02C3 /* PurchaseButtonComponentTests.swift */; };
 		03A98CEF2D1EE048009BCA61 /* FallbackComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98CEE2D1EE040009BCA61 /* FallbackComponentTests.swift */; };
 		03A98CF12D222F5F009BCA61 /* FallbackComponentPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98CF02D222F53009BCA61 /* FallbackComponentPreview.swift */; };
 		03A98D302D240C41009BCA61 /* UIConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A98D2F2D240C3E009BCA61 /* UIConfig.swift */; };
@@ -1360,6 +1361,7 @@
 		038211952DCA730C003C02C3 /* ButtonWithFooterPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonWithFooterPreview.swift; sourceTree = "<group>"; };
 		038211962DCA730C003C02C3 /* PurchaseButtonInPackagePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseButtonInPackagePreview.swift; sourceTree = "<group>"; };
 		0382135F2DCAF6BE003C02C3 /* OpenSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSheet.swift; sourceTree = "<group>"; };
+		038213DA2DD4979A003C02C3 /* PurchaseButtonComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseButtonComponentTests.swift; sourceTree = "<group>"; };
 		03A98CEE2D1EE040009BCA61 /* FallbackComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FallbackComponentTests.swift; sourceTree = "<group>"; };
 		03A98CF02D222F53009BCA61 /* FallbackComponentPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FallbackComponentPreview.swift; sourceTree = "<group>"; };
 		03A98D2F2D240C3E009BCA61 /* UIConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfig.swift; sourceTree = "<group>"; };
@@ -2844,6 +2846,7 @@
 				03C7305A2D35985500297FEC /* TextComponentTests.swift */,
 				03A98CEE2D1EE040009BCA61 /* FallbackComponentTests.swift */,
 				2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */,
+				038213DA2DD4979A003C02C3 /* PurchaseButtonComponentTests.swift */,
 				2C8EC6DE2CCD27A100D6CCF8 /* PartialComponentTests.swift */,
 			);
 			path = Components;
@@ -6826,6 +6829,7 @@
 				A563F586271E072B00246E0C /* MockBeginRefundRequestHelper.swift in Sources */,
 				2DA85A8A26DEA7DC00F1136D /* MockProductsRequestFactory.swift in Sources */,
 				5793397028E77A5100C1232C /* PaymentQueueWrapperTests.swift in Sources */,
+				038213DB2DD4979A003C02C3 /* PurchaseButtonComponentTests.swift in Sources */,
 				5791FDBE299419D900F1FEDA /* MockSigning.swift in Sources */,
 				57FDAA9A2846C2BD009A48F1 /* PurchasesDelegateTests.swift in Sources */,
 				351B516026D44BB600BD2BD7 /* MockAttributionDataMigrator.swift in Sources */,

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -127,58 +127,14 @@ struct ButtonComponentView: View {
         case .url(let url, let method),
                 .privacyPolicy(let url, let method),
                 .terms(let url, let method):
-            navigateToUrl(url: url, method: method)
+            Browser.navigateTo(url: url,
+                               method: method,
+                               openURL: self.openURL,
+                               inAppBrowserURL: self.$inAppBrowserURL)
         case .unknown:
             break
         case .webPaywallLink(url: let url, method: let method):
             openWebPaywallLink(url: url, method: method)
-        }
-    }
-
-    private func navigateToUrl(url: URL, method: PaywallComponent.ButtonComponent.URLMethod) {
-        switch method {
-        case .inAppBrowser:
-#if os(tvOS)
-            // There's no SafariServices on tvOS, so we're falling back to opening in an external browser.
-            Logger.warning(Strings.no_in_app_browser_tvos)
-            openURL(url) { success in
-                if success {
-                    Logger.debug(Strings.successfully_opened_url_external_browser(url.absoluteString))
-                } else {
-                    Logger.error(Strings.failed_to_open_url_external_browser(url.absoluteString))
-                }
-            }
-#else
-            inAppBrowserURL = url
-#endif
-        case .externalBrowser:
-#if os(watchOS)
-            // watchOS doesn't support openURL with a completion handler, so we're just opening the URL.
-            openURL(url)
-#else
-            openURL(url) { success in
-                if success {
-                    Logger.debug(Strings.successfully_opened_url_external_browser(url.absoluteString))
-                } else {
-                    Logger.error(Strings.failed_to_open_url_external_browser(url.absoluteString))
-                }
-            }
-#endif
-        case .deepLink:
-#if os(watchOS)
-            // watchOS doesn't support openURL with a completion handler, so we're just opening the URL.
-            openURL(url)
-#else
-            openURL(url) { success in
-                if success {
-                    Logger.debug(Strings.successfully_opened_url_deep_link(url.absoluteString))
-                } else {
-                    Logger.error(Strings.failed_to_open_url_deep_link(url.absoluteString))
-                }
-            }
-#endif
-        case .unknown:
-            break
         }
     }
 

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
@@ -123,17 +123,4 @@ class ButtonComponentViewModel {
 
 }
 
-fileprivate extension PaywallComponent.LocalizationDictionary {
-
-    func urlFromLid(_ urlLid: String) throws -> URL {
-        do {
-            return try url(key: urlLid)
-        } catch {
-            Logger.error(Strings.paywall_invalid_url(urlLid))
-            throw error
-        }
-    }
-
-}
-
 #endif

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -214,7 +214,8 @@ struct PurchaseButtonComponentView_Previews: PreviewProvider {
                                            trailing: 30)
                         ))
                     ]),
-                    action: .inAppCheckout
+                    action: .inAppCheckout,
+                    method: .inAppCheckout
                 ),
                 localizationProvider: .init(
                     locale: Locale.current,
@@ -258,7 +259,8 @@ struct PurchaseButtonComponentView_Previews: PreviewProvider {
                                                 bottomLeading: 8,
                                                 bottomTrailing: 8))
                     ),
-                    action: .inAppCheckout
+                    action: .inAppCheckout,
+                    method: .inAppCheckout
                 ),
                 localizationProvider: .init(
                     locale: Locale.current,
@@ -298,7 +300,8 @@ fileprivate extension PurchaseButtonComponentViewModel {
             offering: offering
         )
 
-        self.init(
+        try self.init(
+            localizationProvider: localizationProvider,
             component: component,
             offering: offering,
             stackViewModel: stackViewModel

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -108,7 +108,7 @@ struct PurchaseButtonComponentView: View {
     private func purchaseSelectedWebProduct() async throws {
         self.logIfInPreview(package: self.packageContext.package)
 
-        guard let webCheckoutUrl = self.packageContext.package?.webCheckoutUrl else {
+        guard let webCheckoutUrl = self.viewModel.urlForWebProduct(packageContext: self.packageContext) else {
             Logger.error(Strings.no_web_checkout_url_found)
             return
         }
@@ -129,10 +129,10 @@ struct PurchaseButtonComponentView: View {
 
     private func openWebPaywallLink(url: URL, method: PaywallComponent.ButtonComponent.URLMethod) {
         Purchases.shared.invalidateCustomerInfoCache()
-#if os(watchOS)
+        #if os(watchOS)
         // watchOS doesn't support openURL with a completion handler, so we're just opening the URL.
         openURL(url)
-#else
+        #else
         openURL(url) { success in
             if success {
                 Logger.debug(Strings.successfully_opened_url_external_browser(url.absoluteString))
@@ -140,8 +140,11 @@ struct PurchaseButtonComponentView: View {
                 Logger.error(Strings.failed_to_open_url_external_browser(url.absoluteString))
             }
         }
-#endif
-        onDismiss()
+        #endif
+
+        if self.viewModel.webAutoDimiss {
+            self.onDismiss()
+        }
     }
 
     /// Used to see purchasing information when using SwiftUI Previews

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -119,7 +119,7 @@ struct PurchaseButtonComponentView: View {
             return
         }
 
-        self.openWebPaywallLink(url: webCheckoutUrl, method: .externalBrowser)
+        self.openWebPaywallLink(url: webCheckoutUrl.0, method: webCheckoutUrl.1)
     }
 
     private func openWebProductSelection() async throws {
@@ -136,7 +136,7 @@ struct PurchaseButtonComponentView: View {
             return
         }
 
-        self.openWebPaywallLink(url: webCheckoutUrl, method: .externalBrowser)
+        self.openWebPaywallLink(url: webCheckoutUrl.0, method: webCheckoutUrl.1)
     }
 
     private func openWebPaywallLink(url: URL, method: PaywallComponent.ButtonComponent.URLMethod) {

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -113,6 +113,12 @@ struct PurchaseButtonComponentView: View {
             return
         }
 
+        self.logIfInPreview("Web Product: \(webCheckoutUrl)")
+
+        guard !self.isInPreview else {
+            return
+        }
+
         self.openWebPaywallLink(url: webCheckoutUrl, method: .externalBrowser)
     }
 
@@ -121,6 +127,12 @@ struct PurchaseButtonComponentView: View {
 
         guard let webCheckoutUrl = self.viewModel.offeringWebCheckoutUrl else {
             Logger.error(Strings.no_web_checkout_url_found)
+            return
+        }
+
+        self.logIfInPreview("Web Selection: \(webCheckoutUrl)")
+
+        guard !self.isInPreview else {
             return
         }
 
@@ -147,13 +159,31 @@ struct PurchaseButtonComponentView: View {
         }
     }
 
-    /// Used to see purchasing information when using SwiftUI Previews
-    private func logIfInPreview(package: Package?) {
+    private var isInPreview: Bool {
         #if DEBUG
         let isInPreview: Bool = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
 
-        if isInPreview {
-            print("Purchasing package: \(package?.identifier ?? "NOTHING")")
+        return isInPreview
+        #else
+        return false
+        #endif
+    }
+
+    /// Used to see purchasing information when using SwiftUI Previews
+    private func logIfInPreview(package: Package?) {
+        #if DEBUG
+        guard let package else { return }
+
+        self.logIfInPreview(
+            "Purchasing package: \(package.identifier)"
+        )
+        #endif
+    }
+
+    private func logIfInPreview(_ value: String) {
+        #if DEBUG
+        if self.isInPreview {
+            print(value)
         }
         #endif
     }

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -133,50 +133,10 @@ struct PurchaseButtonComponentView: View {
         let method = launchWebCheckout.method
         let url = launchWebCheckout.url
 
-        switch method {
-        case .inAppBrowser:
-#if os(tvOS)
-            // There's no SafariServices on tvOS, so we're falling back to opening in an external browser.
-            Logger.warning(Strings.no_in_app_browser_tvos)
-            openURL(url) { success in
-                if success {
-                    Logger.debug(Strings.successfully_opened_url_external_browser(url.absoluteString))
-                } else {
-                    Logger.error(Strings.failed_to_open_url_external_browser(url.absoluteString))
-                }
-            }
-#else
-            inAppBrowserURL = url
-#endif
-        case .externalBrowser:
-#if os(watchOS)
-            // watchOS doesn't support openURL with a completion handler, so we're just opening the URL.
-            openURL(url)
-#else
-            openURL(url) { success in
-                if success {
-                    Logger.debug(Strings.successfully_opened_url_external_browser(url.absoluteString))
-                } else {
-                    Logger.error(Strings.failed_to_open_url_external_browser(url.absoluteString))
-                }
-            }
-#endif
-        case .deepLink:
-#if os(watchOS)
-            // watchOS doesn't support openURL with a completion handler, so we're just opening the URL.
-            openURL(url)
-#else
-            openURL(url) { success in
-                if success {
-                    Logger.debug(Strings.successfully_opened_url_deep_link(url.absoluteString))
-                } else {
-                    Logger.error(Strings.failed_to_open_url_deep_link(url.absoluteString))
-                }
-            }
-#endif
-        case .unknown:
-            break
-        }
+        Browser.navigateTo(url: url,
+                           method: method,
+                           openURL: self.openURL,
+                           inAppBrowserURL: self.$inAppBrowserURL)
 
         if launchWebCheckout.autoDismiss {
             self.onDismiss()

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -32,6 +32,8 @@ struct PurchaseButtonComponentView: View {
     @EnvironmentObject
     private var purchaseHandler: PurchaseHandler
 
+    @State private var inAppBrowserURL: URL?
+
     private let viewModel: PurchaseButtonComponentViewModel
     private let onDismiss: () -> Void
 
@@ -74,21 +76,24 @@ struct PurchaseButtonComponentView: View {
             $0.disabled(true)
                 .opacity(0.35)
         }
+        #if canImport(SafariServices) && canImport(UIKit)
+        .sheet(isPresented: .isNotNil(self.$inAppBrowserURL)) {
+            SafariView(url: self.inAppBrowserURL!)
+        }
+        #endif
     }
 
     private func purchase() async throws {
-        guard let action = self.viewModel.action else {
+        guard let method = self.viewModel.method else {
             try await self.purchaseInApp()
             return
         }
 
-        switch action {
-        case .inAppCheckout:
+        switch method {
+        case .inAppCheckout, .unknown:
             try await self.purchaseInApp()
-        case .webCheckout:
-            try await self.purchaseSelectedWebProduct()
-        case .webProductSelection:
-            try await self.openWebProductSelection()
+        case .webCheckout, .webProductSelection, .customWebCheckout:
+            try await self.purchaseInWeb()
         }
     }
 
@@ -105,56 +110,75 @@ struct PurchaseButtonComponentView: View {
         _ = try await self.purchaseHandler.purchase(package: selectedPackage)
     }
 
-    private func purchaseSelectedWebProduct() async throws {
+    private func purchaseInWeb() async throws {
         self.logIfInPreview(package: self.packageContext.package)
 
-        guard let webCheckoutUrl = self.viewModel.urlForWebProduct(packageContext: self.packageContext) else {
+        guard let launchWebCheckout = self.viewModel.urlForWebCheckout(packageContext: packageContext) else {
             Logger.error(Strings.no_web_checkout_url_found)
             return
         }
 
-        self.logIfInPreview("Web Product: \(webCheckoutUrl)")
+        self.logIfInPreview("Web Product: \(launchWebCheckout)")
 
         guard !self.isInPreview else {
             return
         }
 
-        self.openWebPaywallLink(url: webCheckoutUrl.0, method: webCheckoutUrl.1)
+        self.openWebPaywallLink(launchWebCheckout: launchWebCheckout)
     }
 
-    private func openWebProductSelection() async throws {
-        self.logIfInPreview(package: self.packageContext.package)
-
-        guard let webCheckoutUrl = self.viewModel.offeringWebCheckoutUrl else {
-            Logger.error(Strings.no_web_checkout_url_found)
-            return
-        }
-
-        self.logIfInPreview("Web Selection: \(webCheckoutUrl)")
-
-        guard !self.isInPreview else {
-            return
-        }
-
-        self.openWebPaywallLink(url: webCheckoutUrl.0, method: webCheckoutUrl.1)
-    }
-
-    private func openWebPaywallLink(url: URL, method: PaywallComponent.ButtonComponent.URLMethod) {
+    private func openWebPaywallLink(launchWebCheckout: PurchaseButtonComponentViewModel.LaunchWebCheckout) {
         Purchases.shared.invalidateCustomerInfoCache()
-        #if os(watchOS)
-        // watchOS doesn't support openURL with a completion handler, so we're just opening the URL.
-        openURL(url)
-        #else
-        openURL(url) { success in
-            if success {
-                Logger.debug(Strings.successfully_opened_url_external_browser(url.absoluteString))
-            } else {
-                Logger.error(Strings.failed_to_open_url_external_browser(url.absoluteString))
-            }
-        }
-        #endif
 
-        if self.viewModel.webAutoDimiss {
+        let method = launchWebCheckout.method
+        let url = launchWebCheckout.url
+
+        switch method {
+        case .inAppBrowser:
+#if os(tvOS)
+            // There's no SafariServices on tvOS, so we're falling back to opening in an external browser.
+            Logger.warning(Strings.no_in_app_browser_tvos)
+            openURL(url) { success in
+                if success {
+                    Logger.debug(Strings.successfully_opened_url_external_browser(url.absoluteString))
+                } else {
+                    Logger.error(Strings.failed_to_open_url_external_browser(url.absoluteString))
+                }
+            }
+#else
+            inAppBrowserURL = url
+#endif
+        case .externalBrowser:
+#if os(watchOS)
+            // watchOS doesn't support openURL with a completion handler, so we're just opening the URL.
+            openURL(url)
+#else
+            openURL(url) { success in
+                if success {
+                    Logger.debug(Strings.successfully_opened_url_external_browser(url.absoluteString))
+                } else {
+                    Logger.error(Strings.failed_to_open_url_external_browser(url.absoluteString))
+                }
+            }
+#endif
+        case .deepLink:
+#if os(watchOS)
+            // watchOS doesn't support openURL with a completion handler, so we're just opening the URL.
+            openURL(url)
+#else
+            openURL(url) { success in
+                if success {
+                    Logger.debug(Strings.successfully_opened_url_deep_link(url.absoluteString))
+                } else {
+                    Logger.error(Strings.failed_to_open_url_deep_link(url.absoluteString))
+                }
+            }
+#endif
+        case .unknown:
+            break
+        }
+
+        if launchWebCheckout.autoDismiss {
             self.onDismiss()
         }
     }

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentViewModel.swift
@@ -39,7 +39,42 @@ class PurchaseButtonComponentViewModel {
     }
 
     var offeringWebCheckoutUrl: URL? {
-        return self.offering.webCheckoutUrl
+        if let customUrl = component.customUrl {
+            return customUrl.url
+        } else {
+            return self.offering.webCheckoutUrl
+        }
+    }
+
+    var webAutoDimiss: Bool {
+        return self.component.webAutoDismiss
+    }
+
+    func urlForWebProduct(packageContext: PackageContext) -> URL? {
+        guard let package = packageContext.package else {
+            return nil
+        }
+
+        if let customUrl = component.customUrl {
+            // Appends package identifier into a query param to a custom url
+            return customUrl.url.appending(name: customUrl.packageParam, value: package.identifier)
+        } else {
+            return package.webCheckoutUrl
+        }
+    }
+
+}
+
+private extension URL {
+
+    func appending(name: String, value: String?) -> URL {
+        var components = URLComponents(url: self, resolvingAgainstBaseURL: false)
+
+        var queryItems = components?.queryItems ?? []
+        queryItems.append(URLQueryItem(name: name, value: value))
+        components?.queryItems = queryItems
+
+        return components?.url ?? self
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentViewModel.swift
@@ -59,26 +59,6 @@ class PurchaseButtonComponentViewModel {
         })
     }
 
-    static let defaultWebAutoDismiss = true
-
-    var webAutoDimiss: Bool {
-        if let method = component.method {
-            switch method {
-            case .webCheckout(let webCheckout), .webProductSelection(let webCheckout):
-                return webCheckout.autoDismiss ?? Self.defaultWebAutoDismiss
-            case .customWebCheckout(let customWebCheckout):
-                return customWebCheckout.autoDismiss ?? Self.defaultWebAutoDismiss
-            case .inAppCheckout, .unknown:
-                break
-            }
-        } else if component.action != nil {
-            // Legacy action was previously always dismissing
-            return Self.defaultWebAutoDismiss
-        }
-
-        return Self.defaultWebAutoDismiss
-    }
-
     typealias LaunchWebCheckout = (url: URL, method: PaywallComponent.ButtonComponent.URLMethod, autoDismiss: Bool)
 
     func urlForWebCheckout(packageContext: PackageContext?) -> LaunchWebCheckout? {

--- a/RevenueCatUI/Templates/V2/Localizations/LocalizationDictionaryExtensions.swift
+++ b/RevenueCatUI/Templates/V2/Localizations/LocalizationDictionaryExtensions.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  LocalizationDictionaryExtensions.swift
+//
+//  Created by Josh Holtz on 5/14/25.
+
+import Foundation
+@_spi(Internal) import RevenueCat
+
+extension PaywallComponent.LocalizationDictionary {
+
+    func urlFromLid(_ urlLid: String) throws -> URL {
+        do {
+            return try url(key: urlLid)
+        } catch {
+            Logger.error(Strings.paywall_invalid_url(urlLid))
+            throw error
+        }
+    }
+
+}

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
@@ -124,7 +124,7 @@ private enum ButtonWithSheetPreview {
             shape: .pill
         ),
         action: nil,
-        method: nil,
+        method: nil
     )
 
     static let viewAllButton = PaywallComponent.ButtonComponent(

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
@@ -259,7 +259,7 @@ private enum ButtonWithSheetPreview {
                                         action: .webCheckout,
                                         method: .customWebCheckout(
                                             .init(customUrl: .init(url: "web_checkout_url", packageParam: "rc_package"))
-                                        ),
+                                        )
                                     )),
                                     .purchaseButton(.init(
                                         stack: .init(
@@ -282,7 +282,7 @@ private enum ButtonWithSheetPreview {
                                         action: .webProductSelection,
                                         method: .customWebCheckout(
                                             .init(customUrl: .init(url: "web_checkout_url"))
-                                        ),
+                                        )
                                     ))
                                 ],
                                 size: .init(width: .fill, height: .fit),

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
@@ -123,7 +123,8 @@ private enum ButtonWithSheetPreview {
             ],
             shape: .pill
         ),
-        action: nil
+        action: nil,
+        method: nil,
     )
 
     static let viewAllButton = PaywallComponent.ButtonComponent(
@@ -192,7 +193,8 @@ private enum ButtonWithSheetPreview {
                                             size: .init(width: .fill, height: .fit),
                                             shape: .pill
                                         ),
-                                        action: .inAppCheckout
+                                        action: .inAppCheckout,
+                                        method: .inAppCheckout
                                     )),
                                     .purchaseButton(.init(
                                         stack: .init(
@@ -212,7 +214,8 @@ private enum ButtonWithSheetPreview {
                                             size: .init(width: .fill, height: .fit),
                                             shape: .pill
                                         ),
-                                        action: .webCheckout
+                                        action: .webCheckout,
+                                        method: .webCheckout(.init())
                                     )),
                                     .purchaseButton(.init(
                                         stack: .init(
@@ -232,7 +235,8 @@ private enum ButtonWithSheetPreview {
                                             size: .init(width: .fill, height: .fit),
                                             shape: .pill
                                         ),
-                                        action: .webProductSelection
+                                        action: .webProductSelection,
+                                        method: .webProductSelection(.init())
                                     )),
                                     .purchaseButton(.init(
                                         stack: .init(
@@ -253,10 +257,9 @@ private enum ButtonWithSheetPreview {
                                             shape: .pill
                                         ),
                                         action: .webCheckout,
-                                        customUrl: .init(
-                                            url: URL(string: "https://rev.cat?rc_app_user_id=123")!,
-                                            packageParam: "rc_package"
-                                        )
+                                        method: .customWebCheckout(
+                                            .init(customUrl: .init(url: "web_checkout_url", packageParam: "rc_package"))
+                                        ),
                                     )),
                                     .purchaseButton(.init(
                                         stack: .init(
@@ -277,10 +280,9 @@ private enum ButtonWithSheetPreview {
                                             shape: .pill
                                         ),
                                         action: .webProductSelection,
-                                        customUrl: .init(
-                                            url: URL(string: "https://rev.cat?rc_app_user_id=123")!,
-                                            packageParam: "rc_package"
-                                        )
+                                        method: .customWebCheckout(
+                                            .init(customUrl: .init(url: "web_checkout_url"))
+                                        ),
                                     ))
                                 ],
                                 size: .init(width: .fill, height: .fit),
@@ -461,6 +463,8 @@ private enum ButtonWithSheetPreview {
             "monthly_title": .string("Buy Monthly"),
             "monthly_desc": .string("Monthly something"),
 
+            "web_checkout_url": .string("https://rev.cat?rc_app_user_id=123"),
+
             "close": .string("X")
         ]],
         revision: 1,
@@ -471,12 +475,14 @@ private enum ButtonWithSheetPreview {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct ButtonWithSheetPreview_Previews: PreviewProvider {
 
+    static let baseUrl = "https://pay.revenuecat.com/abcd1234/the-app-user-id"
+
     static var weeklyPackage: Package {
         return .init(identifier: "weekly",
                      packageType: .weekly,
                      storeProduct: .init(sk1Product: .init()),
                      offeringIdentifier: "default",
-                     webCheckoutUrl: URL(string: "https://pay.revenuecat.com/abcd1234/the-app-user-id")!)
+                     webCheckoutUrl: URL(string: "\(baseUrl)?package_id=weekly")!)
     }
 
     static var monthlyPackage: Package {
@@ -484,7 +490,7 @@ struct ButtonWithSheetPreview_Previews: PreviewProvider {
                      packageType: .monthly,
                      storeProduct: .init(sk1Product: .init()),
                      offeringIdentifier: "default",
-                     webCheckoutUrl: URL(string: "https://pay.revenuecat.com/abcd1234/the-app-user-id")!)
+                     webCheckoutUrl: URL(string: "\(baseUrl)?package_id=monthly")!)
     }
 
     // Need to wrap in VStack otherwise preview rerenders and images won't show
@@ -496,7 +502,7 @@ struct ButtonWithSheetPreview_Previews: PreviewProvider {
             offering: .init(identifier: "default",
                             serverDescription: "",
                             availablePackages: [weeklyPackage, monthlyPackage],
-                            webCheckoutUrl: nil),
+                            webCheckoutUrl: URL(string: "https://pay.revenuecat.com/abcd1234/the-app-user-id")!),
             purchaseHandler: PurchaseHandler.default(),
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
@@ -192,19 +192,107 @@ private enum ButtonWithSheetPreview {
                                             size: .init(width: .fill, height: .fit),
                                             shape: .pill
                                         ),
-                                        action: nil
+                                        action: .inAppCheckout
+                                    )),
+                                    .purchaseButton(.init(
+                                        stack: .init(
+                                            components: [
+                                                // WIP: Intro offer state with "cta_intro",
+                                                .text(.init(
+                                                    text: "cta_web",
+                                                    fontWeight: .bold,
+                                                    color: .init(light: .hex("#ffffff")),
+                                                    backgroundColor: .init(light: .hex("#e89d89")),
+                                                    padding: .init(top: 10,
+                                                                   bottom: 10,
+                                                                   leading: 30,
+                                                                   trailing: 30)
+                                                ))
+                                            ],
+                                            size: .init(width: .fill, height: .fit),
+                                            shape: .pill
+                                        ),
+                                        action: .webCheckout
+                                    )),
+                                    .purchaseButton(.init(
+                                        stack: .init(
+                                            components: [
+                                                // WIP: Intro offer state with "cta_intro",
+                                                .text(.init(
+                                                    text: "cta_web_selection",
+                                                    fontWeight: .bold,
+                                                    color: .init(light: .hex("#ffffff")),
+                                                    backgroundColor: .init(light: .hex("#e89d89")),
+                                                    padding: .init(top: 10,
+                                                                   bottom: 10,
+                                                                   leading: 30,
+                                                                   trailing: 30)
+                                                ))
+                                            ],
+                                            size: .init(width: .fill, height: .fit),
+                                            shape: .pill
+                                        ),
+                                        action: .webProductSelection
+                                    )),
+                                    .purchaseButton(.init(
+                                        stack: .init(
+                                            components: [
+                                                // WIP: Intro offer state with "cta_intro",
+                                                .text(.init(
+                                                    text: "cta_web_custom",
+                                                    fontWeight: .bold,
+                                                    color: .init(light: .hex("#ffffff")),
+                                                    backgroundColor: .init(light: .hex("#e89d89")),
+                                                    padding: .init(top: 10,
+                                                                   bottom: 10,
+                                                                   leading: 30,
+                                                                   trailing: 30)
+                                                ))
+                                            ],
+                                            size: .init(width: .fill, height: .fit),
+                                            shape: .pill
+                                        ),
+                                        action: .webCheckout,
+                                        customUrl: .init(
+                                            url: URL(string: "https://rev.cat?rc_app_user_id=123")!,
+                                            packageParam: "rc_package"
+                                        )
+                                    )),
+                                    .purchaseButton(.init(
+                                        stack: .init(
+                                            components: [
+                                                // WIP: Intro offer state with "cta_intro",
+                                                .text(.init(
+                                                    text: "cta_web_selection_custom",
+                                                    fontWeight: .bold,
+                                                    color: .init(light: .hex("#ffffff")),
+                                                    backgroundColor: .init(light: .hex("#e89d89")),
+                                                    padding: .init(top: 10,
+                                                                   bottom: 10,
+                                                                   leading: 30,
+                                                                   trailing: 30)
+                                                ))
+                                            ],
+                                            size: .init(width: .fill, height: .fit),
+                                            shape: .pill
+                                        ),
+                                        action: .webProductSelection,
+                                        customUrl: .init(
+                                            url: URL(string: "https://rev.cat?rc_app_user_id=123")!,
+                                            packageParam: "rc_package"
+                                        )
                                     ))
                                 ],
                                 size: .init(width: .fill, height: .fit),
-                                background: .color(.init(light: .hex("#ffcc00"))),
+                                background: .color(.init(light: .hex("#2b43bf"))),
                                 padding: .init(top: 0, bottom: 30, leading: 20, trailing: 20),
                                 shape: .rectangle(nil),
-                                overflow: .none
+                                overflow: .default
                              ),
                              // Sheet background
                              background: .color(.init(light: .hex("#2b43bf"))),
                              backgroundBlur: true,
-                             size: .init(width: .fill, height: .relative(0.25))
+                             size: .init(width: .fill, height: .fit)
                             )
             )),
         stack: .init(
@@ -290,34 +378,10 @@ private enum ButtonWithSheetPreview {
             .package(makePackage(packageID: "monthly",
                                  nameTextLid: "monthly_title",
                                  detailTextLid: "monthly_desc",
-                                 isSelectedByDefault: true)),
-            .package(makePackage(packageID: "weekly",
-                                 nameTextLid: "weekly_title",
-                                 detailTextLid: "weekly_desc",
-                                 isSelectedByDefault: true)),
-            .package(makePackage(packageID: "monthly",
-                                 nameTextLid: "monthly_title",
-                                 detailTextLid: "monthly_desc",
-                                 isSelectedByDefault: true)),
-            .package(makePackage(packageID: "weekly",
-                                 nameTextLid: "weekly_title",
-                                 detailTextLid: "weekly_desc",
-                                 isSelectedByDefault: true)),
-            .package(makePackage(packageID: "monthly",
-                                 nameTextLid: "monthly_title",
-                                 detailTextLid: "monthly_desc",
-                                 isSelectedByDefault: true)),
-            .package(makePackage(packageID: "weekly",
-                                 nameTextLid: "weekly_title",
-                                 detailTextLid: "weekly_desc",
-                                 isSelectedByDefault: true)),
-            .package(makePackage(packageID: "monthly",
-                                 nameTextLid: "monthly_title",
-                                 detailTextLid: "monthly_desc",
                                  isSelectedByDefault: true))
         ],
-        size: .init(width: .fill, height: .fill),
-        overflow: .scroll
+        size: .init(width: .fill, height: .fit),
+        overflow: .default
     )
 
     static let contentStack = PaywallComponent.StackComponent(
@@ -384,7 +448,11 @@ private enum ButtonWithSheetPreview {
             "body": .string("Get access to all of our educational content trusted by thousands of pet parents."),
             "package_name": .string("Monthly"),
             "package_detail": .string("Some price into"),
-            "cta": .string("Get Started"),
+            "cta": .string("In-app Checkout"),
+            "cta_web": .string("Web Checkout"),
+            "cta_web_selection": .string("Web Selection"),
+            "cta_web_custom": .string("Web Checkout (Custom)"),
+            "cta_web_selection_custom": .string("Web Selection (Custom)"),
             "cta_intro": .string("Claim Free Trial"),
             "viewall": .string("View all plans"),
 
@@ -393,7 +461,7 @@ private enum ButtonWithSheetPreview {
             "monthly_title": .string("Buy Monthly"),
             "monthly_desc": .string("Monthly something"),
 
-            "close": .string("X")
+            "close": .string("X"),
         ]],
         revision: 1,
         defaultLocaleIdentifier: "en_US"
@@ -403,12 +471,12 @@ private enum ButtonWithSheetPreview {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct ButtonWithSheetPreview_Previews: PreviewProvider {
 
-    static var package: Package {
+    static var weeklyPackage: Package {
         return .init(identifier: "weekly",
                      packageType: .weekly,
                      storeProduct: .init(sk1Product: .init()),
                      offeringIdentifier: "default",
-                     webCheckoutUrl: nil)
+                     webCheckoutUrl: URL(string: "https://pay.revenuecat.com/abcd1234/the-app-user-id")!)
     }
 
     static var monthlyPackage: Package {
@@ -416,7 +484,7 @@ struct ButtonWithSheetPreview_Previews: PreviewProvider {
                      packageType: .monthly,
                      storeProduct: .init(sk1Product: .init()),
                      offeringIdentifier: "default",
-                     webCheckoutUrl: nil)
+                     webCheckoutUrl: URL(string: "https://pay.revenuecat.com/abcd1234/the-app-user-id")!)
     }
 
     // Need to wrap in VStack otherwise preview rerenders and images won't show
@@ -427,7 +495,7 @@ struct ButtonWithSheetPreview_Previews: PreviewProvider {
             paywallComponents: ButtonWithSheetPreview.paywallComponents,
             offering: .init(identifier: "default",
                             serverDescription: "",
-                            availablePackages: [package, monthlyPackage],
+                            availablePackages: [weeklyPackage, monthlyPackage],
                             webCheckoutUrl: nil),
             purchaseHandler: PurchaseHandler.default(),
             introEligibilityChecker: .default(),

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
@@ -461,7 +461,7 @@ private enum ButtonWithSheetPreview {
             "monthly_title": .string("Buy Monthly"),
             "monthly_desc": .string("Monthly something"),
 
-            "close": .string("X"),
+            "close": .string("X")
         ]],
         revision: 1,
         defaultLocaleIdentifier: "en_US"

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
@@ -301,7 +301,8 @@ private enum FamilySharingTogglePreview {
                                     bottomLeading: 16,
                                     bottomTrailing: 16))
         ),
-        action: .inAppCheckout
+        action: .inAppCheckout,
+        method: .inAppCheckout
     )
 
     static let purchaseButtonStack = PaywallComponent.StackComponent(

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
@@ -291,7 +291,8 @@ private enum MultiTierPreview {
                                     bottomLeading: 16,
                                     bottomTrailing: 16))
         ),
-        action: .inAppCheckout
+        action: .inAppCheckout,
+        method: .inAppCheckout
     )
 
     static let purchaseButtonStack = PaywallComponent.StackComponent(

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/PurchaseButtonInPackagePreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/PurchaseButtonInPackagePreview.swift
@@ -120,7 +120,8 @@ private enum PurchaseButtonInPackagePreview {
                         ],
                         shape: .pill
                     ),
-                    action: .inAppCheckout
+                    action: .inAppCheckout,
+                    method: .inAppCheckout
                 ))
             ],
             dimension: .vertical(.center, .start),
@@ -223,7 +224,8 @@ private enum PurchaseButtonInPackagePreview {
                     ],
                     shape: .pill
                 ),
-                action: .inAppCheckout
+                action: .inAppCheckout,
+                method: .inAppCheckout
             )),
             .text(orText),
             .package(.init(

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -123,7 +123,8 @@ private enum Template1Preview {
             ],
             shape: .pill
         ),
-        action: .inAppCheckout
+        action: .inAppCheckout,
+        method: .inAppCheckout
     )
 
     static let contentStack = PaywallComponent.StackComponent(

--- a/RevenueCatUI/Templates/V2/ViewHelpers/NavigatetoURL.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/NavigatetoURL.swift
@@ -1,0 +1,72 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  NavigatetoURL.swift
+//
+//  Created by Josh Holtz on 5/15/25.
+
+import RevenueCat
+import SwiftUI
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+enum Browser {
+
+    static func navigateTo(
+        url: URL,
+        method: PaywallComponent.ButtonComponent.URLMethod,
+        openURL: OpenURLAction,
+        inAppBrowserURL: Binding<URL?>
+    ) {
+        switch method {
+        case .inAppBrowser:
+#if os(tvOS)
+            // There's no SafariServices on tvOS, so we're falling back to opening in an external browser.
+            Logger.warning(Strings.no_in_app_browser_tvos)
+            openURL(url) { success in
+                if success {
+                    Logger.debug(Strings.successfully_opened_url_external_browser(url.absoluteString))
+                } else {
+                    Logger.error(Strings.failed_to_open_url_external_browser(url.absoluteString))
+                }
+            }
+#else
+            inAppBrowserURL.wrappedValue = url
+#endif
+        case .externalBrowser:
+#if os(watchOS)
+            // watchOS doesn't support openURL with a completion handler, so we're just opening the URL.
+            openURL(url)
+#else
+            openURL(url) { success in
+                if success {
+                    Logger.debug(Strings.successfully_opened_url_external_browser(url.absoluteString))
+                } else {
+                    Logger.error(Strings.failed_to_open_url_external_browser(url.absoluteString))
+                }
+            }
+#endif
+        case .deepLink:
+#if os(watchOS)
+            // watchOS doesn't support openURL with a completion handler, so we're just opening the URL.
+            openURL(url)
+#else
+            openURL(url) { success in
+                if success {
+                    Logger.debug(Strings.successfully_opened_url_deep_link(url.absoluteString))
+                } else {
+                    Logger.error(Strings.failed_to_open_url_deep_link(url.absoluteString))
+                }
+            }
+#endif
+        case .unknown:
+            break
+        }
+    }
+
+}

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -172,7 +172,8 @@ struct ViewModelFactory {
             )
 
             return .purchaseButton(
-                PurchaseButtonComponentViewModel(
+                try PurchaseButtonComponentViewModel(
+                    localizationProvider: localizationProvider,
                     component: component,
                     offering: offering,
                     stackViewModel: stackViewModel

--- a/Sources/Paywalls/Components/Common/PaywallComponentLocalization.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentLocalization.swift
@@ -13,6 +13,7 @@
 // swiftlint:disable missing_docs
 
 import Foundation
+@_spi(Internal) import RevenueCat
 
 extension PaywallComponent.LocalizationDictionary {
 

--- a/Sources/Paywalls/Components/Common/PaywallComponentLocalization.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentLocalization.swift
@@ -13,7 +13,6 @@
 // swiftlint:disable missing_docs
 
 import Foundation
-@_spi(Internal) import RevenueCat
 
 extension PaywallComponent.LocalizationDictionary {
 

--- a/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
@@ -12,26 +12,11 @@ public extension PaywallComponent {
 
     final class PurchaseButtonComponent: PaywallComponentBase {
 
-        // swiftlint:disable:next nesting
-        public struct CustomURL: PaywallComponentBase {
-
-            public let url: URL
-            public let packageParam: String
-
-            public init(url: URL, packageParam: String) {
-                self.url = url
-                self.packageParam = packageParam
-            }
-
-        }
-
         let type: ComponentType
         public let stack: PaywallComponent.StackComponent
 
         public let action: Action?
-
-        public let customUrl: CustomURL?
-        public let webAutoDismiss: Bool
+        public let method: Method?
 
         // swiftlint:disable nesting
         public enum Action: String, Codable, Sendable, Hashable, Equatable {
@@ -40,33 +25,114 @@ public extension PaywallComponent {
             case webProductSelection = "web_product_selection"
         }
 
+        public enum Method: Codable, Sendable, Hashable, Equatable {
+            case inAppCheckout
+            case webCheckout(WebCheckout)
+            case webProductSelection(WebCheckout)
+            case customWebCheckout(CustomWebCheckout)
+
+            case unknown
+
+            private enum CodingKeys: String, CodingKey {
+                case type
+
+                case webCheckout
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+
+                switch self {
+                case .inAppCheckout:
+                    try container.encode("in_app_checkout", forKey: .type)
+                case .webCheckout(let webCheckout):
+                    try container.encode("web_checkout", forKey: .type)
+                    try webCheckout.encode(to: encoder)
+                case .webProductSelection(let webCheckout):
+                    try container.encode("web_product_selection", forKey: .type)
+                    try webCheckout.encode(to: encoder)
+                case .customWebCheckout(let customWebCheckout):
+                    try container.encode("custom_web_checkout", forKey: .type)
+                    try customWebCheckout.encode(to: encoder)
+                case .unknown:
+                    try container.encode("unknown", forKey: .type)
+                }
+            }
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let type = try container.decode(String.self, forKey: .type)
+
+                switch type {
+                case "in_app_checkout":
+                    self = .inAppCheckout
+                case "web_checkout":
+                    let webCheckout = try WebCheckout(from: decoder)
+                    self = .webCheckout(webCheckout)
+                case "web_product_selection":
+                    let webCheckout = try WebCheckout(from: decoder)
+                    self = .webProductSelection(webCheckout)
+                case "custom_web_checkout":
+                    let customCheckout = try CustomWebCheckout(from: decoder)
+                    self = .customWebCheckout(customCheckout)
+                case "unknown":
+                    self = .unknown
+                default:
+                    self = .unknown
+                }
+            }
+        }
+
+        public struct WebCheckout: Codable, Sendable, Hashable, Equatable {
+
+            public let autoDismiss: Bool?
+            public let openMethod: ButtonComponent.URLMethod?
+
+        }
+
+        public struct CustomWebCheckout: Codable, Sendable, Hashable, Equatable {
+
+            public struct CustomURL: Codable, Sendable, Hashable, Equatable {
+
+                public let url: LocalizationKey
+                public let packageParam: String?
+
+                private enum CodingKeys: String, CodingKey {
+                    case url = "urlLid"
+                    case packageParam
+                }
+
+            }
+
+            public let customUrl: CustomURL
+            public let autoDismiss: Bool?
+            public let openMethod: ButtonComponent.URLMethod?
+
+        }
+
         public init(
             stack: PaywallComponent.StackComponent,
             action: Action?,
-            customUrl: CustomURL? = nil,
-            webAutoDismiss: Bool = true
+            method: Method?
         ) {
-            self.type = .button
+            self.type = .purchaseButton
             self.stack = stack
             self.action = action
-            self.customUrl = customUrl
-            self.webAutoDismiss = webAutoDismiss
+            self.method = method
         }
 
         public func hash(into hasher: inout Hasher) {
             hasher.combine(type)
             hasher.combine(stack)
             hasher.combine(action)
-            hasher.combine(customUrl)
-            hasher.combine(webAutoDismiss)
+            hasher.combine(method)
         }
 
         public static func == (lhs: PurchaseButtonComponent, rhs: PurchaseButtonComponent) -> Bool {
             return lhs.type == rhs.type &&
                 lhs.stack == rhs.stack &&
                 lhs.action == rhs.action &&
-                lhs.customUrl == rhs.customUrl &&
-                lhs.webAutoDismiss == rhs.webAutoDismiss
+                lhs.method == rhs.method
         }
     }
 

--- a/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
@@ -12,10 +12,17 @@ public extension PaywallComponent {
 
     final class PurchaseButtonComponent: PaywallComponentBase {
 
-        // swiftlint:disable:next swiftlint
+        // swiftlint:disable:next nesting
         public struct CustomURL: PaywallComponentBase {
+
             public let url: URL
             public let packageParam: String
+
+            public init(url: URL, packageParam: String) {
+                self.url = url
+                self.packageParam = packageParam
+            }
+
         }
 
         let type: ComponentType

--- a/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
@@ -12,10 +12,18 @@ public extension PaywallComponent {
 
     final class PurchaseButtonComponent: PaywallComponentBase {
 
+        public struct CustomURL: PaywallComponentBase {
+            public let url: URL
+            public let packageParam: String
+        }
+
         let type: ComponentType
         public let stack: PaywallComponent.StackComponent
 
         public let action: Action?
+
+        public let customUrl: CustomURL?
+        public let webAutoDismiss: Bool
 
         // swiftlint:disable nesting
         public enum Action: String, Codable, Sendable, Hashable, Equatable {
@@ -26,21 +34,31 @@ public extension PaywallComponent {
 
         public init(
             stack: PaywallComponent.StackComponent,
-            action: Action?
+            action: Action?,
+            customUrl: CustomURL? = nil,
+            webAutoDismiss: Bool = true
         ) {
             self.type = .button
             self.stack = stack
             self.action = action
+            self.customUrl = customUrl
+            self.webAutoDismiss = webAutoDismiss
         }
 
         public func hash(into hasher: inout Hasher) {
             hasher.combine(type)
             hasher.combine(stack)
             hasher.combine(action)
+            hasher.combine(customUrl)
+            hasher.combine(webAutoDismiss)
         }
 
         public static func == (lhs: PurchaseButtonComponent, rhs: PurchaseButtonComponent) -> Bool {
-            return lhs.type == rhs.type && lhs.stack == rhs.stack && lhs.action == rhs.action
+            return lhs.type == rhs.type &&
+                lhs.stack == rhs.stack &&
+                lhs.action == rhs.action &&
+                lhs.customUrl == rhs.customUrl &&
+                lhs.webAutoDismiss == rhs.webAutoDismiss
         }
     }
 

--- a/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
@@ -88,6 +88,11 @@ public extension PaywallComponent {
             public let autoDismiss: Bool?
             public let openMethod: ButtonComponent.URLMethod?
 
+            public init(autoDismiss: Bool? = nil, openMethod: PaywallComponent.ButtonComponent.URLMethod? = nil) {
+                self.autoDismiss = autoDismiss
+                self.openMethod = openMethod
+            }
+
         }
 
         public struct CustomWebCheckout: Codable, Sendable, Hashable, Equatable {
@@ -97,11 +102,26 @@ public extension PaywallComponent {
                 public let url: LocalizationKey
                 public let packageParam: String?
 
+                public init(url: PaywallComponent.LocalizationKey, packageParam: String? = nil) {
+                    self.url = url
+                    self.packageParam = packageParam
+                }
+
                 private enum CodingKeys: String, CodingKey {
                     case url = "urlLid"
                     case packageParam
                 }
 
+            }
+
+            public init(
+                customUrl: PaywallComponent.PurchaseButtonComponent.CustomWebCheckout.CustomURL,
+                autoDismiss: Bool? = nil,
+                openMethod: PaywallComponent.ButtonComponent.URLMethod? = nil
+            ) {
+                self.customUrl = customUrl
+                self.autoDismiss = autoDismiss
+                self.openMethod = openMethod
             }
 
             public let customUrl: CustomURL

--- a/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
@@ -12,6 +12,7 @@ public extension PaywallComponent {
 
     final class PurchaseButtonComponent: PaywallComponentBase {
 
+        // swiftlint:disable:next swiftlint
         public struct CustomURL: PaywallComponentBase {
             public let url: URL
             public let packageParam: String

--- a/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
@@ -15,7 +15,6 @@ public extension PaywallComponent {
         let type: ComponentType
         public let stack: PaywallComponent.StackComponent
 
-        @available(*, deprecated, message: "This API is unused and will be removed in a future version.")
         public let action: Action?
         public let method: Method?
 

--- a/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
@@ -15,6 +15,7 @@ public extension PaywallComponent {
         let type: ComponentType
         public let stack: PaywallComponent.StackComponent
 
+        @available(*, deprecated, message: "This API is unused and will be removed in a future version.")
         public let action: Action?
         public let method: Method?
 

--- a/Tests/UnitTests/Paywalls/Components/PurchaseButtonComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/PurchaseButtonComponentTests.swift
@@ -1,0 +1,277 @@
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+#if !os(macOS) && !os(tvOS) // For Paywalls V2
+
+class PurchaseButtonComponentCodableTests: TestCase {
+
+    let jsonStringDefaultStack = """
+    {
+        "type": "stack",
+        "dimension": {
+            "type": "vertical",
+            "alignment": "center",
+            "distribution": "start"
+        },
+        "size": {
+            "width": { "type": "fill" },
+            "height": { "type": "fill" }
+        },
+        "padding": {
+            "top": 0,
+            "bottom": 0,
+            "leading": 0,
+            "trailing": 0
+        },
+        "margin": {
+            "top": 0,
+            "bottom": 0,
+            "leading": 0,
+            "trailing": 0
+        },
+        "components": []
+    }
+    """
+
+    func testDefaultDecoding() throws {
+        let jsonString = """
+        {
+            "type": "purchase_button",
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPurchaseButton = try JSONDecoder.default.decode(PaywallComponent.PurchaseButtonComponent.self,
+                                                                   from: jsonData)
+
+        let purchaseButtonComponent = PaywallComponent.PurchaseButtonComponent(
+            stack: .init(
+                components: [],
+                dimension: .vertical(.center, .start),
+                size: .init(width: .fill, height: .fill)
+            ),
+            action: nil,
+            method: nil
+        )
+
+        XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
+    }
+
+    func testMethodInAppCheckoutDecoding() throws {
+        let jsonString = """
+        {
+            "type": "purchase_button",
+            "method": {
+                "type": "in_app_checkout"
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPurchaseButton = try JSONDecoder.default.decode(PaywallComponent.PurchaseButtonComponent.self,
+                                                                   from: jsonData)
+
+        let purchaseButtonComponent = PaywallComponent.PurchaseButtonComponent(
+            stack: .init(
+                components: [],
+                dimension: .vertical(.center, .start),
+                size: .init(width: .fill, height: .fill)
+            ),
+            action: nil,
+            method: .inAppCheckout
+        )
+
+        XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
+    }
+
+    func testMethodWebCheckoutDecoding() throws {
+        let jsonString = """
+        {
+            "type": "purchase_button",
+            "method": {
+                "type": "web_checkout"
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPurchaseButton = try JSONDecoder.default.decode(PaywallComponent.PurchaseButtonComponent.self,
+                                                                   from: jsonData)
+
+        let purchaseButtonComponent = PaywallComponent.PurchaseButtonComponent(
+            stack: .init(
+                components: [],
+                dimension: .vertical(.center, .start),
+                size: .init(width: .fill, height: .fill)
+            ),
+            action: nil,
+            method: .webCheckout(.init(autoDismiss: nil, openMethod: nil))
+        )
+
+        XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
+    }
+
+    func testMethodWebCheckoutWithOptionsDecoding() throws {
+        let jsonString = """
+        {
+            "type": "purchase_button",
+            "method": {
+                "type": "web_checkout",
+                "auto_dismiss": false,
+                "open_method": "in_app_browser"
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPurchaseButton = try JSONDecoder.default.decode(PaywallComponent.PurchaseButtonComponent.self,
+                                                                   from: jsonData)
+
+        let purchaseButtonComponent = PaywallComponent.PurchaseButtonComponent(
+            stack: .init(
+                components: [],
+                dimension: .vertical(.center, .start),
+                size: .init(width: .fill, height: .fill)
+            ),
+            action: nil,
+            method: .webCheckout(.init(autoDismiss: false, openMethod: .inAppBrowser))
+        )
+
+        XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
+    }
+
+    func testMethodWebProductSelectionDecoding() throws {
+        let jsonString = """
+        {
+            "type": "purchase_button",
+            "method": {
+                "type": "web_product_selection"
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPurchaseButton = try JSONDecoder.default.decode(PaywallComponent.PurchaseButtonComponent.self,
+                                                                   from: jsonData)
+
+        let purchaseButtonComponent = PaywallComponent.PurchaseButtonComponent(
+            stack: .init(
+                components: [],
+                dimension: .vertical(.center, .start),
+                size: .init(width: .fill, height: .fill)
+            ),
+            action: nil,
+            method: .webProductSelection(.init(autoDismiss: nil, openMethod: nil))
+        )
+
+        XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
+    }
+
+    func testMethodWebProductSelectionWithOptionsDecoding() throws {
+        let jsonString = """
+        {
+            "type": "purchase_button",
+            "method": {
+                "type": "web_product_selection",
+                "auto_dismiss": false,
+                "open_method": "in_app_browser"
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPurchaseButton = try JSONDecoder.default.decode(PaywallComponent.PurchaseButtonComponent.self,
+                                                                   from: jsonData)
+
+        let purchaseButtonComponent = PaywallComponent.PurchaseButtonComponent(
+            stack: .init(
+                components: [],
+                dimension: .vertical(.center, .start),
+                size: .init(width: .fill, height: .fill)
+            ),
+            action: nil,
+            method: .webProductSelection(.init(autoDismiss: false, openMethod: .inAppBrowser))
+        )
+
+        XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
+    }
+
+    func testMethodCustomWebCheckoutDecoding() throws {
+        let jsonString = """
+        {
+            "type": "purchase_button",
+            "method": {
+                "type": "custom_web_checkout",
+                "custom_url": {
+                    "url_lid": "123"
+                }
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPurchaseButton = try JSONDecoder.default.decode(PaywallComponent.PurchaseButtonComponent.self,
+                                                                   from: jsonData)
+
+        let purchaseButtonComponent = PaywallComponent.PurchaseButtonComponent(
+            stack: .init(
+                components: [],
+                dimension: .vertical(.center, .start),
+                size: .init(width: .fill, height: .fill)
+            ),
+            action: nil,
+            method: .customWebCheckout(
+                .init(
+                    customUrl: .init(url: "123", packageParam: nil),
+                    autoDismiss: nil,
+                    openMethod: nil
+                )
+            )
+        )
+
+        XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
+    }
+
+    func testMethodCustomWebCheckoutWithOptionsDecoding() throws {
+        let jsonString = """
+        {
+            "type": "purchase_button",
+            "method": {
+                "type": "custom_web_checkout",
+                "custom_url": {
+                    "url_lid": "123",
+                    "package_param": "rc_package"
+                },
+                "auto_dismiss": false,
+                "open_method": "in_app_browser"
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPurchaseButton = try JSONDecoder.default.decode(PaywallComponent.PurchaseButtonComponent.self,
+                                                                   from: jsonData)
+
+        let purchaseButtonComponent = PaywallComponent.PurchaseButtonComponent(
+            stack: .init(
+                components: [],
+                dimension: .vertical(.center, .start),
+                size: .init(width: .fill, height: .fill)
+            ),
+            action: nil,
+            method: .customWebCheckout(
+                .init(
+                    customUrl: .init(url: "123", packageParam: "rc_package"),
+                    autoDismiss: false,
+                    openMethod: .inAppBrowser
+                )
+            )
+        )
+
+        XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
+    }
+
+}
+
+#endif


### PR DESCRIPTION
### Motivation

Allow custom url on paywalls v2 purchase button for web checkout

### Description

`PurchaseButtonComponent` needed a more complex structure than the `action: Action?` enum to work better with web checkout and custom web checkout url

- New `method: Method?` property added as a successor to `action: Action?` (essentially deprecated)
  - `inAppCheckout`
  - `webCheckout(WebCheckout)`
      - `autoDimiss: Bool?`
      - `openMethod: URLMethod?` 
  - `webProductSelection(WebCheckout)`
      - `autoDimiss: Bool?`
      - `openMethod: URLMethod?`
  - `customWebCheckout(CustomWebCheckout)`
      - `autoDimiss: Bool?`
      - `openMethod: URLMethod?`
      - `customUrl: CustomerURL`
          - `url: LocalizationKey`
          - `packageParam: String?`
- Added support for open method (external or in-app browser)
- Added unit tests for deserializing `PurchaseButtonComponent`
- Added more to a SwiftUI preview for testing out all these methods (which prints what it would do in a real app to the console)


### Demo

https://github.com/user-attachments/assets/3e0a1e4f-5f24-47b6-be6b-51932526b72b
