### PR TITLE
Show list if all purchases together are more than one

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -309,7 +309,6 @@
 		3543914426F911F300E669DF /* MockCustomerInfoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B514826D44A2F00BD2BD7 /* MockCustomerInfoManager.swift */; };
 		3543914526F926D900E669DF /* SKProductSubscriptionDurationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDF41E924F6F844005BC22D /* SKProductSubscriptionDurationExtensions.swift */; };
 		3544DA6D2C2C848E00704E9D /* CustomerCenterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3544DA692C2C848E00704E9D /* CustomerCenterViewModelTests.swift */; };
-		3544DA6F2C2C848E00704E9D /* ManageSubscriptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3544DA6A2C2C848E00704E9D /* ManageSubscriptionsViewModelTests.swift */; };
 		3546355C2C391F38001D7E85 /* FeedbackSurveyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3546355A2C391F38001D7E85 /* FeedbackSurveyViewModel.swift */; };
 		3546355D2C391F38001D7E85 /* PromotionalOfferViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3546355B2C391F38001D7E85 /* PromotionalOfferViewModel.swift */; };
 		354895D4267AE4B4001DC5B1 /* AttributionKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 354895D3267AE4B4001DC5B1 /* AttributionKey.swift */; };
@@ -1691,7 +1690,6 @@
 		353FDC0E2CA446F50055F328 /* StoreProductDiscount+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreProductDiscount+Extensions.swift"; sourceTree = "<group>"; };
 		353FDC102CA447270055F328 /* StoreProduct+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreProduct+Extensions.swift"; sourceTree = "<group>"; };
 		3544DA692C2C848E00704E9D /* CustomerCenterViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerCenterViewModelTests.swift; sourceTree = "<group>"; };
-		3544DA6A2C2C848E00704E9D /* ManageSubscriptionsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsViewModelTests.swift; sourceTree = "<group>"; };
 		3546355A2C391F38001D7E85 /* FeedbackSurveyViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedbackSurveyViewModel.swift; sourceTree = "<group>"; };
 		3546355B2C391F38001D7E85 /* PromotionalOfferViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromotionalOfferViewModel.swift; sourceTree = "<group>"; };
 		354895D3267AE4B4001DC5B1 /* AttributionKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionKey.swift; sourceTree = "<group>"; };
@@ -4020,7 +4018,6 @@
 				577782B42D91829D00F97EB4 /* CustomerCenterActionWrapperTests.swift */,
 				3544DA692C2C848E00704E9D /* CustomerCenterViewModelTests.swift */,
 				35617C752D5A3BC000612B7A /* FeedbackSurveyViewModelTests.swift */,
-				3544DA6A2C2C848E00704E9D /* ManageSubscriptionsViewModelTests.swift */,
 				1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */,
 				35A99C802CCB8D530074AB41 /* PurchaseInformationTests.swift */,
 			);
@@ -7220,7 +7217,6 @@
 				887A63352C1D177800E1A461 /* OSVersionEquivalent.swift in Sources */,
 				887A63362C1D177800E1A461 /* SnapshotTesting+Extensions.swift in Sources */,
 				887A63372C1D177800E1A461 /* TestCase.swift in Sources */,
-				3544DA6F2C2C848E00704E9D /* ManageSubscriptionsViewModelTests.swift in Sources */,
 				57BB08642DD3BE37007493E1 /* BaseManageSubscriptionViewModelTests.swift in Sources */,
 				887A63382C1D177800E1A461 /* PurchaseHandlerTests.swift in Sources */,
 				887A63392C1D177800E1A461 /* OtherPaywallViewTests.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -77,6 +77,10 @@ import RevenueCat
         !activeSubscriptionPurchases.isEmpty || activePurchase != nil || !activeNonSubscriptionPurchases.isEmpty
     }
 
+    var shouldShowList: Bool {
+        activeSubscriptionPurchases.count + activeNonSubscriptionPurchases.count > 1
+    }
+
     var  originalAppUserId: String {
         customerInfo?.originalAppUserId ?? ""
     }
@@ -136,6 +140,18 @@ import RevenueCat
     ) {
         self.init(actionWrapper: CustomerCenterActionWrapper(legacyActionHandler: nil))
         self.activePurchase = purchaseInformation
+        self.configuration = configuration
+        self.state = .success
+    }
+
+    convenience init(
+        activeSubscriptionPurchases: [PurchaseInformation],
+        activeNonSubscriptionPurchases: [PurchaseInformation],
+        configuration: CustomerCenterConfigData
+    ) {
+        self.init(actionWrapper: CustomerCenterActionWrapper(legacyActionHandler: nil))
+        self.activeSubscriptionPurchases = activeSubscriptionPurchases
+        self.activeNonSubscriptionPurchases = activeNonSubscriptionPurchases
         self.configuration = configuration
         self.state = .success
     }

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -215,7 +215,7 @@ private extension CustomerCenterView {
                         }
                     }
                 )
-            } else if viewModel.activeSubscriptionPurchases.count > 1 {
+            } else if viewModel.shouldShowList {
                 listView(screen)
             } else {
                 singlePurchaseView(screen)

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -153,7 +153,7 @@ struct RelevantPurchasesListView: View {
                     }
                 }
 
-                ScrollViewSection(title: "ACTIONS") {
+                ScrollViewSection(title: localization[.actionsSectionTitle]) {
                     ActiveSubscriptionButtonsView(viewModel: viewModel)
                         .padding(.top, 16)
                         .padding(.horizontal)
@@ -171,7 +171,7 @@ struct RelevantPurchasesListView: View {
 
     @ViewBuilder
     private var activeSubscriptionsView: some View {
-        ScrollViewSection(title: "SUBSCRIPTIONS") {
+        ScrollViewSection(title: localization[.subscriptionsSectionTitle]) {
             ForEach(viewModel.activeSubscriptionPurchases) { purchase in
                 Button {
                     viewModel.purchaseInformation = purchase
@@ -189,7 +189,7 @@ struct RelevantPurchasesListView: View {
     }
 
     private var otherPurchasesView: some View {
-        ScrollViewSection(title: localization[.otherPurchases]) {
+        ScrollViewSection(title: localization[.purchasesSectionTitle]) {
             ForEach(viewModel.activeNonSubscriptionPurchases.suffix(3)) { purchase in
                 Button {
                     viewModel.purchaseInformation = purchase

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -142,10 +142,6 @@ struct RelevantPurchasesListView: View {
                             .padding(.horizontal)
                             .padding(.top)
                     )
-
-                    ActiveSubscriptionButtonsView(viewModel: viewModel)
-                        .padding(.top, 16)
-                        .padding(.horizontal)
                 } else {
                     if !viewModel.activeSubscriptionPurchases.isEmpty {
                         activeSubscriptionsView
@@ -155,12 +151,19 @@ struct RelevantPurchasesListView: View {
                         otherPurchasesView
                             .padding(.top, 16)
                     }
-
-                    if support?.displayPurchaseHistoryLink == true {
-                        seeAllSubscriptionsButton
-                            .padding(.top, 16)
-                    }
                 }
+
+                ScrollViewSection(title: "ACTIONS") {
+                    ActiveSubscriptionButtonsView(viewModel: viewModel)
+                        .padding(.top, 16)
+                        .padding(.horizontal)
+                }
+
+                if support?.displayPurchaseHistoryLink == true {
+                    seeAllSubscriptionsButton
+                        .padding(.top, 16)
+                }
+
                 accountDetailsView
             }
         }
@@ -168,7 +171,7 @@ struct RelevantPurchasesListView: View {
 
     @ViewBuilder
     private var activeSubscriptionsView: some View {
-        ScrollViewSection(title: localization[.activeSubscriptions]) {
+        ScrollViewSection(title: "SUBSCRIPTIONS") {
             ForEach(viewModel.activeSubscriptionPurchases) { purchase in
                 Button {
                     viewModel.purchaseInformation = purchase
@@ -211,7 +214,7 @@ struct RelevantPurchasesListView: View {
                 Image(systemName: "chevron.forward")
             }
             .padding(.horizontal)
-            .padding(.vertical, 16)
+            .padding(.vertical, 12)
             .background(Color(colorScheme == .light
                               ? UIColor.systemBackground
                               : UIColor.secondarySystemBackground))

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -127,7 +127,7 @@ struct SubscriptionDetailView: View {
         ScrollViewWithOSBackground {
             LazyVStack(spacing: 0) {
                 if let purchaseInformation = self.viewModel.purchaseInformation {
-                    ScrollViewSection(title: "SUBSCRIPTIONS") {
+                    ScrollViewSection(title: sectionTitle) {
                         PurchaseInformationCardView(
                             purchaseInformation: purchaseInformation,
                             localization: localization,
@@ -160,7 +160,7 @@ struct SubscriptionDetailView: View {
                     .padding(.horizontal)
                 }
 
-                ScrollViewSection(title: "ACTIONS") {
+                ScrollViewSection(title: localization[.actionsSectionTitle]) {
                     ActiveSubscriptionButtonsView(viewModel: viewModel)
                         .padding(.top, 16)
                         .padding(.horizontal)
@@ -219,6 +219,14 @@ struct SubscriptionDetailView: View {
         .tint(colorScheme == .dark ? .white : .black)
     }
 
+    var sectionTitle: String {
+        if viewModel.purchaseInformation?.expirationDate == nil
+            && viewModel.purchaseInformation?.renewalDate == nil {
+            return localization[.purchasesSectionTitle]
+        } else {
+            return localization[.subscriptionsSectionTitle]
+        }
+    }
 }
 
  #if DEBUG

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -125,35 +125,23 @@ struct SubscriptionDetailView: View {
     @ViewBuilder
     var content: some View {
         ScrollViewWithOSBackground {
-            LazyVStack {
+            LazyVStack(spacing: 0) {
                 if let purchaseInformation = self.viewModel.purchaseInformation {
-                    PurchaseInformationCardView(
-                        purchaseInformation: purchaseInformation,
-                        localization: localization,
-                        refundStatus: viewModel.refundRequestStatus,
-                        showChevron: false
-                    )
-                    .background(Color(colorScheme == .light
-                                      ? UIColor.systemBackground
-                                      : UIColor.secondarySystemBackground))
-                    .cornerRadius(10)
-                    .shadow(radius: 0.5)
-                    .padding(.horizontal)
+                    ScrollViewSection(title: "SUBSCRIPTIONS") {
+                        PurchaseInformationCardView(
+                            purchaseInformation: purchaseInformation,
+                            localization: localization,
+                            refundStatus: viewModel.refundRequestStatus,
+                            showChevron: false
+                        )
+                        .cornerRadius(10)
+                        .padding(.horizontal)
+                        .padding(.top, 16)
+                    }
 
                     if viewModel.showPurchaseHistory {
-                        Button {
-                            viewModel.showAllPurchases = true
-                        } label: {
-                            CompatibilityLabeledContent(localization[.seeAllPurchases]) {
-                                Image(systemName: "chevron.forward")
-                            }
-                            .padding()
-                            .background(Color(colorScheme == .light
-                                              ? UIColor.systemBackground
-                                              : UIColor.secondarySystemBackground))
-                            .cornerRadius(10)
-                            .padding(.horizontal)
-                        }
+                        seeAllSubscriptionsButton
+                            .padding(.top, 16)
                     }
 
                 } else {
@@ -172,8 +160,11 @@ struct SubscriptionDetailView: View {
                     .padding(.horizontal)
                 }
 
-                ActiveSubscriptionButtonsView(viewModel: viewModel)
-                    .padding(.horizontal)
+                ScrollViewSection(title: "ACTIONS") {
+                    ActiveSubscriptionButtonsView(viewModel: viewModel)
+                        .padding(.top, 16)
+                        .padding(.horizontal)
+                }
 
                 if let url = support?.supportURL(
                     localization: localization,
@@ -210,6 +201,24 @@ struct SubscriptionDetailView: View {
          })
     }
 
+    private var seeAllSubscriptionsButton: some View {
+        Button {
+            viewModel.showAllPurchases = true
+        } label: {
+            CompatibilityLabeledContent(localization[.seeAllPurchases]) {
+                Image(systemName: "chevron.forward")
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 12)
+            .background(Color(colorScheme == .light
+                              ? UIColor.systemBackground
+                              : UIColor.secondarySystemBackground))
+            .cornerRadius(10)
+            .padding(.horizontal)
+        }
+        .tint(colorScheme == .dark ? .white : .black)
+    }
+
 }
 
  #if DEBUG
@@ -226,7 +235,7 @@ struct SubscriptionDetailView: View {
                 SubscriptionDetailView(
                     viewModel: SubscriptionDetailViewModel(
                         screen: CustomerCenterConfigData.default.screens[.management]!,
-                        showPurchaseHistory: false,
+                        showPurchaseHistory: true,
                         purchaseInformation: .yearlyExpiring(),
                         refundRequestStatus: .success
                     )

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -154,6 +154,9 @@ public struct CustomerCenterConfigData: Equatable {
             case badgeCancelled = "badge_cancelled"
             case badgeFreeTrial = "free_trial"
             case refundSuccess = "refund_success"
+            case actionsSectionTitle = "actions_section_title"
+            case subscriptionsSectionTitle = "subscriptions_section_title"
+            case purchasesSectionTitle = "purchases_section_title"
 
             var defaultValue: String {
                 switch self {
@@ -364,6 +367,12 @@ public struct CustomerCenterConfigData: Equatable {
                     return "Free trial"
                 case .refundSuccess:
                     return "Apple has received the refund request"
+                case .actionsSectionTitle:
+                    return "Actions"
+                case .subscriptionsSectionTitle:
+                    return "Subscriptions"
+                case .purchasesSectionTitle:
+                    return "Purchases"
                 }
             }
         }

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -728,6 +728,7 @@ final class CustomerCenterViewModelTests: TestCase {
         await viewModel.loadScreen()
 
         expect(viewModel.state) == .success
+        expect(viewModel.shouldShowList).to(beFalse())
 
         let purchaseInformation = try XCTUnwrap(viewModel.activePurchase)
         expect(viewModel.activeSubscriptionPurchases.count) == 1
@@ -751,6 +752,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         expect(viewModel.activePurchase).to(beNil())
         expect(viewModel.state) == .success
+        expect(viewModel.shouldShowList).to(beFalse())
     }
 
     func testLoadScreenFailure() async throws {
@@ -762,7 +764,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         expect(viewModel.activePurchase).to(beNil())
         expect(viewModel.activeSubscriptionPurchases).to(beEmpty())
-
+        expect(viewModel.shouldShowList).to(beFalse())
         expect(viewModel.state) == .error(error)
     }
 
@@ -916,6 +918,7 @@ final class CustomerCenterViewModelTests: TestCase {
         await viewModel.loadScreen()
 
         expect(viewModel.activePurchase).toNot(beNil())
+        expect(viewModel.shouldShowList).to(beFalse())
         expect(mockStoreKitUtilities.renewalPriceFromRenewalInfoCallCount).to(equal(2))
     }
 
@@ -935,6 +938,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadScreen()
 
+        expect(viewModel.shouldShowList).to(beFalse())
         expect(viewModel.activePurchase?.pricePaid).to(equal(.nonFree(formatted(price: 4.99))))
         expect(viewModel.activePurchase?.renewalPrice).to(equal(.nonFree(formatted(price: 5.0))))
         expect(mockStoreKitUtilities.renewalPriceFromRenewalInfoCallCount).to(equal(2))
@@ -972,6 +976,47 @@ final class CustomerCenterViewModelTests: TestCase {
         // Verify screen was reloaded
         expect(viewModel.configuration).toNot(beNil())
         expect(mockPurchases.loadCustomerCenterCallCount) == 2
+    }
+
+    func testMultiplePurchases() {
+        var viewModel = CustomerCenterViewModel(
+            activeSubscriptionPurchases: [],
+            activeNonSubscriptionPurchases: [],
+            configuration: CustomerCenterConfigData.default
+        )
+
+        expect(viewModel.shouldShowList).to(beFalse())
+
+        viewModel = CustomerCenterViewModel(
+            activeSubscriptionPurchases: [.yearlyExpiring()],
+            activeNonSubscriptionPurchases: [],
+            configuration: CustomerCenterConfigData.default
+        )
+
+        expect(viewModel.shouldShowList).to(beFalse())
+
+        viewModel = CustomerCenterViewModel(
+            activeSubscriptionPurchases: [
+                .yearlyExpiring(productIdentifier: "1"),
+                    .yearlyExpiring(productIdentifier: "2")
+            ],
+            activeNonSubscriptionPurchases: [],
+            configuration: CustomerCenterConfigData.default
+        )
+
+        expect(viewModel.shouldShowList).to(beTrue())
+
+        viewModel = CustomerCenterViewModel(
+            activeSubscriptionPurchases: [
+                .yearlyExpiring(productIdentifier: "1")
+            ],
+            activeNonSubscriptionPurchases: [
+                .consumable
+            ],
+            configuration: CustomerCenterConfigData.default
+        )
+
+        expect(viewModel.shouldShowList).to(beTrue())
     }
 
     private func formatted(price: Decimal, currencyCode: String = "USD") -> String {


### PR DESCRIPTION
### Motivation
We need to show the list if there's at least more than one purchase. 

### Description
The old code checks only for subscription. This fix now takes into account both, and adds tests for it.
