### PR TITLE
reload customer center after re-syncing customer info

### DIFF
--- a/Examples/rc-maestro/Tuist/Package.swift
+++ b/Examples/rc-maestro/Tuist/Package.swift
@@ -18,7 +18,8 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/RevenueCat/purchases-ios", 
-            branch: "main"
+            // branch: "main"
+            revision: "981075481"
         ),
     ]
 )

--- a/Examples/rc-maestro/Tuist/Package.swift
+++ b/Examples/rc-maestro/Tuist/Package.swift
@@ -18,8 +18,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/RevenueCat/purchases-ios", 
-            // branch: "main"
-            revision: "981075481"
+            branch: "main"
         ),
     ]
 )

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -227,6 +227,8 @@ import RevenueCat
 private extension CustomerCenterViewModel {
 
     func loadPurchases(customerInfo: CustomerInfo) async throws {
+        self.customerInfo = customerInfo
+
         let hasActiveProducts =  !customerInfo.activeSubscriptions.isEmpty || !customerInfo.nonSubscriptions.isEmpty
 
         if !hasActiveProducts {
@@ -234,7 +236,6 @@ private extension CustomerCenterViewModel {
             self.activeNonSubscriptionPurchases = []
             self.activePurchase = nil
             self.state = .success
-            self.customerInfo = customerInfo
             return
         }
 
@@ -242,7 +243,6 @@ private extension CustomerCenterViewModel {
             self.activePurchase = nil
             self.activeSubscriptionPurchases = []
             self.activeNonSubscriptionPurchases = []
-            self.customerInfo = customerInfo
 
             Logger.warning(Strings.could_not_find_subscription_information)
             throw CustomerCenterError.couldNotFindSubscriptionInformation
@@ -260,7 +260,6 @@ private extension CustomerCenterViewModel {
 
         await loadActiveSubscriptions(customerInfo: customerInfo)
         await loadActiveNonSubscriptionPurchases(customerInfo: customerInfo)
-        self.customerInfo = customerInfo
     }
 
     func loadActiveNonSubscriptionPurchases(customerInfo: CustomerInfo) async {

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -212,8 +212,6 @@ import RevenueCat
 private extension CustomerCenterViewModel {
 
     func loadPurchases(customerInfo: CustomerInfo) async throws {
-        self.customerInfo = customerInfo
-
         let hasActiveProducts =  !customerInfo.activeSubscriptions.isEmpty || !customerInfo.nonSubscriptions.isEmpty
 
         if !hasActiveProducts {
@@ -221,6 +219,7 @@ private extension CustomerCenterViewModel {
             self.activeNonSubscriptionPurchases = []
             self.activePurchase = nil
             self.state = .success
+            self.customerInfo = customerInfo
             return
         }
 
@@ -228,6 +227,7 @@ private extension CustomerCenterViewModel {
             self.activePurchase = nil
             self.activeSubscriptionPurchases = []
             self.activeNonSubscriptionPurchases = []
+            self.customerInfo = customerInfo
 
             Logger.warning(Strings.could_not_find_subscription_information)
             throw CustomerCenterError.couldNotFindSubscriptionInformation
@@ -245,6 +245,7 @@ private extension CustomerCenterViewModel {
 
         await loadActiveSubscriptions(customerInfo: customerInfo)
         await loadActiveNonSubscriptionPurchases(customerInfo: customerInfo)
+        self.customerInfo = customerInfo
     }
 
     func loadActiveNonSubscriptionPurchases(customerInfo: CustomerInfo) async {

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -13,6 +13,7 @@
 //  Created by Cesar de la Vega on 27/5/24.
 //
 
+import Combine
 import Foundation
 import RevenueCat
 
@@ -168,6 +169,20 @@ import RevenueCat
     }
 
     #endif
+
+    func publisher(for purchase: PurchaseInformation?) -> AnyPublisher<PurchaseInformation, Never>? {
+        guard let productIdentifier = purchase?.productIdentifier else {
+            return nil
+        }
+
+        return $activeSubscriptionPurchases.combineLatest($activeNonSubscriptionPurchases)
+            .throttle(for: .seconds(0.3), scheduler: DispatchQueue.main, latest: true)
+            .compactMap {
+                $0.first(where: { $0.productIdentifier == productIdentifier })
+                ?? $1.first(where: { $0.productIdentifier == productIdentifier })
+            }
+            .eraseToAnyPublisher()
+    }
 
     func loadScreen(shouldSync: Bool = false) async {
         do {

--- a/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
@@ -26,6 +26,9 @@ import SwiftUI
 @MainActor
 final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
 
+    @Published
+    var isRefreshing: Bool = false
+
     let showPurchaseHistory: Bool
 
     var shouldShowContactSupport: Bool {
@@ -60,6 +63,10 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
         }
 
     func reloadPurchaseInformation(from customerInfoViewModel: CustomerCenterViewModel) {
+        defer {
+            isRefreshing = false
+        }
+
         guard let productIdentifier = purchaseInformation?.productIdentifier else {
             return
         }

--- a/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
@@ -71,6 +71,7 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
 
     func refreshPurchase() {
         cancellable = customerInfoViewModel.publisher(for: purchaseInformation)?
+            .dropFirst() // skip current value
             .sink(receiveValue: { [weak self] in
                 defer { self?.isRefreshing = false }
 

--- a/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
@@ -59,8 +59,14 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
             )
         }
 
-    func reloadPurchaseInformation(_ purchaseInformation: PurchaseInformation?) {
-        self.purchaseInformation = purchaseInformation
+    func reloadPurchaseInformation(from customerInfoViewModel: CustomerCenterViewModel) {
+        guard let productIdentifier = purchaseInformation?.productIdentifier else {
+            return
+        }
+        self.purchaseInformation = customerInfoViewModel.activeSubscriptionPurchases
+            .first(where: { $0.productIdentifier == productIdentifier })
+        ?? customerInfoViewModel.activeNonSubscriptionPurchases
+            .first(where: { $0.productIdentifier == productIdentifier })
     }
 
     // Previews

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -104,6 +104,9 @@ struct SubscriptionDetailView: View {
                     }
                 }
             }
+            .onChangeOf(customerInfoViewModel.customerInfo, perform: { _ in
+                viewModel.reloadPurchaseInformation(from: customerInfoViewModel)
+            })
             .compatibleNavigation(
                 isPresented: $viewModel.showAllPurchases,
                 usesNavigationStack: navigationOptions.usesNavigationStack

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -55,6 +55,7 @@ struct SubscriptionDetailView: View {
         purchasesProvider: CustomerCenterPurchasesType,
         actionWrapper: CustomerCenterActionWrapper) {
             let viewModel = SubscriptionDetailViewModel(
+                customerInfoViewModel: customerInfoViewModel,
                 screen: screen,
                 showPurchaseHistory: showPurchaseHistory,
                 allowsMissingPurchaseAction: allowsMissingPurchaseAction,
@@ -88,11 +89,7 @@ struct SubscriptionDetailView: View {
                         customerInfoViewModel.manageSubscriptionsSheet = manage } }
                 )))
             .onCustomerCenterPromotionalOfferSuccess {
-                viewModel.isRefreshing = true
-                Task {
-                    await reloadPurchases()
-
-                }
+                viewModel.refreshPurchase()
             }
             .onCustomerCenterShowingManageSubscriptions {
                 Task { @MainActor in
@@ -101,15 +98,9 @@ struct SubscriptionDetailView: View {
             }
             .onChangeOf(customerInfoViewModel.manageSubscriptionsSheet) { manageSubscriptionsSheet in
                 if !manageSubscriptionsSheet {
-                    viewModel.isRefreshing = true
-                    Task {
-                        await reloadPurchases()
-                    }
+                    viewModel.refreshPurchase()
                 }
             }
-            .onChangeOf(customerInfoViewModel.customerInfo, perform: { _ in
-                viewModel.reloadPurchaseInformation(from: customerInfoViewModel)
-            })
             .compatibleNavigation(
                 isPresented: $viewModel.showAllPurchases,
                 usesNavigationStack: navigationOptions.usesNavigationStack
@@ -240,14 +231,6 @@ struct SubscriptionDetailView: View {
         .buttonStyle(.customerCenterButtonStyle(for: colorScheme))
         .tint(colorScheme == .dark ? .white : .black)
     }
-
-    // Note that we set refreshing to false, in case loadScreen does not trigger a new update (error)
-    private func reloadPurchases() async {
-        await customerInfoViewModel.loadScreen(shouldSync: true)
-        await MainActor.run {
-            viewModel.isRefreshing = false
-        }
-    }
 }
 
  #if DEBUG
@@ -267,6 +250,9 @@ struct SubscriptionDetailView: View {
                         configuration: .default
                     ),
                     viewModel: SubscriptionDetailViewModel(
+                        customerInfoViewModel: CustomerCenterViewModel(
+                            uiPreviewPurchaseProvider: MockCustomerCenterPurchases()
+                        ),
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
                         allowsMissingPurchaseAction: false,
@@ -285,6 +271,9 @@ struct SubscriptionDetailView: View {
                         configuration: .default
                     ),
                     viewModel: SubscriptionDetailViewModel(
+                        customerInfoViewModel: CustomerCenterViewModel(
+                            uiPreviewPurchaseProvider: MockCustomerCenterPurchases()
+                        ),
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
                         allowsMissingPurchaseAction: false,
@@ -302,6 +291,9 @@ struct SubscriptionDetailView: View {
                         configuration: .default
                     ),
                     viewModel: SubscriptionDetailViewModel(
+                        customerInfoViewModel: CustomerCenterViewModel(
+                            uiPreviewPurchaseProvider: MockCustomerCenterPurchases()
+                        ),
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: false,
                         allowsMissingPurchaseAction: false,
@@ -319,6 +311,9 @@ struct SubscriptionDetailView: View {
                         configuration: .default
                     ),
                     viewModel: SubscriptionDetailViewModel(
+                        customerInfoViewModel: CustomerCenterViewModel(
+                            uiPreviewPurchaseProvider: MockCustomerCenterPurchases()
+                        ),
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
                         allowsMissingPurchaseAction: false,
@@ -336,6 +331,9 @@ struct SubscriptionDetailView: View {
                         configuration: .default
                     ),
                     viewModel: SubscriptionDetailViewModel(
+                        customerInfoViewModel: CustomerCenterViewModel(
+                            uiPreviewPurchaseProvider: MockCustomerCenterPurchases()
+                        ),
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
                         allowsMissingPurchaseAction: false,

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
@@ -28,6 +28,9 @@ final class SubscriptionDetailViewModelTests: TestCase {
 
     func testShouldShowContactSupport() {
         let viewModelAppStore = SubscriptionDetailViewModel(
+            customerInfoViewModel: CustomerCenterViewModel(
+                uiPreviewPurchaseProvider: MockCustomerCenterPurchases()
+            ),
             screen: CustomerCenterConfigData.default.screens[.management]!,
             showPurchaseHistory: false,
             allowsMissingPurchaseAction: false,
@@ -50,6 +53,9 @@ final class SubscriptionDetailViewModelTests: TestCase {
 
         otherStores.forEach {
             let viewModelOther = SubscriptionDetailViewModel(
+                customerInfoViewModel: CustomerCenterViewModel(
+                    uiPreviewPurchaseProvider: MockCustomerCenterPurchases()
+                ),
                 screen: CustomerCenterConfigData.default.screens[.management]!,
                 showPurchaseHistory: false,
                 allowsMissingPurchaseAction: true,


### PR DESCRIPTION
### Motivation
While doing the last testing round, I noticed the detail wasn't reloading properly:
- The view uses it's own published property that needs to be reloaded

### Description
1. Reposition where we update customer info in CustomerCenterViewModel
2. Use combine to subscribe to updates
3. publisher method in customer center view model

https://github.com/user-attachments/assets/945d1873-2b63-44cf-a858-003dadb0df2e

### Discussion
I think the ultimate solution would be what we've discussed, and have a CustomerInfoViewModel that only handles:
- active subs
- other purchases
- selected purchase

With that, we can remove the `purchaseInformation` published property from any other StateObject, and rely only on `CustomerInfoViewModel` to handle refreshing
