### PR TITLE
Fix contact support button UI to match ButtonsView

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -339,7 +339,7 @@ struct ActiveSubscriptionsListView_Previews: PreviewProvider {
                 RelevantPurchasesListView(
                     viewModel: RelevantPurchasesListViewModel(
                         screen: warningOffMock.screens[.management]!,
-                        originalAppUserId: UUID().uuidString,
+                        originalAppUserId: "originalAppUserId",
                         activePurchases: purchases,
                         nonSubscriptionPurchases: [.consumable, .lifetime]
                     )

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -180,21 +180,8 @@ struct SubscriptionDetailView: View {
                     purchasesProvider: viewModel.purchasesProvider
                 ), viewModel.shouldShowContactSupport,
                     URLUtilities.canOpenURL(url) || RuntimeUtils.isSimulator {
-                    AsyncButton {
-                        if RuntimeUtils.isSimulator {
-                            self.showSimulatorAlert = true
-                        } else {
-                            viewModel.inAppBrowserURL = IdentifiableURL(url: url)
-                        }
-                    } label: {
-                        Text(localization[.contactSupport])
-                            .padding()
-                            .background(Color(colorScheme == .light
-                                              ? UIColor.systemBackground
-                                              : UIColor.secondarySystemBackground))
-                            .cornerRadius(10)
-                            .padding(.horizontal)
-                    }
+                    contactSupportView(url)
+                        .padding(.top)
                 }
             }
         }
@@ -210,6 +197,25 @@ struct SubscriptionDetailView: View {
          })
     }
 
+    @ViewBuilder
+    func contactSupportView(_ url: URL) -> some View {
+        AsyncButton {
+            if RuntimeUtils.isSimulator {
+                self.showSimulatorAlert = true
+            } else {
+                viewModel.inAppBrowserURL = IdentifiableURL(url: url)
+            }
+        } label: {
+            CompatibilityLabeledContent(localization[.contactSupport])
+                .padding(.horizontal)
+                .padding(.vertical, 12)
+        }
+        .background(Color(colorScheme == .light
+                          ? UIColor.systemBackground
+                          : UIColor.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal)
+    }
 }
 
  #if DEBUG

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -170,7 +170,7 @@ struct SubscriptionDetailView: View {
                     localization: localization,
                     purchasesProvider: viewModel.purchasesProvider
                 ), viewModel.shouldShowContactSupport,
-                    URLUtilities.canOpenURL(url) || RuntimeUtils.isSimulator {
+                   URLUtilities.canOpenURL(url) || RuntimeUtils.isSimulator {
                     contactSupportView(url)
                         .padding(.top)
                 }
@@ -185,7 +185,7 @@ struct SubscriptionDetailView: View {
         .applyIf(self.viewModel.screen.type == .management, apply: {
             $0.navigationTitle(self.viewModel.screen.title)
                 .navigationBarTitleDisplayMode(.inline)
-         })
+        })
     }
 
     @ViewBuilder
@@ -236,12 +236,12 @@ struct SubscriptionDetailView: View {
     }
 }
 
- #if DEBUG
- @available(iOS 15.0, *)
- @available(macOS, unavailable)
- @available(tvOS, unavailable)
- @available(watchOS, unavailable)
- struct SubscriptionDetailView_Previews: PreviewProvider {
+#if DEBUG
+@available(iOS 15.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct SubscriptionDetailView_Previews: PreviewProvider {
 
     // swiftlint:disable force_unwrapping
     static var previews: some View {
@@ -311,8 +311,8 @@ struct SubscriptionDetailView: View {
         .environment(\.appearance, CustomerCenterConfigData.default.appearance)
     }
 
- }
+}
 
- #endif
+#endif
 
 #endif

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -207,7 +207,7 @@ struct SubscriptionDetailView: View {
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .padding(.horizontal)
     }
-  
+
     private var seeAllSubscriptionsButton: some View {
         Button {
             viewModel.showAllPurchases = true


### PR DESCRIPTION
### Motivation
After re-designing `ActiveSubscriptionButtonsView` I missed updating the UI for contact support button.

### Description
This PR matches that, and now both buttons look neat 💅 

<img width="412" alt="Screenshot 2025-05-20 at 14 57 44" src="https://github.com/user-attachments/assets/1872b3b3-bf96-4e6f-aad8-480d1c193750" />
