### PR TITLE
add missing import Foundation in Tests

### DIFF
--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -3,6 +3,7 @@
 // Copyright (c) 2020 Purchases. All rights reserved.
 //
 
+import Foundation
 @testable import RevenueCat
 
 // swiftlint:disable large_tuple line_length

--- a/Tests/UnitTests/Mocks/MockDateProvider.swift
+++ b/Tests/UnitTests/Mocks/MockDateProvider.swift
@@ -3,6 +3,7 @@
 // Copyright (c) 2020 Purchases. All rights reserved.
 //
 
+import Foundation
 @testable import RevenueCat
 
 class MockDateProvider: DateProvider {

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -3,6 +3,7 @@
 //  Copyright © 2020 RevenueCat. All rights reserved.
 //
 
+import Foundation
 @testable import RevenueCat
 
 class MockDeviceCache: DeviceCache {

--- a/Tests/UnitTests/Mocks/MockFileReader.swift
+++ b/Tests/UnitTests/Mocks/MockFileReader.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Nacho Soto on 1/10/23.
 
+import Foundation
 @testable import RevenueCat
 
 final class MockFileReader: FileReader {

--- a/Tests/UnitTests/Mocks/MockInMemoryCachedOfferings.swift
+++ b/Tests/UnitTests/Mocks/MockInMemoryCachedOfferings.swift
@@ -3,6 +3,7 @@
 // Copyright (c) 2020 Purchases. All rights reserved.
 //
 
+import Foundation
 @testable import RevenueCat
 
 class MockInMemoryCachedOfferings<T: Offerings>: InMemoryCachedObject<Offerings> {

--- a/Tests/UnitTests/Mocks/MockReceiptFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockReceiptFetcher.swift
@@ -10,6 +10,7 @@
 //  MockReceiptFetcher.swift
 //
 
+import Foundation
 @testable import RevenueCat
 
 class MockReceiptFetcher: ReceiptFetcher {

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListenerDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListenerDelegate.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Nacho Soto on 11/14/22.
 
+import Foundation
 @testable import RevenueCat
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/Tests/UnitTests/Mocks/MockStoreProductDiscount.swift
+++ b/Tests/UnitTests/Mocks/MockStoreProductDiscount.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Nacho Soto on 1/17/22.
 
+import Foundation
 @_spi(Internal) @testable import RevenueCat
 
 struct MockStoreProductDiscount {

--- a/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
@@ -3,6 +3,7 @@
 // Copyright (c) 2020 Purchases. All rights reserved.
 //
 
+import Foundation
 @testable import RevenueCat
 
 // swiftlint:disable identifier_name

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -78,7 +78,7 @@ class MockSystemInfo: SystemInfo {
 
 extension MockSystemInfo: @unchecked Sendable {}
 
-extension RevenueCat.OperatingSystemVersion: Swift.Comparable {
+extension OperatingSystemVersion: Swift.Comparable {
 
     public static func < (lhs: OperatingSystemVersion, rhs: OperatingSystemVersion) -> Bool {
         if lhs.majorVersion == rhs.majorVersion {


### PR DESCRIPTION
### Motivation
I don't have all the context on why these are missing, but here they are.

### Description
Add missing imports
