### PR TITLE
CircleCI: save Ruby 3.2.0 installation in cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v3-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
+            - v4.alpha.1-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
       # CircleCI images fail on Ruby 3.3
       # https://github.com/fastlane/fastlane/issues/21794#issuecomment-2021331335
       # Also, not using macos/switch-ruby because its broken
@@ -157,7 +157,7 @@ commands:
             bundle config set --local path 'vendor/bundle'
             bundle install
       - save_cache:
-          key: v3-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
+          key: v4.alpha.1-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
           paths:
             - vendor/bundle
             - ~/.rbenv/versions/3.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v4-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
+            # This cache key should be updated whenever we change the Ruby version
+            - v4-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}-ruby-3.2.0
       # CircleCI images fail on Ruby 3.3
       # https://github.com/fastlane/fastlane/issues/21794#issuecomment-2021331335
       # Also, not using macos/switch-ruby because its broken
@@ -157,7 +158,8 @@ commands:
             bundle config set --local path 'vendor/bundle'
             bundle install
       - save_cache:
-          key: v4-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
+          # This cache key should be updated whenever we change the Ruby version
+          key: v4-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}-ruby-3.2.0
           paths:
             - vendor/bundle
             - ~/.rbenv/versions/3.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,7 @@ commands:
           key: v3-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
           paths:
             - vendor/bundle
+            - ~/.rbenv/versions/3.2.0
             
             
   install-dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v4.alpha.1-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
+            - v4-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
       # CircleCI images fail on Ruby 3.3
       # https://github.com/fastlane/fastlane/issues/21794#issuecomment-2021331335
       # Also, not using macos/switch-ruby because its broken
@@ -157,7 +157,7 @@ commands:
             bundle config set --local path 'vendor/bundle'
             bundle install
       - save_cache:
-          key: v4.alpha.1-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
+          key: v4-gem-cache-{{ checksum "Gemfile.lock" }}-{{ arch }}
           paths:
             - vendor/bundle
             - ~/.rbenv/versions/3.2.0


### PR DESCRIPTION
### Motivation
Each Circle CI job that needs to install Ruby 3.2.0 (that is most of the jobs) takes ~2 minutes to install Ruby

### Description
This PR adds the Ruby installation folder in the cache of bundle dependencies so that the Install Ruby 3.2.0 step does not really need to do anything, saving the ~2 minutes for (almost) every Circle CI job

You can see this working in [this past workflow](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/27647/workflows/32495c87-cf7b-45b4-a562-31d2c694b77a)
