### PR TITLE
Dont show `see all purchases` button if there's nothing else to show

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -742,6 +742,7 @@
 		57ACB12528174B9F000DCC9F /* CustomerInfo+TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ACB12328174B9F000DCC9F /* CustomerInfo+TestExtensions.swift */; };
 		57ACB13728184CF1000DCC9F /* DecoderExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ACB13628184CF1000DCC9F /* DecoderExtensionTests.swift */; };
 		57B179D32DAE4C9A009A5CFE /* CustomerInfo+ActiveTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B179D22DAE4C94009A5CFE /* CustomerInfo+ActiveTransaction.swift */; };
+		57B29DC42DDDBD6B00AD1D86 /* CustomerInfo+SeeAllPurchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B29DC32DDDBD4800AD1D86 /* CustomerInfo+SeeAllPurchases.swift */; };
 		57BA943128330ACA00CD5FC5 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BA943028330ACA00CD5FC5 /* ConfigurationTests.swift */; };
 		57BAF6C82DD4AAD100CFECFF /* DiscountsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BAF6C72DD4AACF00CFECFF /* DiscountsHandler.swift */; };
 		57BB070E28D27A2B007F5DF0 /* CachingProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BB070D28D27A2B007F5DF0 /* CachingProductsManager.swift */; };
@@ -2122,6 +2123,7 @@
 		57ACB12328174B9F000DCC9F /* CustomerInfo+TestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+TestExtensions.swift"; sourceTree = "<group>"; };
 		57ACB13628184CF1000DCC9F /* DecoderExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderExtensionTests.swift; sourceTree = "<group>"; };
 		57B179D22DAE4C94009A5CFE /* CustomerInfo+ActiveTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+ActiveTransaction.swift"; sourceTree = "<group>"; };
+		57B29DC32DDDBD4800AD1D86 /* CustomerInfo+SeeAllPurchases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+SeeAllPurchases.swift"; sourceTree = "<group>"; };
 		57B530E52858F3FD00FA4E37 /* SwiftStyleGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SwiftStyleGuide.swift; path = Contributing/SwiftStyleGuide.swift; sourceTree = "<group>"; };
 		57BA943028330ACA00CD5FC5 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		57BAF6C72DD4AACF00CFECFF /* DiscountsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountsHandler.swift; sourceTree = "<group>"; };
@@ -4095,6 +4097,7 @@
 		35D41B412D40354A000621C7 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				57B29DC32DDDBD4800AD1D86 /* CustomerInfo+SeeAllPurchases.swift */,
 				57B179D22DAE4C94009A5CFE /* CustomerInfo+ActiveTransaction.swift */,
 				57CD17262D9D830F00B4B667 /* CustomerCenterConfigDataSupport+URL.swift */,
 				35D41B422D403550000621C7 /* Store+Localization.swift */,
@@ -7038,6 +7041,7 @@
 				2C8EC7202CCF276100D6CCF8 /* PresentedPartials.swift in Sources */,
 				7707A9502CAD9775006E0313 /* ButtonComponentView.swift in Sources */,
 				887A60BE2C1D037000E1A461 /* PaywallFooterViewController.swift in Sources */,
+				57B29DC42DDDBD6B00AD1D86 /* CustomerInfo+SeeAllPurchases.swift in Sources */,
 				887A608A2C1D037000E1A461 /* PurchaseHandler.swift in Sources */,
 				2D2AFE8D2C6A834D00D1B0B4 /* TestData.swift in Sources */,
 				03A98D382D2AC63B009BCA61 /* UIConfigProvider.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/Extensions/CustomerInfo+SeeAllPurchases.swift
+++ b/RevenueCatUI/CustomerCenter/Extensions/CustomerInfo+SeeAllPurchases.swift
@@ -1,0 +1,49 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerInfo+SeeAllPurchases.swift
+//
+//  Created by Facundo Menzella on 21/5/25.
+
+import RevenueCat
+
+extension CustomerInfo {
+
+    /// Determines whether the "See All Purchases" button should be shown.
+    ///
+    /// - Parameters:
+    ///   - maxNonSubscriptions: The maximum number of non-subscription purchases allowed before showing the button.
+    ///
+    /// - Returns: `true` if:
+    ///   - There's both active and inactive subscriptions.
+    ///   - There's only inactive subscriptions and more than one of them.
+    ///   - The number of non-subscription purchases exceeds `maxNonSubscriptions`.
+    ///   Otherwise, returns `false`.
+    func shouldShowSeeAllPurchasesButton(
+        maxNonSubscriptions: Int
+    ) -> Bool {
+        let totalSubscriptions = subscriptionsByProductIdentifier.count
+        let activeSubscriptionsCount = activeSubscriptions.count
+        let inactiveSubscriptionsCount = totalSubscriptions - activeSubscriptionsCount
+
+        if activeSubscriptionsCount > 0 && inactiveSubscriptionsCount > 0 {
+            return true
+        }
+
+        if activeSubscriptionsCount == 0 && inactiveSubscriptionsCount > 1 {
+            return true
+        }
+
+        if nonSubscriptions.count > maxNonSubscriptions {
+            return true
+        }
+
+        return false
+    }
+}

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -91,7 +91,9 @@ import RevenueCat
 
     var shouldShowSeeAllPurchases: Bool {
         configuration?.support.displayPurchaseHistoryLink == true
-            && customerInfo?.shouldShowSeeAllPurchasesButton(maxNonSubscriptions: 2) ?? false
+        && customerInfo?.shouldShowSeeAllPurchasesButton(
+            maxNonSubscriptions: RelevantPurchasesListViewModel.maxNonSubscriptionsToShow
+        ) ?? false
     }
 
     @Published

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -89,6 +89,11 @@ import RevenueCat
         customerInfo?.originalPurchaseDate
     }
 
+    var shouldShowSeeAllPurchases: Bool {
+        configuration?.support.displayPurchaseHistoryLink == true
+            && customerInfo?.shouldShowSeeAllPurchasesButton(maxNonSubscriptions: 2) ?? false
+    }
+
     @Published
     var activeSubscriptionPurchases: [PurchaseInformation] = []
 

--- a/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseHistoryViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseHistoryViewModel.swift
@@ -41,6 +41,10 @@ final class PurchaseHistoryViewModel: ObservableObject {
     var inactiveSubscriptions: [PurchaseInfo] = []
     var nonSubscriptions: [PurchaseInfo] = []
 
+    var isEmpty: Bool {
+        activeSubscriptions.isEmpty && inactiveSubscriptions.isEmpty && nonSubscriptions.isEmpty
+    }
+
     let purchasesProvider: CustomerCenterPurchasesType
 
     init(

--- a/RevenueCatUI/CustomerCenter/ViewModels/RelevantPurchasesListViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/RelevantPurchasesListViewModel.swift
@@ -36,6 +36,7 @@ final class RelevantPurchasesListViewModel: BaseManageSubscriptionViewModel {
 
     let originalAppUserId: String
     let originalPurchaseDate: Date?
+    let shouldShowSeeAllPurchases: Bool
 
     init(
         screen: CustomerCenterConfigData.Screen,
@@ -44,6 +45,7 @@ final class RelevantPurchasesListViewModel: BaseManageSubscriptionViewModel {
         nonSubscriptionPurchases: [PurchaseInformation] = [],
         originalAppUserId: String,
         originalPurchaseDate: Date?,
+        shouldShowSeeAllPurchases: Bool,
         refundRequestStatus: RefundRequestStatus? = nil,
         purchasesProvider: CustomerCenterPurchasesType,
         loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType? = nil) {
@@ -51,6 +53,7 @@ final class RelevantPurchasesListViewModel: BaseManageSubscriptionViewModel {
             self.activeNonSubscriptionPurchases = nonSubscriptionPurchases
             self.originalAppUserId = originalAppUserId
             self.originalPurchaseDate = originalPurchaseDate
+            self.shouldShowSeeAllPurchases = shouldShowSeeAllPurchases
 
             super.init(
                 screen: screen,
@@ -68,7 +71,8 @@ final class RelevantPurchasesListViewModel: BaseManageSubscriptionViewModel {
         originalAppUserId: String,
         activePurchases: [PurchaseInformation] = [],
         nonSubscriptionPurchases: [PurchaseInformation] = [],
-        originalPurchaseDate: Date? = nil
+        shouldShowSeeAllPurchases: Bool,
+        originalPurchaseDate: Date? = nil,
     ) {
         self.init(
             screen: screen,
@@ -77,6 +81,7 @@ final class RelevantPurchasesListViewModel: BaseManageSubscriptionViewModel {
             nonSubscriptionPurchases: nonSubscriptionPurchases,
             originalAppUserId: originalAppUserId,
             originalPurchaseDate: originalPurchaseDate,
+            shouldShowSeeAllPurchases: shouldShowSeeAllPurchases,
             purchasesProvider: MockCustomerCenterPurchases()
         )
     }

--- a/RevenueCatUI/CustomerCenter/ViewModels/RelevantPurchasesListViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/RelevantPurchasesListViewModel.swift
@@ -24,6 +24,8 @@ import SwiftUI
 @MainActor
 final class RelevantPurchasesListViewModel: BaseManageSubscriptionViewModel {
 
+    static let maxNonSubscriptionsToShow = 2
+
     @Published
     private(set) var activeSubscriptionPurchases: [PurchaseInformation] = []
 

--- a/RevenueCatUI/CustomerCenter/ViewModels/RelevantPurchasesListViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/RelevantPurchasesListViewModel.swift
@@ -74,7 +74,7 @@ final class RelevantPurchasesListViewModel: BaseManageSubscriptionViewModel {
         activePurchases: [PurchaseInformation] = [],
         nonSubscriptionPurchases: [PurchaseInformation] = [],
         shouldShowSeeAllPurchases: Bool,
-        originalPurchaseDate: Date? = nil,
+        originalPurchaseDate: Date? = nil
     ) {
         self.init(
             screen: screen,

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -249,6 +249,7 @@ private extension CustomerCenterView {
             nonSubscriptionPurchases: $viewModel.activeNonSubscriptionPurchases,
             originalAppUserId: viewModel.originalAppUserId,
             originalPurchaseDate: viewModel.originalPurchaseDate,
+            shouldShowSeeAllPurchases: viewModel.shouldShowSeeAllPurchases,
             purchasesProvider: self.viewModel.purchasesProvider,
             actionWrapper: self.viewModel.actionWrapper
         )
@@ -259,7 +260,7 @@ private extension CustomerCenterView {
         SubscriptionDetailView(
             screen: screen,
             purchaseInformation: viewModel.activePurchase,
-            showPurchaseHistory: viewModel.configuration?.support.displayPurchaseHistoryLink == true,
+            showPurchaseHistory: viewModel.shouldShowSeeAllPurchases,
             purchasesProvider: self.viewModel.purchasesProvider,
             actionWrapper: self.viewModel.actionWrapper
         )

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -195,8 +195,10 @@ struct RelevantPurchasesListView: View {
     }
 
     private var otherPurchasesView: some View {
-        ScrollViewSection(title: localization[.purchasesSectionTitle]) {
-            ForEach(viewModel.activeNonSubscriptionPurchases.prefix(2)) { purchase in
+        let prefix = RelevantPurchasesListViewModel.maxNonSubscriptionsToShow
+
+        return ScrollViewSection(title: localization[.purchasesSectionTitle]) {
+            ForEach(viewModel.activeNonSubscriptionPurchases.prefix(prefix)) { purchase in
                 Button {
                     viewModel.purchaseInformation = purchase
                 } label: {

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -29,9 +29,6 @@ struct RelevantPurchasesListView: View {
     @Environment(\.colorScheme)
     private var colorScheme
 
-    @Environment(\.supportInformation)
-    private var support
-
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
 
@@ -54,6 +51,7 @@ struct RelevantPurchasesListView: View {
          nonSubscriptionPurchases: Binding<[PurchaseInformation]>,
          originalAppUserId: String,
          originalPurchaseDate: Date?,
+         shouldShowSeeAllPurchases: Bool,
          purchasesProvider: CustomerCenterPurchasesType,
          actionWrapper: CustomerCenterActionWrapper) {
         let viewModel = RelevantPurchasesListViewModel(
@@ -63,6 +61,7 @@ struct RelevantPurchasesListView: View {
             nonSubscriptionPurchases: nonSubscriptionPurchases.wrappedValue,
             originalAppUserId: originalAppUserId,
             originalPurchaseDate: originalPurchaseDate,
+            shouldShowSeeAllPurchases: shouldShowSeeAllPurchases,
             purchasesProvider: purchasesProvider
         )
 
@@ -166,7 +165,7 @@ struct RelevantPurchasesListView: View {
                         .padding(.horizontal)
                 }
 
-                if support?.displayPurchaseHistoryLink == true {
+                if viewModel.shouldShowSeeAllPurchases {
                     seeAllSubscriptionsButton
                         .padding(.top, 16)
                 }
@@ -197,7 +196,7 @@ struct RelevantPurchasesListView: View {
 
     private var otherPurchasesView: some View {
         ScrollViewSection(title: localization[.purchasesSectionTitle]) {
-            ForEach(viewModel.activeNonSubscriptionPurchases.suffix(3)) { purchase in
+            ForEach(viewModel.activeNonSubscriptionPurchases.prefix(2)) { purchase in
                 Button {
                     viewModel.purchaseInformation = purchase
                 } label: {
@@ -337,7 +336,8 @@ struct ActiveSubscriptionsListView_Previews: PreviewProvider {
                     viewModel: RelevantPurchasesListViewModel(
                         screen: warningOffMock.screens[.management]!,
                         originalAppUserId: "originalAppUserId",
-                        activePurchases: purchases
+                        activePurchases: purchases,
+                        shouldShowSeeAllPurchases: false
                     )
                 )
                 .environment(\.supportInformation, warningOffMock.support)
@@ -351,7 +351,8 @@ struct ActiveSubscriptionsListView_Previews: PreviewProvider {
                         screen: warningOffMock.screens[.management]!,
                         originalAppUserId: "originalAppUserId",
                         activePurchases: purchases,
-                        nonSubscriptionPurchases: [.consumable, .lifetime]
+                        nonSubscriptionPurchases: [.consumable, .lifetime],
+                        shouldShowSeeAllPurchases: false
                     )
                 )
                 .environment(\.supportInformation, warningOffMock.support)
@@ -364,7 +365,8 @@ struct ActiveSubscriptionsListView_Previews: PreviewProvider {
                     viewModel: RelevantPurchasesListViewModel(
                         screen: warningOnMock.screens[.management]!,
                         originalAppUserId: "originalAppUserId",
-                        activePurchases: []
+                        activePurchases: [],
+                        shouldShowSeeAllPurchases: false
                     )
                 )
                 .environment(\.supportInformation, warningOnMock.support)


### PR DESCRIPTION
### Motivation
In the old and new version, the see all purchases was being shown even if there was no more new data. This tweaks that, and takes into account what's being shown.

### Description
Add extension to `CustomerInfo` to decide if the button should be shown.
