### PR TITLE
Fix StoreKitVersionTests on iOS 15

### DIFF
--- a/Tests/StoreKitUnitTests/TestHelpers/AvailabilityChecks.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/AvailabilityChecks.swift
@@ -62,6 +62,13 @@ enum AvailabilityChecks {
         }
     }
 
+    /// Opposite of `iOS16APIAvailableOrSkipTest`.
+    static func iOS16APINotAvailableOrSkipTest() throws {
+        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+            throw XCTSkip("Test only for older devices")
+        }
+    }
+
     static func skipIfTVOrWatchOSOrMacOS() throws {
         #if os(watchOS) || os(tvOS) || os(macOS)
         throw XCTSkip("Test not for watchOS or tvOS or macOS")

--- a/Tests/UnitTests/Misc/StoreKitVersionTests.swift
+++ b/Tests/UnitTests/Misc/StoreKitVersionTests.swift
@@ -19,19 +19,20 @@ import XCTest
 final class StoreKitVersionTests: TestCase {
 
     func testDefaultIsStoreKit2() throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         expect(StoreKitVersion.default) == .storeKit2
     }
 
     func testVersionStringIsStoreKit1IfStoreKit2EnabledButNotAvailable() throws {
-        try AvailabilityChecks.iOS15APINotAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APINotAvailableOrSkipTest()
 
         expect(StoreKitVersion.storeKit2.effectiveVersion.debugDescription) == "1"
     }
 
     func testVersionStringIsStoreKit2IfStoreKit2EnabledAndAvailable() throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         expect(StoreKitVersion.storeKit2.effectiveVersion.debugDescription) == "2"
     }
@@ -41,13 +42,13 @@ final class StoreKitVersionTests: TestCase {
     }
 
     func testStoreKit2EnabledButNotAvailable() throws {
-        try AvailabilityChecks.iOS15APINotAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APINotAvailableOrSkipTest()
 
         expect(StoreKitVersion.storeKit2.isStoreKit2EnabledAndAvailable) == false
     }
 
     func testStoreKit2EnabledAndAvailable() throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         expect(StoreKitVersion.storeKit2.isStoreKit2EnabledAndAvailable) == true
     }
@@ -57,13 +58,13 @@ final class StoreKitVersionTests: TestCase {
     }
 
     func testStoreKit2NotAvailableOnOlderDevices() throws {
-        try AvailabilityChecks.iOS15APINotAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APINotAvailableOrSkipTest()
 
         expect(StoreKitVersion.isStoreKit2Available) == false
     }
 
     func testStoreKit2AvailableOnNewerDevices() throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
         expect(StoreKitVersion.isStoreKit2Available) == true
     }


### PR DESCRIPTION
### Description
We found in https://github.com/RevenueCat/purchases-ios/pull/5213 that `StoreKitVersionTests` weren't being run. They're now failing in main for iOS 15 only. They're failing because we treat StoreKit 2 as being unavailable on iOS 15. 

I believe that what happened is that the `StoreKitVersionTests` file was excluded from the `UnitTests` test plan before we made StoreKit 2 exclusive to iOS 16+, we didn't update these tests, and didn't notice that they were broken because the tests weren't being run.

This PR updates the tests in `StoreKitVersionTests` to reflect that we treat StoreKit 1 as unavailable on iOS 15.
