### PR TITLE
[DX-404] Adds API Tests for SDK Health Report

### DIFF
--- a/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/PurchasesDiagnosticsAPI.swift
+++ b/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/PurchasesDiagnosticsAPI.swift
@@ -78,7 +78,7 @@ func checkHealthReportErrors(_ error: PurchasesDiagnostics.SDKHealthError) {
     case .invalidProducts(let products):
         let copy: [PurchasesDiagnostics.ProductDiagnosticsPayload] = products
 
-        products.forEach {
+        copy.forEach {
             let _: String = $0.identifier
             let _: String? = $0.title
             let _: PurchasesDiagnostics.ProductStatus = $0.status

--- a/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/PurchasesDiagnosticsAPI.swift
+++ b/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/PurchasesDiagnosticsAPI.swift
@@ -47,14 +47,56 @@ func checkHealthReportErrors(_ error: PurchasesDiagnostics.SDKHealthError) {
     case .noOfferings:
         break
     case .offeringConfiguration(let offerings):
-        print(offerings)
+        let copy: [PurchasesDiagnostics.OfferingDiagnosticsPayload] = offerings
+
+        copy.forEach {
+            let _: String = $0.identifier
+            let packages: [PurchasesDiagnostics.OfferingPackageDiagnosticsPayload] = $0.packages
+            packages.forEach { package in
+                let _: String = package.identifier
+                let _: String? = package.title
+                let _: PurchasesDiagnostics.ProductStatus = package.status
+                let _: String = package.description
+                let _: String = package.productIdentifier
+                let _: String? = package.productTitle
+            }
+
+            let _: PurchasesDiagnostics.SDKHealthCheckStatus = $0.status
+            switch $0.status {
+            case .passed: break
+            case .failed: break
+            case .warning: break
+            }
+        }
     case .invalidBundleId(let invalidBundleIdErrorPayload):
-        if let invalidBundleIdErrorPayload { print(invalidBundleIdErrorPayload) }
+        guard let copy: PurchasesDiagnostics.InvalidBundleIdErrorPayload = invalidBundleIdErrorPayload else {
+            return
+        }
+
+        let _: String = copy.appBundleId
+        let _: String = copy.sdkBundleId
     case .invalidProducts(let products):
-        print(products)
+        let copy: [PurchasesDiagnostics.ProductDiagnosticsPayload] = products
+
+        products.forEach {
+            let _: String = $0.identifier
+            let _: String? = $0.title
+            let _: PurchasesDiagnostics.ProductStatus = $0.status
+            let _: String = $0.description
+
+            switch $0.status {
+            case .valid,
+                 .couldNotCheck,
+                 .notFound,
+                 .actionInProgress,
+                 .needsAction,
+                 .unknown:
+                break
+            }
+        }
     case .notAuthorizedToMakePayments:
         break
     case .unknown(let error):
-        print(error)
+        let _: Swift.Error = error
     }
 }

--- a/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/PurchasesDiagnosticsAPI.swift
+++ b/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/PurchasesDiagnosticsAPI.swift
@@ -13,6 +13,11 @@ func checkPurchasesDiagnostics() {
 }
 
 private func checkPurchasesDiagnosticsAsync(_ diagnostics: PurchasesDiagnostics) async {
+    try? await diagnostics.checkSDKHealth()
+}
+
+@available(*, deprecated) // Ignore deprecation warnings
+private func checkDeprecatedPurchasesDiagnosticsAsync(_ diagnostics: PurchasesDiagnostics) async {
     _ = try? await diagnostics.testSDKHealth()
 }
 
@@ -31,6 +36,25 @@ func checkDiagnosticsErrors(_ error: PurchasesDiagnostics.Error) {
         print(error)
 
     case let .unknown(error):
+        print(error)
+    }
+}
+
+func checkHealthReportErrors(_ error: PurchasesDiagnostics.SDKHealthError) {
+    switch error {
+    case .invalidAPIKey:
+        break
+    case .noOfferings:
+        break
+    case .offeringConfiguration(let offerings):
+        print(offerings)
+    case .invalidBundleId(let invalidBundleIdErrorPayload):
+        if let invalidBundleIdErrorPayload { print(invalidBundleIdErrorPayload) }
+    case .invalidProducts(let products):
+        print(products)
+    case .notAuthorizedToMakePayments:
+        break
+    case .unknown(let error):
         print(error)
     }
 }


### PR DESCRIPTION
We recently realised that, while we deprecated a method in `PurchasesDiagnostics`, we never added API Tests for the API that replaces it.

This PR adds API tests to make sure that backwards compatibility is preserved on that method going forward.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids
