### PR TITLE
Add _spi(Internal) to StoreProductType

### DIFF
--- a/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -24,7 +24,7 @@ public typealias SK2Product = StoreKit.Product
 
 // It's an @objc wrapper of a `StoreProductType`. Swift-only code can use the protocol directly.
 /// Type that provides access to all of `StoreKit`'s product type's properties.
-@objc(RCStoreProduct) public final class StoreProduct: NSObject, StoreProductType {
+@objc(RCStoreProduct) public final class StoreProduct: NSObject {
 
     let product: StoreProductType
 
@@ -95,7 +95,7 @@ public typealias SK2Product = StoreKit.Product
 }
 
 /// Type that provides access to all of `StoreKit`'s product type's properties.
-internal protocol StoreProductType: Sendable {
+@_spi(Internal) public protocol StoreProductType: Sendable {
 
     /// The category of this product, whether a subscription or a one-time purchase.
 
@@ -192,6 +192,8 @@ internal protocol StoreProductType: Sendable {
     var discounts: [StoreProductDiscount] { get }
 
 }
+
+@_spi(Internal) extension StoreProduct: StoreProductType { }
 
 public extension StoreProduct {
 

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -100,21 +100,24 @@ public struct TestStoreProduct {
 }
 
 // Ensure consistency with the internal type
-extension TestStoreProduct: StoreProductType {
+extension TestStoreProduct {
+    // swiftlint:disable missing_docs
 
-    internal var productCategory: StoreProduct.ProductCategory { return self.productType.productCategory }
+    @_spi(Internal) public var productCategory: StoreProduct.ProductCategory { return self.productType.productCategory }
 
-    internal var currencyCode: String? {
+    @_spi(Internal) public var currencyCode: String? {
         return self.locale.rc_currencyCode
     }
 
-    internal var priceFormatter: NumberFormatter? {
+    @_spi(Internal) public var priceFormatter: NumberFormatter? {
         return self.currencyCode.map {
             self.priceFormatterProvider.priceFormatterForSK2(withCurrencyCode: $0, locale: self.locale)
         }
     }
-
+    // swiftlint:enable missing_docs
 }
+
+@_spi(Internal) extension TestStoreProduct: StoreProductType { }
 
 extension TestStoreProduct {
 


### PR DESCRIPTION
### Motivation
While working on some tests for https://github.com/RevenueCat/purchases-ios/pull/5031 I realised I need to use `StoreProductType` instead of `StoreProduct` to be able to write some tests.
 
### Description
Make `StoreProductType` `_spi(Internal)` to be able to use it from `RevenueCaUI`
