### PR TITLE
Show account details in active subscription list

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/ActiveSubscriptionsListViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/ActiveSubscriptionsListViewModel.swift
@@ -27,14 +27,22 @@ final class ActiveSubscriptionsListViewModel: BaseManageSubscriptionViewModel {
     @Published
     private(set) var activePurchases: [PurchaseInformation] = []
 
+    let originalAppUserId: String
+    let originalPurchaseDate: Date?
+
     init(
         screen: CustomerCenterConfigData.Screen,
         actionWrapper: CustomerCenterActionWrapper,
         activePurchases: [PurchaseInformation] = [],
+        originalAppUserId: String,
+        originalPurchaseDate: Date?,
         refundRequestStatus: RefundRequestStatus? = nil,
         purchasesProvider: CustomerCenterPurchasesType,
         loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType? = nil) {
             self.activePurchases = activePurchases
+            self.originalAppUserId = originalAppUserId
+            self.originalPurchaseDate = originalPurchaseDate
+
             super.init(
                 screen: screen,
                 actionWrapper: actionWrapper,
@@ -48,12 +56,16 @@ final class ActiveSubscriptionsListViewModel: BaseManageSubscriptionViewModel {
     // Used for Previews
     convenience init(
         screen: CustomerCenterConfigData.Screen,
-        activePurchases: [PurchaseInformation] = []
+        activePurchases: [PurchaseInformation] = [],
+        originalAppUserId: String = UUID().uuidString,
+        originalPurchaseDate: Date? = Date()
     ) {
         self.init(
             screen: screen,
             actionWrapper: CustomerCenterActionWrapper(),
             activePurchases: activePurchases,
+            originalAppUserId: originalAppUserId,
+            originalPurchaseDate: originalPurchaseDate,
             purchasesProvider: MockCustomerCenterPurchases()
         )
     }

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -77,6 +77,14 @@ import RevenueCat
         !activePurchases.isEmpty || activePurchase != nil
     }
 
+    var  originalAppUserId: String {
+        customerInfo?.originalAppUserId ?? ""
+    }
+
+    var originalPurchaseDate: Date? {
+        customerInfo?.originalPurchaseDate
+    }
+
     @Published
     var activePurchases: [PurchaseInformation] = []
 
@@ -84,6 +92,8 @@ import RevenueCat
     var activePurchase: PurchaseInformation?
 
     private let currentVersionFetcher: CurrentVersionFetcher
+
+    internal let customerInfo: CustomerInfo?
 
     /// The action wrapper that handles both the deprecated handler and the new preference system
     internal let actionWrapper: CustomerCenterActionWrapper
@@ -107,6 +117,7 @@ import RevenueCat
         self.actionWrapper = actionWrapper
         self.purchasesProvider = purchasesProvider
         self.customerCenterStoreKitUtilities = customerCenterStoreKitUtilities
+        self.customerInfo = nil
     }
 
     convenience init(uiPreviewPurchaseProvider: CustomerCenterPurchasesType) {

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -219,6 +219,8 @@ private extension CustomerCenterView {
                 ActiveSubscriptionsListView(
                     screen: screen,
                     activePurchases: $viewModel.activePurchases,
+                    originalAppUserId: viewModel.originalAppUserId,
+                    originalPurchaseDate: viewModel.originalPurchaseDate,
                     purchasesProvider: self.viewModel.purchasesProvider,
                     actionWrapper: self.viewModel.actionWrapper
                 )

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseHistory/PurchaseHistoryView.swift
@@ -79,32 +79,6 @@ struct PurchaseHistoryView: View {
                         }
                     }
                 }
-
-                // Account Details Section
-
-                Section(header: Text(
-                    localization[.accountDetails]
-                )) {
-                    if let originalPurchaseDate = info.originalPurchaseDate {
-                        CompatibilityLabeledContent(
-                            localization[.dateWhenAppWasPurchased],
-                            content: dateFormatter.string(from: originalPurchaseDate)
-                        )
-                    }
-
-                    CompatibilityLabeledContent(
-                        localization[.userId],
-                        content: info.originalAppUserId
-                    )
-                    .contextMenu {
-                        Button {
-                            UIPasteboard.general.string = info.originalAppUserId
-                        } label: {
-                            Text(localization[.copy])
-                            Image(systemName: "doc.on.clipboard")
-                        }
-                    }
-                }
             }
         }
         .compatibleNavigation(


### PR DESCRIPTION
### Motivation
We are sunsetting purchase history in favor of one list with all the purchases.

### Description
1. Move account details to active list
2. Remove account details from purchase history

