### PR TITLE
CAT-1975: Dont Post Receipt with No Receipt or AppTransaction when Syncing Purchases with SK2

### DIFF
--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -95,6 +95,8 @@ enum StoreKitStrings {
 
     case skunknown_purchase_result(String)
 
+    case sk2_sync_purchases_no_transaction_or_apptransaction_found
+
 }
 
 extension StoreKitStrings: LogMessage {
@@ -225,6 +227,10 @@ extension StoreKitStrings: LogMessage {
 
         case let .skunknown_purchase_result(name):
             return "Unrecognized Product.PurchaseResult: \(name)"
+
+        case .sk2_sync_purchases_no_transaction_or_apptransaction_found:
+            return "syncPurchases was called, but we were unable to fetch any transactions or an AppTransaction " +
+            "from StoreKit 2. This seems to occur occassionally in sandbox."
         }
     }
 

--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -230,7 +230,7 @@ extension StoreKitStrings: LogMessage {
 
         case .sk2_sync_purchases_no_transaction_or_apptransaction_found:
             return "syncPurchases was called, but we were unable to fetch any transactions or an AppTransaction " +
-            "from StoreKit 2. This seems to occur occassionally in sandbox."
+            "from StoreKit 2."
         }
     }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1598,6 +1598,28 @@ private extension PurchasesOrchestrator {
                     return
                 }
 
+                guard let appTransactionJWS else {
+                    // The AppTransaction is not present, and the cached CustomerInfo is either nil
+                    // or is missing the originalPurchaseDate and/or originalApplicationVersion.
+                    Logger.warn(Strings.storeKit.sk2_sync_purchases_no_transaction_or_apptransaction_found)
+
+                    self.customerInfoManager.customerInfo(
+                        appUserID: currentAppUserID,
+                        fetchPolicy: .fetchCurrent
+                    ) { result in
+                        switch result {
+                        case .success(let customerInfo):
+                            completion?(.success(customerInfo))
+                            return
+                        case .failure(let backendError):
+                            completion?(.failure(backendError.asPurchasesError))
+                            return
+                        }
+                    }
+
+                    return
+                }
+
                 let transactionData: PurchasedTransactionData = .init(
                     appUserID: currentAppUserID,
                     presentedOfferingContext: nil,


### PR DESCRIPTION
### Motivation
We've identified what appears to be an SDK bug in `PurchasesOrchestrator.syncPurchasesSK2` where we call POST /receipt with no `fetch_token` and no `appTransaction` when:
- No transactions are found on the device
- No app transaction is able to be fetched from StoreKit
- One or more of the following is true:
   - There is no cached CustomerInfo
   - The cached CustomerInfo has no `originalPurchaseDate`
   -  The cached CustomerInfo has no `originalApplicationVersion`

When this occurs, the backend returns a 400: bad request response, and the SDK will return an error to the calling code.

To maintain the `syncPurchases()` contract, we should address this issue by not POSTing to /v1/receipt in this scenario and instead fetching and returning the CustomerInfo.

### Description
This PR modifies the syncPurchasesSK2 logic so that if the above scenario occurs, we log a message, and then hard refresh and return CustomerInfo.

### TODO
- Write a test or two
