### PR TITLE
Add ownership type to PurchaseInformation

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -81,6 +81,8 @@ struct PurchaseInformation {
 
     let periodType: PeriodType
 
+    let ownershipType: PurchaseOwnershipType?
+
     private let dateFormatter: DateFormatter
     private let numberFormatter: NumberFormatter
 
@@ -100,7 +102,8 @@ struct PurchaseInformation {
          managementURL: URL?,
          expirationDate: Date? = nil,
          renewalDate: Date? = nil,
-         periodType: PeriodType = .normal
+         periodType: PeriodType = .normal,
+         ownershipType: PurchaseOwnershipType? = nil
     ) {
         self.title = title
         self.durationTitle = durationTitle
@@ -119,6 +122,7 @@ struct PurchaseInformation {
         self.dateFormatter = dateFormatter
         self.periodType = periodType
         self.numberFormatter = numberFormatter
+        self.ownershipType = ownershipType
     }
 
     init(entitlement: EntitlementInfo? = nil,
@@ -151,14 +155,16 @@ struct PurchaseInformation {
             self.expirationDate = entitlement.expirationDate
             self.renewalDate = entitlement.willRenew ? entitlement.expirationDate : nil
             self.periodType = entitlement.periodType
+            self.ownershipType = entitlement.ownershipType
         } else {
             switch transaction.type {
-            case let .subscription(_, willRenew, expiresDate, isTrial):
+            case let .subscription(_, willRenew, expiresDate, isTrial, ownershipType):
                 self.isLifetime = false
                 self.isTrial = isTrial
                 self.latestPurchaseDate = (transaction as? RevenueCat.SubscriptionInfo)?.purchaseDate
                 self.expirationDate = expiresDate
                 self.renewalDate = willRenew ? expiresDate : nil
+                self.ownershipType = ownershipType
 
             case .nonSubscription:
                 self.isLifetime = true
@@ -166,6 +172,7 @@ struct PurchaseInformation {
                 self.latestPurchaseDate = (transaction as? NonSubscriptionTransaction)?.purchaseDate
                 self.renewalDate = nil
                 self.expirationDate = nil
+                self.ownershipType = nil
             }
 
             self.productIdentifier = transaction.productIdentifier
@@ -348,7 +355,7 @@ private extension Transaction {
     }
 
     var unableToInferRenewalPrice: Bool {
-        if case let .subscription(_, willRenew, _, isTrial) = self.type {
+        if case let .subscription(_, willRenew, _, isTrial, _) = self.type {
             return !willRenew || isTrial
         }
 

--- a/RevenueCatUI/CustomerCenter/Data/Transaction.swift
+++ b/RevenueCatUI/CustomerCenter/Data/Transaction.swift
@@ -27,17 +27,26 @@ protocol Transaction {
 
 enum TransactionType {
 
-    case subscription(isActive: Bool, willRenew: Bool, expiresDate: Date?, isTrial: Bool)
+    case subscription(
+        isActive: Bool,
+        willRenew: Bool,
+        expiresDate: Date?,
+        isTrial: Bool,
+        ownershipType: PurchaseOwnershipType
+    )
     case nonSubscription
 }
 
 @_spi(Internal) extension RevenueCat.SubscriptionInfo: Transaction {
 
     var type: TransactionType {
-        .subscription(isActive: isActive,
-                      willRenew: willRenew,
-                      expiresDate: expiresDate,
-                      isTrial: periodType == .trial)
+        .subscription(
+            isActive: isActive,
+            willRenew: willRenew,
+            expiresDate: expiresDate,
+            isTrial: periodType == .trial,
+            ownershipType: ownershipType
+        )
     }
 
     var isCancelled: Bool {

--- a/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
@@ -91,7 +91,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: true,
                 willRenew: true,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -145,7 +146,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: true,
                 willRenew: true,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -200,7 +202,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: true,
                 willRenew: true,
                 expiresDate: nil,
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -256,7 +259,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: true,
                 willRenew: false,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -310,7 +314,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: false,
                 willRenew: false,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2000"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -352,7 +357,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: true,
                 willRenew: true,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -393,7 +399,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: true,
                 willRenew: false,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -434,7 +441,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: false,
                 willRenew: false,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2000"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -475,7 +483,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: true,
                 willRenew: false,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -516,7 +525,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: true,
                 willRenew: false,
                 expiresDate: nil,
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -558,7 +568,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: true,
                 willRenew: true,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -599,7 +610,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: true,
                 willRenew: false,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -640,7 +652,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: false,
                 willRenew: false,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2000"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -681,7 +694,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: true,
                 willRenew: true,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -722,7 +736,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: true,
                 willRenew: false,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -763,7 +778,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: false,
                 willRenew: false,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2000"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,
@@ -801,7 +817,8 @@ final class PurchaseInformationTests: TestCase {
                 isActive: false,
                 willRenew: false,
                 expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2000"),
-                isTrial: false
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
             ),
             isCancelled: false,
             managementURL: URL(string: "https://www.revenuecat.com")!,


### PR DESCRIPTION
### Motivation
The long term goal is to delete `PurchaseInfo` from `PurchaseHistory`, in favor of using `PurchaseInformation`. This info is not available for PurchaseInformation right now.

### Description
- Add `ownershipType` to `PurchaseInformation`