### PR TITLE
Minor UI tweaks for CustomerCenter 2.0

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -27,7 +27,14 @@ class BaseManageSubscriptionViewModel: ObservableObject {
     let screen: CustomerCenterConfigData.Screen
 
     var relevantPathsForPurchase: [CustomerCenterConfigData.HelpPath] {
-        paths.relevantPahts(for: purchaseInformation)
+        paths.relevantPahts(for: purchaseInformation, allowMissingPurchase: allowMissingPurchase)
+    }
+
+    /// Used to exclude .missingPurchase path
+    ///
+    /// If the detail screen is the root of the stack, then we should show it. Otherwise, it should be excluded
+    var allowMissingPurchase: Bool {
+        false
     }
 
     @Published
@@ -233,7 +240,8 @@ private extension CustomerCenterConfigData.Screen {
 
 private extension Array<CustomerCenterConfigData.HelpPath> {
     func relevantPahts(
-        for purchaseInformation: PurchaseInformation?
+        for purchaseInformation: PurchaseInformation?,
+        allowMissingPurchase: Bool
     ) -> [CustomerCenterConfigData.HelpPath] {
         guard let purchaseInformation else {
             return filter {
@@ -243,7 +251,7 @@ private extension Array<CustomerCenterConfigData.HelpPath> {
 
         return filter {
             // we don't show missing purchase when a purchase is selected
-            if $0.type == .missingPurchase {
+            if !allowMissingPurchase && $0.type == .missingPurchase {
                 return false
             }
 

--- a/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
@@ -41,22 +41,23 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
     init(
         screen: CustomerCenterConfigData.Screen,
         showPurchaseHistory: Bool,
+        allowsMissingPurchaseAction: Bool,
         actionWrapper: CustomerCenterActionWrapper,
         purchaseInformation: PurchaseInformation? = nil,
         refundRequestStatus: RefundRequestStatus? = nil,
         purchasesProvider: CustomerCenterPurchasesType,
         loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType? = nil) {
-        self.showPurchaseHistory = showPurchaseHistory
-
-        super.init(
-            screen: screen,
-            actionWrapper: actionWrapper,
-            purchaseInformation: purchaseInformation,
-            refundRequestStatus: refundRequestStatus,
-            purchasesProvider: purchasesProvider,
-            loadPromotionalOfferUseCase: loadPromotionalOfferUseCase
-        )
-    }
+            self.showPurchaseHistory = showPurchaseHistory
+            self.allowsMissingPurchaseAction = allowsMissingPurchaseAction
+            super.init(
+                screen: screen,
+                actionWrapper: actionWrapper,
+                purchaseInformation: purchaseInformation,
+                refundRequestStatus: refundRequestStatus,
+                purchasesProvider: purchasesProvider,
+                loadPromotionalOfferUseCase: loadPromotionalOfferUseCase
+            )
+        }
 
     func reloadPurchaseInformation(_ purchaseInformation: PurchaseInformation?) {
         self.purchaseInformation = purchaseInformation
@@ -66,12 +67,14 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
     convenience init(
         screen: CustomerCenterConfigData.Screen,
         showPurchaseHistory: Bool,
+        allowsMissingPurchaseAction: Bool,
         purchaseInformation: PurchaseInformation? = nil,
         refundRequestStatus: RefundRequestStatus? = nil
     ) {
         self.init(
             screen: screen,
             showPurchaseHistory: showPurchaseHistory,
+            allowsMissingPurchaseAction: allowsMissingPurchaseAction,
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: purchaseInformation,
             refundRequestStatus: refundRequestStatus,

--- a/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
@@ -28,8 +28,6 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
 
     let showPurchaseHistory: Bool
 
-    var allowsMissingPurchaseAction: Bool = true
-
     var shouldShowContactSupport: Bool {
         purchaseInformation?.store != .appStore
     }
@@ -37,6 +35,8 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
     override var allowMissingPurchase: Bool {
         allowsMissingPurchaseAction
     }
+
+    private var allowsMissingPurchaseAction: Bool = true
 
     init(
         screen: CustomerCenterConfigData.Screen,

--- a/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
@@ -28,8 +28,14 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
 
     let showPurchaseHistory: Bool
 
+    var allowsMissingPurchaseAction: Bool = true
+
     var shouldShowContactSupport: Bool {
         purchaseInformation?.store != .appStore
+    }
+
+    override var allowMissingPurchase: Bool {
+        allowsMissingPurchaseAction
     }
 
     init(

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -238,6 +238,7 @@ private extension CustomerCenterView {
             screen: screen,
             purchaseInformation: viewModel.activePurchase,
             showPurchaseHistory: viewModel.shouldShowSeeAllPurchases,
+            allowsMissingPurchaseAction: true,
             purchasesProvider: self.viewModel.purchasesProvider,
             actionWrapper: self.viewModel.actionWrapper
         )

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
@@ -31,6 +31,7 @@ struct PurchaseInformationCardView: View {
 
     private let storeTitle: String
 
+    private let additionalIcon: Image?
     private let additionalInfo: String?
 
     private let paidPrice: String
@@ -41,6 +42,7 @@ struct PurchaseInformationCardView: View {
         storeTitle: String,
         paidPrice: String,
         badge: PurchaseInformationCardView.Badge? = nil,
+        additionalIcon: Image? = nil,
         additionalInfo: String? = nil,
         subtitle: String? = nil,
         showChevron: Bool = true
@@ -49,6 +51,7 @@ struct PurchaseInformationCardView: View {
         self.paidPrice = paidPrice
         self.subtitle = subtitle
         self.badge = badge
+        self.additionalIcon = additionalIcon
         self.additionalInfo = additionalInfo
         self.storeTitle = storeTitle
         self.showChevron = showChevron
@@ -75,13 +78,16 @@ struct PurchaseInformationCardView: View {
             self.subtitle = purchaseInformation.pricePaidString(localizations: localization)
         }
 
+        self.additionalIcon = refundStatus?.icon
         self.additionalInfo = refundStatus?.subtitle(localization: localization)
 
         switch purchaseInformation.pricePaid {
         case .free, .unknown:
             self.paidPrice = ""
-        case .nonFree(let pricePaid):
+        case .nonFree(let pricePaid) where purchaseInformation.shoulShowPricePaid:
             self.paidPrice = pricePaid
+        case .nonFree:
+            self.paidPrice = ""
         }
         self.storeTitle = localization[purchaseInformation.store.localizationKey]
         self.showChevron = showChevron
@@ -153,14 +159,22 @@ struct PurchaseInformationCardView: View {
                               ? UIColor.systemBackground
                               : UIColor.secondarySystemBackground))
 
-            if let additionalInfo {
-                Text(additionalInfo)
-                    .font(.caption)
-                    .foregroundStyle(.primary)
-                    .padding(.bottom, 4)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .multilineTextAlignment(.leading)
-                    .padding()
+            if let additionalInfo, let additionalIcon {
+                HStack(alignment: .center, spacing: 12) {
+                    additionalIcon
+                        .resizable()
+                        .renderingMode(.template)
+                        .foregroundStyle(.secondary)
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 16, height: 16)
+
+                    Text(additionalInfo)
+                        .font(.caption)
+                        .foregroundStyle(.primary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .multilineTextAlignment(.leading)
+                }
+                .padding()
             }
         }
         .background(Color(colorScheme == .light
@@ -169,7 +183,27 @@ struct PurchaseInformationCardView: View {
     }
 }
 
+private extension PurchaseInformation {
+    var shoulShowPricePaid: Bool {
+        renewalPrice != nil || expirationDate != nil
+    }
+}
+
 private extension RefundRequestStatus {
+
+    var icon: Image? {
+        switch self {
+        case .error:
+            return Image(systemName: "exclamationmark.triangle.fill")
+        case .success:
+            return Image(systemName: "info.circle.fill")
+        case .userCancelled:
+            return nil
+        @unknown default:
+            return nil
+        }
+    }
+
     func subtitle(
         localization: CustomerCenterConfigData.Localization
     ) -> String? {
@@ -253,15 +287,34 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     storeTitle: Store.playStore.localizationKey.rawValue,
                     paidPrice: "$19.99",
                     badge: .active("Active"),
-                    additionalInfo: "Apple has received it!",
+                    additionalIcon: Image(systemName: "exclamationmark.triangle.fill"),
+                    additionalInfo: "Apple has received the refund request Apple has received the refund request",
                     subtitle: "Renews 24 May for $19.99"
+                )
+                .cornerRadius(10)
+                .padding([.leading, .trailing])
+
+                PurchaseInformationCardView(
+                    title: "Product name",
+                    storeTitle: Store.playStore.localizationKey.rawValue,
+                    paidPrice: "$19.99",
+                    badge: .active("Active"),
+                    additionalIcon: Image(systemName: "info.circle.fill"),
+                    additionalInfo: "An error occurred while processing the refund request. Please try again.",
+                    subtitle: "Renews 24 May for $19.99"
+                )
+                .cornerRadius(10)
+                .padding([.leading, .trailing])
+
+                PurchaseInformationCardView(
+                    purchaseInformation: .consumable,
+                    localization: CustomerCenterConfigData.default.localization
                 )
                 .cornerRadius(10)
                 .padding([.leading, .trailing])
             }
             .preferredColorScheme(colorScheme)
         }
-        .environment(\.localization, CustomerCenterConfigData.default.localization)
         .environment(\.appearance, CustomerCenterConfigData.default.appearance)
     }
 

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -88,6 +88,7 @@ struct RelevantPurchasesListView: View {
                     screen: viewModel.screen,
                     purchaseInformation: viewModel.purchaseInformation,
                     showPurchaseHistory: false,
+                    allowsMissingPurchaseAction: false,
                     purchasesProvider: self.viewModel.purchasesProvider,
                     actionWrapper: self.viewModel.actionWrapper
                 )
@@ -141,6 +142,7 @@ struct RelevantPurchasesListView: View {
                 } else {
                     if !customerInfoViewModel.activeSubscriptionPurchases.isEmpty {
                         PurchasesInformationSection(
+                            title: localization[.actionsSectionTitle],
                             items: customerInfoViewModel.activeSubscriptionPurchases,
                             localization: localization
                         ) {
@@ -151,6 +153,7 @@ struct RelevantPurchasesListView: View {
 
                     if !customerInfoViewModel.activeNonSubscriptionPurchases.isEmpty {
                         PurchasesInformationSection(
+                            title: localization[.purchasesSectionTitle],
                             items: activeNonSubscriptionPurchasesToShow,
                             localization: localization
                         ) {

--- a/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
@@ -46,12 +46,13 @@ struct ScrollViewSection<Content: View>: View {
 @available(watchOS, unavailable)
 struct PurchasesInformationSection: View {
 
+    let title: String
     let items: [PurchaseInformation]
     let localization: CustomerCenterConfigData.Localization
     let action: (PurchaseInformation) -> Void
 
     var body: some View {
-        ScrollViewSection(title: localization[.purchasesSectionTitle]) {
+        ScrollViewSection(title: title) {
             ForEach(items) { purchase in
                 Button {
                     action(purchase)

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -51,6 +51,7 @@ struct SubscriptionDetailView: View {
         screen: CustomerCenterConfigData.Screen,
         purchaseInformation: PurchaseInformation?,
         showPurchaseHistory: Bool,
+        allowsMissingPurchaseAction: Bool,
         purchasesProvider: CustomerCenterPurchasesType,
         actionWrapper: CustomerCenterActionWrapper) {
             let viewModel = SubscriptionDetailViewModel(

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -57,6 +57,7 @@ struct SubscriptionDetailView: View {
             let viewModel = SubscriptionDetailViewModel(
                 screen: screen,
                 showPurchaseHistory: showPurchaseHistory,
+                allowsMissingPurchaseAction: allowsMissingPurchaseAction,
                 actionWrapper: actionWrapper,
                 purchaseInformation: purchaseInformation,
                 purchasesProvider: purchasesProvider)
@@ -277,6 +278,7 @@ struct SubscriptionDetailView: View {
                     viewModel: SubscriptionDetailViewModel(
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
+                        allowsMissingPurchaseAction: false,
                         purchaseInformation: .yearlyExpiring(),
                         refundRequestStatus: .success
                     )
@@ -294,6 +296,7 @@ struct SubscriptionDetailView: View {
                     viewModel: SubscriptionDetailViewModel(
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
+                        allowsMissingPurchaseAction: false,
                         purchaseInformation: .free
                     )
                 )
@@ -310,6 +313,7 @@ struct SubscriptionDetailView: View {
                     viewModel: SubscriptionDetailViewModel(
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: false,
+                        allowsMissingPurchaseAction: false,
                         purchaseInformation: .consumable
                     )
                 )
@@ -326,6 +330,7 @@ struct SubscriptionDetailView: View {
                     viewModel: SubscriptionDetailViewModel(
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
+                        allowsMissingPurchaseAction: false,
                         purchaseInformation: nil
                     )
                 )
@@ -342,6 +347,7 @@ struct SubscriptionDetailView: View {
                     viewModel: SubscriptionDetailViewModel(
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
+                        allowsMissingPurchaseAction: false,
                         purchaseInformation: .yearlyExpiring(store: .playStore)
                     )
                 )

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
@@ -30,10 +30,12 @@ final class SubscriptionDetailViewModelTests: TestCase {
         let viewModelAppStore = SubscriptionDetailViewModel(
             screen: CustomerCenterConfigData.default.screens[.management]!,
             showPurchaseHistory: false,
+            allowsMissingPurchaseAction: false,
             purchaseInformation: .yearlyExpiring(store: .appStore)
         )
 
         expect(viewModelAppStore.shouldShowContactSupport).to(beFalse())
+        expect(viewModelAppStore.allowMissingPurchase).to(beFalse())
 
         let otherStores = [
             Store.macAppStore,
@@ -50,10 +52,12 @@ final class SubscriptionDetailViewModelTests: TestCase {
             let viewModelOther = SubscriptionDetailViewModel(
                 screen: CustomerCenterConfigData.default.screens[.management]!,
                 showPurchaseHistory: false,
+                allowsMissingPurchaseAction: true,
                 purchaseInformation: .yearlyExpiring(store: $0)
             )
 
             expect(viewModelOther.shouldShowContactSupport).to(beTrue())
+            expect(viewModelOther.allowMissingPurchase).to(beTrue())
         }
     }
 }


### PR DESCRIPTION
### Motivation
We did a round of testing with Kike, and this came out.

### Description
- Filter .missingPurchase only if the detail is not the root. If the detail is the second screen, then don't show it.
- Add icon in the additionalInfo HStack
- Fix section titles for RelevantList
- Dont show consumable price next to the chevron (only below the title)
