### PR TITLE
Reset alertType state for RestorePurchasesAlertViewModel before dismissing

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RestorePurchasesAlert.swift
@@ -171,6 +171,7 @@ struct RestorePurchasesAlert: View {
     private func dismissAlert() {
         self.customerCenterViewModel.onDismissRestorePurchasesAlert()
         self.isPresented = false
+        self.viewModel.alertType = .loading
     }
 }
 


### PR DESCRIPTION
### Motivation
https://github.com/RevenueCat/purchases-ios/issues/5223

### Description
As the alert is showed using an overlay, we need to make sure the state is reset before showing it again.

