### PR TITLE
remove vc compiler flag

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,6 @@ if shouldIncludeDocCPlugin {
 // See https://github.com/RevenueCat/purchases-ios/pull/2989
 // #if os(visionOS) can't really be used in Xcode 13, so we use this instead.
 let visionOSSetting: SwiftSetting = .define("VISION_OS", .when(platforms: [.visionOS]))
-let virtualCurrenciesSetting: SwiftSetting = .define("ENABLE_VIRTUAL_CURRENCIES")
 
 let package = Package(
     name: "RevenueCat",
@@ -86,7 +85,7 @@ let package = Package(
                 resources: [
                     .copy("../Sources/PrivacyInfo.xcprivacy")
                 ],
-                swiftSettings: [visionOSSetting, virtualCurrenciesSetting] + ciCompilerFlags + additionalCompilerFlags),
+                swiftSettings: [visionOSSetting] + ciCompilerFlags + additionalCompilerFlags),
         .target(name: "RevenueCat_CustomEntitlementComputation",
                 path: "CustomEntitlementComputation",
                 exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"],
@@ -115,7 +114,7 @@ let package = Package(
                     .copy("Resources/background.jpg"),
                     .process("Resources/icons.xcassets")
                 ],
-                swiftSettings: [virtualCurrenciesSetting] + ciCompilerFlags + additionalCompilerFlags),
+                swiftSettings: ciCompilerFlags + additionalCompilerFlags),
         .testTarget(name: "RevenueCatUITests",
                     dependencies: [
                         "RevenueCatUI",

--- a/RevenueCat.podspec
+++ b/RevenueCat.podspec
@@ -24,9 +24,8 @@ Pod::Spec.new do |s|
   
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
-    'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'ENABLE_VIRTUAL_CURRENCIES',
     'SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xros*]' => '$(inherited) VISION_OS',
-    'SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xrsimulator*]' => '$(inherited) VISION_OS',
+    'SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xrsimulator*]' => '$(inherited) VISION_OS'
   }
 
   s.source_files = 'Sources/**/*.swift'

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1165,7 +1165,6 @@
 		FD43D2FE2C41867600077235 /* TimeInterval+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD43D2FD2C41867600077235 /* TimeInterval+ExtensionsTests.swift */; };
 		FD7247F22DB8358F00FA3A8D /* VirtualCurrencyBalanceListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7247F12DB8358F00FA3A8D /* VirtualCurrencyBalanceListRow.swift */; };
 		FD89DB872DB97D2E00A8C231 /* VirtualCurrencyBalancesScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD89DB862DB97D2E00A8C231 /* VirtualCurrencyBalancesScreenViewModelTests.swift */; };
-		FD89DB882DB97D2E00A8C231 /* VirtualCurrencyBalancesScreenViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD89DB862DB97D2E00A8C231 /* VirtualCurrencyBalancesScreenViewModelTests.swift */; };
 		FD9BCEBC2DC946C400408A5D /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9BCEBB2DC946C400408A5D /* BottomSheetView.swift */; };
 		FD9F982D2BE28A7F0091A5BF /* MockNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B515526D44B2300BD2BD7 /* MockNotificationCenter.swift */; };
 		FDAADFCB2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAADFCA2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift */; };
@@ -7105,7 +7104,6 @@
 				887A60812C1D037000E1A461 /* PaywallData+Default.swift in Sources */,
 				887A606A2C1D037000E1A461 /* TrialOrIntroEligibilityChecker.swift in Sources */,
 				88B1BAEE2C813A3C001B7EE5 /* TextComponentView.swift in Sources */,
-				FD89DB882DB97D2E00A8C231 /* VirtualCurrencyBalancesScreenViewModelTests.swift in Sources */,
 				2C7457882CEDF7C0004ACE52 /* BackgroundStyle.swift in Sources */,
 				2C8EC6DD2CCC7C5B00D6CCF8 /* PackageValidator.swift in Sources */,
 				4DEB9BC52D08CA1700D33E36 /* BadgeModifier.swift in Sources */,

--- a/RevenueCatUI.podspec
+++ b/RevenueCatUI.podspec
@@ -26,8 +26,7 @@ Pod::Spec.new do |s|
   s.visionos.deployment_target = '1.0'
   
   s.pod_target_xcconfig = { 
-    'DEFINES_MODULE' => 'YES',
-    'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'ENABLE_VIRTUAL_CURRENCIES'
+    'DEFINES_MODULE' => 'YES'
   }
 
   s.source_files = 'RevenueCatUI/**/*.swift'

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -99,10 +99,8 @@ public typealias ProductIdentifier = String
     /// Dictionary of all subscription product identifiers and their subscription info
     @objc public let subscriptionsByProductIdentifier: [ProductIdentifier: SubscriptionInfo]
 
-    #if ENABLE_VIRTUAL_CURRENCIES
     /// Dictionary of all virtual currency codes to their info
     @objc public let virtualCurrencies: [String: VirtualCurrencyInfo]
-    #endif
 
     /// Get the expiration date for a given product identifier. You should use Entitlements though!
     /// - Parameter productIdentifier: Product identifier for product
@@ -228,9 +226,7 @@ public typealias ProductIdentifier = String
         self.allPurchasedProductIdentifiers = Set(self.expirationDatesByProductId.keys)
             .union(self.nonSubscriptions.map { $0.productIdentifier })
 
-        #if ENABLE_VIRTUAL_CURRENCIES
         self.virtualCurrencies = Self.convertVirtualCurrenciesResponse(subscriber.virtualCurrencies)
-        #endif
 
         self.subscriptionsByProductIdentifier =
         Dictionary(uniqueKeysWithValues: subscriber.subscriptions.map { (key, subscriptionData) in
@@ -379,7 +375,6 @@ private extension CustomerInfo {
 
 }
 
-#if ENABLE_VIRTUAL_CURRENCIES
 internal extension CustomerInfo {
     static func convertVirtualCurrenciesResponse(
         _ values: [String: CustomerInfoResponse.VirtualCurrencyInfo]
@@ -389,7 +384,6 @@ internal extension CustomerInfo {
         }
     }
 }
-#endif
 
 /// `Codable` implementation that puts the content of`response` and `schemaVersion`
 /// at the same level instead of nested.

--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -43,10 +43,8 @@ extension CustomerInfoResponse {
         @DefaultDecodable.EmptyDictionary
         var entitlements: [String: Entitlement]
 
-        #if ENABLE_VIRTUAL_CURRENCIES
         @DefaultDecodable.EmptyDictionary
         var virtualCurrencies: [String: VirtualCurrencyInfo]
-        #endif
 
     }
 
@@ -110,11 +108,9 @@ extension CustomerInfoResponse {
 
     }
 
-    #if ENABLE_VIRTUAL_CURRENCIES
     internal struct VirtualCurrencyInfo {
         let balance: Int
     }
-    #endif
 
 }
 
@@ -124,9 +120,7 @@ extension CustomerInfoResponse.Subscriber: Codable, Hashable {}
 extension CustomerInfoResponse.Subscription: Codable, Hashable {}
 extension CustomerInfoResponse.PurchasePaidPrice: Codable, Hashable {}
 
-#if ENABLE_VIRTUAL_CURRENCIES
 extension CustomerInfoResponse.VirtualCurrencyInfo: Codable, Hashable {}
-#endif
 
 extension CustomerInfoResponse.Entitlement: Hashable {}
 extension CustomerInfoResponse.Entitlement: Encodable {}

--- a/Sources/Purchasing/VirtualCurrencyInfo.swift
+++ b/Sources/Purchasing/VirtualCurrencyInfo.swift
@@ -11,7 +11,6 @@
 //
 //  Created by Will Taylor on 2/27/25.
 
-#if ENABLE_VIRTUAL_CURRENCIES
 import Foundation
 
 /// A class representing information about a virtual currency in the app.
@@ -33,5 +32,3 @@ public final class VirtualCurrencyInfo: NSObject {
 
 extension VirtualCurrencyInfo: Codable {}
 extension VirtualCurrencyInfo: Sendable {}
-
-#endif

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCCustomerInfoAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCCustomerInfoAPI.m
@@ -38,9 +38,7 @@
 
     NSDictionary<NSString *, id> *rawData = [ci rawData];
 
-    #if ENABLE_VIRTUAL_CURRENCIES
     NSDictionary<NSString *, RCVirtualCurrencyInfo *> *vci = ci.virtualCurrencies;
-    #endif
 
     NSLog(ci, ei, as, appis, led, ncp, ns, nst, oav, opd, rd, fs, oaud, murl, edfpi, pdfpi, exdf, pdfe, d, rawData);
 }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCVirtualCurrencyInfoAPI.h
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCVirtualCurrencyInfoAPI.h
@@ -5,7 +5,6 @@
 //  Created by Will Taylor on 2/28/25.
 //
 
-#if ENABLE_VIRTUAL_CURRENCIES
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -17,4 +16,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-#endif

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCVirtualCurrencyInfoAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCVirtualCurrencyInfoAPI.m
@@ -5,7 +5,6 @@
 //  Created by Will Taylor on 2/28/25.
 //
 
-#if ENABLE_VIRTUAL_CURRENCIES
 @import RevenueCat;
 #import "RCVirtualCurrencyInfoAPI.h"
 
@@ -17,5 +16,3 @@
 }
 
 @end
-
-#endif

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerInfoAPI.swift
@@ -46,9 +46,7 @@ func checkCustomerInfoAPI() {
 
     let subsp: [ProductIdentifier: SubscriptionInfo] = customerInfo.subscriptionsByProductIdentifier
 
-    #if ENABLE_VIRTUAL_CURRENCIES
     let _: [String: VirtualCurrencyInfo] = customerInfo.virtualCurrencies
-    #endif
 
     print(customerInfo!, entitlementInfo, asubs, appis, led!, nst, oav!, opd!, rDate!, fSeen,
           oaud!, murl!, edfpi!, pdfpi!, exdf!, pdfe!, desc, rawData, subs)

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/VirtualCurrencyInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/VirtualCurrencyInfoAPI.swift
@@ -5,11 +5,9 @@
 //  Created by Will Taylor on 2/28/25.
 //
 
-#if ENABLE_VIRTUAL_CURRENCIES
 import Foundation
 @testable import RevenueCat
 
 func checkVirtualCurrencyInfo(virtualCurrencyInfo: VirtualCurrencyInfo) {
     let balance: Int = virtualCurrencyInfo.balance
 }
-#endif

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/VirtualCurrencyInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/VirtualCurrencyInfoAPI.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@testable import RevenueCat
+import RevenueCat
 
 func checkVirtualCurrencyInfo(virtualCurrencyInfo: VirtualCurrencyInfo) {
     let balance: Int = virtualCurrencyInfo.balance

--- a/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncoding.1.json
+++ b/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncoding.1.json
@@ -50,6 +50,9 @@
         "purchase_date" : "2022-04-12T00:03:28Z",
         "store" : "app_store"
       }
+    },
+    "virtual_currencies" : {
+
     }
   }
 }

--- a/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncodingWithFailedVerificationResponse.1.json
+++ b/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncodingWithFailedVerificationResponse.1.json
@@ -50,6 +50,9 @@
         "purchase_date" : "2022-04-12T00:03:28Z",
         "store" : "app_store"
       }
+    },
+    "virtual_currencies" : {
+
     }
   }
 }

--- a/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncodingWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncodingWithVerifiedResponse.1.json
@@ -50,6 +50,9 @@
         "purchase_date" : "2022-04-12T00:03:28Z",
         "store" : "app_store"
       }
+    },
+    "virtual_currencies" : {
+
     }
   }
 }

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -883,7 +883,6 @@ class BasicCustomerInfoTests: TestCase {
         == Set(["onemonth_freetrial", "twomonth_freetrial", "threemonth_freetrial"])
     }
 
-    #if ENABLE_VIRTUAL_CURRENCIES
     func testVirtualCurrenciesIncludesBalancesForOneCurrency() throws {
         let validJSONWithOneVirtualCurrency = """
             {
@@ -957,7 +956,6 @@ class BasicCustomerInfoTests: TestCase {
         let coin2: VirtualCurrencyInfo = try XCTUnwrap(customerInfo?.virtualCurrencies["COIN2"])
         expect(coin2.balance).to(equal(500))
     }
-    #endif
 
     func testCopyWithSameVerificationResult() throws {
         expect(self.customerInfo.copy(with: .notRequested)) === self.customerInfo


### PR DESCRIPTION
### Motivation
The ENABLE_VIRTUAL_CURRENCIES compiler flag was getting in the way of RevenueCatUI tests in CI, so this PR removes them
