### PR TITLE
Add accessibility identifier to PurchaseCardView

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
@@ -28,6 +28,7 @@ struct PurchaseInformationCardView: View {
     private let title: String
     private let subtitle: String?
     private let badge: Badge?
+    private let identifier: String?
 
     private let storeTitle: String
 
@@ -45,7 +46,8 @@ struct PurchaseInformationCardView: View {
         additionalIcon: Image? = nil,
         additionalInfo: String? = nil,
         subtitle: String? = nil,
-        showChevron: Bool = true
+        showChevron: Bool = true,
+        identifier: String? = nil
     ) {
         self.title = title
         self.paidPrice = paidPrice
@@ -55,15 +57,18 @@ struct PurchaseInformationCardView: View {
         self.additionalInfo = additionalInfo
         self.storeTitle = storeTitle
         self.showChevron = showChevron
+        self.identifier = identifier
     }
 
     init(
         purchaseInformation: PurchaseInformation,
         localization: CustomerCenterConfigData.Localization,
+        identifier: String,
         refundStatus: RefundRequestStatus? = nil,
-        showChevron: Bool = true
+        showChevron: Bool = true,
     ) {
         self.title = purchaseInformation.title
+        self.identifier = identifier
 
         if let renewalDate = purchaseInformation.renewalDate {
             self.subtitle = purchaseInformation.priceRenewalString(
@@ -93,11 +98,11 @@ struct PurchaseInformationCardView: View {
         self.showChevron = showChevron
 
         if purchaseInformation.isCancelled {
-            self.badge = .cancelled(localization[.badgeCancelled])
+            self.badge = .cancelled(localization)
         } else if purchaseInformation.isTrial, purchaseInformation.pricePaid == .free {
-            self.badge = .freeTrial(localization[.badgeFreeTrial])
+            self.badge = .freeTrial(localization)
         } else if purchaseInformation.isActive {
-            self.badge = .active(localization[.active])
+            self.badge = .active(localization)
         } else {
             self.badge = nil
         }
@@ -122,6 +127,7 @@ struct PurchaseInformationCardView: View {
                                 .padding(.horizontal, 4)
                                 .background(badge.backgroundColor)
                                 .clipShape(RoundedRectangle(cornerRadius: 4))
+                                .accessibilityIdentifier(badge.id)
                         }
                     }
                     .padding(.bottom, 8)
@@ -225,29 +231,34 @@ private extension RefundRequestStatus {
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension PurchaseInformationCardView {
-    enum Badge {
-        case cancelled(String), freeTrial(String), active(String)
 
-        var title: String {
-            switch self {
-            case let .cancelled(title):
-                return title
-            case let .freeTrial(title):
-                return title
-            case let .active(title):
-                return title
-            }
+    struct Badge {
+        let title: String
+        let id: String
+        let backgroundColor: Color
+
+        static func cancelled(_ localizations: CustomerCenterConfigData.Localization) -> Badge {
+            Badge(
+                title: localizations[.badgeCancelled],
+                id: CCLocalizedString.badgeCancelled.rawValue,
+                backgroundColor: Color(red: 242 / 256, green: 84 / 256, blue: 91 / 256, opacity: 0.15)
+            )
         }
 
-        var backgroundColor: Color {
-            switch self {
-            case .cancelled:
-                return Color(red: 242 / 256, green: 84 / 256, blue: 91 / 256, opacity: 0.15)
-            case .freeTrial:
-                return Color(red: 245 / 256, green: 202 / 256, blue: 92 / 256, opacity: 0.2)
-            case .active:
-                return Color(red: 52 / 256, green: 199 / 256, blue: 89 / 256, opacity: 0.2)
-            }
+        static func freeTrial(_ localizations: CustomerCenterConfigData.Localization) -> Badge {
+            Badge(
+                title: localizations[.badgeFreeTrial],
+                id: CCLocalizedString.badgeFreeTrial.rawValue,
+                backgroundColor: Color(red: 245 / 256, green: 202 / 256, blue: 92 / 256, opacity: 0.2)
+            )
+        }
+
+        static func active(_ localizations: CustomerCenterConfigData.Localization) -> Badge {
+            Badge(
+                title: localizations[.active],
+                id: CCLocalizedString.active.rawValue,
+                backgroundColor: Color(red: 52 / 256, green: 199 / 256, blue: 89 / 256, opacity: 0.2)
+            )
         }
     }
 }
@@ -266,7 +277,7 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     title: "Product name",
                     storeTitle: Store.appStore.localizationKey.rawValue,
                     paidPrice: "$19.99",
-                    badge: .cancelled("Cancelled"),
+                    badge: .cancelled(CustomerCenterConfigData.default.localization),
                     subtitle: "Renews 24 May for $19.99"
                 )
                 .cornerRadius(10)
@@ -276,7 +287,7 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     title: "Product name",
                     storeTitle: Store.playStore.localizationKey.rawValue,
                     paidPrice: "$19.99",
-                    badge: .freeTrial("Free Trial"),
+                    badge: .freeTrial(CustomerCenterConfigData.default.localization),
                     subtitle: "Renews 24 May for $19.99"
                 )
                 .cornerRadius(10)
@@ -286,7 +297,7 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     title: "Product name",
                     storeTitle: Store.playStore.localizationKey.rawValue,
                     paidPrice: "$19.99",
-                    badge: .active("Active"),
+                    badge: .active(CustomerCenterConfigData.default.localization),
                     additionalIcon: Image(systemName: "exclamationmark.triangle.fill"),
                     additionalInfo: "Apple has received the refund request Apple has received the refund request",
                     subtitle: "Renews 24 May for $19.99"
@@ -298,7 +309,7 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     title: "Product name",
                     storeTitle: Store.playStore.localizationKey.rawValue,
                     paidPrice: "$19.99",
-                    badge: .active("Active"),
+                    badge: .active(CustomerCenterConfigData.default.localization),
                     additionalIcon: Image(systemName: "info.circle.fill"),
                     additionalInfo: "An error occurred while processing the refund request. Please try again.",
                     subtitle: "Renews 24 May for $19.99"
@@ -308,7 +319,8 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
 
                 PurchaseInformationCardView(
                     purchaseInformation: .consumable,
-                    localization: CustomerCenterConfigData.default.localization
+                    localization: CustomerCenterConfigData.default.localization,
+                    identifier: "1"
                 )
                 .cornerRadius(10)
                 .padding([.leading, .trailing])

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
@@ -28,7 +28,8 @@ struct PurchaseInformationCardView: View {
     private let title: String
     private let subtitle: String?
     private let badge: Badge?
-    private let identifier: String?
+    /// accessibility identifier
+    private let identifier: String
 
     private let storeTitle: String
 
@@ -42,12 +43,12 @@ struct PurchaseInformationCardView: View {
         title: String,
         storeTitle: String,
         paidPrice: String,
+        identifier: String,
         badge: PurchaseInformationCardView.Badge? = nil,
         additionalIcon: Image? = nil,
         additionalInfo: String? = nil,
         subtitle: String? = nil,
-        showChevron: Bool = true,
-        identifier: String? = nil
+        showChevron: Bool = true
     ) {
         self.title = title
         self.paidPrice = paidPrice
@@ -127,7 +128,7 @@ struct PurchaseInformationCardView: View {
                                 .padding(.horizontal, 4)
                                 .background(badge.backgroundColor)
                                 .clipShape(RoundedRectangle(cornerRadius: 4))
-                                .accessibilityIdentifier(badge.id)
+                                .accessibilityIdentifier([identifier, badge.id].joined(separator: "_"))
                         }
                     }
                     .padding(.bottom, 8)
@@ -277,6 +278,7 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     title: "Product name",
                     storeTitle: Store.appStore.localizationKey.rawValue,
                     paidPrice: "$19.99",
+                    identifier: "identifier",
                     badge: .cancelled(CustomerCenterConfigData.default.localization),
                     subtitle: "Renews 24 May for $19.99"
                 )
@@ -287,6 +289,7 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     title: "Product name",
                     storeTitle: Store.playStore.localizationKey.rawValue,
                     paidPrice: "$19.99",
+                    identifier: "identifier",
                     badge: .freeTrial(CustomerCenterConfigData.default.localization),
                     subtitle: "Renews 24 May for $19.99"
                 )
@@ -297,6 +300,7 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     title: "Product name",
                     storeTitle: Store.playStore.localizationKey.rawValue,
                     paidPrice: "$19.99",
+                    identifier: "identifier",
                     badge: .active(CustomerCenterConfigData.default.localization),
                     additionalIcon: Image(systemName: "exclamationmark.triangle.fill"),
                     additionalInfo: "Apple has received the refund request Apple has received the refund request",
@@ -309,6 +313,7 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     title: "Product name",
                     storeTitle: Store.playStore.localizationKey.rawValue,
                     paidPrice: "$19.99",
+                    identifier: "identifier",
                     badge: .active(CustomerCenterConfigData.default.localization),
                     additionalIcon: Image(systemName: "info.circle.fill"),
                     additionalInfo: "An error occurred while processing the refund request. Please try again.",

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
@@ -28,8 +28,8 @@ struct PurchaseInformationCardView: View {
     private let title: String
     private let subtitle: String?
     private let badge: Badge?
-    /// accessibility identifier
-    private let identifier: String
+
+    private let accessibilityIdentifier: String
 
     private let storeTitle: String
 
@@ -43,7 +43,7 @@ struct PurchaseInformationCardView: View {
         title: String,
         storeTitle: String,
         paidPrice: String,
-        identifier: String,
+        accessibilityIdentifier: String,
         badge: PurchaseInformationCardView.Badge? = nil,
         additionalIcon: Image? = nil,
         additionalInfo: String? = nil,
@@ -58,18 +58,18 @@ struct PurchaseInformationCardView: View {
         self.additionalInfo = additionalInfo
         self.storeTitle = storeTitle
         self.showChevron = showChevron
-        self.identifier = identifier
+        self.accessibilityIdentifier = accessibilityIdentifier
     }
 
     init(
         purchaseInformation: PurchaseInformation,
         localization: CustomerCenterConfigData.Localization,
-        identifier: String,
+        accessibilityIdentifier: String,
         refundStatus: RefundRequestStatus? = nil,
         showChevron: Bool = true
     ) {
         self.title = purchaseInformation.title
-        self.identifier = identifier
+        self.accessibilityIdentifier = accessibilityIdentifier
 
         if let renewalDate = purchaseInformation.renewalDate {
             self.subtitle = purchaseInformation.priceRenewalString(
@@ -128,7 +128,7 @@ struct PurchaseInformationCardView: View {
                                 .padding(.horizontal, 4)
                                 .background(badge.backgroundColor)
                                 .clipShape(RoundedRectangle(cornerRadius: 4))
-                                .accessibilityIdentifier([identifier, badge.id].joined(separator: "_"))
+                                .accessibilityIdentifier([accessibilityIdentifier, badge.id].joined(separator: "_"))
                         }
                     }
                     .padding(.bottom, 8)
@@ -278,7 +278,7 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     title: "Product name",
                     storeTitle: Store.appStore.localizationKey.rawValue,
                     paidPrice: "$19.99",
-                    identifier: "identifier",
+                    accessibilityIdentifier: "accessibilityIdentifier",
                     badge: .cancelled(CustomerCenterConfigData.default.localization),
                     subtitle: "Renews 24 May for $19.99"
                 )
@@ -289,7 +289,7 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     title: "Product name",
                     storeTitle: Store.playStore.localizationKey.rawValue,
                     paidPrice: "$19.99",
-                    identifier: "identifier",
+                    accessibilityIdentifier: "accessibilityIdentifier",
                     badge: .freeTrial(CustomerCenterConfigData.default.localization),
                     subtitle: "Renews 24 May for $19.99"
                 )
@@ -300,7 +300,7 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     title: "Product name",
                     storeTitle: Store.playStore.localizationKey.rawValue,
                     paidPrice: "$19.99",
-                    identifier: "identifier",
+                    accessibilityIdentifier: "accessibilityIdentifier",
                     badge: .active(CustomerCenterConfigData.default.localization),
                     additionalIcon: Image(systemName: "exclamationmark.triangle.fill"),
                     additionalInfo: "Apple has received the refund request Apple has received the refund request",
@@ -313,7 +313,7 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     title: "Product name",
                     storeTitle: Store.playStore.localizationKey.rawValue,
                     paidPrice: "$19.99",
-                    identifier: "identifier",
+                    accessibilityIdentifier: "accessibilityIdentifier",
                     badge: .active(CustomerCenterConfigData.default.localization),
                     additionalIcon: Image(systemName: "info.circle.fill"),
                     additionalInfo: "An error occurred while processing the refund request. Please try again.",
@@ -325,7 +325,7 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                 PurchaseInformationCardView(
                     purchaseInformation: .consumable,
                     localization: CustomerCenterConfigData.default.localization,
-                    identifier: "1"
+                    accessibilityIdentifier: "accessibilityIdentifier"
                 )
                 .cornerRadius(10)
                 .padding([.leading, .trailing])

--- a/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
@@ -67,7 +67,6 @@ struct PurchasesInformationSection: View {
                     )
                     .cornerRadius(10)
                     .padding(.horizontal)
-                    .accessibilityIdentifier("title_\(id)")
                 }
                 .padding(.bottom, 16)
             }

--- a/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
@@ -54,15 +54,20 @@ struct PurchasesInformationSection: View {
     var body: some View {
         ScrollViewSection(title: title) {
             ForEach(items) { purchase in
+                // only a few active subscriptions
+                let id = items.firstIndex(of: purchase)?.description ?? "0"
+
                 Button {
                     action(purchase)
                 } label: {
                     PurchaseInformationCardView(
                         purchaseInformation: purchase,
-                        localization: localization
+                        localization: localization,
+                        identifier: id
                     )
                     .cornerRadius(10)
                     .padding(.horizontal)
+                    .accessibilityIdentifier("title_\(id)")
                 }
                 .padding(.bottom, 16)
             }

--- a/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
@@ -63,7 +63,7 @@ struct PurchasesInformationSection: View {
                     PurchaseInformationCardView(
                         purchaseInformation: purchase,
                         localization: localization,
-                        identifier: id
+                        accessibilityIdentifier: id
                     )
                     .cornerRadius(10)
                     .padding(.horizontal)

--- a/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
@@ -53,17 +53,14 @@ struct PurchasesInformationSection: View {
 
     var body: some View {
         ScrollViewSection(title: title) {
-            ForEach(items) { purchase in
-                // only a few active subscriptions
-                let id = items.firstIndex(of: purchase)?.description ?? "0"
-
+            ForEach(Array(items.enumerated()), id: \.element) { (offset, purchase) in
                 Button {
                     action(purchase)
                 } label: {
                     PurchaseInformationCardView(
                         purchaseInformation: purchase,
                         localization: localization,
-                        accessibilityIdentifier: id
+                        accessibilityIdentifier: "purchase_card_\(offset)"
                     )
                     .cornerRadius(10)
                     .padding(.horizontal)

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -150,7 +150,7 @@ struct SubscriptionDetailView: View {
                     PurchaseInformationCardView(
                         purchaseInformation: purchaseInformation,
                         localization: localization,
-                        identifier: "0",
+                        accessibilityIdentifier: "0",
                         refundStatus: viewModel.refundRequestStatus,
                         showChevron: false
                     )

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -150,6 +150,7 @@ struct SubscriptionDetailView: View {
                     PurchaseInformationCardView(
                         purchaseInformation: purchaseInformation,
                         localization: localization,
+                        identifier: "0",
                         refundStatus: viewModel.refundRequestStatus,
                         showChevron: false
                     )


### PR DESCRIPTION
### Motivation
While writing tests to verify the state of the card after a successful / unsuccessful promo offer, I need an id to validate multiple subs.

### Description
- Add identifier to card