### PR TITLE
Set environmentObject for CustomerCenterViewModel when using an external navstack

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -152,6 +152,7 @@ private extension CustomerCenterView {
                         .environment(\.customerCenterPresentationMode, self.mode)
                         .environment(\.navigationOptions, self.navigationOptions)
                         .environment(\.supportInformation, configuration.support)
+                        .environmentObject(viewModel)
                 } else {
                     TintedProgressView()
                 }

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -36,6 +36,8 @@ struct NoSubscriptionsView: View {
     @Environment(\.colorScheme)
     private var colorScheme
 
+    @EnvironmentObject private var customerCenterViewModel: CustomerCenterViewModel
+
     @State
     private var showRestoreAlert: Bool = false
 
@@ -72,6 +74,7 @@ struct NoSubscriptionsView: View {
                 isPresented: $showRestoreAlert,
                 actionWrapper: actionWrapper
             )
+            .environmentObject(customerCenterViewModel)
         }
     }
 

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -74,7 +74,6 @@ struct NoSubscriptionsView: View {
                 isPresented: $showRestoreAlert,
                 actionWrapper: actionWrapper
             )
-            .environmentObject(customerCenterViewModel)
         }
     }
 

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -105,6 +105,7 @@ struct RelevantPurchasesListView: View {
                 .environment(\.appearance, appearance)
                 .environment(\.localization, localization)
                 .environment(\.navigationOptions, navigationOptions)
+                .environmentObject(customerCenterViewModel)
             }
             .compatibleNavigation(
                 isPresented: $viewModel.showAllPurchases,
@@ -116,6 +117,7 @@ struct RelevantPurchasesListView: View {
                 .environment(\.appearance, appearance)
                 .environment(\.localization, localization)
                 .environment(\.navigationOptions, navigationOptions)
+                .environmentObject(customerCenterViewModel)
             }
             .onChangeOf(activePurchases) { _ in
                 viewModel.updatePurchases(activePurchases)

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -35,6 +35,8 @@ struct RelevantPurchasesListView: View {
     @Environment(\.navigationOptions)
     var navigationOptions
 
+    @EnvironmentObject private var customerCenterViewModel: CustomerCenterViewModel
+
     @StateObject
     private var viewModel: RelevantPurchasesListViewModel
 
@@ -123,6 +125,7 @@ struct RelevantPurchasesListView: View {
                     isPresented: self.$viewModel.showRestoreAlert,
                     actionWrapper: self.viewModel.actionWrapper
                 )
+                .environmentObject(customerCenterViewModel)
             }
     }
 

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -37,6 +37,8 @@ struct SubscriptionDetailView: View {
     @Environment(\.supportInformation)
     private var support
 
+    @EnvironmentObject private var customerCenterViewModel: CustomerCenterViewModel
+
     @StateObject
     private var viewModel: SubscriptionDetailViewModel
 
@@ -181,6 +183,7 @@ struct SubscriptionDetailView: View {
                 isPresented: self.$viewModel.showRestoreAlert,
                 actionWrapper: self.viewModel.actionWrapper
             )
+            .environmentObject(customerCenterViewModel)
         }
         .applyIf(self.viewModel.screen.type == .management, apply: {
             $0.navigationTitle(self.viewModel.screen.title)


### PR DESCRIPTION
### Motivation
When using an external navigation stack, the customer center viewmodel is not present, so we need to explicitly set it.

### Description
Set the environment object for pushed views, so RestoreAlert has it available:

```swift
        .overlay {
            RestorePurchasesAlert(
                isPresented: $showRestoreAlert,
                actionWrapper: actionWrapper
            )
        }
```

```swift
struct RestorePurchasesAlert: View {
    @EnvironmentObject private var customerCenterViewModel: CustomerCenterViewModel
    // more things
}
``
