### PR TITLE
Fix paywall auto dismiss from bottom sheet

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
@@ -44,6 +44,7 @@ struct SheetViewModel: Equatable {
 struct BottomSheetOverlayModifier: ViewModifier {
     @Binding var sheetViewModel: SheetViewModel?
     let safeAreaInsets: EdgeInsets
+    let onDismiss: (() -> Void)?
 
     @State private var parentHeight: CGFloat?
 
@@ -100,6 +101,7 @@ struct BottomSheetOverlayModifier: ViewModifier {
                         viewModel: sheetViewModel.sheetStackViewModel,
                         onDismiss: {
                             self.sheetViewModel = nil
+                            onDismiss?()
                         },
                         additionalPadding: self.safeAreaInsets
                     )
@@ -139,10 +141,11 @@ extension View {
     /// - Returns: A view that presents the sheet when `isPresented` is true.
     func bottomSheet(
         sheet: Binding<SheetViewModel?>,
-        safeAreaInsets: EdgeInsets
+        safeAreaInsets: EdgeInsets,
+        onDismiss: (() -> Void)?
     ) -> some View {
         modifier(
-            BottomSheetOverlayModifier(sheetViewModel: sheet, safeAreaInsets: safeAreaInsets)
+            BottomSheetOverlayModifier(sheetViewModel: sheet, safeAreaInsets: safeAreaInsets, onDismiss: onDismiss)
         )
     }
 }
@@ -193,7 +196,7 @@ struct BottomSheetViewTestView: View {
             VStack {
                 Text("This view will have a sheet over it")
                     .bottomSheet(sheet: $sheetViewModel,
-                                 safeAreaInsets: .init(top: 0, leading: 0, bottom: 0, trailing: 0))
+                                 safeAreaInsets: .init(top: 0, leading: 0, bottom: 0, trailing: 0), onDismiss: nil)
             }
         }
         .edgesIgnoringSafeArea(.all)

--- a/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
@@ -58,7 +58,7 @@ struct RootView: View {
         .environment(\.openSheet, { sheet in
             self.sheetViewModel = sheet
         })
-        .bottomSheet(sheet: $sheetViewModel, safeAreaInsets: self.safeAreaInsets)
+        .bottomSheet(sheet: $sheetViewModel, safeAreaInsets: self.safeAreaInsets, onDismiss: onDismiss)
     }
 
 }


### PR DESCRIPTION

### Motivation
If the auto dismiss of a paywall happened from the paywall's bottom sheet, only the bottom sheet would get dismissed, and not the whole paywall.

### Description
This PR fixes this bug so that the whole paywall gets dismissed if it gets auto dismissed from the bottom sheet (i.e. both the bottom sheet and the paywall itself get dismissed)