### PR TITLE
Use env openURL instead of SFSafariVC to open mailto

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -34,6 +34,9 @@ struct SubscriptionDetailView: View {
     @Environment(\.navigationOptions)
     var navigationOptions
 
+    @Environment(\.openURL)
+    var openURL
+
     @Environment(\.supportInformation)
     private var support
 
@@ -184,7 +187,8 @@ struct SubscriptionDetailView: View {
                 if let url = support?.supportURL(
                     localization: localization,
                     purchasesProvider: viewModel.purchasesProvider
-                ), viewModel.shouldShowContactSupport,
+                ),
+                   viewModel.shouldShowContactSupport,
                    URLUtilities.canOpenURL(url) || RuntimeUtils.isSimulator {
                     contactSupportView(url)
                         .padding(.top)
@@ -210,7 +214,7 @@ struct SubscriptionDetailView: View {
             if RuntimeUtils.isSimulator {
                 self.showSimulatorAlert = true
             } else {
-                viewModel.inAppBrowserURL = IdentifiableURL(url: url)
+                openURL(url)
             }
         } label: {
             CompatibilityLabeledContent(localization[.contactSupport])


### PR DESCRIPTION
### Motivation
https://github.com/RevenueCat/purchases-ios/issues/5219

### Description
Use environment `openURL` instead of SFSafariVC to open the mailto URL
