### PR TITLE
Fix Customer Center VC Navigation Warnings

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -57,6 +57,9 @@ class BaseManageSubscriptionViewModel: ObservableObject {
     var purchaseInformation: PurchaseInformation?
 
     @Published
+    var showAllInAppCurrenciesScreen: Bool = false
+
+    @Published
     private(set) var refundRequestStatus: RefundRequestStatus?
 
     /// Virtual currencies to display. If it is set to nil, nothing will be displayed.
@@ -131,6 +134,10 @@ class BaseManageSubscriptionViewModel: ObservableObject {
 
     func onDismissInAppBrowser() {
         self.inAppBrowserURL = nil
+    }
+
+    func displayAllInAppCurrenciesScreen() {
+        self.showAllInAppCurrenciesScreen = true
     }
 
 #endif

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsView.swift
@@ -39,8 +39,14 @@ struct NoSubscriptionsView: View {
     @Environment(\.supportInformation)
     private var support
 
+    @Environment(\.navigationOptions)
+    var navigationOptions
+
     @State
     private var showRestoreAlert: Bool = false
+
+    @State
+    private var showAllInAppCurrenciesScreen: Bool = false
 
     private let virtualCurrencies: [String: RevenueCat.VirtualCurrencyInfo]?
     private let purchasesProvider: CustomerCenterPurchasesType
@@ -72,7 +78,7 @@ struct NoSubscriptionsView: View {
             if let virtualCurrencies, !virtualCurrencies.isEmpty {
                 VirtualCurrenciesListSection(
                     virtualCurrencies: virtualCurrencies,
-                    purchasesProvider: self.purchasesProvider
+                    onSeeAllInAppCurrenciesButtonTapped: { self.showAllInAppCurrenciesScreen = true }
                 )
             }
 
@@ -84,6 +90,17 @@ struct NoSubscriptionsView: View {
 
         }
         .dismissCircleButtonToolbarIfNeeded()
+        .compatibleNavigation(
+            isPresented: $showAllInAppCurrenciesScreen,
+            usesNavigationStack: navigationOptions.usesNavigationStack
+        ) {
+            VirtualCurrencyBalancesScreen(
+                viewModel: VirtualCurrencyBalancesScreenViewModel(purchasesProvider: self.purchasesProvider)
+            )
+            .environment(\.appearance, appearance)
+            .environment(\.localization, localization)
+            .environment(\.navigationOptions, navigationOptions)
+        }
         .overlay {
             RestorePurchasesAlert(
                 isPresented: $showRestoreAlert,

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -119,6 +119,19 @@ struct RelevantPurchasesListView: View {
                 .environment(\.localization, localization)
                 .environment(\.navigationOptions, navigationOptions)
             }
+            .compatibleNavigation(
+                isPresented: $viewModel.showAllInAppCurrenciesScreen,
+                usesNavigationStack: navigationOptions.usesNavigationStack
+            ) {
+                VirtualCurrencyBalancesScreen(
+                    viewModel: VirtualCurrencyBalancesScreenViewModel(
+                        purchasesProvider: self.viewModel.purchasesProvider
+                    )
+                )
+                .environment(\.appearance, appearance)
+                .environment(\.localization, localization)
+                .environment(\.navigationOptions, navigationOptions)
+            }
             .onChangeOf(activePurchases) { _ in
                 viewModel.updatePurchases(activePurchases)
             }
@@ -165,7 +178,7 @@ struct RelevantPurchasesListView: View {
                     if let virtualCurrencies = viewModel.virtualCurrencies, !virtualCurrencies.isEmpty {
                         VirtualCurrenciesScrollViewWithOSBackgroundSection(
                             virtualCurrencies: virtualCurrencies,
-                            purchasesProvider: self.viewModel.purchasesProvider
+                            onSeeAllInAppCurrenciesButtonTapped: self.viewModel.displayAllInAppCurrenciesScreen
                         )
                     }
                 }

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -94,6 +94,19 @@ struct SubscriptionDetailView: View {
                 .environment(\.localization, localization)
                 .environment(\.navigationOptions, navigationOptions)
             }
+            .compatibleNavigation(
+                isPresented: $viewModel.showAllInAppCurrenciesScreen,
+                usesNavigationStack: navigationOptions.usesNavigationStack
+            ) {
+                VirtualCurrencyBalancesScreen(
+                    viewModel: VirtualCurrencyBalancesScreenViewModel(
+                        purchasesProvider: self.viewModel.purchasesProvider
+                    )
+                )
+                .environment(\.appearance, appearance)
+                .environment(\.localization, localization)
+                .environment(\.navigationOptions, navigationOptions)
+            }
             .sheet(item: self.$viewModel.promotionalOfferData) { promotionalOfferData in
                 PromotionalOfferView(
                     promotionalOffer: promotionalOfferData.promotionalOffer,
@@ -165,7 +178,7 @@ struct SubscriptionDetailView: View {
                 if let virtualCurrencies = viewModel.virtualCurrencies, !virtualCurrencies.isEmpty {
                     VirtualCurrenciesScrollViewWithOSBackgroundSection(
                         virtualCurrencies: virtualCurrencies,
-                        purchasesProvider: self.viewModel.purchasesProvider
+                        onSeeAllInAppCurrenciesButtonTapped: self.viewModel.displayAllInAppCurrenciesScreen
                     )
                 }
 

--- a/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrenciesListSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrenciesListSection.swift
@@ -11,17 +11,44 @@ import Foundation
 import RevenueCat
 import SwiftUI
 
+/// A SwiftUI view that displays a list of virtual currency balances in a section format.
+///
+/// This view shows up to three virtual currencies sorted by balance in descending order.
+/// If there are more than three currencies, a "See All" button is displayed that navigates
+/// to a full list of virtual currencies. Designed for use in a SwiftUI ``List`` view.
+///
+/// ## Navigation Considerations
+///
+/// Due to SwiftUI's limitations with placing navigation destinations inside ``List`` and ``LazyVStack`` views,
+/// it is the responsibility of the parent view to implement the `onSeeAllInAppCurrenciesButtonTapped`
+/// closure to present the ``VirtualCurrencyBalancesScreen``. This closure is called when the user
+/// taps the "See All In-App Currencies" button.
+///
+/// > SwiftUI will print the following warning if navigation destinations are used inside ``List`` or ``LazyVStack``:
+/// > ```
+/// > Do not put a navigation destination modifier inside a "lazy" container, like `List` or `LazyVStack`.
+/// > These containers create child views only when needed to render on screen. Add the navigation destination
+/// > modifier outside these containers so that the navigation stack can always see the destination.
+/// > There's a misplaced `navigationDestination(isPresented:destination:)` modifier presenting
+/// > `VirtualCurrencyBalancesScreen`. It will be ignored in a future release.
+/// > ```
+/// >
+/// > The extraction of the navigation logic to the parent view circumvents this warning.
+///
+/// Example implementation:
+/// ```swift
+/// VirtualCurrenciesListSection(
+///     virtualCurrencies: virtualCurrencies,
+///     onSeeAllInAppCurrenciesButtonTapped: {
+///         // Present VirtualCurrencyBalancesScreen here
+///         // For example, using NavigationLink or sheet presentation
+///     }
+/// )
+/// ```
 @available(iOS 15.0, *)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-/// A SwiftUI view that displays a list of virtual currency balances in a section format.
-///
-/// Designed for use in a SwiftUI ``List`` view.
-///
-/// This view shows up to three virtual currencies sorted by balance in descending order.
-/// If there are more than three currencies, a "See All" button is displayed that navigates
-/// to a full list of virtual currencies.
 struct VirtualCurrenciesListSection: View {
 
     private static let maxNumberOfRows = 4
@@ -31,8 +58,18 @@ struct VirtualCurrenciesListSection: View {
 
     private let virtualCurrencies: [VirtualCurrencyBalanceListRow.RowData]
     private let displayShowAllButton: Bool
+
+    /// Closure called when the user taps the "See All In-App Currencies" button.
+    /// The parent view should implement this to present the ``VirtualCurrencyBalancesScreen``
+    /// since navigation destinations cannot be nested inside ``List`` or ``LazyVStack``.
     private let onSeeAllInAppCurrenciesButtonTapped: () -> Void
 
+    /// Creates a new virtual currencies list section.
+    /// - Parameters:
+    ///   - virtualCurrencies: Dictionary of virtual currency codes to their balance information
+    ///   - onSeeAllInAppCurrenciesButtonTapped: Closure to handle navigation to the full list screen.
+    ///     Must be implemented by the parent view to present ``VirtualCurrencyBalancesScreen``
+    ///     since navigation destinations cannot be nested inside ``List`` or ``LazyVStack``.
     init(
         virtualCurrencies: [String: RevenueCat.VirtualCurrencyInfo],
         onSeeAllInAppCurrenciesButtonTapped: @escaping () -> Void

--- a/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrenciesListSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrenciesListSection.swift
@@ -29,18 +29,13 @@ struct VirtualCurrenciesListSection: View {
     @Environment(\.localization)
     private var localization: CustomerCenterConfigData.Localization
 
-    @Environment(\.navigationOptions)
-    var navigationOptions
-
-    @State private var showVirtualCurrenciesListScreen = false
-
     private let virtualCurrencies: [VirtualCurrencyBalanceListRow.RowData]
     private let displayShowAllButton: Bool
-    private let purchasesProvider: CustomerCenterPurchasesType
+    private let onSeeAllInAppCurrenciesButtonTapped: () -> Void
 
     init(
         virtualCurrencies: [String: RevenueCat.VirtualCurrencyInfo],
-        purchasesProvider: CustomerCenterPurchasesType
+        onSeeAllInAppCurrenciesButtonTapped: @escaping () -> Void
     ) {
         let sortedCurrencies = virtualCurrencies.map {
             VirtualCurrencyBalanceListRow.RowData(
@@ -60,7 +55,7 @@ struct VirtualCurrenciesListSection: View {
             self.virtualCurrencies = Array(sortedCurrencies.prefix(3))
             self.displayShowAllButton = true
         }
-        self.purchasesProvider = purchasesProvider
+        self.onSeeAllInAppCurrenciesButtonTapped = onSeeAllInAppCurrenciesButtonTapped
     }
 
     var body: some View {
@@ -72,21 +67,13 @@ struct VirtualCurrenciesListSection: View {
 
                 if displayShowAllButton {
                     Button {
-                        self.showVirtualCurrenciesListScreen = true
+                        self.onSeeAllInAppCurrenciesButtonTapped()
                     } label: {
                         CompatibilityLabeledContent(localization[.seeAllVirtualCurrencies].localizedCapitalized) {
                             Image(systemName: "chevron.forward")
                         }
                     }
                     .buttonStyle(.plain)
-                    .compatibleNavigation(
-                        isPresented: $showVirtualCurrenciesListScreen,
-                        usesNavigationStack: navigationOptions.usesNavigationStack
-                    ) {
-                        VirtualCurrencyBalancesScreen(
-                            viewModel: VirtualCurrencyBalancesScreenViewModel(purchasesProvider: self.purchasesProvider)
-                        )
-                    }
                 }
             }
         }
@@ -106,7 +93,7 @@ struct VirtualCurrenciesListSection_Previews: PreviewProvider {
         List {
             VirtualCurrenciesListSection(
                 virtualCurrencies: CustomerCenterConfigData.fourVirtualCurrencies,
-                purchasesProvider: CustomerCenterPurchases()
+                onSeeAllInAppCurrenciesButtonTapped: { }
             )
         }
         .previewDisplayName("4 Virtual Currencies")
@@ -114,7 +101,7 @@ struct VirtualCurrenciesListSection_Previews: PreviewProvider {
         List {
             VirtualCurrenciesListSection(
                 virtualCurrencies: CustomerCenterConfigData.fiveVirtualCurrencies,
-                purchasesProvider: CustomerCenterPurchases()
+                onSeeAllInAppCurrenciesButtonTapped: { }
             )
         }
         .previewDisplayName("5 Virtual Currencies")

--- a/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrenciesScrollViewWithOSBackgroundSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrenciesScrollViewWithOSBackgroundSection.swift
@@ -17,17 +17,44 @@ import Foundation
 import RevenueCat
 import SwiftUI
 
+/// A SwiftUI view that displays a list of virtual currency balances in a section format.
+///
+/// This view shows up to three virtual currencies sorted by balance in descending order.
+/// If there are more than three currencies, a "See All" button is displayed that navigates
+/// to a full list of virtual currencies. Designed for use in a ``ScrollViewWithOSBackground`` view.
+///
+/// ## Navigation Considerations
+///
+/// Due to SwiftUI's limitations with placing navigation destinations inside ``List`` and ``LazyVStack`` views,
+/// it is the responsibility of the parent view to implement the `onSeeAllInAppCurrenciesButtonTapped`
+/// closure to present the ``VirtualCurrencyBalancesScreen``. This closure is called when the user
+/// taps the "See All In-App Currencies" button.
+///
+/// > SwiftUI will print the following warning if navigation destinations are used inside ``List`` or ``LazyVStack``:
+/// > ```
+/// > Do not put a navigation destination modifier inside a "lazy" container, like `List` or `LazyVStack`.
+/// > These containers create child views only when needed to render on screen. Add the navigation destination
+/// > modifier outside these containers so that the navigation stack can always see the destination.
+/// > There's a misplaced `navigationDestination(isPresented:destination:)` modifier presenting
+/// > `VirtualCurrencyBalancesScreen`. It will be ignored in a future release.
+/// > ```
+/// >
+/// > The extraction of the navigation logic to the parent view circumvents this warning.
+///
+/// Example implementation:
+/// ```swift
+/// VirtualCurrenciesListSection(
+///     virtualCurrencies: virtualCurrencies,
+///     onSeeAllInAppCurrenciesButtonTapped: {
+///         // Present VirtualCurrencyBalancesScreen here
+///         // For example, using NavigationLink or sheet presentation
+///     }
+/// )
+/// ```
 @available(iOS 15.0, *)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-/// A SwiftUI view that displays a list of virtual currency balances in a section format.
-///
-/// Designed for use in a ``ScrollViewWithOSBackground`` view.
-///
-/// This view shows up to three virtual currencies sorted by balance in descending order.
-/// If there are more than three currencies, a "See All" button is displayed that navigates
-/// to a full list of virtual currencies.
 // swiftlint:disable:next type_name
 struct VirtualCurrenciesScrollViewWithOSBackgroundSection: View {
 
@@ -41,8 +68,18 @@ struct VirtualCurrenciesScrollViewWithOSBackgroundSection: View {
 
     private let virtualCurrencies: [VirtualCurrencyBalanceListRow.RowData]
     private let displayShowAllButton: Bool
+
+    /// Closure called when the user taps the "See All In-App Currencies" button.
+    /// The parent view should implement this to present the ``VirtualCurrencyBalancesScreen``
+    /// since navigation destinations cannot be nested inside ``List`` or ``LazyVStack``.
     private let onSeeAllInAppCurrenciesButtonTapped: () -> Void
 
+    /// Creates a new virtual currencies list section.
+    /// - Parameters:
+    ///   - virtualCurrencies: Dictionary of virtual currency codes to their balance information
+    ///   - onSeeAllInAppCurrenciesButtonTapped: Closure to handle navigation to the full list screen.
+    ///     Must be implemented by the parent view to present ``VirtualCurrencyBalancesScreen``
+    ///     since navigation destinations cannot be nested inside ``List`` or ``LazyVStack``.
     init(
         virtualCurrencies: [String: RevenueCat.VirtualCurrencyInfo],
         onSeeAllInAppCurrenciesButtonTapped: @escaping () -> Void

--- a/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrenciesScrollViewWithOSBackgroundSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrenciesScrollViewWithOSBackgroundSection.swift
@@ -39,18 +39,13 @@ struct VirtualCurrenciesScrollViewWithOSBackgroundSection: View {
     @Environment(\.colorScheme)
     private var colorScheme
 
-    @Environment(\.navigationOptions)
-    var navigationOptions
-
-    @State private var showVirtualCurrenciesListScreen = false
-
     private let virtualCurrencies: [VirtualCurrencyBalanceListRow.RowData]
     private let displayShowAllButton: Bool
-    private let purchasesProvider: CustomerCenterPurchasesType
+    private let onSeeAllInAppCurrenciesButtonTapped: () -> Void
 
     init(
         virtualCurrencies: [String: RevenueCat.VirtualCurrencyInfo],
-        purchasesProvider: CustomerCenterPurchasesType
+        onSeeAllInAppCurrenciesButtonTapped: @escaping () -> Void
     ) {
         let sortedCurrencies = virtualCurrencies.map {
             VirtualCurrencyBalanceListRow.RowData(
@@ -70,7 +65,7 @@ struct VirtualCurrenciesScrollViewWithOSBackgroundSection: View {
             self.virtualCurrencies = Array(sortedCurrencies.prefix(3))
             self.displayShowAllButton = true
         }
-        self.purchasesProvider = purchasesProvider
+        self.onSeeAllInAppCurrenciesButtonTapped = onSeeAllInAppCurrenciesButtonTapped
     }
 
     var body: some View {
@@ -87,7 +82,6 @@ struct VirtualCurrenciesScrollViewWithOSBackgroundSection: View {
                                 .padding(.vertical, 12)
                             if index < virtualCurrencies.count - 1 {
                                 Divider()
-                                    .padding(.vertical, 4)
                             }
                         }
 
@@ -95,7 +89,7 @@ struct VirtualCurrenciesScrollViewWithOSBackgroundSection: View {
                             Divider()
                                 .padding(.vertical, 4)
                             Button {
-                                self.showVirtualCurrenciesListScreen = true
+                                self.onSeeAllInAppCurrenciesButtonTapped()
                             } label: {
                                 CompatibilityLabeledContent(
                                     localization[.seeAllVirtualCurrencies].localizedCapitalized
@@ -106,16 +100,6 @@ struct VirtualCurrenciesScrollViewWithOSBackgroundSection: View {
                             .buttonStyle(.plain)
                             .padding(.horizontal)
                             .padding(.vertical, 12)
-                            .compatibleNavigation(
-                                isPresented: $showVirtualCurrenciesListScreen,
-                                usesNavigationStack: navigationOptions.usesNavigationStack
-                            ) {
-                                VirtualCurrencyBalancesScreen(
-                                    viewModel: VirtualCurrencyBalancesScreenViewModel(
-                                        purchasesProvider: self.purchasesProvider
-                                    )
-                                )
-                            }
                         }
                     }
                     .background(Color(colorScheme == .light
@@ -144,7 +128,7 @@ struct VirtualCurrenciesScrollViewWithOSBackgroundSection_Previews: PreviewProvi
         ScrollViewWithOSBackground {
             VirtualCurrenciesScrollViewWithOSBackgroundSection(
                 virtualCurrencies: CustomerCenterConfigData.fourVirtualCurrencies,
-                purchasesProvider: CustomerCenterPurchases()
+                onSeeAllInAppCurrenciesButtonTapped: { }
             )
         }
         .previewDisplayName("4 Virtual Currencies")
@@ -152,7 +136,7 @@ struct VirtualCurrenciesScrollViewWithOSBackgroundSection_Previews: PreviewProvi
         ScrollViewWithOSBackground {
             VirtualCurrenciesScrollViewWithOSBackgroundSection(
                 virtualCurrencies: CustomerCenterConfigData.fiveVirtualCurrencies,
-                purchasesProvider: CustomerCenterPurchases()
+                onSeeAllInAppCurrenciesButtonTapped: { }
             )
         }
         .previewDisplayName("5 Virtual Currencies")

--- a/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
@@ -54,6 +54,7 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
         expect(viewModel.refundRequestStatus).to(beNil())
         expect(viewModel.screen).toNot(beNil())
         expect(viewModel.showRestoreAlert) == false
+        expect(viewModel.showAllInAppCurrenciesScreen).to(equal(false))
     }
 
     func testNoPurchaseOnlyMissingPurchasePath() {
@@ -396,6 +397,22 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
 
             expect(loadPromotionalOfferUseCase.offerToLoadPromoFor).to(beNil())
         }
+    }
+
+    func testDisplayAllInAppCurrenciesScreen() async throws {
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: BaseManageSubscriptionViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: nil,
+            virtualCurrencies: nil,
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        expect(viewModel.showAllInAppCurrenciesScreen).to(equal(false))
+
+        viewModel.displayAllInAppCurrenciesScreen()
+
+        expect(viewModel.showAllInAppCurrenciesScreen).to(equal(true))
     }
 
     // Helper methods


### PR DESCRIPTION
### Motivation
In the current implementation of the virtual currency feature in the Customer Center, SwiftUI logs the following warning in the console when the `VirtualCurrenciesListSection` and `VirtualCurrenciesScrollViewWithOSBackgroundSection` is displayed:

```
Do not put a navigation destination modifier inside a "lazy” container, like 
`List` or `LazyVStack`. These containers create child views only when 
needed to render on screen. Add the navigation destination modifier 
outside these containers so that the navigation stack can always see 
the destination. There's a misplaced 
`navigationDestination(isPresented:destination:)` modifier presenting 
`VirtualCurrencyBalancesScreen`. It will be ignored in a future release.
```

This is because the navigationDestination is inside the section view, which is then nested inside a `List` or `LazyVStack`, respectively. This PR prevents this warning from being displayed by extracting the navigation logic outside of the Virtual Currency Sections themselves and outside of the parent `List` or `LazyVStack`.

### Description
- Hoists navigation logic out of the virtual currency list sections above the `List` or `LazyVStack` to prevent the warning from being logged
- Adds an automated test
- Adds documentation so consumers of these views know that they're responsible for implementing the navigation logic.

### Testing
- Added an automated test
- Manually verified that the warning is no longer being logged