### PR TITLE
Feat/addprice nonsubscription

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/Transaction.swift
+++ b/RevenueCatUI/CustomerCenter/Data/Transaction.swift
@@ -60,11 +60,6 @@ extension NonSubscriptionTransaction: Transaction {
         nil
     }
 
-    var price: ProductPaidPrice? {
-        // We don't have that information in the CustomerInfo
-        nil
-    }
-
     var periodType: PeriodType {
         .normal
     }

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
@@ -75,7 +75,7 @@ struct PurchaseInformationCardView: View {
                 localizations: localization
             )
         } else {
-            self.subtitle = nil
+            self.subtitle = purchaseInformation.pricePaidString(localizations: localization)
         }
 
         if let refundStatus, let message = refundStatus.subtitle(localization: localization) {

--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -142,7 +142,7 @@ extension CustomerInfoResponse.Transaction: Codable, Hashable {
         case store
         case isSandbox
         case displayName
-
+        case price
     }
 
 }

--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -90,7 +90,8 @@ extension CustomerInfoResponse {
         var store: Store
         var isSandbox: Bool
         var displayName: String?
-
+        /// Price paid for the subscription
+        var price: PurchasePaidPrice?
     }
 
     struct Entitlement {

--- a/Sources/Purchasing/NonSubscriptionTransaction.swift
+++ b/Sources/Purchasing/NonSubscriptionTransaction.swift
@@ -37,6 +37,9 @@ public final class NonSubscriptionTransaction: NSObject {
     /// The ``Store`` where this transaction was performed.
     @objc public let store: Store
 
+    /// Paid price for the subscription
+    @objc public let price: ProductPaidPrice?
+
     init?(with transaction: CustomerInfoResponse.Transaction, productID: String) {
         guard let transactionIdentifier = transaction.transactionIdentifier,
               let storeTransactionIdentifier = transaction.storeTransactionIdentifier else {
@@ -50,6 +53,7 @@ public final class NonSubscriptionTransaction: NSObject {
         self.purchaseDate = transaction.purchaseDate
         self.productIdentifier = productID
         self.store = transaction.store
+        self.price = transaction.price.map { ProductPaidPrice(currency: $0.currency, amount: $0.amount) }
     }
 
     public override var description: String {


### PR DESCRIPTION
### Motivation
While testing non-consumables for CustomerCenter, I realized the price was missing.

### Description
Adds price paid for `Transaction` and `NonSubscriptionTransaction`, and showcases it in the PurchaseInformationCardView.
