### PR TITLE
Introduce ActiveSubscriptionButtonsView to use it inside a scrollview

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -542,6 +542,7 @@
 		537B4B392DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B352DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift */; };
 		537B4B3A2DA9744B00CEFF4C /* ProductStatus+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B342DA9744B00CEFF4C /* ProductStatus+Icon.swift */; };
 		537BA85B2DBBFAF200C93327 /* SDKHealthError+CustomNSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537BA85A2DBBFAE700C93327 /* SDKHealthError+CustomNSError.swift */; };
+		5703050A2DDB7DF900393089 /* ActiveSubscriptionButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570305092DDB7DF300393089 /* ActiveSubscriptionButtonsView.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
 		57045B3C29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */; };
@@ -1932,6 +1933,7 @@
 		537B4B352DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthCheckStatus+Icon.swift"; sourceTree = "<group>"; };
 		537B4B362DA9744B00CEFF4C /* SDKHealthStatus+Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthStatus+Icon.swift"; sourceTree = "<group>"; };
 		537BA85A2DBBFAE700C93327 /* SDKHealthError+CustomNSError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthError+CustomNSError.swift"; sourceTree = "<group>"; };
+		570305092DDB7DF300393089 /* ActiveSubscriptionButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSubscriptionButtonsView.swift; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
 		57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProductEntitlementMappingOperation.swift; sourceTree = "<group>"; };
 		57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingCallback.swift; sourceTree = "<group>"; };
@@ -3874,6 +3876,7 @@
 		353756602C382C2800A1B8D6 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				570305092DDB7DF300393089 /* ActiveSubscriptionButtonsView.swift */,
 				57740F412DD6460F00585B5A /* PurchaseHistory */,
 				75F660162DDB2E7B00DBED1C /* UIKit Compatibility */,
 				57740F2F2DD6460F00585B5A /* ActiveSubscriptionsListView.swift */,
@@ -7160,6 +7163,7 @@
 				4D3BA5B22D47AB4400668AFC /* TimelineComponentView.swift in Sources */,
 				4D3BA5B32D47AB4400668AFC /* TimelineComponentViewModel.swift in Sources */,
 				03C72FC22D349BAE00297FEC /* IconComponentViewModel.swift in Sources */,
+				5703050A2DDB7DF900393089 /* ActiveSubscriptionButtonsView.swift in Sources */,
 				887A60872C1D037000E1A461 /* ViewExtensions.swift in Sources */,
 				2C8EC6DB2CCC23B700D6CCF8 /* MultiTierPreview.swift in Sources */,
 				88B1BB022C813A3C001B7EE5 /* StackComponentView.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -83,7 +83,7 @@ class BaseManageSubscriptionViewModel: ObservableObject {
         }
 
 #if os(iOS) || targetEnvironment(macCatalyst)
-    func handleHelpPath(_ path: CustomerCenterConfigData.HelpPath, wihtActiveProductId: String? = nil) async {
+    func handleHelpPath(_ path: CustomerCenterConfigData.HelpPath, withActiveProductId: String? = nil) async {
         // Convert the path to an appropriate action using the extension
         if let action = path.asAction() {
             // Send the action through the action wrapper
@@ -113,7 +113,7 @@ class BaseManageSubscriptionViewModel: ObservableObject {
                 }
             } else {
                 Logger.debug(Strings.promo_offer_not_eligible_for_product(
-                    promotionalOffer.iosOfferId, wihtActiveProductId ?? ""
+                    promotionalOffer.iosOfferId, withActiveProductId ?? ""
                 ))
                 await self.onPathSelected(path: path)
             }

--- a/RevenueCatUI/CustomerCenter/Views/ActiveSubscriptionButtonsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ActiveSubscriptionButtonsView.swift
@@ -35,7 +35,7 @@ struct ActiveSubscriptionButtonsView: View {
                 AsyncButton(action: {
                     await self.viewModel.handleHelpPath(
                         path,
-                        wihtActiveProductId: viewModel.purchaseInformation?.productIdentifier)
+                        withActiveProductId: viewModel.purchaseInformation?.productIdentifier)
                 }, label: {
                     if self.viewModel.loadingPath?.id == path.id {
                         TintedProgressView()

--- a/RevenueCatUI/CustomerCenter/Views/ActiveSubscriptionButtonsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ActiveSubscriptionButtonsView.swift
@@ -1,0 +1,63 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ActiveSubscriptionButtonsView.swift
+//
+//  Created by Facundo Menzella on 19/5/25.
+
+import Foundation
+import RevenueCat
+import SwiftUI
+
+#if os(iOS)
+
+@available(iOS 15.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct ActiveSubscriptionButtonsView: View {
+
+    @Environment(\.colorScheme)
+    private var colorScheme
+
+    @ObservedObject
+    var viewModel: BaseManageSubscriptionViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(self.viewModel.relevantPathsForPurchase, id: \.id) { path in
+                AsyncButton(action: {
+                    await self.viewModel.handleHelpPath(
+                        path,
+                        wihtActiveProductId: viewModel.purchaseInformation?.productIdentifier)
+                }, label: {
+                    if self.viewModel.loadingPath?.id == path.id {
+                        TintedProgressView()
+                    } else {
+                        CompatibilityLabeledContent(path.title)
+                            .padding()
+                    }
+                })
+                .disabled(self.viewModel.loadingPath != nil)
+                .frame(maxWidth: .infinity)
+
+                if path != self.viewModel.relevantPathsForPurchase.last {
+                    Divider()
+                }
+            }
+        }
+        .background(Color(colorScheme == .light
+                          ? UIColor.systemBackground
+                          : UIColor.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/CustomerCenter/Views/ActiveSubscriptionsListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ActiveSubscriptionsListView.swift
@@ -229,7 +229,7 @@ struct ActiveSubscriptionsListView: View {
             AsyncButton(action: {
                 await self.viewModel.handleHelpPath(
                     path,
-                    wihtActiveProductId: viewModel.purchaseInformation?.productIdentifier
+                    withActiveProductId: viewModel.purchaseInformation?.productIdentifier
                 )
             }, label: {
                 Group {

--- a/RevenueCatUI/CustomerCenter/Views/CompatibilityLabeledContent.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CompatibilityLabeledContent.swift
@@ -103,6 +103,17 @@ extension CompatibilityLabeledContent where Label == Text {
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
+extension CompatibilityLabeledContent where Label == Text, Content == EmptyView {
+    init(_ label: String) {
+        self.label = { Text(label) }
+        self.content = { EmptyView() }
+    }
+}
+
+@available(iOS 15.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
 extension CompatibilityLabeledContent where Label == Text, Content == Text {
     init(_ label: String, content: String) {
         self.label = { Text(label) }

--- a/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsButtonsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ManageSubscriptionsButtonsView.swift
@@ -52,7 +52,7 @@ private struct ManageSubscriptionButton: View {
         AsyncButton(action: {
             await self.viewModel.handleHelpPath(
                 path,
-                wihtActiveProductId: viewModel.purchaseInformation?.productIdentifier)
+                withActiveProductId: viewModel.purchaseInformation?.productIdentifier)
         }, label: {
             if self.viewModel.loadingPath?.id == path.id {
                 TintedProgressView()

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -124,14 +124,20 @@ struct SubscriptionDetailView: View {
 
     @ViewBuilder
     var content: some View {
-        List {
-            if let purchaseInformation = self.viewModel.purchaseInformation {
-                SubscriptionDetailsView(
-                    purchaseInformation: purchaseInformation,
-                    refundRequestStatus: self.viewModel.refundRequestStatus
-                )
+        ScrollViewWithOSBackground {
+            LazyVStack {
+                if let purchaseInformation = self.viewModel.purchaseInformation {
+                    SubscriptionDetailsView(
+                        purchaseInformation: purchaseInformation,
+                        refundRequestStatus: self.viewModel.refundRequestStatus
+                    )
+                    .padding()
+                    .background(Color(colorScheme == .light
+                                      ? UIColor.systemBackground
+                                      : UIColor.secondarySystemBackground))
+                    .cornerRadius(10)
+                    .padding(.horizontal)
 
-                Section {
                     if viewModel.showPurchaseHistory {
                         Button {
                             viewModel.showAllPurchases = true
@@ -139,45 +145,54 @@ struct SubscriptionDetailView: View {
                             CompatibilityLabeledContent(localization[.seeAllPurchases]) {
                                 Image(systemName: "chevron.forward")
                             }
+                            .padding()
+                            .background(Color(colorScheme == .light
+                                              ? UIColor.systemBackground
+                                              : UIColor.secondarySystemBackground))
+                            .cornerRadius(10)
+                            .padding(.horizontal)
                         }
                     }
+
+                } else {
+                    let fallbackDescription = localization[.tryCheckRestore]
+
+                    CompatibilityContentUnavailableView(
+                        self.viewModel.screen.title,
+                        systemImage: "exclamationmark.triangle.fill",
+                        description: Text(self.viewModel.screen.subtitle ?? fallbackDescription)
+                    )
+                    .padding()
+                    .background(Color(colorScheme == .light
+                                      ? UIColor.systemBackground
+                                      : UIColor.secondarySystemBackground))
+                    .cornerRadius(10)
+                    .padding(.horizontal)
                 }
 
-                Section {
-                    ManageSubscriptionsButtonsView(viewModel: viewModel)
-                }
+                ActiveSubscriptionButtonsView(viewModel: viewModel)
+                    .padding(.horizontal)
 
                 if let url = support?.supportURL(
                     localization: localization,
                     purchasesProvider: viewModel.purchasesProvider
                 ), viewModel.shouldShowContactSupport,
                     URLUtilities.canOpenURL(url) || RuntimeUtils.isSimulator {
-                    Section {
-                        AsyncButton {
-                            if RuntimeUtils.isSimulator {
-                                self.showSimulatorAlert = true
-                            } else {
-                                viewModel.inAppBrowserURL = IdentifiableURL(url: url)
-                            }
-                        } label: {
-                            Text(localization[.contactSupport])
+                    AsyncButton {
+                        if RuntimeUtils.isSimulator {
+                            self.showSimulatorAlert = true
+                        } else {
+                            viewModel.inAppBrowserURL = IdentifiableURL(url: url)
                         }
+                    } label: {
+                        Text(localization[.contactSupport])
+                            .padding()
+                            .background(Color(colorScheme == .light
+                                              ? UIColor.systemBackground
+                                              : UIColor.secondarySystemBackground))
+                            .cornerRadius(10)
+                            .padding(.horizontal)
                     }
-                }
-
-            } else {
-                let fallbackDescription = localization[.tryCheckRestore]
-
-                Section {
-                    CompatibilityContentUnavailableView(
-                        self.viewModel.screen.title,
-                        systemImage: "exclamationmark.triangle.fill",
-                        description: Text(self.viewModel.screen.subtitle ?? fallbackDescription)
-                    )
-                }
-
-                Section {
-                    ManageSubscriptionsButtonsView(viewModel: viewModel)
                 }
             }
         }
@@ -258,6 +273,18 @@ struct SubscriptionDetailView: View {
                     viewModel: SubscriptionDetailViewModel(
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: false,
+                        purchaseInformation: nil
+                    )
+                )
+            }
+            .preferredColorScheme(colorScheme)
+            .previewDisplayName("Emtpy state - \(colorScheme)")
+
+            CompatibilityNavigationStack {
+                SubscriptionDetailView(
+                    viewModel: SubscriptionDetailViewModel(
+                        screen: CustomerCenterConfigData.default.screens[.management]!,
+                        showPurchaseHistory: true,
                         purchaseInformation: .yearlyExpiring(store: .playStore)
                     )
                 )


### PR DESCRIPTION
### Motivation
We're using `List` instead of `ScrollView`, and we want to do the opposite. 

### Description
Create a duplicate ButtonsView inspired in `ManageSubscriptionsButtonsView` so I can keep this PR as small as possible. 

After merging this, I can go with https://github.com/RevenueCat/purchases-ios/pull/5121 and use `PurchaseInformationCardView` in the same way its used in `ActiveSubscriptionsListView` (inside a scrollview)

I'll delete the old `ManageSubscriptionsButtonsView` once this is places everywhere.

