### PR TITLE
Introduce CustomerCenterButtonStyle to highlight CustomerCenter buttons

### DIFF
--- a/RevenueCatUI/CustomerCenter/ButtonStyles.swift
+++ b/RevenueCatUI/CustomerCenter/ButtonStyles.swift
@@ -66,7 +66,7 @@ struct CustomerCenterButtonStyle: ButtonStyle {
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension ButtonStyle where Self == CustomerCenterButtonStyle {
-    static func customerCenterScrollView(for colorScheme: ColorScheme) -> CustomerCenterButtonStyle {
+    static func customerCenterButtonStyle(for colorScheme: ColorScheme) -> CustomerCenterButtonStyle {
         CustomerCenterButtonStyle(
             normalColor: Color(colorScheme == .light
                                ? UIColor.systemBackground

--- a/RevenueCatUI/CustomerCenter/ButtonStyles.swift
+++ b/RevenueCatUI/CustomerCenter/ButtonStyles.swift
@@ -42,7 +42,40 @@ struct ProminentButtonStyle: PrimitiveButtonStyle {
         .applyIf(background != nil, apply: { $0.tint(background) })
         .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
     }
+}
 
+@available(iOS 15.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+struct CustomerCenterButtonStyle: ButtonStyle {
+    let normalColor: Color
+    let pressedColor: Color
+
+    func makeBody(configuration: ButtonStyleConfiguration) -> some View {
+        configuration.label
+            .padding(.horizontal)
+            .padding(.vertical, 12)
+            .background(configuration.isPressed ? pressedColor : normalColor)
+            .cornerRadius(10)
+    }
+}
+
+@available(iOS 15.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension ButtonStyle where Self == CustomerCenterButtonStyle {
+    static func customerCenterScrollView(for colorScheme: ColorScheme) -> CustomerCenterButtonStyle {
+        CustomerCenterButtonStyle(
+            normalColor: Color(colorScheme == .light
+                               ? UIColor.systemBackground
+                               : UIColor.secondarySystemBackground),
+            pressedColor: Color(colorScheme == .light
+                                ? UIColor.secondarySystemBackground
+                                : UIColor.systemBackground)
+        )
+    }
 }
 
 @available(iOS 15.0, *)

--- a/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
@@ -114,12 +114,17 @@ struct FeedbackSurveyView: View {
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
+// This is a duplicate of ActiveSubscriptionButtonsView. It should be unified in the near future.
 struct FeedbackSurveyButtonsView: View {
 
     let options: [CustomerCenterConfigData.HelpPath.FeedbackSurvey.Option]
     let onOptionSelected: (_ optionSelected: CustomerCenterConfigData.HelpPath.FeedbackSurvey.Option) async -> Void
 
-    @Environment(\.appearance) private var appearance: CustomerCenterConfigData.Appearance
+    @Environment(\.appearance)
+    private var appearance: CustomerCenterConfigData.Appearance
+
+    @Environment(\.colorScheme)
+    private var colorScheme
 
     @Binding
     var loadingOption: String?
@@ -137,9 +142,12 @@ struct FeedbackSurveyButtonsView: View {
             }
             .disabled(self.loadingOption != nil)
         }
-
+        .applyIf(tintColor != nil, apply: { $0.tint(tintColor) })
     }
 
+    private var tintColor: Color? {
+        Color.from(colorInformation: appearance.accentColor, for: self.colorScheme)
+    }
 }
 
 #if DEBUG

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -228,14 +228,9 @@ struct SubscriptionDetailView: View {
             }
         } label: {
             CompatibilityLabeledContent(localization[.contactSupport])
-                .padding(.horizontal)
-                .padding(.vertical, 12)
         }
-        .background(Color(colorScheme == .light
-                          ? UIColor.systemBackground
-                          : UIColor.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 10))
         .padding(.horizontal)
+        .buttonStyle(.customerCenterScrollView(for: colorScheme))
     }
 
     private var seeAllSubscriptionsButton: some View {
@@ -245,14 +240,9 @@ struct SubscriptionDetailView: View {
             CompatibilityLabeledContent(localization[.seeAllPurchases]) {
                 Image(systemName: "chevron.forward")
             }
-            .padding(.horizontal)
-            .padding(.vertical, 12)
-            .background(Color(colorScheme == .light
-                              ? UIColor.systemBackground
-                              : UIColor.secondarySystemBackground))
-            .cornerRadius(10)
-            .padding(.horizontal)
         }
+        .padding(.horizontal)
+        .buttonStyle(.customerCenterScrollView(for: colorScheme))
         .tint(colorScheme == .dark ? .white : .black)
     }
 }

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -230,7 +230,7 @@ struct SubscriptionDetailView: View {
             CompatibilityLabeledContent(localization[.contactSupport])
         }
         .padding(.horizontal)
-        .buttonStyle(.customerCenterScrollView(for: colorScheme))
+        .buttonStyle(.customerCenterButtonStyle(for: colorScheme))
     }
 
     private var seeAllSubscriptionsButton: some View {
@@ -242,7 +242,7 @@ struct SubscriptionDetailView: View {
             }
         }
         .padding(.horizontal)
-        .buttonStyle(.customerCenterScrollView(for: colorScheme))
+        .buttonStyle(.customerCenterButtonStyle(for: colorScheme))
         .tint(colorScheme == .dark ? .white : .black)
     }
 }


### PR DESCRIPTION
### Motivation
"See all button" is not correctly highlighted when tapping on it. This adds a button style that takes into account the pressed state.

### Description
- Use button style for both buttons that are inside the scrollview 💅 
- Apply tint to feedback survey
