### PR TITLE
return .free for CustomerCenterStoreKitUtilities if price.isZero

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -430,10 +430,11 @@ extension PurchaseInformation {
 
         switch renewalPrice {
         case .free:
-            return localizations[.renewsOnDate]
+            return localizations[.renewsOnDateForPrice]
                 .replacingOccurrences(of: "{{ date }}", with: dateFormatter.string(from: date))
+                .replacingOccurrences(of: "{{ price }}", with: localizations[.free].lowercased())
         case .nonFree(let priceString):
-            return "Your next charge is {{ price }} on {{ date }}."
+            return localizations[.renewsOnDateForPrice]
                 .replacingOccurrences(of: "{{ date }}", with: dateFormatter.string(from: date))
                 .replacingOccurrences(of: "{{ price }}", with: priceString)
         }


### PR DESCRIPTION
### Motivation
I've noticed that the renewal price does not return free if it's zero.


### Description
- return free if `isZero` == true
- comparison done with `isZero` instead of `== 0`
