### PR TITLE
Add hash validation of downloaded font

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -555,7 +555,6 @@
 		570A671C2DD2021400DEBABE /* PurchaseInformation+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570A671B2DD2021000DEBABE /* PurchaseInformation+Mock.swift */; };
 		570A671E2DD2026600DEBABE /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570A671D2DD2026500DEBABE /* Transaction.swift */; };
 		570A67202DD2029D00DEBABE /* IdentifiableURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570A671F2DD2029B00DEBABE /* IdentifiableURL.swift */; };
-		570BDB0A2DE9C71000D703DE /* PaywallFontFetcherType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570BDB092DE9C70F00D703DE /* PaywallFontFetcherType.swift */; };
 		570FAF4B2864EC2300D3C769 /* NonSubscriptionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */; };
 		5712120F2DDC957200A792C7 /* RelevantPurchasesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5712120E2DDC957200A792C7 /* RelevantPurchasesListView.swift */; };
 		5712BE9029241EB500A83F15 /* TimingUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5712BE8F29241EB500A83F15 /* TimingUtil.swift */; };
@@ -854,6 +853,7 @@
 		6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECF627761D375C8431EB866 /* StoreProduct.swift */; };
 		752F94922DD21A1300ED7DFE /* CustomerCenterConfigData+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752F94912DD21A1300ED7DFE /* CustomerCenterConfigData+Mock.swift */; };
 		75425E0F2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75425E0E2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift */; };
+		7542E4E92DEDCC2A002CE340 /* PaywallFontManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7542E4E82DEDCC2A002CE340 /* PaywallFontManagerType.swift */; };
 		756AE8352D8816CD00BA2E39 /* PurchasesDiagnosticsTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756AE8342D8816CD00BA2E39 /* PurchasesDiagnosticsTrackingTests.swift */; };
 		7571BE9F2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7571BE9E2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift */; };
 		75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */; };
@@ -1951,7 +1951,6 @@
 		570A671B2DD2021000DEBABE /* PurchaseInformation+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PurchaseInformation+Mock.swift"; sourceTree = "<group>"; };
 		570A671D2DD2026500DEBABE /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
 		570A671F2DD2029B00DEBABE /* IdentifiableURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableURL.swift; sourceTree = "<group>"; };
-		570BDB092DE9C70F00D703DE /* PaywallFontFetcherType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallFontFetcherType.swift; sourceTree = "<group>"; };
 		570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonSubscriptionTransaction.swift; sourceTree = "<group>"; };
 		5712120E2DDC957200A792C7 /* RelevantPurchasesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelevantPurchasesListView.swift; sourceTree = "<group>"; };
 		5712BE8F29241EB500A83F15 /* TimingUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingUtil.swift; sourceTree = "<group>"; };
@@ -2208,6 +2207,7 @@
 		57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreTransaction.swift; sourceTree = "<group>"; };
 		752F94912DD21A1300ED7DFE /* CustomerCenterConfigData+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerCenterConfigData+Mock.swift"; sourceTree = "<group>"; };
 		75425E0E2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentsDataTests.swift; sourceTree = "<group>"; };
+		7542E4E82DEDCC2A002CE340 /* PaywallFontManagerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallFontManagerType.swift; sourceTree = "<group>"; };
 		756AE8342D8816CD00BA2E39 /* PurchasesDiagnosticsTrackingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesDiagnosticsTrackingTests.swift; sourceTree = "<group>"; };
 		7571BE9E2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift; sourceTree = "<group>"; };
 		75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerUIPreviewModeTests.swift; sourceTree = "<group>"; };
@@ -4343,7 +4343,7 @@
 		4F87610D2A5C9E330006FA14 /* Paywalls */ = {
 			isa = PBXGroup;
 			children = (
-				570BDB092DE9C70F00D703DE /* PaywallFontFetcherType.swift */,
+				7542E4E82DEDCC2A002CE340 /* PaywallFontManagerType.swift */,
 				88AD010B2C740CF400AA1F2B /* Components */,
 				4FD368B22AA7CFDD00F63354 /* Events */,
 				4FBBD4E52A620573001CBA21 /* PaywallColor.swift */,
@@ -6239,7 +6239,6 @@
 				88AD010F2C740CF400AA1F2B /* PaywallImageComponent.swift in Sources */,
 				4FD3688B2AA7C12600F63354 /* PaywallEvent.swift in Sources */,
 				5766AA3E283C750300FA6091 /* Operators+Extensions.swift in Sources */,
-				570BDB0A2DE9C71000D703DE /* PaywallFontFetcherType.swift in Sources */,
 				1ED4CA532CC154E00021AB8F /* WebPurchaseRedemptionHelper.swift in Sources */,
 				4FFCED892AA941D200118EF4 /* PaywallHTTPRequestPath.swift in Sources */,
 				FDAADFD12BE2B87000BD1659 /* StoreKit2ObserverModePurchaseDetector.swift in Sources */,
@@ -6563,6 +6562,7 @@
 				5766C622282DAA700067D886 /* GetIntroEligibilityResponse.swift in Sources */,
 				35E840CC270FB70D00899AE2 /* ManageSubscriptionsHelper.swift in Sources */,
 				6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */,
+				7542E4E92DEDCC2A002CE340 /* PaywallFontManagerType.swift in Sources */,
 				03E37BEA2D30B32200CD9678 /* PaywallTabsComponent.swift in Sources */,
 				FD20467F2CB82F2000166727 /* StoreKit2PurchaseIntentListener.swift in Sources */,
 				B34605BD279A6E380031CA74 /* CallbackCacheStatus.swift in Sources */,

--- a/Sources/FoundationExtensions/Data+Extensions.swift
+++ b/Sources/FoundationExtensions/Data+Extensions.swift
@@ -58,6 +58,11 @@ extension Data {
         return self.hash(with: &sha1)
     }
 
+    var md5String: String {
+        var md5 = Insecure.MD5()
+        return self.hashString(with: &md5)
+    }
+
     fileprivate static func hexString(_ iterator: Array<UInt8>.Iterator) -> String {
         return iterator
             .lazy

--- a/Sources/Logging/Strings/PaywallsStrings.swift
+++ b/Sources/Logging/Strings/PaywallsStrings.swift
@@ -21,7 +21,7 @@ enum PaywallsStrings {
     case warming_up_images(imageURLs: Set<URL>)
     case warming_up_fonts(fontsURLS: Set<URL>)
     case error_prefetching_image(URL, Error)
-    case error_prefetching_font(URL, Error)
+    case error_installing_font(URL, Error)
     case error_prefetching_font_invalid_url(String)
 
     case caching_presented_paywall
@@ -68,7 +68,7 @@ extension PaywallsStrings: LogMessage {
         case let .error_prefetching_image(url, error):
             return "Error pre-fetching paywall image '\(url)': \((error as NSError).description)"
 
-        case let .error_prefetching_font(url, error):
+        case let .error_installing_font(url, error):
             return "Error pre-fetching paywall font '\(url)': \((error as NSError).description)"
 
         case let .error_prefetching_font_invalid_url(urlString):

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -181,7 +181,7 @@ final class PaywallCacheWarmingTests: TestCase {
         let mockFileManager = MockFileManager()
         let mockRegistrar = MockRegistrar()
 
-        let sut = DefaultPaywallFontsFetcher(
+        let sut = DefaultPaywallFontsManager(
             fileManager: mockFileManager,
             session: mockSession,
             registrar: mockRegistrar
@@ -204,7 +204,7 @@ final class PaywallCacheWarmingTests: TestCase {
         mockFileManager.fileExistsAtPath = true
         let mockRegistrar = MockRegistrar()
 
-        let sut = DefaultPaywallFontsFetcher(
+        let sut = DefaultPaywallFontsManager(
             fileManager: mockFileManager,
             session: mockSession,
             registrar: mockRegistrar
@@ -299,7 +299,10 @@ private final class MockSession: FontDownloadSession {
     }
 }
 
-private final class MockFileManager: FileManaging {
+private final class MockFileManager: FontsFileManaging {
+    func cachesDirectory() throws -> URL {
+        return URL(fileURLWithPath: "/tmp/RevenueCatTestSupport", isDirectory: true)
+    }
 
     var fileExistsAtPath = false
     func fileExists(atPath path: String) -> Bool {
@@ -313,10 +316,6 @@ private final class MockFileManager: FileManaging {
     func write(_ data: Data, to url: URL) throws {
         didWriteData = true
         didWriteDataToURL = url
-    }
-
-    func applicationSupportDirectory() throws -> URL {
-        return URL(fileURLWithPath: "/tmp/RevenueCatTestSupport", isDirectory: true)
     }
 }
 


### PR DESCRIPTION
Implements downloaded font hash validation.

### Considerations
* Using md5 (this can change potentially before merging)
* Changed to use `cachesDirectory()` instead of `applicationSupportDirectory()`, since I believe it's more appropriate (the fonts cache is reproducible data that can be purged by the system if needed).
* Implemented `withTaskGroup` in `warmUpPaywallFontsCache()` for concurrent font installation.
* Renamed `FontsFetcher` to `FontsManager`, since it contains more logic besides fetching the fonts.
* Renamed `DefaultPaywallFontsFetcher.UnknownError` to be `DefaultPaywallFontsManager.FontsManagerError` to also contain more detailed information about what failed.