### PR TITLE
Wait a max of 20 minutes for TestFlight processing

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -865,10 +865,14 @@ platform :ios do
       }
     )
 
+    # Wait 20 minutes for the build to be processed by Apple otherwise fail
+    wait_processing_timeout_duration_in_seconds = 60 * 20
+
     if not dry_run
       upload_to_testflight(
       changelog: changelog,
       app_identifier: "com.revenuecat.sampleapp",
+      wait_processing_timeout_duration: wait_processing_timeout_duration_in_seconds
     )
     else
       UI.message("Dry run mode enabled. Skipping upload to TestFlight")
@@ -903,6 +907,7 @@ platform :ios do
         changelog: changelog,
         app_platform: 'osx',
         app_identifier: "com.revenuecat.sampleapp",
+        wait_processing_timeout_duration: wait_processing_timeout_duration_in_seconds
       )
     else
         UI.message("Dry run mode enabled. Skipping upload to TestFlight")


### PR DESCRIPTION
### Motivation

Waiting for builds to process on CI can sometimes go indefinitely and that is bad for environment and $$$$

### Description

Set a max of 20 minutes for waiting for build processing (if it's longer than 20 minutes, odds are its not going to happen)
