### PR TITLE
Adds `showStoreMessagesAutomatically` parameter to CEC mode

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1454,11 +1454,11 @@ public extension Purchases {
     @objc(configureInCustomEntitlementsModeWithApiKey:appUserID:)
     @discardableResult static func configureInCustomEntitlementsComputationMode(apiKey: String,
                                                                                 appUserID: String) -> Purchases {
-        Self.configure(
-            with: .builder(withAPIKey: apiKey)
-                .with(appUserID: appUserID)
-                .with(dangerousSettings: DangerousSettings(customEntitlementComputation: true))
-                .build())
+        Self.configureInCustomEntitlementsComputationMode(
+            apiKey: apiKey,
+            appUserID: appUserID,
+            showStoreMessagesAutomatically: true
+        )
     }
 
     /**

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -182,6 +182,10 @@ func checkNonAsyncMethods(_ purchases: Purchases) {
 }
 
 private func checkConfigure() -> Purchases! {
+	    Purchases.configureInCustomEntitlementsComputationMode(
+        apiKey: "",
+        appUserID: ""
+    )
     Purchases.configureInCustomEntitlementsComputationMode(
         apiKey: "",
         appUserID: "",


### PR DESCRIPTION
## Description
This adds the `showStoreMessagesAutomatically` parameter to the `configureInCustomEntitlementsComputationMode()` function, with a default value. There's no `configure(Configuration)` function in v4 as far as I can tell. This is a source compatible change, which I think is sufficient (we don't ship binaries). Let me know if you think otherwise!

Let me know if I missed anything!

## TODO
- [x] Delete lingering v4 release branches.
- [x] Recreate `release/4.43.5` from the tag.
- [x] Target `release/4.43.5`.
- [x] Merge this PR.
- [ ] `bundle exec fastlane bump` from `release/4.43.5`, which will create `release/4.43.6` and a release PR. 
- [ ] Cherry-pick the changes into `main`.