### PR TITLE
Add missing fields to PurchaseInformation

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -81,12 +81,36 @@ struct PurchaseInformation {
     /// Note: `nil` for non-subscriptions, and for expiring subscriptions
      let renewalDate: Date?
 
+    /// The date an unsubscribe was detected.
+    ///
+    /// Note: `nil` for non-subscriptions, and for expiring subscriptions
+    let unsubscribeDetectedAt: Date?
+
+    /// Date when RevenueCat detected any billing issues with this subscription.
+    ///
+    /// Note: `nil` for non-subscriptions, and for expiring subscriptions
+    let billingIssuesDetectedAt: Date?
+
+    /// Date when any grace period for this subscription expires/expired.
+    /// nil if the customer has never been in a grace period.
+    ///
+    /// Note: `nil` for non-subscriptions, and for expiring subscriptions
+    let gracePeriodExpiresDate: Date?
+
+    let refundedAtDate: Date?
+
     /// Product specific management URL
     let managementURL: URL?
 
     let periodType: PeriodType
 
     let ownershipType: PurchaseOwnershipType?
+
+    /// The unique identifier for the transaction created by RevenueCat.
+    let transactionIdentifier: String?
+
+    /// The unique identifier for the transaction created by the Store.
+    let storeTransactionIdentifier: String?
 
     private let dateFormatter: DateFormatter
     private let numberFormatter: NumberFormatter
@@ -109,7 +133,13 @@ struct PurchaseInformation {
          expirationDate: Date? = nil,
          renewalDate: Date? = nil,
          periodType: PeriodType = .normal,
-         ownershipType: PurchaseOwnershipType? = nil
+         ownershipType: PurchaseOwnershipType? = nil,
+         unsubscribeDetectedAt: Date? = nil,
+         billingIssuesDetectedAt: Date? = nil,
+         gracePeriodExpiresDate: Date? = nil,
+         refundedAtDate: Date? = nil,
+         transactionIdentifier: String? = nil,
+         storeTransactionIdentifier: String? = nil
     ) {
         self.title = title
         self.durationTitle = durationTitle
@@ -130,8 +160,15 @@ struct PurchaseInformation {
         self.periodType = periodType
         self.numberFormatter = numberFormatter
         self.ownershipType = ownershipType
+        self.unsubscribeDetectedAt = unsubscribeDetectedAt
+        self.billingIssuesDetectedAt = billingIssuesDetectedAt
+        self.gracePeriodExpiresDate = gracePeriodExpiresDate
+        self.refundedAtDate = refundedAtDate
+        self.transactionIdentifier = transactionIdentifier
+        self.storeTransactionIdentifier = storeTransactionIdentifier
     }
 
+    // swiftlint:disable:next function_body_length
     init(entitlement: EntitlementInfo? = nil,
          subscribedProduct: StoreProduct? = nil,
          transaction: Transaction,
@@ -166,6 +203,12 @@ struct PurchaseInformation {
             self.periodType = entitlement.periodType
             self.ownershipType = entitlement.ownershipType
             self.isActive = entitlement.isActive
+            self.unsubscribeDetectedAt = entitlement.unsubscribeDetectedAt
+            self.billingIssuesDetectedAt = entitlement.billingIssueDetectedAt
+            self.gracePeriodExpiresDate = nil
+            self.refundedAtDate = nil
+            self.transactionIdentifier = nil
+            self.storeTransactionIdentifier = nil
         } else {
             switch transaction.type {
             case let .subscription(isActive, willRenew, expiresDate, isTrial, ownershipType):
@@ -190,6 +233,12 @@ struct PurchaseInformation {
             self.store = transaction.store
             self.isCancelled = transaction.isCancelled
             self.periodType = transaction.periodType
+            self.unsubscribeDetectedAt = transaction.unsubscribeDetectedAt
+            self.billingIssuesDetectedAt = transaction.billingIssuesDetectedAt
+            self.gracePeriodExpiresDate = transaction.gracePeriodExpiresDate
+            self.refundedAtDate = transaction.refundedAtDate
+            self.transactionIdentifier = transaction.identifier
+            self.storeTransactionIdentifier = transaction.storeIdentifier
         }
 
         if self.expirationDate == nil {

--- a/RevenueCatUI/CustomerCenter/Data/Transaction.swift
+++ b/RevenueCatUI/CustomerCenter/Data/Transaction.swift
@@ -24,6 +24,12 @@ protocol Transaction {
     var price: ProductPaidPrice? { get }
     var periodType: PeriodType { get }
     var purchaseDate: Date { get }
+    var unsubscribeDetectedAt: Date? { get }
+    var billingIssuesDetectedAt: Date? { get }
+    var gracePeriodExpiresDate: Date? { get }
+    var refundedAtDate: Date? { get }
+    var storeIdentifier: String? { get }
+    var identifier: String? { get }
 }
 
 enum TransactionType {
@@ -54,6 +60,17 @@ enum TransactionType {
         unsubscribeDetectedAt != nil && !willRenew
     }
 
+    var refundedAtDate: Date? {
+        refundedAt
+    }
+
+    var storeIdentifier: String? {
+        storeTransactionId
+    }
+
+    var identifier: String? {
+        nil
+    }
 }
 
 extension NonSubscriptionTransaction: Transaction {
@@ -74,4 +91,27 @@ extension NonSubscriptionTransaction: Transaction {
         .normal
     }
 
+    var unsubscribeDetectedAt: Date? {
+        nil
+    }
+
+    var billingIssuesDetectedAt: Date? {
+        nil
+    }
+
+    var gracePeriodExpiresDate: Date? {
+        nil
+    }
+
+    var refundedAtDate: Date? {
+        nil
+    }
+
+    var storeIdentifier: String? {
+        storeTransactionIdentifier
+    }
+
+    var identifier: String? {
+        transactionIdentifier
+    }
 }

--- a/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
@@ -66,6 +66,12 @@ final class PurchaseInformationTests: TestCase {
         let displayName: String?
         let periodType: RevenueCat.PeriodType
         let purchaseDate: Date
+        var unsubscribeDetectedAt: Date?
+        var billingIssuesDetectedAt: Date?
+        var gracePeriodExpiresDate: Date?
+        var refundedAtDate: Date?
+        var storeIdentifier: String?
+        var identifier: String?
     }
 
     func testAppleEntitlementAndSubscribedProductWithoutRenewalInfo() throws {


### PR DESCRIPTION
### Motivation
The goal is to re-write PurchaseHistory using `PurchaseInformation` instead of `PurchaseInfo` so we can reuse all the UI from `RelevantPurchasesListView`

### Description
- Add missing fields

### Discussion
The more I see `PurchaseInformation`, I think that we could go to something that just wraps either `SubscriptionInfo` o `NonSubscriptionTransaction`, and an optional `StoreProduct` + `Entitlement. That should reduce a lot of code.

I'll probably explore this once PurchaseHistory is refactored.

