### PR TITLE
Use effectiveVersion.debugDescription in StoreKitVersionTests

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -631,6 +631,7 @@
 		57554CC1282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
 		57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
 		575642B62910116900719219 /* EligibilityStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642B52910116900719219 /* EligibilityStrings.swift */; };
+		5757EDE72DEE08C100AC4BE1 /* StoreKitVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5757EDE62DEE08C100AC4BE1 /* StoreKitVersionTests.swift */; };
 		5759B322296DEF56002472D5 /* OptionalExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B321296DEF56002472D5 /* OptionalExtensionsTests.swift */; };
 		5759B3F4296DF65D002472D5 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B36824BD268FBC5B00957E4C /* XCTest.framework */; };
 		5759B3F7296DF65D002472D5 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B335296DF65D002472D5 /* Nimble */; };
@@ -2020,6 +2021,7 @@
 		57554C87282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseOwnershipTypeTests.swift; sourceTree = "<group>"; };
 		57554CC0282AE1E3009A7E58 /* TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
 		575642B52910116900719219 /* EligibilityStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EligibilityStrings.swift; sourceTree = "<group>"; };
+		5757EDE62DEE08C100AC4BE1 /* StoreKitVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitVersionTests.swift; sourceTree = "<group>"; };
 		5759B321296DEF56002472D5 /* OptionalExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalExtensionsTests.swift; sourceTree = "<group>"; };
 		5759B401296DF65D002472D5 /* ReceiptParserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReceiptParserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5759B404296DF6C4002472D5 /* ReceiptParserFetchingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptParserFetchingTests.swift; sourceTree = "<group>"; };
@@ -3792,6 +3794,7 @@
 		35272E1A26D0023400F22C3B /* Misc */ = {
 			isa = PBXGroup;
 			children = (
+				5757EDE62DEE08C100AC4BE1 /* StoreKitVersionTests.swift */,
 				575F19B52D5A29860089A64F /* ISODurationFormatterTests.swift */,
 				576C8A9027D180540058FA6E /* __Snapshots__ */,
 				37E35B9AC7A350CA2437049D /* ISOPeriodFormatterTests.swift */,
@@ -6598,6 +6601,7 @@
 				35109DAB2BC6E436001030C8 /* BackendPostDiagnosticsTests.swift in Sources */,
 				57554C84282AC273009A7E58 /* PeriodTypeTests.swift in Sources */,
 				4FE6FEEA2AA940E300780B45 /* PaywallEventStoreTests.swift in Sources */,
+				5757EDE72DEE08C100AC4BE1 /* StoreKitVersionTests.swift in Sources */,
 				57057FF828B0048900995F21 /* TestLogHandler.swift in Sources */,
 				57E415F12846997B00EA5460 /* PurchasesAttributionDataTests.swift in Sources */,
 				2DDF41CF24F6F4C3005BC22D /* ReceiptParsing+TestsWithRealReceipts.swift in Sources */,

--- a/Tests/UnitTests/Misc/StoreKitVersionTests.swift
+++ b/Tests/UnitTests/Misc/StoreKitVersionTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class StoreKitVersionTests: TestCase {
+final class StoreKitVersionTests: TestCase {
 
     func testDefaultIsStoreKit2() throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()

--- a/Tests/UnitTests/Misc/StoreKitVersionTests.swift
+++ b/Tests/UnitTests/Misc/StoreKitVersionTests.swift
@@ -27,17 +27,17 @@ class StoreKitVersionTests: TestCase {
     func testVersionStringIsStoreKit1IfStoreKit2EnabledButNotAvailable() throws {
         try AvailabilityChecks.iOS15APINotAvailableOrSkipTest()
 
-        expect(StoreKitVersion.storeKit2.versionString) == "1"
+        expect(StoreKitVersion.storeKit2.effectiveVersion.debugDescription) == "1"
     }
 
     func testVersionStringIsStoreKit2IfStoreKit2EnabledAndAvailable() throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        expect(StoreKitVersion.storeKit2.versionString) == "2"
+        expect(StoreKitVersion.storeKit2.effectiveVersion.debugDescription) == "2"
     }
 
     func testVersionStringIsStoreKit1IfStoreKit2NotEnabled() {
-        expect(StoreKitVersion.storeKit1.versionString) == "1"
+        expect(StoreKitVersion.storeKit1.effectiveVersion.debugDescription) == "1"
     }
 
     func testStoreKit2EnabledButNotAvailable() throws {


### PR DESCRIPTION
### Motivation
While trying to fix tests for the workspace, I noticed this is not compiling.


### Description
- Use ` effectiveVersion.debugDescription` instead of `versionString` that does not exist.
- Add test to `UnitTests` testplan
