### PR TITLE
Improve descriptions for SDK Health errors

### DIFF
--- a/Sources/Support/SDKHealthError+CustomNSError.swift
+++ b/Sources/Support/SDKHealthError+CustomNSError.swift
@@ -27,44 +27,87 @@ extension PurchasesDiagnostics.SDKHealthError: CustomNSError {
     var localizedDescription: String {
         switch self {
         case .notAuthorizedToMakePayments:
-            return "This device is not authorized to make purchases. This can happen if Content & Privacy Restrictions are enabled in Screen Time, or if the device has a mobile device management (MDM) profile that prevents purchases. Please check your Screen Time settings or contact your device administrator, or try again from a different device."
+            return """
+            This device is not authorized to make purchases. This can happen if Content & Privacy Restrictions are \
+            enabled in Screen Time, or if the device has a mobile device management (MDM) profile that prevents \
+            purchases. Please check your Screen Time settings or contact your device administrator, or try again \
+            from a different device.
+            """
 
         case let .unknown(error):
-            return "We encountered an unknown error that prevented the operation from completing. This is likely a temporary issue. Please try again in a few moments and, if the problem persists, contact support with this error: \(error.localizedDescription)."
+            return """
+            We encountered an unknown error that prevented the operation from completing. This is likely a \
+            temporary issue. Please try again in a few moments and, if the problem persists, contact support \
+            with this error: \(error.localizedDescription).
+            """
 
         case .invalidAPIKey:
-            return "Your API key is not valid or has been revoked. This prevents your app from accessing RevenueCat services and among other things, retrieving products. Please verify your API key in the RevenueCat website and update your app's configuration."
+            return """
+            Your API key is not valid or has been revoked. This prevents your app from accessing RevenueCat \
+            services and among other things, retrieving products. Please verify your API key in the RevenueCat \
+            website and update your app's configuration.
+            """
 
         case .noOfferings:
-            return "Your app doesn't have any offerings configured in RevenueCat. This means users can't see available product options through offerings. If you plan on using offerings to show products to your users, please configure them in the RevenueCat website."
+            return """
+            Your app doesn't have any offerings configured in RevenueCat. This means users can't see available \
+            product options through offerings. If you plan on using offerings to show products to your users, \
+            please configure them in the RevenueCat website.
+            """
 
         case let .offeringConfiguration(payload):
             guard let offendingOffering = payload.first(where: { $0.status == .failed }) else {
-                return "Your default offering is not configured correctly in RevenueCat. This prevents users from seeing product options. Please check your offering configuration in the RevenueCat website."
+                return """
+                Your default offering is not configured correctly in RevenueCat. This prevents users from \
+                seeing product options. Please check your offering configuration in the RevenueCat website.
+                """
             }
 
             let offeringIdentifier = offendingOffering.identifier
-            let offendingPackageCount = offendingOffering.packages.filter({ $0.status != .valid }).count
+            let offendingPackageCount = offendingOffering.packages.filter { $0.status != .valid }.count
 
             if offendingOffering.packages.isEmpty {
-                return "Offering '\(offeringIdentifier)' has no packages configured, so users won't see any product options. Please add packages to this offering in the RevenueCat website."
+                return """
+                Offering '\(offeringIdentifier)' has no packages configured, so users won't see any product \
+                options. Please add packages to this offering in the RevenueCat website.
+                """
             } else {
-                return "Offering '\(offeringIdentifier)' uses \(offendingPackageCount) products that are not approved in App Store Connect yet. While such products may work while testing, users won't be able to make purchases in production. Please ensure all products are approved and available in App Store Connect."
+                return """
+                Offering '\(offeringIdentifier)' uses \(offendingPackageCount) products that are not approved \
+                in App Store Connect yet. While such products may work while testing, users won't be able to \
+                make purchases in production. Please ensure all products are approved and available in App Store \
+                Connect.
+                """
             }
 
         case let .invalidBundleId(payload):
             guard let payload else {
-                return "Your app's Bundle ID doesn't match the one configured in RevenueCat. This will cause the SDK to not show any products and won't allow users to make purchases. Please update your Bundle ID in either your app or the RevenueCat website to match."
+                return """
+                Your app's Bundle ID doesn't match the one configured in RevenueCat. This will cause the SDK \
+                to not show any products and won't allow users to make purchases. Please update your Bundle ID \
+                in either your app or the RevenueCat website to match.
+                """
             }
             let sdkBundleId = payload.sdkBundleId
             let appBundleId = payload.appBundleId
-            return "Your app's Bundle ID '\(sdkBundleId)' doesn't match the RevenueCat configuration '\(appBundleId)'. This will cause the SDK to not show any products and won't allow users to make purchases. Please update your Bundle ID in either your app or the RevenueCat website to match."
+            return """
+            Your app's Bundle ID '\(sdkBundleId)' doesn't match the RevenueCat configuration '\(appBundleId)'. \
+            This will cause the SDK to not show any products and won't allow users to make purchases. Please \
+            update your Bundle ID in either your app or the RevenueCat website to match.
+            """
 
         case let .invalidProducts(products):
             if products.isEmpty {
-                return "Your app doesn't have any products set up, so users can't make any purchases. Please create and configure products in the RevenueCat website."
+                return """
+                Your app doesn't have any products set up, so users can't make any purchases. Please create \
+                and configure products in the RevenueCat website.
+                """
             } else {
-                return "Your products are configured in RevenueCat but aren't approved in App Store Connect yet. This prevents users from making purchases in production. Please ensure all products are approved and available for sale in App Store Connect."
+                return """
+                Your products are configured in RevenueCat but aren't approved in App Store Connect yet. This \
+                prevents users from making purchases in production. Please ensure all products are approved and \
+                available for sale in App Store Connect.
+                """
             }
         }
     }

--- a/Sources/Support/SDKHealthError+CustomNSError.swift
+++ b/Sources/Support/SDKHealthError+CustomNSError.swift
@@ -26,37 +26,46 @@ extension PurchasesDiagnostics.SDKHealthError: CustomNSError {
 
     var localizedDescription: String {
         switch self {
-        case .notAuthorizedToMakePayments: return "The person is not authorized to make payments on this device"
-        case let .unknown(error): return "Unknown error: \(error.localizedDescription)"
-        case .invalidAPIKey: return "API key is not valid"
-        case .noOfferings: return "No offerings configured"
+        case .notAuthorizedToMakePayments:
+            return "This device is not authorized to make purchases. This can happen if Content & Privacy Restrictions are enabled in Screen Time, or if the device has a mobile device management (MDM) profile that prevents purchases. Please check your Screen Time settings or contact your device administrator, or try again from a different device."
+
+        case let .unknown(error):
+            return "We encountered an unknown error that prevented the operation from completing. This is likely a temporary issue. Please try again in a few moments and, if the problem persists, contact support with this error: \(error.localizedDescription)."
+
+        case .invalidAPIKey:
+            return "Your API key is not valid or has been revoked. This prevents your app from accessing RevenueCat services and among other things, retrieving products. Please verify your API key in the RevenueCat website and update your app's configuration."
+
+        case .noOfferings:
+            return "Your app doesn't have any offerings configured in RevenueCat. This means users can't see available product options through offerings. If you plan on using offerings to show products to your users, please configure them in the RevenueCat website."
+
         case let .offeringConfiguration(payload):
             guard let offendingOffering = payload.first(where: { $0.status == .failed }) else {
-                return "Default offering is not configured correctly"
+                return "Your default offering is not configured correctly in RevenueCat. This prevents users from seeing product options. Please check your offering configuration in the RevenueCat website."
             }
 
             let offeringIdentifier = offendingOffering.identifier
             let offendingPackageCount = offendingOffering.packages.filter({ $0.status != .valid }).count
-            let noPackages = "Offering '\(offeringIdentifier)' has no packages"
-            let packagesNotReady = """
-            Offering '\(offeringIdentifier)' uses \(offendingPackageCount) products \
-            that are not ready in App Store Connect
-            """
 
-            return offendingOffering.packages.isEmpty ? noPackages : packagesNotReady
+            if offendingOffering.packages.isEmpty {
+                return "Offering '\(offeringIdentifier)' has no packages configured, so users won't see any product options. Please add packages to this offering in the RevenueCat website."
+            } else {
+                return "Offering '\(offeringIdentifier)' uses \(offendingPackageCount) products that are not approved in App Store Connect yet. While such products may work while testing, users won't be able to make purchases in production. Please ensure all products are approved and available in App Store Connect."
+            }
+
         case let .invalidBundleId(payload):
             guard let payload else {
-                return "Bundle ID in your app does not match the Bundle ID in the RevenueCat Website"
+                return "Your app's Bundle ID doesn't match the one configured in RevenueCat. This will cause the SDK to not show any products and won't allow users to make purchases. Please update your Bundle ID in either your app or the RevenueCat website to match."
             }
             let sdkBundleId = payload.sdkBundleId
             let appBundleId = payload.appBundleId
-            return "Bundle ID in your app '\(sdkBundleId)' does not match the RevenueCat app Bundle ID '\(appBundleId)'"
+            return "Your app's Bundle ID '\(sdkBundleId)' doesn't match the RevenueCat configuration '\(appBundleId)'. This will cause the SDK to not show any products and won't allow users to make purchases. Please update your Bundle ID in either your app or the RevenueCat website to match."
+
         case let .invalidProducts(products):
             if products.isEmpty {
-                return "Your app has no products"
+                return "Your app doesn't have any products set up, so users can't make any purchases. Please create and configure products in the RevenueCat website."
+            } else {
+                return "Your products are configured in RevenueCat but aren't approved in App Store Connect yet. This prevents users from making purchases in production. Please ensure all products are approved and available for sale in App Store Connect."
             }
-
-            return "You must have at least one product approved in App Store Connect"
         }
     }
 

--- a/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
+++ b/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
@@ -178,7 +178,11 @@ class PurchasesDiagnosticsTests: TestCase {
         let error = PurchasesDiagnostics.SDKHealthError.noOfferings
 
         expect(error.errorUserInfo[NSUnderlyingErrorKey] as? NSNull).toNot(beNil())
-        expect(error.localizedDescription) == "No offerings configured"
+        expect(error.localizedDescription) == """
+        Your app doesn't have any offerings configured in RevenueCat. This means users can't see available \
+        product options through offerings. If you plan on using offerings to show products to your users, \
+        please configure them in the RevenueCat website.
+        """
     }
 
     func testOfferingConfigurationError() {
@@ -202,7 +206,12 @@ class PurchasesDiagnosticsTests: TestCase {
         )
 
         expect(error.errorUserInfo[NSUnderlyingErrorKey] as? NSNull).toNot(beNil())
-        let expected = "Offering 'test_offering' uses 1 products that are not ready in App Store Connect"
+        let expected = """
+        Offering 'test_offering' uses 1 products that are not approved \
+        in App Store Connect yet. While such products may work while testing, users won't be able to \
+        make purchases in production. Please ensure all products are approved and available in App Store \
+        Connect.
+        """
         expect(error.localizedDescription) == expected
     }
 
@@ -218,7 +227,10 @@ class PurchasesDiagnosticsTests: TestCase {
         )
 
         expect(error.errorUserInfo[NSUnderlyingErrorKey] as? NSNull).toNot(beNil())
-        let expected = "Offering 'test_offering' has no packages"
+        let expected = """
+        Offering 'test_offering' has no packages configured, so users won't see any product \
+        options. Please add packages to this offering in the RevenueCat website.
+        """
         expect(error.localizedDescription) == expected
     }
 
@@ -226,7 +238,10 @@ class PurchasesDiagnosticsTests: TestCase {
         let error = PurchasesDiagnostics.SDKHealthError.offeringConfiguration([])
 
         expect(error.errorUserInfo[NSUnderlyingErrorKey] as? NSNull).toNot(beNil())
-        let expected = "Default offering is not configured correctly"
+        let expected = """
+        Your default offering is not configured correctly in RevenueCat. This prevents users from \
+        seeing product options. Please check your offering configuration in the RevenueCat website.
+        """
         expect(error.localizedDescription) == expected
     }
 
@@ -240,8 +255,9 @@ class PurchasesDiagnosticsTests: TestCase {
 
         expect(error.errorUserInfo[NSUnderlyingErrorKey] as? NSNull).toNot(beNil())
         let expected = """
-        Bundle ID in your app 'sdk_bundle_id' does not match \
-        the RevenueCat app Bundle ID 'app_bundle_id'
+        Your app's Bundle ID 'sdk_bundle_id' doesn't match the RevenueCat configuration 'app_bundle_id'. \
+        This will cause the SDK to not show any products and won't allow users to make purchases. Please \
+        update your Bundle ID in either your app or the RevenueCat website to match.
         """
         expect(error.localizedDescription) == expected
     }
@@ -250,7 +266,11 @@ class PurchasesDiagnosticsTests: TestCase {
         let error = PurchasesDiagnostics.SDKHealthError.invalidBundleId(nil)
 
         expect(error.errorUserInfo[NSUnderlyingErrorKey] as? NSNull).toNot(beNil())
-        let expected = "Bundle ID in your app does not match the Bundle ID in the RevenueCat Website"
+        let expected = """
+        Your app's Bundle ID doesn't match the one configured in RevenueCat. This will cause the SDK \
+        to not show any products and won't allow users to make purchases. Please update your Bundle ID \
+        in either your app or the RevenueCat website to match.
+        """
         expect(error.localizedDescription) == expected
     }
 
@@ -258,7 +278,10 @@ class PurchasesDiagnosticsTests: TestCase {
         let error = PurchasesDiagnostics.SDKHealthError.invalidProducts([])
 
         expect(error.errorUserInfo[NSUnderlyingErrorKey] as? NSNull).toNot(beNil())
-        let expected = "Your app has no products"
+        let expected = """
+        Your app doesn't have any products set up, so users can't make any purchases. Please create \
+        and configure products in the RevenueCat website.
+        """
         expect(error.localizedDescription) == expected
     }
 
@@ -268,7 +291,11 @@ class PurchasesDiagnosticsTests: TestCase {
         ])
 
         expect(error.errorUserInfo[NSUnderlyingErrorKey] as? NSNull).toNot(beNil())
-        let expected = "You must have at least one product approved in App Store Connect"
+        let expected = """
+        Your products are configured in RevenueCat but aren't approved in App Store Connect yet. This \
+        prevents users from making purchases in production. Please ensure all products are approved and \
+        available for sale in App Store Connect.
+        """
         expect(error.localizedDescription) == expected
     }
 


### PR DESCRIPTION
This PR introduces some improvements to the descriptions that we associated with SDK Health errors.

These changes inspired by [Wix's When life gives you lemos write better error messages article](https://wix-ux.com/when-life-gives-you-lemons-write-better-error-messages-46c5223e1a2f).

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids
