### PR TITLE
fix: Do not reload actions when selecting purchase

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -612,6 +612,7 @@
 		574BA26B2D3E762E009B8EA6 /* PurchaseInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574BA2662D3E762E009B8EA6 /* PurchaseInfo.swift */; };
 		574CBC842D944D7100B8B9FA /* CustomerCenterView+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574CBC822D944D7100B8B9FA /* CustomerCenterView+Actions.swift */; };
 		574CBC852D944D7100B8B9FA /* CustomerCenter+PreferenceKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574CBC812D944D7100B8B9FA /* CustomerCenter+PreferenceKeys.swift */; };
+		5751186F2DE06650001F3153 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5751186E2DE06649001F3153 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift */; };
 		5751379527F4C4D80064AB2C /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5751379427F4C4D80064AB2C /* Optional+Extensions.swift */; };
 		575137CF27F50D2F0064AB2C /* HTTPResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575137CE27F50D2F0064AB2C /* HTTPResponseBody.swift */; };
 		5752E8482892DC500069281E /* ErrorUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5752E8472892DC500069281E /* ErrorUtilsTests.swift */; };
@@ -2004,6 +2005,7 @@
 		574BA2662D3E762E009B8EA6 /* PurchaseInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseInfo.swift; sourceTree = "<group>"; };
 		574CBC812D944D7100B8B9FA /* CustomerCenter+PreferenceKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerCenter+PreferenceKeys.swift"; sourceTree = "<group>"; };
 		574CBC822D944D7100B8B9FA /* CustomerCenterView+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerCenterView+Actions.swift"; sourceTree = "<group>"; };
+		5751186E2DE06649001F3153 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerCenterConfigData.HelpPath+PurchaseInformation.swift"; sourceTree = "<group>"; };
 		5751379427F4C4D80064AB2C /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
 		575137CE27F50D2F0064AB2C /* HTTPResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseBody.swift; sourceTree = "<group>"; };
 		5752E8472892DC500069281E /* ErrorUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorUtilsTests.swift; sourceTree = "<group>"; };
@@ -4519,6 +4521,7 @@
 		574CBC832D944D7100B8B9FA /* Actions */ = {
 			isa = PBXGroup;
 			children = (
+				5751186E2DE06649001F3153 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift */,
 				574CBC812D944D7100B8B9FA /* CustomerCenter+PreferenceKeys.swift */,
 				574CBC822D944D7100B8B9FA /* CustomerCenterView+Actions.swift */,
 			);
@@ -7141,6 +7144,7 @@
 				2C7457422CE81107004ACE52 /* IntroOfferEligibilityContext.swift in Sources */,
 				2C08B3072CD55D660024857B /* FlexHStack.swift in Sources */,
 				35F249CC2C493DCC0058993A /* CustomerCenterPurchasesType.swift in Sources */,
+				5751186F2DE06650001F3153 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift in Sources */,
 				887A60672C1D037000E1A461 /* PaywallError.swift in Sources */,
 				57B179D32DAE4C9A009A5CFE /* CustomerInfo+ActiveTransaction.swift in Sources */,
 				2C74574B2CEA6B80004ACE52 /* LocalizationProvider.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
@@ -1,0 +1,126 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
+//
+//  Created by Facundo Menzella on 23/5/25.
+
+import Foundation
+import RevenueCat
+
+extension Array<CustomerCenterConfigData.HelpPath> {
+    func relevantPahts(
+        for purchaseInformation: PurchaseInformation?,
+        allowMissingPurchase: Bool
+    ) -> [CustomerCenterConfigData.HelpPath] {
+        guard let purchaseInformation else {
+            return filter {
+                $0.type == .missingPurchase
+            }
+        }
+
+        return filter {
+            // we don't show missing purchase when a purchase is selected
+            if !allowMissingPurchase && $0.type == .missingPurchase {
+                return false
+            }
+
+            let isNonAppStorePurchase = purchaseInformation.store != .appStore
+            let isAppStoreOnlyPath = $0.type.isAppStoreOnly
+
+            let isCancel = $0.type == .cancel
+            // if it's cancel, it cannot be a lifetime subscription
+            let isEligibleCancel = !purchaseInformation.isLifetime && !purchaseInformation.isCancelled
+
+            // if it's refundRequest, it cannot be free nor within trial period
+            let isRefund = $0.type == .refundRequest
+            let isRefundEligible = purchaseInformation.pricePaid != .free
+                                    && !purchaseInformation.isTrial
+                                    && !purchaseInformation.isCancelled
+
+            // if it has a refundDuration, check it's still valid
+            let refundWindowIsValid = $0.refundWindowDuration?.isWithin(purchaseInformation) ?? true
+
+            // skip AppStore only paths if the purchase is not from App Store
+            if isNonAppStorePurchase && isAppStoreOnlyPath {
+                return false
+            }
+
+            // don't show cancel if there's no URL
+            if isCancel && isNonAppStorePurchase && purchaseInformation.managementURL == nil {
+                 return false
+            }
+
+            // can't change plans if it's not a subscription
+            if $0.type == .changePlans && purchaseInformation.isLifetime {
+                return false
+            }
+
+            return (!isCancel || isEligibleCancel) &&
+                    (!isRefund || isRefundEligible) &&
+                    refundWindowIsValid
+        }
+    }
+}
+
+private extension CustomerCenterConfigData.HelpPath.PathType {
+
+    var isAppStoreOnly: Bool {
+        switch self {
+        case .cancel, .customUrl:
+            return false
+
+        case .changePlans, .refundRequest, .missingPurchase, .unknown:
+            return true
+
+        @unknown default:
+            return false
+        }
+    }
+}
+
+private extension CustomerCenterConfigData.HelpPath.RefundWindowDuration {
+    func isWithin(_ purchaseInformation: PurchaseInformation) -> Bool {
+        switch self {
+        case .forever:
+            return true
+
+        case let .duration(duration):
+            return duration.isWithin(
+                from: purchaseInformation.latestPurchaseDate,
+                now: purchaseInformation.customerInfoRequestedDate
+            )
+
+        @unknown default:
+            return true
+        }
+    }
+}
+
+private extension ISODuration {
+    func isWithin(from startDate: Date?, now: Date) -> Bool {
+        guard let startDate else {
+            return true
+        }
+
+        var dateComponents = DateComponents()
+        dateComponents.year = self.years
+        dateComponents.month = self.months
+        dateComponents.weekOfYear = self.weeks
+        dateComponents.day = self.days
+        dateComponents.hour = self.hours
+        dateComponents.minute = self.minutes
+        dateComponents.second = self.seconds
+
+        let calendar = Calendar.current
+        let endDate = calendar.date(byAdding: dateComponents, to: startDate) ?? startDate
+
+        return startDate < endDate && now <= endDate
+    }
+}

--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -68,7 +68,7 @@ class BaseManageSubscriptionViewModel: ObservableObject {
 
     private var error: Error?
     private let loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType
-    private(set) var paths: [CustomerCenterConfigData.HelpPath]
+    let paths: [CustomerCenterConfigData.HelpPath]
     private(set) var purchasesProvider: CustomerCenterPurchasesType
 
     init(

--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -68,7 +68,7 @@ class BaseManageSubscriptionViewModel: ObservableObject {
 
     private var error: Error?
     private let loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType
-    private let paths: [CustomerCenterConfigData.HelpPath]
+    private(set) var paths: [CustomerCenterConfigData.HelpPath]
     private(set) var purchasesProvider: CustomerCenterPurchasesType
 
     init(
@@ -236,117 +236,6 @@ private extension CustomerCenterConfigData.Screen {
         }
     }
 
-}
-
-private extension Array<CustomerCenterConfigData.HelpPath> {
-    func relevantPahts(
-        for purchaseInformation: PurchaseInformation?,
-        allowMissingPurchase: Bool
-    ) -> [CustomerCenterConfigData.HelpPath] {
-        guard let purchaseInformation else {
-            return filter {
-                $0.type == .missingPurchase
-            }
-        }
-
-        return filter {
-            // we don't show missing purchase when a purchase is selected
-            if !allowMissingPurchase && $0.type == .missingPurchase {
-                return false
-            }
-
-            let isNonAppStorePurchase = purchaseInformation.store != .appStore
-            let isAppStoreOnlyPath = $0.type.isAppStoreOnly
-
-            let isCancel = $0.type == .cancel
-            // if it's cancel, it cannot be a lifetime subscription
-            let isEligibleCancel = !purchaseInformation.isLifetime && !purchaseInformation.isCancelled
-
-            // if it's refundRequest, it cannot be free nor within trial period
-            let isRefund = $0.type == .refundRequest
-            let isRefundEligible = purchaseInformation.pricePaid != .free
-                                    && !purchaseInformation.isTrial
-                                    && !purchaseInformation.isCancelled
-
-            // if it has a refundDuration, check it's still valid
-            let refundWindowIsValid = $0.refundWindowDuration?.isWithin(purchaseInformation) ?? true
-
-            // skip AppStore only paths if the purchase is not from App Store
-            if isNonAppStorePurchase && isAppStoreOnlyPath {
-                return false
-            }
-
-            // don't show cancel if there's no URL
-            if isCancel && isNonAppStorePurchase && purchaseInformation.managementURL == nil {
-                 return false
-            }
-
-            // can't change plans if it's not a subscription
-            if $0.type == .changePlans && purchaseInformation.isLifetime {
-                return false
-            }
-
-            return (!isCancel || isEligibleCancel) &&
-                    (!isRefund || isRefundEligible) &&
-                    refundWindowIsValid
-        }
-    }
-}
-
-private extension CustomerCenterConfigData.HelpPath.PathType {
-
-    var isAppStoreOnly: Bool {
-        switch self {
-        case .cancel, .customUrl:
-            return false
-
-        case .changePlans, .refundRequest, .missingPurchase, .unknown:
-            return true
-
-        @unknown default:
-            return false
-        }
-    }
-}
-
-private extension CustomerCenterConfigData.HelpPath.RefundWindowDuration {
-    func isWithin(_ purchaseInformation: PurchaseInformation) -> Bool {
-        switch self {
-        case .forever:
-            return true
-
-        case let .duration(duration):
-            return duration.isWithin(
-                from: purchaseInformation.latestPurchaseDate,
-                now: purchaseInformation.customerInfoRequestedDate
-            )
-
-        @unknown default:
-            return true
-        }
-    }
-}
-
-private extension ISODuration {
-    func isWithin(from startDate: Date?, now: Date) -> Bool {
-        guard let startDate else {
-            return true
-        }
-
-        var dateComponents = DateComponents()
-        dateComponents.year = self.years
-        dateComponents.month = self.months
-        dateComponents.weekOfYear = self.weeks
-        dateComponents.day = self.days
-        dateComponents.hour = self.hours
-        dateComponents.minute = self.minutes
-        dateComponents.second = self.seconds
-
-        let calendar = Calendar.current
-        let endDate = calendar.date(byAdding: dateComponents, to: startDate) ?? startDate
-
-        return startDate < endDate && now <= endDate
-    }
 }
 
 #endif

--- a/RevenueCatUI/CustomerCenter/ViewModels/RelevantPurchasesListViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/RelevantPurchasesListViewModel.swift
@@ -30,6 +30,10 @@ final class RelevantPurchasesListViewModel: BaseManageSubscriptionViewModel {
     let originalPurchaseDate: Date?
     let shouldShowSeeAllPurchases: Bool
 
+    override var relevantPathsForPurchase: [CustomerCenterConfigData.HelpPath] {
+        paths.relevantPahts(for: nil, allowMissingPurchase: allowMissingPurchase)
+    }
+
     init(
         screen: CustomerCenterConfigData.Screen,
         actionWrapper: CustomerCenterActionWrapper,


### PR DESCRIPTION
### Motivation
With @ajpallares we noticed that the buttons were reloading on selection. This addressed it

### Description
While the detail computes it for every purchase selected, the list now just passes `nil` to it.


https://github.com/user-attachments/assets/36bb4194-2e41-4559-a58f-2eefe40324f2

