### PR TITLE
Remove ObservableObject from FeedbackSurveyData

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/FeedbackSurveyData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/FeedbackSurveyData.swift
@@ -22,7 +22,7 @@ import RevenueCat
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-class FeedbackSurveyData: ObservableObject, Equatable {
+struct FeedbackSurveyData: Equatable {
 
     var configuration: CustomerCenterConfigData.HelpPath.FeedbackSurvey
     var path: CustomerCenterConfigData.HelpPath


### PR DESCRIPTION
### Motivation
As part of cleaning up CustomerCenter, we've noticed that this shouldn't be a class nor observable object
