### PR TITLE
Refactor NoSubscriptionsView in CustomerCenter

### DIFF
--- a/Examples/rc-maestro/rc-maestro/Resources/StoreKit/StoreKitConfiguration.storekit
+++ b/Examples/rc-maestro/rc-maestro/Resources/StoreKit/StoreKitConfiguration.storekit
@@ -14,7 +14,36 @@
 
   ],
   "products" : [
-
+    {
+      "displayPrice" : "3.99",
+      "familyShareable" : false,
+      "internalID" : "8D0DA65C",
+      "localizations" : [
+        {
+          "description" : "Non consumable 01",
+          "displayName" : "Non consumable 01",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "maestro.nonconsumable.tests.01",
+      "referenceName" : "Non consumable 01",
+      "type" : "NonConsumable"
+    },
+    {
+      "displayPrice" : "0.99",
+      "familyShareable" : false,
+      "internalID" : "A714FBF4",
+      "localizations" : [
+        {
+          "description" : "Consumable 01",
+          "displayName" : "Consumable 01",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "maestro.consumable.tests.01",
+      "referenceName" : "Consumable 01",
+      "type" : "Consumable"
+    }
   ],
   "settings" : {
     "_failTransactionsEnabled" : false,

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/ContentView.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/ContentView.swift
@@ -100,7 +100,9 @@ public struct ContentView: View {
          [
              "maestro.weekly.tests.01",
              "maestro.monthly.tests.02",
-             "maestro.weekly2.tests.01"
+             "maestro.weekly2.tests.01",
+             "maestro.nonconsumable.tests.01",
+             "maestro.consumable.tests.01"
          ]
      }
 }

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 		57740F572DD6460F00585B5A /* PurchaseHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57740F3F2DD6460F00585B5A /* PurchaseHistoryView.swift */; };
 		57740F582DD6460F00585B5A /* CompatibilityNavigationStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57740F332DD6460F00585B5A /* CompatibilityNavigationStack.swift */; };
 		57740F592DD6460F00585B5A /* ManageSubscriptionsButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57740F3A2DD6460F00585B5A /* ManageSubscriptionsButtonsView.swift */; };
-		57740F5A2DD6460F00585B5A /* NoSubscriptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57740F3B2DD6460F00585B5A /* NoSubscriptionsView.swift */; };
+		57740F5A2DD6460F00585B5A /* FallbackNoSubscriptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57740F3B2DD6460F00585B5A /* FallbackNoSubscriptionsView.swift */; };
 		57740F5B2DD6460F00585B5A /* PromotionalOfferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57740F3C2DD6460F00585B5A /* PromotionalOfferView.swift */; };
 		57740F5D2DD6460F00585B5A /* CompatibilityContentUnavailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57740F312DD6460F00585B5A /* CompatibilityContentUnavailableView.swift */; };
 		57740F5E2DD6460F00585B5A /* PurchaseLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57740F402DD6460F00585B5A /* PurchaseLinkView.swift */; };
@@ -2065,7 +2065,7 @@
 		57740F382DD6460F00585B5A /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		57740F392DD6460F00585B5A /* FeedbackSurveyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackSurveyView.swift; sourceTree = "<group>"; };
 		57740F3A2DD6460F00585B5A /* ManageSubscriptionsButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsButtonsView.swift; sourceTree = "<group>"; };
-		57740F3B2DD6460F00585B5A /* NoSubscriptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoSubscriptionsView.swift; sourceTree = "<group>"; };
+		57740F3B2DD6460F00585B5A /* FallbackNoSubscriptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FallbackNoSubscriptionsView.swift; sourceTree = "<group>"; };
 		57740F3C2DD6460F00585B5A /* PromotionalOfferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOfferView.swift; sourceTree = "<group>"; };
 		57740F3D2DD6460F00585B5A /* PurchaseCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseCardView.swift; sourceTree = "<group>"; };
 		57740F3E2DD6460F00585B5A /* PurchaseDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseDetailView.swift; sourceTree = "<group>"; };
@@ -3894,7 +3894,7 @@
 				57740F382DD6460F00585B5A /* ErrorView.swift */,
 				57740F392DD6460F00585B5A /* FeedbackSurveyView.swift */,
 				57740F3A2DD6460F00585B5A /* ManageSubscriptionsButtonsView.swift */,
-				57740F3B2DD6460F00585B5A /* NoSubscriptionsView.swift */,
+				57740F3B2DD6460F00585B5A /* FallbackNoSubscriptionsView.swift */,
 				57740F3C2DD6460F00585B5A /* PromotionalOfferView.swift */,
 				57740F3D2DD6460F00585B5A /* PurchaseCardView.swift */,
 				57740F422DD6460F00585B5A /* RestorePurchasesAlert.swift */,
@@ -7012,7 +7012,7 @@
 				57A9AFE02DDC716100F77341 /* ScrollViewSection.swift in Sources */,
 				57740F582DD6460F00585B5A /* CompatibilityNavigationStack.swift in Sources */,
 				57740F592DD6460F00585B5A /* ManageSubscriptionsButtonsView.swift in Sources */,
-				57740F5A2DD6460F00585B5A /* NoSubscriptionsView.swift in Sources */,
+				57740F5A2DD6460F00585B5A /* FallbackNoSubscriptionsView.swift in Sources */,
 				75F660192DDB2EBE00DBED1C /* RelevantPurchasesListViewModel.swift in Sources */,
 				57740F5B2DD6460F00585B5A /* PromotionalOfferView.swift in Sources */,
 				57740F5D2DD6460F00585B5A /* CompatibilityContentUnavailableView.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -612,7 +612,6 @@
 		574BA26B2D3E762E009B8EA6 /* PurchaseInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574BA2662D3E762E009B8EA6 /* PurchaseInfo.swift */; };
 		574CBC842D944D7100B8B9FA /* CustomerCenterView+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574CBC822D944D7100B8B9FA /* CustomerCenterView+Actions.swift */; };
 		574CBC852D944D7100B8B9FA /* CustomerCenter+PreferenceKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574CBC812D944D7100B8B9FA /* CustomerCenter+PreferenceKeys.swift */; };
-		5751186F2DE06650001F3153 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5751186E2DE06649001F3153 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift */; };
 		5751379527F4C4D80064AB2C /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5751379427F4C4D80064AB2C /* Optional+Extensions.swift */; };
 		575137CF27F50D2F0064AB2C /* HTTPResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575137CE27F50D2F0064AB2C /* HTTPResponseBody.swift */; };
 		5752E8482892DC500069281E /* ErrorUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5752E8472892DC500069281E /* ErrorUtilsTests.swift */; };
@@ -736,6 +735,7 @@
 		57A0FBF22749CF66009E2FC3 /* SynchronizedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */; };
 		57A17727276A721D0052D3A8 /* Set+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A17726276A721D0052D3A8 /* Set+Extensions.swift */; };
 		57A1772B276A726C0052D3A8 /* SetExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */; };
+		57A325142DE4773F0030E463 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A325132DE4773F0030E463 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift */; };
 		57A9AFE02DDC716100F77341 /* ScrollViewSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A9AFDF2DDC715900F77341 /* ScrollViewSection.swift */; };
 		57ABA76D28F08DDA003D9181 /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ABA76C28F08DDA003D9181 /* Either.swift */; };
 		57AC4C182770F55C00DDE30F /* SK2StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AC4C172770F55C00DDE30F /* SK2StoreProduct.swift */; };
@@ -2005,7 +2005,6 @@
 		574BA2662D3E762E009B8EA6 /* PurchaseInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseInfo.swift; sourceTree = "<group>"; };
 		574CBC812D944D7100B8B9FA /* CustomerCenter+PreferenceKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerCenter+PreferenceKeys.swift"; sourceTree = "<group>"; };
 		574CBC822D944D7100B8B9FA /* CustomerCenterView+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerCenterView+Actions.swift"; sourceTree = "<group>"; };
-		5751186E2DE06649001F3153 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerCenterConfigData.HelpPath+PurchaseInformation.swift"; sourceTree = "<group>"; };
 		5751379427F4C4D80064AB2C /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
 		575137CE27F50D2F0064AB2C /* HTTPResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseBody.swift; sourceTree = "<group>"; };
 		5752E8472892DC500069281E /* ErrorUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorUtilsTests.swift; sourceTree = "<group>"; };
@@ -2120,6 +2119,7 @@
 		57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaults.swift; sourceTree = "<group>"; };
 		57A17726276A721D0052D3A8 /* Set+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+Extensions.swift"; sourceTree = "<group>"; };
 		57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetExtensionsTests.swift; sourceTree = "<group>"; };
+		57A325132DE4773F0030E463 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerCenterConfigData.HelpPath+PurchaseInformation.swift"; sourceTree = "<group>"; };
 		57A9AFDF2DDC715900F77341 /* ScrollViewSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewSection.swift; sourceTree = "<group>"; };
 		57ABA76C28F08DDA003D9181 /* Either.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Either.swift; sourceTree = "<group>"; };
 		57AC4C172770F55C00DDE30F /* SK2StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProduct.swift; sourceTree = "<group>"; };
@@ -4521,7 +4521,7 @@
 		574CBC832D944D7100B8B9FA /* Actions */ = {
 			isa = PBXGroup;
 			children = (
-				5751186E2DE06649001F3153 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift */,
+				57A325132DE4773F0030E463 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift */,
 				574CBC812D944D7100B8B9FA /* CustomerCenter+PreferenceKeys.swift */,
 				574CBC822D944D7100B8B9FA /* CustomerCenterView+Actions.swift */,
 			);
@@ -7144,7 +7144,7 @@
 				2C7457422CE81107004ACE52 /* IntroOfferEligibilityContext.swift in Sources */,
 				2C08B3072CD55D660024857B /* FlexHStack.swift in Sources */,
 				35F249CC2C493DCC0058993A /* CustomerCenterPurchasesType.swift in Sources */,
-				5751186F2DE06650001F3153 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift in Sources */,
+				57A325142DE4773F0030E463 /* CustomerCenterConfigData.HelpPath+PurchaseInformation.swift in Sources */,
 				887A60672C1D037000E1A461 /* PaywallError.swift in Sources */,
 				57B179D32DAE4C9A009A5CFE /* CustomerInfo+ActiveTransaction.swift in Sources */,
 				2C74574B2CEA6B80004ACE52 /* LocalizationProvider.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
@@ -15,7 +15,7 @@ import Foundation
 import RevenueCat
 
 extension Array<CustomerCenterConfigData.HelpPath> {
-    func relevantPahts(
+    func relevantPaths(
         for purchaseInformation: PurchaseInformation?,
         allowMissingPurchase: Bool
     ) -> [CustomerCenterConfigData.HelpPath] {

--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -27,7 +27,7 @@ class BaseManageSubscriptionViewModel: ObservableObject {
     let screen: CustomerCenterConfigData.Screen
 
     var relevantPathsForPurchase: [CustomerCenterConfigData.HelpPath] {
-        paths.relevantPahts(for: purchaseInformation, allowMissingPurchase: allowMissingPurchase)
+        paths.relevantPaths(for: purchaseInformation, allowMissingPurchase: allowMissingPurchase)
     }
 
     /// Used to exclude .missingPurchase path

--- a/RevenueCatUI/CustomerCenter/ViewModels/RelevantPurchasesListViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/RelevantPurchasesListViewModel.swift
@@ -31,7 +31,7 @@ final class RelevantPurchasesListViewModel: BaseManageSubscriptionViewModel {
     let shouldShowSeeAllPurchases: Bool
 
     override var relevantPathsForPurchase: [CustomerCenterConfigData.HelpPath] {
-        paths.relevantPahts(for: nil, allowMissingPurchase: allowMissingPurchase)
+        paths.relevantPaths(for: nil, allowMissingPurchase: allowMissingPurchase)
     }
 
     init(

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -200,8 +200,7 @@ private extension CustomerCenterView {
             if let screen = configuration.screens[.noActive] {
                 singlePurchaseView(screen)
             } else {
-                // Fallback with a restore button
-                NoSubscriptionsView(
+                FallbackNoSubscriptionsView(
                     customerCenterViewModel: viewModel,
                     configuration: configuration,
                     actionWrapper: self.viewModel.actionWrapper

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -202,7 +202,6 @@ private extension CustomerCenterView {
             } else {
                 FallbackNoSubscriptionsView(
                     customerCenterViewModel: viewModel,
-                    configuration: configuration,
                     actionWrapper: self.viewModel.actionWrapper
                 )
             }

--- a/RevenueCatUI/CustomerCenter/Views/FallbackNoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FallbackNoSubscriptionsView.swift
@@ -25,7 +25,6 @@ import SwiftUI
 @available(watchOS, unavailable)
 struct FallbackNoSubscriptionsView: View {
 
-    let configuration: CustomerCenterConfigData
     let actionWrapper: CustomerCenterActionWrapper
 
     @Environment(\.appearance)
@@ -45,23 +44,19 @@ struct FallbackNoSubscriptionsView: View {
 
     init(
         customerCenterViewModel: CustomerCenterViewModel,
-        configuration: CustomerCenterConfigData,
-        actionWrapper: CustomerCenterActionWrapper) {
+        actionWrapper: CustomerCenterActionWrapper
+    ) {
         self.customerCenterViewModel = customerCenterViewModel
-        self.configuration = configuration
         self.actionWrapper = actionWrapper
     }
 
     var body: some View {
-        let fallbackDescription = localization[.tryCheckRestore]
-        let fallbackTitle = localization[.noSubscriptionsFound]
-
         ScrollViewWithOSBackground {
             LazyVStack(spacing: 0) {
                 CompatibilityContentUnavailableView(
-                    configuration.screens[.noActive]?.title ?? fallbackTitle,
+                    localization[.noSubscriptionsFound],
                     systemImage: "exclamationmark.triangle.fill",
-                    description: Text(self.configuration.screens[.noActive]?.subtitle ?? fallbackDescription)
+                    description: Text(localization[.tryCheckRestore])
                 )
                 .padding()
                 .fixedSize(horizontal: false, vertical: true)
@@ -119,7 +114,6 @@ struct NoSubscriptionsView_Previews: PreviewProvider {
     static var previews: some View {
         FallbackNoSubscriptionsView(
             customerCenterViewModel: CustomerCenterViewModel(uiPreviewPurchaseProvider: MockCustomerCenterPurchases()),
-            configuration: CustomerCenterConfigData.default,
             actionWrapper: CustomerCenterActionWrapper()
         )
     }

--- a/RevenueCatUI/CustomerCenter/Views/FallbackNoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FallbackNoSubscriptionsView.swift
@@ -72,7 +72,7 @@ struct FallbackNoSubscriptionsView: View {
                 )
                 .padding(.bottom, 32)
 
-                restorePurchasesView
+                restorePurchasesButton
             }
         }
         .dismissCircleButtonToolbarIfNeeded()
@@ -85,7 +85,7 @@ struct FallbackNoSubscriptionsView: View {
         }
     }
 
-    private var restorePurchasesView: some View {
+    private var restorePurchasesButton: some View {
         Button {
             showRestoreAlert = true
         } label: {


### PR DESCRIPTION
### Motivation
We're moving away from lists, and every screen should follow the same structure. 

### Description
- Use scrollview as other screens
- Remove the use of configuration, since this screen is a fallback
- Renamed screen to reflect the correct use of it + comment
