### PR TITLE
Trigger download of font that failed to load in a paywall

### DIFF
--- a/RevenueCatUI/Purchasing/MockPurchases.swift
+++ b/RevenueCatUI/Purchasing/MockPurchases.swift
@@ -65,9 +65,13 @@ final class MockPurchases: PaywallPurchasesType {
         await self.trackEventBlock(paywallEvent)
     }
 
+#if !os(macOS) && !os(tvOS)
+
     func failedToLoadFontWithConfig(_ fontConfig: UIConfig.FontsConfig) {
         // No-op, this is a mock implementation.
     }
+
+#endif
 
 }
 

--- a/RevenueCatUI/Purchasing/MockPurchases.swift
+++ b/RevenueCatUI/Purchasing/MockPurchases.swift
@@ -65,6 +65,10 @@ final class MockPurchases: PaywallPurchasesType {
         await self.trackEventBlock(paywallEvent)
     }
 
+    func failedToLoadFontWithConfig(_ fontConfig: UIConfig.FontsConfig) {
+        // No-op, this is a mock implementation.
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
+++ b/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Nacho Soto on 9/12/23.
 
-import RevenueCat
+@_spi(Internal) import RevenueCat
 
 /// A simplified protocol for the subset of `PurchasesType` needed for `RevenueCatUI`.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -30,6 +30,9 @@ protocol PaywallPurchasesType: Sendable {
 
     @Sendable
     func track(paywallEvent: PaywallEvent) async
+
+    @Sendable
+    func failedToLoadFontWithConfig(_ fontConfig: UIConfig.FontsConfig)
 
 }
 

--- a/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
+++ b/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
@@ -31,8 +31,12 @@ protocol PaywallPurchasesType: Sendable {
     @Sendable
     func track(paywallEvent: PaywallEvent) async
 
+#if !os(macOS) && !os(tvOS)
+
     @Sendable
     func failedToLoadFontWithConfig(_ fontConfig: UIConfig.FontsConfig)
+
+#endif
 
 }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -421,7 +421,11 @@ private final class NotConfiguredPurchases: PaywallPurchasesType {
 
     func track(paywallEvent: PaywallEvent) async {}
 
+#if !os(macOS) && !os(tvOS)
+
     func failedToLoadFontWithConfig(_ fontConfig: UIConfig.FontsConfig) {}
+
+#endif
 
 }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -421,6 +421,8 @@ private final class NotConfiguredPurchases: PaywallPurchasesType {
 
     func track(paywallEvent: PaywallEvent) async {}
 
+    func failedToLoadFontWithConfig(_ fontConfig: UIConfig.FontsConfig) {}
+
 }
 
 // MARK: - Preference Keys

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -286,33 +286,8 @@ extension TextComponentStyle {
             return GenericFont.sansSerif.makeFont(fontSize: fontSize)
         }
 
-        let customFont = self.resolveFont(size: fontSize, name: name, uiConfigProvider: uiConfigProvider)
+        let customFont = uiConfigProvider.resolveFont(size: fontSize, name: name)
         return customFont ?? GenericFont.sansSerif.makeFont(fontSize: fontSize)
-    }
-
-    static private func resolveFont(
-        size fontSize: CGFloat,
-        name: String,
-        uiConfigProvider: UIConfigProvider
-    ) -> Font? {
-        guard let familyName = uiConfigProvider.getFontFamily(for: name)  else {
-            Logger.warning("Mapping for '\(name)' could not be found. Falling back to system font.")
-            return nil
-        }
-
-        // Check if the family name is a generic font (serif, sans-serif, monospace)
-        if let genericFont = GenericFont(rawValue: familyName) {
-            return genericFont.makeFont(fontSize: fontSize)
-        }
-
-        guard let customFont = UIFont(name: familyName, size: fontSize) else {
-            Logger.warning("Custom font '\(familyName)' could not be loaded. Falling back to system font.")
-            return nil
-        }
-
-        // Apply dynamic type scaling
-        let uiFont = UIFontMetrics.default.scaledFont(for: customFont)
-        return Font(uiFont)
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -43,6 +43,7 @@ class TextComponentViewModel {
     }
 
     @ViewBuilder
+    @MainActor
     func styles(
         state: ComponentViewState,
         condition: ScreenCondition,
@@ -213,6 +214,7 @@ extension LocalizedTextPartial {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
 struct TextComponentStyle {
 
     let visible: Bool
@@ -280,6 +282,7 @@ enum GenericFont: String {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension TextComponentStyle {
 
+    @MainActor
     static func makeFont(size fontSize: CGFloat, name: String?, uiConfigProvider: UIConfigProvider) -> Font {
         // Use default font if no name given
         guard let name = name else {

--- a/RevenueCatUI/Templates/V2/ViewHelpers/DisplayableColor.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/DisplayableColor.swift
@@ -17,6 +17,7 @@ import SwiftUI
 
 #if !os(macOS) && !os(tvOS) // For Paywalls V2
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PaywallComponent.Background {
 
     func asDisplayable(uiConfigProvider: UIConfigProvider) -> BackgroundStyle {
@@ -61,6 +62,7 @@ enum DisplayableColorInfo: Codable, Sendable, Hashable {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension DisplayableColorScheme {
 
     static func from(colorScheme: PaywallComponent.ColorScheme,
@@ -73,6 +75,7 @@ extension DisplayableColorScheme {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PaywallComponent.ColorScheme {
 
     func asDisplayable(uiConfigProvider: UIConfigProvider) -> DisplayableColorScheme {
@@ -86,6 +89,7 @@ extension PaywallComponent.ColorScheme {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PaywallComponent.ColorInfo {
 
     func asDisplayable(forLight: Bool, uiConfigProvider: UIConfigProvider) throws -> DisplayableColorInfo {

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -18,7 +18,7 @@ import SwiftUI
 #if !os(macOS) && !os(tvOS) // For Paywalls V2
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-final class UIConfigProvider: Sendable {
+struct UIConfigProvider {
     private let uiConfig: UIConfig
     private let purchases: PaywallPurchasesType
 

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -13,15 +13,18 @@
 
 import Foundation
 import RevenueCat
+import SwiftUI
 
 #if !os(macOS) && !os(tvOS) // For Paywalls V2
 
-struct UIConfigProvider {
-
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class UIConfigProvider: Sendable {
     private let uiConfig: UIConfig
+    private let purchases: PaywallPurchasesType
 
-    init(uiConfig: UIConfig) {
+    init(uiConfig: UIConfig, purchases: PaywallPurchasesType = Purchases.shared) {
         self.uiConfig = uiConfig
+        self.purchases = purchases
     }
 
     var variableConfig: UIConfig.VariableConfig {
@@ -30,23 +33,6 @@ struct UIConfigProvider {
 
     func getColor(for name: String) -> PaywallComponent.ColorScheme? {
         return self.uiConfig.app.colors[name]
-    }
-
-    func getFontFamily(for name: String?) -> String? {
-        guard let name, let fontInfo = self.uiConfig.app.fonts[name]?.ios else {
-            return nil
-        }
-
-        switch fontInfo {
-        case .name(let fontFamily):
-            return fontFamily
-        case .googleFonts:
-            // Not supported on this platform (yet)
-            Logger.warning("Google Fonts are not supported on this platform")
-            return nil
-        @unknown default:
-            return nil
-        }
     }
 
     func getLocalizations(for locale: Locale) -> [String: String] {
@@ -58,6 +44,40 @@ struct UIConfigProvider {
         return localizations
     }
 
+    func resolveFont(size fontSize: CGFloat, name: String) -> Font? {
+
+        guard let fontsConfig = self.uiConfig.app.fonts[name] else {
+            Logger.warning("Mapping for '\(name)' could not be found. Falling back to system font.")
+            return nil
+        }
+
+        let familyName: String
+        switch fontsConfig.ios {
+        case .name(let fontFamilyName):
+            familyName = fontFamilyName
+        case .googleFonts:
+            // Not supported on this platform (yet)
+            Logger.warning("Google Fonts are not supported on this platform")
+            return nil
+        @unknown default:
+            return nil
+        }
+
+        // Check if the family name is a generic font (serif, sans-serif, monospace)
+        if let genericFont = GenericFont(rawValue: familyName) {
+            return genericFont.makeFont(fontSize: fontSize)
+        }
+
+        guard let customFont = UIFont(name: familyName, size: fontSize) else {
+            Logger.warning("Custom font '\(familyName)' could not be loaded. Falling back to system font.")
+            self.purchases.failedToLoadFontWithConfig(fontsConfig)
+            return nil
+        }
+
+        // Apply dynamic type scaling
+        let uiFont = UIFontMetrics.default.scaledFont(for: customFont)
+        return Font(uiFont)
+    }
 }
 
 #endif

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -44,6 +44,7 @@ struct UIConfigProvider {
         return localizations
     }
 
+    @MainActor
     func resolveFont(size fontSize: CGFloat, name: String) -> Font? {
 
         guard let fontsConfig = self.uiConfig.app.fonts[name] else {

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -51,10 +51,10 @@ final class UIConfigProvider: Sendable {
             return nil
         }
 
-        let familyName: String
+        let fontName: String
         switch fontsConfig.ios {
-        case .name(let fontFamilyName):
-            familyName = fontFamilyName
+        case .name(let name):
+            fontName = name
         case .googleFonts:
             // Not supported on this platform (yet)
             Logger.warning("Google Fonts are not supported on this platform")
@@ -63,13 +63,13 @@ final class UIConfigProvider: Sendable {
             return nil
         }
 
-        // Check if the family name is a generic font (serif, sans-serif, monospace)
-        if let genericFont = GenericFont(rawValue: familyName) {
+        // Check if the font name is a generic font (serif, sans-serif, monospace)
+        if let genericFont = GenericFont(rawValue: fontName) {
             return genericFont.makeFont(fontSize: fontSize)
         }
 
-        guard let customFont = UIFont(name: familyName, size: fontSize) else {
-            Logger.warning("Custom font '\(familyName)' could not be loaded. Falling back to system font.")
+        guard let customFont = UIFont(name: fontName, size: fontSize) else {
+            Logger.warning("Custom font '\(fontName)' could not be loaded. Falling back to system font.")
             self.purchases.failedToLoadFontWithConfig(fontsConfig)
             return nil
         }

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -171,6 +171,10 @@ private final class LoadingPaywallPurchases: PaywallPurchasesType {
         // Ignoring events from loading paywall view
     }
 
+    func failedToLoadFontWithConfig(_ fontConfig: RevenueCat.UIConfig.FontsConfig) {
+        // Ignoring font loading errors from paywall view
+    }
+
 }
 
 // MARK: - Shimmer

--- a/Sources/Logging/Strings/PaywallsStrings.swift
+++ b/Sources/Logging/Strings/PaywallsStrings.swift
@@ -22,7 +22,8 @@ enum PaywallsStrings {
     case warming_up_fonts(fontsURLS: Set<URL>)
     case error_prefetching_image(URL, Error)
     case error_installing_font(URL, Error)
-    case error_prefetching_font_invalid_url(String)
+    case error_prefetching_font_invalid_url(name: String, invalidURLString: String)
+    case error_prefetching_font_missing_hash(name: String)
 
     case caching_presented_paywall
     case clearing_presented_paywall
@@ -71,8 +72,11 @@ extension PaywallsStrings: LogMessage {
         case let .error_installing_font(url, error):
             return "Error installing font with url: '\(url)': \((error as NSError).description)"
 
-        case let .error_prefetching_font_invalid_url(urlString):
-            return "Error installing font. Invalid url: \(urlString)"
+        case let .error_prefetching_font_invalid_url(name, invalidURLString):
+            return "Error installing font \(name). Invalid url: \(invalidURLString)"
+
+        case let .error_prefetching_font_missing_hash(name):
+            return "Error installing font \(name). Hash is missing"
 
         case .caching_presented_paywall:
             return "PurchasesOrchestrator: caching presented paywall"

--- a/Sources/Logging/Strings/PaywallsStrings.swift
+++ b/Sources/Logging/Strings/PaywallsStrings.swift
@@ -76,7 +76,8 @@ extension PaywallsStrings: LogMessage {
             return "Error installing font \(name). Invalid url: \(invalidURLString)"
 
         case let .error_prefetching_font_missing_hash(name):
-            return "Error installing font \(name). Hash is missing"
+            return "Font \(name) does not have a validation hash. " +
+            "Please try to re-upload the font in the RevenueCat dashboard."
 
         case .caching_presented_paywall:
             return "PurchasesOrchestrator: caching presented paywall"

--- a/Sources/Logging/Strings/PaywallsStrings.swift
+++ b/Sources/Logging/Strings/PaywallsStrings.swift
@@ -69,10 +69,10 @@ extension PaywallsStrings: LogMessage {
             return "Error pre-fetching paywall image '\(url)': \((error as NSError).description)"
 
         case let .error_installing_font(url, error):
-            return "Error pre-fetching paywall font '\(url)': \((error as NSError).description)"
+            return "Error installing font with url: '\(url)': \((error as NSError).description)"
 
         case let .error_prefetching_font_invalid_url(urlString):
-            return "Error pre-fetching font with url: \(urlString)"
+            return "Error installing font. Invalid url: \(urlString)"
 
         case .caching_presented_paywall:
             return "PurchasesOrchestrator: caching presented paywall"

--- a/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
@@ -32,15 +32,18 @@ public struct UIConfig: Codable, Equatable, Sendable {
     }
 
     public struct FontsConfig: Codable, Equatable, Sendable {
+        public var family: String?
         public var ios: FontInfo
         public var web: WebFontInfo?
 
         public init(
             ios: FontInfo,
-            web: WebFontInfo? = nil
+            web: WebFontInfo? = nil,
+            family: String? = nil
         ) {
             self.ios = ios
             self.web = web
+            self.family = family
         }
     }
 

--- a/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
@@ -100,12 +100,10 @@ public struct UIConfig: Codable, Equatable, Sendable {
     public struct WebFontInfo: Codable, Sendable, Hashable {
         public var value: String
         public var hash: String
-        public var type: String
 
-        public init(value: String, hash: String, type: String) {
+        public init(value: String, hash: String) {
             self.value = value
             self.hash = hash
-            self.type = type
         }
     }
 

--- a/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
@@ -99,6 +99,11 @@ public struct UIConfig: Codable, Equatable, Sendable {
 
     public struct WebFontInfo: Codable, Sendable, Hashable {
         public var value: String
+
+        /// MD5 hash of the font file.
+        ///
+        /// Should never be `nil`, but it is optional to prevent potential decoding errors if, for some reason,
+        /// the hash is not provided from the server.
         public var hash: String?
 
         public init(value: String, hash: String?) {

--- a/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
@@ -99,9 +99,9 @@ public struct UIConfig: Codable, Equatable, Sendable {
 
     public struct WebFontInfo: Codable, Sendable, Hashable {
         public var value: String
-        public var hash: String
+        public var hash: String?
 
-        public init(value: String, hash: String) {
+        public init(value: String, hash: String?) {
             self.value = value
             self.hash = hash
         }

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -158,7 +158,7 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
             do {
                 try await self.fontsManager.installFont(from: font.url, hash: font.hash)
             } catch {
-                Logger.error(Strings.paywalls.error_prefetching_image(font.url, error))
+                Logger.error(Strings.paywalls.error_installing_font(font.url, error))
             }
         }
 

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -140,6 +140,10 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
         #if canImport(UIKit)
         if let fontFamily = font.fontFamily {
             availableFontNames = UIFont.fontNames(forFamilyName: fontFamily)
+        } else {
+            availableFontNames = UIFont.familyNames.flatMap {
+                UIFont.fontNames(forFamilyName: $0)
+            }
         }
         #elseif canImport(AppKit)
         availableFontNames = NSFontManager.shared.availableFonts

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -370,7 +370,7 @@ private extension UIConfig.FontsConfig {
         return nil
     }
 
-    var iOSName: String? {
+    private var iOSName: String? {
         switch self.ios {
         case .googleFonts:
             return nil
@@ -379,16 +379,30 @@ private extension UIConfig.FontsConfig {
         }
     }
 
+    private var nameForError: String {
+        switch self.ios {
+        case .googleFonts(let name), .name(let name):
+            return name
+        }
+
+    }
+
     var downloadURLAndHash: (URL, String)? {
         guard let web = self.web else {
             return nil
         }
 
         guard let url = URL(string: web.value) else {
-            Logger.error(PaywallsStrings.error_prefetching_font_invalid_url(web.value))
+            Logger.error(PaywallsStrings.error_prefetching_font_invalid_url(name: self.nameForError,
+                                                                            invalidURLString: web.value))
             return nil
         }
-        return (url, web.hash)
+
+        guard let hash = web.hash else {
+            Logger.error(PaywallsStrings.error_prefetching_font_missing_hash(name: self.nameForError))
+            return nil
+        }
+        return (url, hash)
     }
 }
 

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -358,7 +358,7 @@ private extension UIConfig.FontsConfig {
            let (url, hash) = self.downloadURLAndHash {
             return DownloadableFont(
                 name: iOSName,
-                fontFamily: self.fontFamily,
+                fontFamily: self.family,
                 url: url,
                 hash: hash
             )

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -123,7 +123,6 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
     /// Downloads and installs the font if it is not already installed.
     func triggerFontDownloadIfNeeded(fontsConfig: UIConfig.FontsConfig) async {
         guard let downloadableFont = fontsConfig.downloadableFont else { return }
-        
         await self.installFont(from: downloadableFont)
     }
 
@@ -163,11 +162,8 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
         }
 
         ongoingFontDownloads[font] = task
-        defer {
-            ongoingFontDownloads[font] = nil
-        }
-
         await task.value
+        ongoingFontDownloads[font] = nil
     }
 
 }
@@ -318,7 +314,6 @@ private extension Offering {
                 .map(\.storeProduct.productIdentifier)
         )
     }
-
 }
 
 private extension PaywallData.Configuration.Images {
@@ -328,10 +323,8 @@ private extension PaywallData.Configuration.Images {
             self.header,
             self.background,
             self.icon
-        ]
-            .compactMap { $0 }
+        ].compactMap { $0 }
     }
-
 }
 
 private struct DownloadableFont: Hashable, Sendable {
@@ -384,13 +377,10 @@ private extension UIConfig.FontsConfig {
         case .googleFonts(let name), .name(let name):
             return name
         }
-
     }
 
     var downloadURLAndHash: (URL, String)? {
-        guard let web = self.web else {
-            return nil
-        }
+        guard let web = self.web else { return nil }
 
         guard let url = URL(string: web.value) else {
             Logger.error(PaywallsStrings.error_prefetching_font_invalid_url(name: self.nameForError,
@@ -402,6 +392,7 @@ private extension UIConfig.FontsConfig {
             Logger.error(PaywallsStrings.error_prefetching_font_missing_hash(name: self.nameForError))
             return nil
         }
+
         return (url, hash)
     }
 }

--- a/Sources/Paywalls/PaywallFontManagerType.swift
+++ b/Sources/Paywalls/PaywallFontManagerType.swift
@@ -23,8 +23,6 @@ struct SystemFontRegistry: FontRegistrar {
     func registerFont(at url: URL) throws {
         var errorRef: Unmanaged<CFError>?
 
-        // WIP: Check if already registered??
-
         if !CTFontManagerRegisterFontsForURL(url as CFURL, .process, &errorRef) {
             throw DefaultPaywallFontsManager.FontsManagerError.registrationError(errorRef?.takeUnretainedValue())
         }
@@ -116,7 +114,7 @@ actor DefaultPaywallFontsManager: PaywallFontManagerType {
 
     private func fileURLForFontAtRemoteURL(_ remoteURL: URL) throws -> URL {
         let fontsDirectory = try fontsDirectory()
-        let fileName = remoteURL.lastPathComponent
+        let fileName = Data(remoteURL.absoluteString.utf8).md5String + remoteURL.pathExtension
         return fontsDirectory.appendingPathComponent(fileName, isDirectory: false)
     }
 

--- a/Sources/Paywalls/PaywallFontManagerType.swift
+++ b/Sources/Paywalls/PaywallFontManagerType.swift
@@ -114,7 +114,7 @@ actor DefaultPaywallFontsManager: PaywallFontManagerType {
 
     private func fileURLForFontAtRemoteURL(_ remoteURL: URL) throws -> URL {
         let fontsDirectory = try fontsDirectory()
-        let fileName = Data(remoteURL.absoluteString.utf8).md5String + remoteURL.pathExtension
+        let fileName = Data(remoteURL.absoluteString.utf8).md5String + "." + remoteURL.pathExtension
         return fontsDirectory.appendingPathComponent(fileName, isDirectory: false)
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1331,12 +1331,16 @@ public extension Purchases {
         return CustomerCenterConfigData(from: response)
     }
 
+#if !os(macOS) && !os(tvOS)
+
     /// Used by `RevenueCatUI` to notify `RevenueCat` when a font in a paywall fails to load.
     @_spi(Internal) func failedToLoadFontWithConfig(_ fontConfig: UIConfig.FontsConfig) {
         self.operationDispatcher.dispatchOnWorkerThread {
             await self.paywallCache?.triggerFontDownloadIfNeeded(fontsConfig: fontConfig)
         }
     }
+
+#endif
 
     /// Used by `RevenueCatUI` to download and cache paywall images.
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1331,6 +1331,11 @@ public extension Purchases {
         return CustomerCenterConfigData(from: response)
     }
 
+    /// Used by `RevenueCatUI` to notify `RevenueCat` when a font in a paywall fails to load.
+    @_spi(Internal) func failedToLoadFontWithConfig(_ fontConfig: UIConfig.FontsConfig) {
+        
+    }
+
     /// Used by `RevenueCatUI` to download and cache paywall images.
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
     static let paywallImageDownloadSession: URLSession = PaywallCacheWarming.downloadSession

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1333,7 +1333,9 @@ public extension Purchases {
 
     /// Used by `RevenueCatUI` to notify `RevenueCat` when a font in a paywall fails to load.
     @_spi(Internal) func failedToLoadFontWithConfig(_ fontConfig: UIConfig.FontsConfig) {
-        
+        self.operationDispatcher.dispatchOnWorkerThread {
+            await self.paywallCache?.triggerFontDownloadIfNeeded(fontsConfig: fontConfig)
+        }
     }
 
     /// Used by `RevenueCatUI` to download and cache paywall images.


### PR DESCRIPTION
### Motivation
When a paywall fails to load a custom font, the font should be tried to be downloaded when applicable

### Description
When a paywall fails to load, `Purchases` gets notified and triggers the font download