### PR TITLE
Change to use new endpoint to fetch web product info

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		1EDB6AA62DC9517300C771A4 /* WebProductsCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EDB6AA52DC9517300C771A4 /* WebProductsCallback.swift */; };
 		1EDB6AA82DC9519D00C771A4 /* WebProductsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EDB6AA72DC9519D00C771A4 /* WebProductsResponse.swift */; };
 		1EDB6AAA2DC95AB400C771A4 /* WebBillingHTTPRequestPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EDB6AA92DC95AB400C771A4 /* WebBillingHTTPRequestPath.swift */; };
+		1EDB6C942DDDC39C00C771A4 /* BackendGetWebProductsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EDB6C932DDDC39C00C771A4 /* BackendGetWebProductsTests.swift */; };
 		1EF46BC62D9C1FA7005C94A6 /* PurchasesSystemInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF46BC52D9C1FA7005C94A6 /* PurchasesSystemInfoTests.swift */; };
 		1EFA950D2CDB6B6500CA5951 /* BackendPostRedeemWebPurchaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFA950C2CDB6B6500CA5951 /* BackendPostRedeemWebPurchaseTests.swift */; };
 		1EFA95102CDB7FAA00CA5951 /* WebPurchaseRedemptionHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFA950F2CDB7FAA00CA5951 /* WebPurchaseRedemptionHelperTests.swift */; };
@@ -1413,6 +1414,7 @@
 		1EDB6AA52DC9517300C771A4 /* WebProductsCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebProductsCallback.swift; sourceTree = "<group>"; };
 		1EDB6AA72DC9519D00C771A4 /* WebProductsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebProductsResponse.swift; sourceTree = "<group>"; };
 		1EDB6AA92DC95AB400C771A4 /* WebBillingHTTPRequestPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebBillingHTTPRequestPath.swift; sourceTree = "<group>"; };
+		1EDB6C932DDDC39C00C771A4 /* BackendGetWebProductsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetWebProductsTests.swift; sourceTree = "<group>"; };
 		1EF46BC52D9C1FA7005C94A6 /* PurchasesSystemInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesSystemInfoTests.swift; sourceTree = "<group>"; };
 		1EFA950C2CDB6B6500CA5951 /* BackendPostRedeemWebPurchaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostRedeemWebPurchaseTests.swift; sourceTree = "<group>"; };
 		1EFA950F2CDB7FAA00CA5951 /* WebPurchaseRedemptionHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPurchaseRedemptionHelperTests.swift; sourceTree = "<group>"; };
@@ -4636,6 +4638,7 @@
 				5796A38927D6B96300653165 /* BackendGetCustomerInfoTests.swift */,
 				5796A38F27D6BCD100653165 /* BackendGetIntroEligibilityTests.swift */,
 				5796A39327D6BD6900653165 /* BackendGetOfferingsTests.swift */,
+				1EDB6C932DDDC39C00C771A4 /* BackendGetWebProductsTests.swift */,
 				579D2E3928F0BF5A0094B36F /* BackendInternalTests.swift */,
 				5796A38B27D6BA1600653165 /* BackendLoginTests.swift */,
 				57488BF129CB84D40000EE7E /* BackendOfflineEntitlementsTests.swift */,
@@ -6726,6 +6729,7 @@
 				579189EB28F47F0F00BF4963 /* MockPurchases.swift in Sources */,
 				574A2EE9282C403800150D40 /* AnyDecodableTests.swift in Sources */,
 				351B519F26D4508A00BD2BD7 /* DeviceCacheTests.swift in Sources */,
+				1EDB6C942DDDC39C00C771A4 /* BackendGetWebProductsTests.swift in Sources */,
 				2D22BF6826F3CC6D001AE2F9 /* XCTestCase+Extensions.swift in Sources */,
 				579189E928F47E8D00BF4963 /* PurchasesDiagnosticsTests.swift in Sources */,
 				351B51B626D450E800BD2BD7 /* ReceiptFetcherTests.swift in Sources */,

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -103,7 +103,7 @@ extension HTTPRequest {
 
     enum WebBillingPath: Hashable {
 
-        case getWebProducts(appUserId: String, productIds: Set<String>)
+        case getWebProducts(appUserID: String)
 
     }
 

--- a/Sources/Networking/OfferingsAPI.swift
+++ b/Sources/Networking/OfferingsAPI.swift
@@ -56,12 +56,11 @@ class OfferingsAPI {
         )
     }
 
-    func getWebProducts(appUserID: String, productIDs: Set<String>, completion: @escaping WebProductsResponseHandler) {
+    func getWebProducts(appUserID: String, completion: @escaping WebProductsResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)
         let factory = GetWebProductsOperation.createFactory(
             configuration: config,
-            productIds: productIDs,
             webProductsCallbackCache: self.webProductsCallbacksCache
         )
 

--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -68,6 +68,12 @@ extension OfferingsResponse {
         )
     }
 
+    var hasAnyWebCheckoutUrl: Bool {
+        return self.offerings
+            .lazy
+            .contains { $0.webCheckoutUrl != nil }
+    }
+
     var packages: [Offering.Package] {
         return self.offerings.flatMap { $0.packages }
     }

--- a/Sources/Networking/Responses/WebProductsResponse.swift
+++ b/Sources/Networking/Responses/WebProductsResponse.swift
@@ -23,7 +23,7 @@ struct WebProductsResponse {
 
     struct PricingPhase {
         let periodDuration: String?
-        let price: Price
+        let price: Price?
         let cycleCount: Int
     }
 
@@ -48,10 +48,24 @@ struct WebProductsResponse {
         let purchaseOptions: [String: PurchaseOption]
     }
 
-    let productDetails: [Product]
+    struct Package {
+        let identifier: String
+        let webCheckoutUrl: String
+        let productDetails: Product
+    }
+
+    struct Offering {
+        let identifier: String
+        let description: String?
+        let packages: [String: Package]
+    }
+
+    let offerings: [String: Offering]
 
 }
 
+extension WebProductsResponse.Offering: Codable, Equatable {}
+extension WebProductsResponse.Package: Codable, Equatable {}
 extension WebProductsResponse.Product: Codable, Equatable {}
 extension WebProductsResponse.PurchaseOption: Codable, Equatable {}
 extension WebProductsResponse.PricingPhase: Codable, Equatable {}

--- a/Sources/Networking/WebBillingHTTPRequestPath.swift
+++ b/Sources/Networking/WebBillingHTTPRequestPath.swift
@@ -48,9 +48,8 @@ extension HTTPRequest.WebBillingPath: HTTPRequestPath {
 
     var relativePath: String {
         switch self {
-        case let .getWebProducts(appUserId, productIds):
-            let productIdsQuery = productIds.map(\.trimmedAndEscaped).joined(separator: "&id=")
-            return "/rcbilling/v1/subscribers/\(appUserId.trimmedAndEscaped))/products?id=\(productIdsQuery)"
+        case let .getWebProducts(appUserID):
+            return "/rcbilling/v1/subscribers/\(appUserID.trimmedAndEscaped)/offering_products"
         }
     }
 

--- a/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
@@ -57,16 +57,14 @@ class MockOfferingsAPI: OfferingsAPI {
     var invokedGetWebProducts = false
     var invokedGetWebProductsCount = 0
     var invokedGetWebProductsParameters: (appUserID: String,
-                                          productIDs: Set<String>,
                                           completion: WebProductsResponseHandler)?
     var stubbedGetWebProductsCompletionResult: Result<WebProductsResponse, BackendError>?
 
     override func getWebProducts(appUserID: String,
-                                 productIDs: Set<String>,
                                  completion: @escaping WebProductsResponseHandler) {
         self.invokedGetWebProducts = true
         self.invokedGetWebProductsCount += 1
-        self.invokedGetWebProductsParameters = (appUserID, productIDs, completion)
+        self.invokedGetWebProductsParameters = (appUserID, completion)
 
         completion(self.stubbedGetWebProductsCompletionResult!)
     }

--- a/Tests/UnitTests/Networking/Backend/BackendGetWebProductsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetWebProductsTests.swift
@@ -1,0 +1,315 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  BackendGetWebProductsTests.swift
+//
+//  Created by Toni Rico on 5/21/22.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class BackendGetWebProductsTests: BaseBackendTests {
+
+    override func createClient() -> MockHTTPClient {
+        super.createClient(#file)
+    }
+
+    func testGetWebProductsCallsHTTPMethod() {
+        self.httpClient.mock(
+            requestPath: .getWebProducts(appUserID: Self.userID),
+            response: .init(statusCode: .success, response: Self.noOfferingsResponse as [String: Any])
+        )
+
+        let result = waitUntilValue { completed in
+            self.offerings.getWebProducts(appUserID: Self.userID, completion: completed)
+        }
+
+        expect(result).to(beSuccess())
+        expect(self.httpClient.calls).to(haveCount(1))
+        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadDelayParam) == JitterableDelay.none
+    }
+
+    func testGetWebProductsCallsHTTPMethodWithNoDelay() {
+        self.httpClient.mock(
+            requestPath: .getWebProducts(appUserID: Self.userID),
+            response: .init(statusCode: .success, response: Self.noOfferingsResponse as [String: Any])
+        )
+
+        let result = waitUntilValue { completed in
+            self.offerings.getWebProducts(appUserID: Self.userID, completion: completed)
+        }
+
+        expect(result).to(beSuccess())
+        expect(self.httpClient.calls).to(haveCount(1))
+        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadDelayParam) == JitterableDelay.none
+    }
+
+    func testGetWebProductsCachesForSameUserID() {
+        self.httpClient.mock(
+            requestPath: .getWebProducts(appUserID: Self.userID),
+            response: .init(statusCode: .success,
+                            response: Self.noOfferingsResponse as [String: Any],
+                            delay: .milliseconds(10))
+        )
+        self.offerings.getWebProducts(appUserID: Self.userID) { _ in }
+        self.offerings.getWebProducts(appUserID: Self.userID) { _ in }
+
+        expect(self.httpClient.calls).toEventually(haveCount(1))
+    }
+
+    func testRepeatedRequestsLogDebugMessage() {
+        self.httpClient.mock(
+            requestPath: .getWebProducts(appUserID: Self.userID),
+            response: .init(statusCode: .success,
+                            response: Self.noOfferingsResponse as [String: Any],
+                            delay: .milliseconds(10))
+        )
+        self.offerings.getWebProducts(appUserID: Self.userID) { _ in }
+        self.offerings.getWebProducts(appUserID: Self.userID) { _ in }
+
+        expect(self.httpClient.calls).toEventually(haveCount(1))
+
+        self.logger.verifyMessageWasLogged(
+            "Network operation '\(GetWebProductsOperation.self)' found with the same cache key",
+            level: .debug
+        )
+    }
+
+    func testGetWebProductsDoesntCacheForMultipleUserID() {
+        let response = MockHTTPClient.Response(statusCode: .success,
+                                               response: Self.noOfferingsResponse as [String: Any])
+        let userID2 = "user_id_2"
+
+        self.httpClient.mock(requestPath: .getWebProducts(appUserID: Self.userID), response: response)
+        self.httpClient.mock(requestPath: .getWebProducts(appUserID: userID2), response: response)
+
+        self.offerings.getWebProducts(appUserID: Self.userID, completion: { _ in })
+        self.offerings.getWebProducts(appUserID: userID2, completion: { _ in })
+
+        expect(self.httpClient.calls).toEventually(haveCount(2))
+    }
+
+    func testGetWebProductsOneOffering() throws {
+        self.httpClient.mock(
+            requestPath: .getWebProducts(appUserID: Self.userID),
+            response: .init(statusCode: .success, response: Self.oneOfferingResponse)
+        )
+
+        let result: Atomic<Result<WebProductsResponse, BackendError>?> = nil
+        self.offerings.getWebProducts(appUserID: Self.userID) {
+            result.value = $0
+        }
+
+        expect(result.value).toEventuallyNot(beNil())
+
+        let response = try XCTUnwrap(result.value?.value)
+        let offerings = try XCTUnwrap(response.offerings)
+        let offeringA = try XCTUnwrap(offerings["offering_a"])
+        let packages = try XCTUnwrap(offeringA.packages)
+        let monthlyPackage = try XCTUnwrap(packages["$rc_monthly"])
+        let annualPackage = try XCTUnwrap(packages["$rc_annual"])
+        let lifetimePackage = try XCTUnwrap(packages["$rc_lifetime"])
+        let monthlyPurchaseOption = try XCTUnwrap(monthlyPackage.productDetails.purchaseOptions["base_option"])
+        let annualPurchaseOption = try XCTUnwrap(annualPackage.productDetails.purchaseOptions["base_option"])
+        let lifetimePurchaseOption = try XCTUnwrap(lifetimePackage.productDetails.purchaseOptions["base_option"])
+
+        expect(offerings).to(haveCount(1))
+        expect(offeringA.identifier) == "offering_a"
+        expect(offeringA.description) == "This is the base offering"
+
+        expect(monthlyPackage.identifier) == "$rc_monthly"
+        expect(monthlyPackage.webCheckoutUrl) == "https://test.rev.cat/web-billing-monthly"
+        expect(monthlyPackage.productDetails.identifier) == "test_monthly"
+        expect(monthlyPackage.productDetails.productType) == "subscription"
+        expect(monthlyPackage.productDetails.title) == "Test Monthly"
+        expect(monthlyPackage.productDetails.description) == "Test Monthly description"
+        expect(monthlyPackage.productDetails.defaultPurchaseOptionId) == "base_option"
+        expect(monthlyPurchaseOption.trial).to(beNil())
+        expect(monthlyPurchaseOption.basePrice).to(beNil())
+        expect(monthlyPurchaseOption.base?.periodDuration) == "P1M"
+        expect(monthlyPurchaseOption.base?.cycleCount) == 1
+        expect(monthlyPurchaseOption.base?.price?.amountMicros) == 8990000
+        expect(monthlyPurchaseOption.base?.price?.currency) == "EUR"
+
+        expect(annualPackage.identifier) == "$rc_annual"
+        expect(annualPackage.webCheckoutUrl) == "https://test.rev.cat/web-billing-annual"
+        expect(annualPackage.productDetails.identifier) == "test_annual"
+        expect(annualPackage.productDetails.productType) == "subscription"
+        expect(annualPackage.productDetails.title) == "Test Annual"
+        expect(annualPackage.productDetails.description) == "Test Annual description"
+        expect(annualPackage.productDetails.defaultPurchaseOptionId) == "base_option"
+        expect(annualPurchaseOption.trial?.periodDuration) == "P7D"
+        expect(annualPurchaseOption.trial?.price).to(beNil())
+        expect(annualPurchaseOption.basePrice).to(beNil())
+        expect(annualPurchaseOption.base?.periodDuration) == "P1Y"
+        expect(annualPurchaseOption.base?.cycleCount) == 1
+        expect(annualPurchaseOption.base?.price?.amountMicros) == 58990000
+        expect(annualPurchaseOption.base?.price?.currency) == "EUR"
+
+        expect(lifetimePackage.identifier) == "$rc_lifetime"
+        expect(lifetimePackage.webCheckoutUrl) == "https://test.rev.cat/web-billing-lifetime"
+        expect(lifetimePackage.productDetails.identifier) == "test_lifetime"
+        expect(lifetimePackage.productDetails.productType) == "non_consumable"
+        expect(lifetimePackage.productDetails.title) == "Test Lifetime"
+        expect(lifetimePackage.productDetails.description) == "Test Lifetime description"
+        expect(lifetimePackage.productDetails.defaultPurchaseOptionId) == "base_option"
+        expect(lifetimePurchaseOption.trial).to(beNil())
+        expect(lifetimePurchaseOption.base).to(beNil())
+        expect(lifetimePurchaseOption.basePrice?.amountMicros) == 199990000
+        expect(lifetimePurchaseOption.basePrice?.currency) == "EUR"
+    }
+
+    func testGetWebProductsFailSendsError() {
+        self.httpClient.mock(
+            requestPath: .getWebProducts(appUserID: Self.userID),
+            response: .init(error: .unexpectedResponse(nil))
+        )
+
+        let result = waitUntilValue { completed in
+            self.offerings.getWebProducts(appUserID: Self.userID, completion: completed)
+        }
+
+        expect(result).to(beFailure())
+    }
+
+    func testGetWebProductsNetworkErrorSendsError() {
+        let mockedError: NetworkError = .unexpectedResponse(nil)
+
+        self.httpClient.mock(
+            requestPath: .getWebProducts(appUserID: Self.userID),
+            response: .init(error: mockedError)
+        )
+
+        let result = waitUntilValue { completed in
+            self.offerings.getWebProducts(appUserID: Self.userID, completion: completed)
+        }
+
+        expect(result).to(beFailure())
+        expect(result?.error) == .networkError(mockedError)
+    }
+
+    func testGetWebProductsSkipsBackendCallIfAppUserIDIsEmpty() {
+        waitUntil { completed in
+            self.offerings.getWebProducts(appUserID: "") { _ in
+                completed()
+            }
+        }
+
+        expect(self.httpClient.calls).to(beEmpty())
+    }
+
+    func testGetWebProductsCallsCompletionWithErrorIfAppUserIDIsEmpty() {
+        let receivedError = waitUntilValue { completed in
+            self.offerings.getWebProducts(appUserID: "") { result in
+                completed(result.error)
+            }
+        }
+
+        expect(receivedError) == .missingAppUserID()
+    }
+
+}
+
+private extension BackendGetWebProductsTests {
+
+    static let noOfferingsResponse: [String: Any?] = [
+        "offerings": [:] as [String: Any]
+    ]
+
+    static let oneOfferingResponse: [String: Any] = [
+        "offerings": [
+            "offering_a": [
+                "identifier": "offering_a",
+                "description": "This is the base offering",
+                "packages": [
+                    "$rc_monthly": [
+                        "identifier": "$rc_monthly",
+                        "web_checkout_url": "https://test.rev.cat/web-billing-monthly",
+                        "product_details": [
+                            "identifier": "test_monthly",
+                            "product_type": "subscription",
+                            "title": "Test Monthly",
+                            "description": "Test Monthly description",
+                            "default_purchase_option_id": "base_option",
+                            "purchase_options": [
+                                "base_option": [
+                                    "id": "base_option",
+                                    "price_id": "test_monthly_price_id",
+                                    "base": [
+                                        "cycle_count": 1,
+                                        "period_duration": "P1M",
+                                        "price": [
+                                            "amount_micros": 8990000,
+                                            "currency": "EUR"
+                                        ]
+                                    ],
+                                    "trial": nil
+                                ]
+                            ]
+                        ]
+                    ],
+                    "$rc_annual": [
+                        "identifier": "$rc_annual",
+                        "web_checkout_url": "https://test.rev.cat/web-billing-annual",
+                        "product_details": [
+                            "identifier": "test_annual",
+                            "product_type": "subscription",
+                            "title": "Test Annual",
+                            "description": "Test Annual description",
+                            "default_purchase_option_id": "base_option",
+                            "purchase_options": [
+                                "base_option": [
+                                    "id": "base_option",
+                                    "price_id": "test_annual_price_id",
+                                    "base": [
+                                        "cycle_count": 1,
+                                        "period_duration": "P1Y",
+                                        "price": [
+                                            "amount_micros": 58990000,
+                                            "currency": "EUR"
+                                        ]
+                                    ],
+                                    "trial": [
+                                        "cycle_count": 1,
+                                        "period_duration": "P7D"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    "$rc_lifetime": [
+                        "identifier": "$rc_lifetime",
+                        "web_checkout_url": "https://test.rev.cat/web-billing-lifetime",
+                        "product_details": [
+                            "identifier": "test_lifetime",
+                            "product_type": "non_consumable",
+                            "title": "Test Lifetime",
+                            "description": "Test Lifetime description",
+                            "default_purchase_option_id": "base_option",
+                            "purchase_options": [
+                                "base_option": [
+                                    "id": "base_option",
+                                    "price_id": "test_lifetime_price_id",
+                                    "base_price": [
+                                        "amount_micros": 199990000,
+                                        "currency": "EUR"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ] as [String: Any]
+        ]
+    ]
+
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsCachesForSameUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "x86_64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsCallsHTTPMethod.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "x86_64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "x86_64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsDoesntCacheForMultipleUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "x86_64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsDoesntCacheForMultipleUserID.2.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "x86_64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user_id_2/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsFailSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "x86_64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsNetworkErrorSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "x86_64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testGetWebProductsOneOffering.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "x86_64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "x86_64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsCachesForSameUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsCallsHTTPMethod.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsDoesntCacheForMultipleUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsDoesntCacheForMultipleUserID.2.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user_id_2/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsFailSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsNetworkErrorSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testGetWebProductsOneOffering.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsCachesForSameUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsCallsHTTPMethod.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsDoesntCacheForMultipleUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsDoesntCacheForMultipleUserID.2.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user_id_2/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsFailSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsNetworkErrorSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testGetWebProductsOneOffering.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsCachesForSameUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsCallsHTTPMethod.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsDoesntCacheForMultipleUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsDoesntCacheForMultipleUserID.2.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user_id_2/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsFailSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsNetworkErrorSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testGetWebProductsOneOffering.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsCachesForSameUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsCallsHTTPMethod.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsDoesntCacheForMultipleUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsDoesntCacheForMultipleUserID.2.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user_id_2/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsFailSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsNetworkErrorSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testGetWebProductsOneOffering.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS17-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsCachesForSameUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsCallsHTTPMethod.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsDoesntCacheForMultipleUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsDoesntCacheForMultipleUserID.2.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user_id_2/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsFailSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsNetworkErrorSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testGetWebProductsOneOffering.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/iOS18-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsCachesForSameUserID.1.json
@@ -1,0 +1,28 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsCallsHTTPMethod.1.json
@@ -1,0 +1,28 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
@@ -1,0 +1,28 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsDoesntCacheForMultipleUserID.1.json
@@ -1,0 +1,28 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsDoesntCacheForMultipleUserID.2.json
@@ -1,0 +1,28 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user_id_2/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsFailSendsError.1.json
@@ -1,0 +1,28 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsNetworkErrorSendsError.1.json
@@ -1,0 +1,28 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testGetWebProductsOneOffering.1.json
@@ -1,0 +1,28 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/macOS-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,28 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsCachesForSameUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsCallsHTTPMethod.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsCallsHTTPMethodWithNoDelay.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsDoesntCacheForMultipleUserID.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsDoesntCacheForMultipleUserID.2.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user_id_2/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsFailSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsNetworkErrorSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testGetWebProductsOneOffering.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWebProductsTests/watchOS-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/rcbilling/v1/subscribers/user/offering_products"
+  }
+}


### PR DESCRIPTION
### Description
We ended up changing to use a new endpoint instead of relying on the existing offerings + products endpoints to fetch product info. This changes the implementation to use this new endpoint. This is currently unused, so it's not a problem to change it.
