### PR TITLE
Fix ManageSubscriptionView Virtual Currency Previews in Customer Center

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -287,7 +287,10 @@ struct ManageSubscriptionsView: View {
                 ManageSubscriptionsView(purchaseInformation: .constant(nil), viewModel: viewModelWith4VCs)
                     .environment(\.localization, CustomerCenterConfigData.default.localization)
                     .environment(\.appearance, CustomerCenterConfigData.default.appearance)
-                    .environment(\.supportInformation, CustomerCenterConfigData.mock(displayVirtualCurrencies: true).support)
+                    .environment(
+                        \.supportInformation,
+                        CustomerCenterConfigData.mock(displayVirtualCurrencies: true).support
+                    )
             }
             .preferredColorScheme(colorScheme)
             .previewDisplayName("4 Virtual Currencies - \(colorScheme)")
@@ -302,7 +305,10 @@ struct ManageSubscriptionsView: View {
                 ManageSubscriptionsView(purchaseInformation: .constant(nil), viewModel: viewModelWith5VCs)
                     .environment(\.localization, CustomerCenterConfigData.default.localization)
                     .environment(\.appearance, CustomerCenterConfigData.default.appearance)
-                    .environment(\.supportInformation, CustomerCenterConfigData.mock(displayVirtualCurrencies: true).support)
+                    .environment(
+                        \.supportInformation,
+                        CustomerCenterConfigData.mock(displayVirtualCurrencies: true).support
+                    )
             }
             .preferredColorScheme(colorScheme)
             .previewDisplayName("5 Virtual Currencies - \(colorScheme)")

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsView.swift
@@ -287,7 +287,7 @@ struct ManageSubscriptionsView: View {
                 ManageSubscriptionsView(purchaseInformation: .constant(nil), viewModel: viewModelWith4VCs)
                     .environment(\.localization, CustomerCenterConfigData.default.localization)
                     .environment(\.appearance, CustomerCenterConfigData.default.appearance)
-                    .environment(\.supportInformation, CustomerCenterConfigData.default.support)
+                    .environment(\.supportInformation, CustomerCenterConfigData.mock(displayVirtualCurrencies: true).support)
             }
             .preferredColorScheme(colorScheme)
             .previewDisplayName("4 Virtual Currencies - \(colorScheme)")
@@ -302,7 +302,7 @@ struct ManageSubscriptionsView: View {
                 ManageSubscriptionsView(purchaseInformation: .constant(nil), viewModel: viewModelWith5VCs)
                     .environment(\.localization, CustomerCenterConfigData.default.localization)
                     .environment(\.appearance, CustomerCenterConfigData.default.appearance)
-                    .environment(\.supportInformation, CustomerCenterConfigData.default.support)
+                    .environment(\.supportInformation, CustomerCenterConfigData.mock(displayVirtualCurrencies: true).support)
             }
             .preferredColorScheme(colorScheme)
             .previewDisplayName("5 Virtual Currencies - \(colorScheme)")


### PR DESCRIPTION
### Description
When merging main into the `virtual-currency-dev` branch, we accidentally broke a few of the `ManageSubscriptionView` previews that show the virtual currency balances. This PR fixes the previews by modifying the mocked customer center config to set `displayVirtualCurrencies` to true.