### PR TITLE
Fix some flaky tests (Part 3)

### DIFF
--- a/Tests/UnitTests/Misc/TimingUtilTests.swift
+++ b/Tests/UnitTests/Misc/TimingUtilTests.swift
@@ -71,7 +71,7 @@ class TimingUtilAsyncTests: TestCase {
         }
 
         expect(result) == expectedResult
-        expect(self.logger.messages).to(beEmpty())
+        self.logger.verifyMessageWasNotLogged("Too slow", allowNoMessages: true)
     }
 
     func testMeasureAndLogWithResult() async {
@@ -118,7 +118,7 @@ class TimingUtilAsyncTests: TestCase {
             expect(error).to(matchError(expectedError))
         }
 
-        expect(self.logger.messages).to(beEmpty())
+        self.logger.verifyMessageWasNotLogged("Too slow", allowNoMessages: true)
     }
 
     func testMeasureSyncAndLogDoesNotLogIfLowerThanThreshold() {
@@ -134,7 +134,7 @@ class TimingUtilAsyncTests: TestCase {
         }
 
         expect(result) == expectedResult
-        expect(self.logger.messages).to(beEmpty())
+        self.logger.verifyMessageWasNotLogged("Too slow", allowNoMessages: true)
     }
 
     func testMeasureSyncAndLogThrowsError() {
@@ -151,7 +151,7 @@ class TimingUtilAsyncTests: TestCase {
             expect(error).to(matchError(expectedError))
         }
 
-        expect(self.logger.messages).to(beEmpty())
+        self.logger.verifyMessageWasNotLogged("Too slow", allowNoMessages: true)
     }
 
     func testMeasureSyncAndLogWithResult() {
@@ -238,7 +238,7 @@ class TimingUtilCompletionBlockTests: TestCase {
 
         expect(result).toEventuallyNot(beNil())
         expect(result) == expectedResult
-        expect(self.logger.messages).to(beEmpty())
+        self.logger.verifyMessageWasNotLogged("Too slow", allowNoMessages: true)
     }
 
     func testMeasureAndLogWithResult() {

--- a/Tests/UnitTests/Misc/TimingUtilTests.swift
+++ b/Tests/UnitTests/Misc/TimingUtilTests.swift
@@ -24,6 +24,7 @@ class TimingUtilAsyncTests: TestCase {
         try super.setUpWithError()
 
         self.clock = TestClock()
+        self.logger.clearMessages()
     }
 
     func testMeasureNonThrowingBlockReturnsValueAndDuration() async {


### PR DESCRIPTION
Continues the work of #5104

### Motivation
[These](https://circleci.com/gh/RevenueCat/purchases-ios/326466) flaky tests

### Description
Fixes some flaky tests in `TimingUtilAsyncTests`, where the tests were checking that no messages were being logged and sometimes some logs from other tests were causing the tests to fail.
Now, the tests only fail if the logs contain the specific message that is expected not to be logged.