### PR TITLE
PurchaseInformation conforms to Identifiable & Equatable

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -17,7 +17,7 @@ import Foundation
 import RevenueCat
 import StoreKit
 
-// swiftlint:disable nesting
+// swiftlint:disable nesting file_length
 
 /// Information about a purchase.
 struct PurchaseInformation {
@@ -194,7 +194,7 @@ struct PurchaseInformation {
         }
     }
 
-    struct ExpirationOrRenewal {
+    struct ExpirationOrRenewal: Equatable {
         let label: Label
         let date: Date
 
@@ -235,6 +235,16 @@ struct PurchaseInformation {
          return dateFormatter
      }()
 }
+
+extension PurchaseInformation: Identifiable {
+
+     var id: String {
+         return "\(productIdentifier)_\(Self.defaultDateFormatter.string(from: customerInfoRequestedDate))"
+     }
+ }
+
+extension PurchaseInformation: Equatable { }
+
 // swiftlint:enable nesting
 
 extension PurchaseInformation {


### PR DESCRIPTION
### Motivation
I need `PurchaseInformation` conforming to these protocols

### Description
1. Identifiable: Use it inside a `ForEach`
2. Equatable: Use it with `onChangeOf` to update the view
