### PR TITLE
Remove unused durationTitle from PurchaseInformation

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation+Mock.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation+Mock.swift
@@ -22,7 +22,6 @@ extension PurchaseInformation {
 
     static let monthlyRenewing = PurchaseInformation(
         title: "Basic",
-        durationTitle: "Monthly",
         pricePaid: .nonFree("$4.99"),
         renewalPrice: .nonFree("$4.99"),
         productIdentifier: "product_id5",
@@ -40,7 +39,6 @@ extension PurchaseInformation {
 
     static let lifetime = PurchaseInformation(
         title: "Lifetime",
-        durationTitle: "Lifetime",
         pricePaid: .nonFree("$4.99"),
         renewalPrice: .nonFree("$4.99"),
         productIdentifier: "product_id5",
@@ -58,7 +56,6 @@ extension PurchaseInformation {
 
     static let free = PurchaseInformation(
         title: "Basic",
-        durationTitle: "Monthly",
         pricePaid: .free,
         renewalPrice: .nonFree("$4.99"),
         productIdentifier: "product_id2",
@@ -85,7 +82,6 @@ extension PurchaseInformation {
     ) -> PurchaseInformation {
         PurchaseInformation(
             title: title,
-            durationTitle: "Yearly",
             pricePaid: .nonFree("$49.99"),
             renewalPrice: .nonFree("$49.99"),
             productIdentifier: productIdentifier,
@@ -104,7 +100,6 @@ extension PurchaseInformation {
 
     static let consumable: PurchaseInformation = PurchaseInformation(
         title: "Basic",
-        durationTitle: nil,
         pricePaid: .nonFree("$49.99"),
         renewalPrice: nil,
         productIdentifier: "product_id",
@@ -122,7 +117,6 @@ extension PurchaseInformation {
 
     static let subscriptionInformationMonthlyRenewing = PurchaseInformation(
         title: "Basic",
-        durationTitle: "Monthly",
         pricePaid: .nonFree("$4.99"),
         renewalPrice: .nonFree("$4.99"),
         productIdentifier: "product_id",
@@ -140,7 +134,6 @@ extension PurchaseInformation {
 
     static let subscriptionInformationFree = PurchaseInformation(
         title: "Basic",
-        durationTitle: "Monthly",
         pricePaid: .free,
         renewalPrice: .nonFree("$4.99"),
         productIdentifier: "product_id",

--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -27,10 +27,6 @@ struct PurchaseInformation {
     /// If neither the title or the display name are available, the product identifier will be used as a fallback.
     let title: String
 
-    /// The duration of the product, if applicable.
-    /// - Note: See `StoreProduct.localizedDetails` for more details.
-    let durationTitle: String?
-
     /// Pricing details of the latest purchase.
     let pricePaid: PricePaid
 
@@ -92,7 +88,6 @@ struct PurchaseInformation {
     private let numberFormatter: NumberFormatter
 
     init(title: String,
-         durationTitle: String?,
          pricePaid: PricePaid,
          renewalPrice: RenewalPrice?,
          productIdentifier: String,
@@ -112,7 +107,6 @@ struct PurchaseInformation {
          ownershipType: PurchaseOwnershipType? = nil
     ) {
         self.title = title
-        self.durationTitle = durationTitle
         self.pricePaid = pricePaid
         self.renewalPrice = renewalPrice
         self.productIdentifier = productIdentifier
@@ -146,7 +140,6 @@ struct PurchaseInformation {
 
         // Title and duration from product if available
         self.title = subscribedProduct?.localizedTitle ?? transaction.productIdentifier
-        self.durationTitle = subscribedProduct?.subscriptionPeriod?.durationTitle
 
         self.customerInfoRequestedDate = customerInfoRequestedDate
         self.managementURL = managementURL
@@ -231,7 +224,6 @@ extension PurchaseInformation: Hashable {
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(title)
-        hasher.combine(durationTitle)
         hasher.combine(pricePaid)
         hasher.combine(renewalPrice)
         hasher.combine(renewalDate)
@@ -383,20 +375,6 @@ private extension EntitlementInfo {
 
     var isCancelled: Bool {
         unsubscribeDetectedAt != nil && !willRenew
-    }
-
-    func durationTitleBestEffort(productIdentifier: String) -> String? {
-        switch self.store {
-        case .promotional:
-            if productIdentifier.isPromotionalLifetime(store: store) {
-                return "Lifetime"
-            }
-        case .appStore, .macAppStore, .playStore, .stripe, .unknownStore, .amazon, .rcBilling, .external:
-            return nil
-        @unknown default:
-            return nil
-        }
-        return nil
     }
 }
 

--- a/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
@@ -545,7 +545,6 @@ private extension PurchaseInformation {
     ) -> PurchaseInformation {
         PurchaseInformation(
             title: "",
-            durationTitle: "",
             pricePaid: .nonFree(""),
             renewalPrice: nil,
             productIdentifier: "",
@@ -572,7 +571,6 @@ private extension PurchaseInformation {
     ) -> PurchaseInformation {
         PurchaseInformation(
             title: "",
-            durationTitle: "",
             pricePaid: pricePaid,
             renewalPrice: renewalPrice,
             productIdentifier: "",

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -238,7 +238,6 @@ final class CustomerCenterViewModelTests: TestCase {
                 == purchaseInformation.productIdentifier
 
             expect(purchaseInformation.title) == "title"
-            expect(purchaseInformation.durationTitle) == "1 month"
 
             expect(purchaseInformation.pricePaid) == .nonFree(formatted(price: 4.99))
             if let renewalPrice {
@@ -293,8 +292,6 @@ final class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.activeSubscriptionPurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
 
         expect(purchaseInformation.title) == "title"
-        expect(purchaseInformation.durationTitle) == "1 month"
-
         expect(purchaseInformation.pricePaid) == .nonFree(formatted(price: 3.99, currencyCode: currency))
         expect(purchaseInformation.renewalPrice).to(beNil())
 
@@ -376,7 +373,6 @@ final class CustomerCenterViewModelTests: TestCase {
 
             // Should always show yearly subscription since it expires first
             expect(purchaseInformation.title) == yearlyProduct.title
-            expect(purchaseInformation.durationTitle) == yearlyProduct.duration
 
             expect(purchaseInformation.pricePaid) == .nonFree(formatted(price: 29.99))
 
@@ -466,7 +462,6 @@ final class CustomerCenterViewModelTests: TestCase {
                 == purchaseInformation.productIdentifier
 
             expect(purchaseInformation.title) == "monthly"
-            expect(purchaseInformation.durationTitle) == "1 month"
             expect(purchaseInformation.pricePaid) == .nonFree(formatted(price: 1.99, currencyCode: "USD"))
             expect(purchaseInformation.renewalPrice).to(beNil())
 
@@ -521,7 +516,6 @@ final class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.activeSubscriptionPurchases.count) == 0
 
         expect(purchaseInformation.title) == "lifetime"
-        expect(purchaseInformation.durationTitle).to(beNil())
         expect(purchaseInformation.pricePaid) == .unknown // no info about non-subscriptions in customer info
         expect(purchaseInformation.productIdentifier) == productIdLifetime
     }
@@ -601,7 +595,6 @@ final class CustomerCenterViewModelTests: TestCase {
 
             // Should always show yearly subscription since it expires first
             expect(purchaseInformation.title) == yearlyProduct.title
-            expect(purchaseInformation.durationTitle) == yearlyProduct.duration
             expect(purchaseInformation.pricePaid) == .nonFree(formatted(price: 29.99))
 
             expect(purchaseInformation.productIdentifier) == yearlyProduct.id
@@ -685,7 +678,6 @@ final class CustomerCenterViewModelTests: TestCase {
 
             // We expect to see the monthly one, because the yearly one is a Google subscription
             expect(purchaseInformation.title) == appleProduct.title
-            expect(purchaseInformation.durationTitle) == appleProduct.duration
             expect(purchaseInformation.pricePaid) == .nonFree(formatted(price: appleProduct.price))
 
             expect(purchaseInformation.productIdentifier) == appleProduct.id
@@ -735,7 +727,6 @@ final class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.activeSubscriptionPurchases.first?.productIdentifier) == purchaseInformation.productIdentifier
 
         expect(purchaseInformation.title) == "com.revenuecat.product" // product identifier
-        expect(purchaseInformation.durationTitle).to(beNil())
         expect(purchaseInformation.store) == .appStore
         expect(purchaseInformation.pricePaid) == .nonFree(formatted(price: 1.99)) // from transaction
 

--- a/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
@@ -115,7 +115,6 @@ final class PurchaseInformationTests: TestCase {
             )
         )
         expect(subscriptionInfo.title) == "Monthly Product"
-        expect(subscriptionInfo.durationTitle) == "1 month"
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -172,7 +171,6 @@ final class PurchaseInformationTests: TestCase {
 
         let subscriptionInfo = try XCTUnwrap(subscriptionInfoNullable)
         expect(subscriptionInfo.title) == "Monthly Product"
-        expect(subscriptionInfo.durationTitle) == "1 month"
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice) == .nonFree("$7.99")
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -230,7 +228,6 @@ final class PurchaseInformationTests: TestCase {
         let subscriptionInfo = try XCTUnwrap(subscriptionInfoNullable)
 
         expect(subscriptionInfo.title) == "Monthly Product"
-        expect(subscriptionInfo.durationTitle) == "1 month"
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beTrue())
@@ -287,7 +284,6 @@ final class PurchaseInformationTests: TestCase {
 
         let subscriptionInfo = try XCTUnwrap(subscriptionInfoNullable)
         expect(subscriptionInfo.title) == "Monthly Product"
-        expect(subscriptionInfo.durationTitle) == "1 month"
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.isLifetime).to(beFalse())
 
@@ -343,7 +339,6 @@ final class PurchaseInformationTests: TestCase {
 
         let subscriptionInfo = try XCTUnwrap(subscriptionInfoNullable)
         expect(subscriptionInfo.title) == "Monthly Product"
-        expect(subscriptionInfo.durationTitle) == "1 month"
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -386,7 +381,6 @@ final class PurchaseInformationTests: TestCase {
         )
 
         expect(subscriptionInfo.title) == "com.revenuecat.product"
-        expect(subscriptionInfo.durationTitle).to(beNil())
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -429,7 +423,6 @@ final class PurchaseInformationTests: TestCase {
         )
 
         expect(subscriptionInfo.title) == "com.revenuecat.product"
-        expect(subscriptionInfo.durationTitle).to(beNil())
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -472,7 +465,6 @@ final class PurchaseInformationTests: TestCase {
         )
 
         expect(subscriptionInfo.title) == "com.revenuecat.product"
-        expect(subscriptionInfo.durationTitle).to(beNil())
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -515,7 +507,6 @@ final class PurchaseInformationTests: TestCase {
         )
 
         expect(subscriptionInfo.title) == "rc_promo_pro_cat_yearly"
-        expect(subscriptionInfo.durationTitle).to(beNil())
         expect(subscriptionInfo.pricePaid) == .free
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -558,7 +549,6 @@ final class PurchaseInformationTests: TestCase {
         )
 
         expect(subscriptionInfo.title) == "rc_promo_pro_cat_lifetime"
-        expect(subscriptionInfo.durationTitle).to(beNil())
         expect(subscriptionInfo.pricePaid) == .free
         expect(subscriptionInfo.renewalPrice).to(beNil())
         // false - no way to know if its lifetime
@@ -602,7 +592,6 @@ final class PurchaseInformationTests: TestCase {
         )
 
         expect(subscriptionInfo.title) == "com.revenuecat.product"
-        expect(subscriptionInfo.durationTitle).to(beNil())
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -645,7 +634,6 @@ final class PurchaseInformationTests: TestCase {
         )
 
         expect(subscriptionInfo.title) == "com.revenuecat.product"
-        expect(subscriptionInfo.durationTitle).to(beNil())
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -688,7 +676,6 @@ final class PurchaseInformationTests: TestCase {
         )
 
         expect(subscriptionInfo.title) == "com.revenuecat.product"
-        expect(subscriptionInfo.durationTitle).to(beNil())
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -731,7 +718,6 @@ final class PurchaseInformationTests: TestCase {
         )
 
         expect(subscriptionInfo.title) == "com.revenuecat.product"
-        expect(subscriptionInfo.durationTitle).to(beNil())
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice) == .nonFree("$1.99")
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -774,7 +760,6 @@ final class PurchaseInformationTests: TestCase {
         )
 
         expect(subscriptionInfo.title) == "com.revenuecat.product"
-        expect(subscriptionInfo.durationTitle).to(beNil())
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -817,7 +802,6 @@ final class PurchaseInformationTests: TestCase {
         )
 
         expect(subscriptionInfo.title) == "com.revenuecat.product"
-        expect(subscriptionInfo.durationTitle).to(beNil())
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -857,7 +841,6 @@ final class PurchaseInformationTests: TestCase {
             )
         )
         expect(subscriptionInfo.title) == "product_id"
-        expect(subscriptionInfo.durationTitle).to(beNil())
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.isLifetime).to(beFalse())
 


### PR DESCRIPTION
### Motivation
Cleanup after the release

### Description
- Delete unused `durationTitle` from `PurchaseInformation`
