### PR TITLE
New schema for `UIConfig.FontInfo`

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -14,7 +14,7 @@
 // swiftlint:disable file_length
 
 import Foundation
-import RevenueCat
+@_spi(Internal) import RevenueCat
 import SwiftUI
 
 #if !os(macOS) && !os(tvOS) // For Paywalls V2
@@ -239,7 +239,7 @@ struct TextComponentView_Previews: PreviewProvider {
                     ),
                     uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
                         fonts: [
-                            "primary": .init(ios: .name("Chalkduster"))
+                            "primary": UIConfig.FontsConfig(ios: UIConfig.FontInfo(name: "Chalkduster"))
                         ]
                     )),
                     component: .init(
@@ -262,7 +262,7 @@ struct TextComponentView_Previews: PreviewProvider {
                     ),
                     uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
                         fonts: [
-                            "primary": .init(ios: .name("Chalkduster"))
+                            "primary": UIConfig.FontsConfig(ios: UIConfig.FontInfo(name: "Chalkduster"))
                         ]
                     )),
                     component: .init(
@@ -285,7 +285,7 @@ struct TextComponentView_Previews: PreviewProvider {
                     ),
                     uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
                         fonts: [
-                            "primary": .init(ios: .name("This Font Does Not Exist"))
+                            "primary": UIConfig.FontsConfig(ios: UIConfig.FontInfo(name: "This Font Does Not Exist"))
                         ]
                     )),
                     component: .init(
@@ -314,7 +314,7 @@ struct TextComponentView_Previews: PreviewProvider {
                     ),
                     uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
                         fonts: [
-                            "generic": .init(ios: .name("serif"))
+                            "generic": UIConfig.FontsConfig(ios: UIConfig.FontInfo(name: "serif"))
                         ]
                     )),
                     component: .init(
@@ -337,7 +337,7 @@ struct TextComponentView_Previews: PreviewProvider {
                     ),
                     uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
                         fonts: [
-                            "generic": .init(ios: .name("sans-serif"))
+                            "generic": UIConfig.FontsConfig(ios: UIConfig.FontInfo(name: "sans-serif"))
                         ]
                     )),
                     component: .init(
@@ -360,7 +360,7 @@ struct TextComponentView_Previews: PreviewProvider {
                     ),
                     uiConfigProvider: .init(uiConfig: PreviewUIConfig.make(
                         fonts: [
-                            "generic": .init(ios: .name("monospace"))
+                            "generic": UIConfig.FontsConfig(ios: UIConfig.FontInfo(name: "monospace"))
                         ]
                     )),
                     component: .init(

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -71,7 +71,7 @@ class TextComponentViewModel {
                 localizations: self.uiConfigProvider.getLocalizations(for: self.localizationProvider.locale)
             ),
             fontName: partial?.fontName ?? self.component.fontName,
-            fontWeight: partial?.fontWeight ?? self.component.fontWeight,
+            fontWeight: partial?.fontWeightResolved ?? self.component.fontWeightResolved,
             color: partial?.color ?? self.component.color,
             backgroundColor: partial?.backgroundColor ?? self.component.backgroundColor,
             size: partial?.size ?? self.component.size,
@@ -184,7 +184,7 @@ struct LocalizedTextPartial: PresentedPartial {
                 visible: otherPartial?.visible ?? basePartial?.visible,
                 text: otherPartial?.text ?? basePartial?.text,
                 fontName: otherPartial?.fontName ?? basePartial?.fontName,
-                fontWeight: otherPartial?.fontWeight ?? basePartial?.fontWeight,
+                fontWeight: otherPartial?.fontWeightResolved ?? basePartial?.fontWeightResolved,
                 color: otherPartial?.color ?? basePartial?.color,
                 backgroundColor: otherPartial?.backgroundColor ?? basePartial?.backgroundColor,
                 padding: otherPartial?.padding ?? basePartial?.padding,

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -12,7 +12,7 @@
 //  Created by Josh Holtz on 1/5/25.
 
 import Foundation
-import RevenueCat
+@_spi(Internal) import RevenueCat
 import SwiftUI
 
 #if !os(macOS) && !os(tvOS) // For Paywalls V2
@@ -53,9 +53,9 @@ struct UIConfigProvider {
         }
 
         let fontName: String
-        switch fontsConfig.ios {
-        case .name(let name):
-            fontName = name
+        switch fontsConfig.ios.type {
+        case .name:
+            fontName = fontsConfig.ios.value
         case .googleFonts:
             // Not supported on this platform (yet)
             Logger.warning("Google Fonts are not supported on this platform")

--- a/Sources/Logging/Strings/PaywallsStrings.swift
+++ b/Sources/Logging/Strings/PaywallsStrings.swift
@@ -27,7 +27,6 @@ enum PaywallsStrings {
     case error_creating_fonts_directory(Error)
     case error_installing_font(URL, Error)
     case error_prefetching_font_invalid_url(name: String, invalidURLString: String)
-    case error_prefetching_font_missing_hash(name: String)
 
     case caching_presented_paywall
     case clearing_presented_paywall
@@ -90,10 +89,6 @@ extension PaywallsStrings: LogMessage {
 
         case let .error_prefetching_font_invalid_url(name, invalidURLString):
             return "Error installing font \(name). Malformed url: \(invalidURLString)"
-
-        case let .error_prefetching_font_missing_hash(name):
-            return "Font \(name) does not have a validation hash. Skipping download. " +
-            "Please try to re-upload the font in the RevenueCat dashboard."
 
         case .caching_presented_paywall:
             return "PurchasesOrchestrator: caching presented paywall"

--- a/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
@@ -44,10 +44,10 @@ public struct UIConfig: Codable, Equatable, Sendable {
         @_spi(Internal) public let value: String
         let webFontInfo: WebFontInfo?
 
-        @_spi(Internal) public init(name: String) {
+        @_spi(Internal) public init(name: String, webFontInfo: WebFontInfo? = nil) {
             self.type = .name
             self.value = name
-            self.webFontInfo = nil
+            self.webFontInfo = webFontInfo
         }
 
         // swiftlint:disable:next nesting
@@ -89,6 +89,12 @@ public struct UIConfig: Codable, Equatable, Sendable {
         /// Should never be `nil`, but it is optional to prevent potential decoding errors if, for some reason,
         /// the hash is not provided from the server.
         internal let hash: String
+
+        @_spi(Internal) public init(url: String, hash: String) {
+            self.family = nil
+            self.url = url
+            self.hash = hash
+        }
     }
 
     public struct VariableConfig: Codable, Equatable, Sendable {

--- a/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
@@ -50,6 +50,7 @@ public struct UIConfig: Codable, Equatable, Sendable {
             self.webFontInfo = nil
         }
 
+        // swiftlint:disable:next nesting
         enum CodingKeys: String, CodingKey {
             case type
             case value
@@ -69,7 +70,7 @@ public struct UIConfig: Codable, Equatable, Sendable {
         }
 
         // swiftlint:disable:next nesting
-        @_spi(Internal) public enum FontInfoType: String, Codable, Sendable{
+        @_spi(Internal) public enum FontInfoType: String, Codable, Sendable {
             case name
             case googleFonts = "google_fonts"
         }

--- a/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
@@ -32,84 +32,62 @@ public struct UIConfig: Codable, Equatable, Sendable {
     }
 
     public struct FontsConfig: Codable, Equatable, Sendable {
-        public var family: String?
-        public var ios: FontInfo
-        public var web: WebFontInfo?
+        @_spi(Internal) public let ios: FontInfo
 
-        public init(
-            ios: FontInfo,
-            web: WebFontInfo? = nil,
-            family: String? = nil
-        ) {
+        @_spi(Internal) public init(ios: FontInfo) {
             self.ios = ios
-            self.web = web
-            self.family = family
         }
     }
 
-    public enum FontInfo: Codable, Sendable, Hashable {
+    @_spi(Internal) public struct FontInfo: Codable, Sendable, Hashable {
+        @_spi(Internal) public let type: FontInfoType
+        @_spi(Internal) public let value: String
+        let webFontInfo: WebFontInfo?
 
-        case name(String)
-        case googleFonts(String)
-
-        public func encode(to encoder: any Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-
-            switch self {
-            case .name(let name):
-                try container.encode(FontInfoTypes.name.rawValue, forKey: .type)
-                try container.encode(name, forKey: .value)
-            case .googleFonts(let name):
-                try container.encode(FontInfoTypes.googleFonts.rawValue, forKey: .type)
-                try container.encode(name, forKey: .value)
-            }
+        @_spi(Internal) public init(name: String) {
+            self.type = .name
+            self.value = name
+            self.webFontInfo = nil
         }
 
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            let type = try container.decode(FontInfoTypes.self, forKey: .type)
-
-            switch type {
-            case .name:
-                let value = try container.decode(String.self, forKey: .value)
-                self = .name(value)
-            case .googleFonts:
-                let value = try container.decode(String.self, forKey: .value)
-                self = .googleFonts(value)
-            }
-        }
-
-        // swiftlint:disable:next nesting
-        private enum CodingKeys: String, CodingKey {
-
+        enum CodingKeys: String, CodingKey {
             case type
             case value
+        }
 
+        @_spi(Internal) public init(from decoder: Decoder) throws {
+            self.webFontInfo = try? WebFontInfo(from: decoder)
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.type = try container.decode(FontInfoType.self, forKey: .type)
+            self.value = try container.decode(String.self, forKey: .value)
+        }
+
+        @_spi(Internal) public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: UIConfig.FontInfo.CodingKeys.self)
+            try container.encode(self.type, forKey: UIConfig.FontInfo.CodingKeys.type)
+            try container.encode(self.value, forKey: UIConfig.FontInfo.CodingKeys.value)
         }
 
         // swiftlint:disable:next nesting
-        private enum FontInfoTypes: String, Decodable {
-
+        @_spi(Internal) public enum FontInfoType: String, Codable, Sendable{
             case name
             case googleFonts = "google_fonts"
-
         }
-
     }
 
-    public struct WebFontInfo: Codable, Sendable, Hashable {
-        public var value: String
+    @_spi(Internal) public struct WebFontInfo: Codable, Sendable, Hashable {
+
+        /// The font family name.
+        internal let family: String?
+
+        /// The remote URL to the font resource file.
+        internal let url: String
 
         /// MD5 hash of the font file.
         ///
         /// Should never be `nil`, but it is optional to prevent potential decoding errors if, for some reason,
         /// the hash is not provided from the server.
-        public var hash: String?
-
-        public init(value: String, hash: String?) {
-            self.value = value
-            self.hash = hash
-        }
+        internal let hash: String
     }
 
     public struct VariableConfig: Codable, Equatable, Sendable {

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -63,7 +63,7 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
 
     private var hasLoadedEligibility = false
     private var hasLoadedImages = false
-    private var ongoingFontDownloads: [DownloadableFont: Task<Void, Never>] = [:]
+    private var ongoingFontDownloads: [URL: Task<Void, Never>] = [:]
 
     init(
         introEligibiltyChecker: TrialOrIntroPriceEligibilityCheckerType,
@@ -129,7 +129,7 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
 #endif
 
     private func installFont(from font: DownloadableFont) async {
-        if let existingTask = ongoingFontDownloads[font] {
+        if let existingTask = ongoingFontDownloads[font.url] {
             // Already downloading, await the existing task.
             Logger.debug(Strings.paywalls.font_download_already_in_progress(
                 name: font.name,
@@ -165,9 +165,9 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
             }
         }
 
-        ongoingFontDownloads[font] = task
+        ongoingFontDownloads[font.url] = task
         await task.value
-        ongoingFontDownloads[font] = nil
+        ongoingFontDownloads[font.url] = nil
     }
 
 }
@@ -332,7 +332,7 @@ private extension PaywallData.Configuration.Images {
 }
 
 /// Business logic object to easily manage the download of fonts.
-struct DownloadableFont: Hashable, Sendable {
+struct DownloadableFont: Sendable {
 
     /// The font name.
     let name: String
@@ -342,11 +342,6 @@ struct DownloadableFont: Hashable, Sendable {
 
     let url: URL
     let hash: String
-
-    func hash(into hasher: inout Hasher) {
-        // Purposedly only hash the url, as two fonts with the same remote URL should only downloaded once
-        hasher.combine(url)
-    }
 }
 
 #if !os(macOS) && !os(tvOS) // For Paywalls V2

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -50,7 +50,7 @@ protocol PaywallImageFetcherType: Sendable {
 protocol PaywallFontManagerType: Sendable {
 
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
-    func installFont(from remoteURL: URL, hash: String) async throws
+    func installFont(_ font: DownloadableFont) async throws
 
 }
 
@@ -159,8 +159,7 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
 
         let task = Task {
             do {
-                try await self.fontsManager.installFont(from: font.url, hash: font.hash)
-                Logger.debug(Strings.paywalls.font_downloaded_sucessfully(name: font.name, fontURL: font.url))
+                try await self.fontsManager.installFont(font)
             } catch {
                 Logger.error(Strings.paywalls.error_installing_font(font.url, error))
             }

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -21,7 +21,6 @@ import UIKit
 import AppKit
 #endif
 
-// swiftlint:disable file_length
 protocol PaywallCacheWarmingType: Sendable {
 
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
@@ -369,7 +368,7 @@ private extension UIConfig.FontsConfig {
                                                                                 invalidURLString: webFontInfo.url))
                 return nil
             }
-            
+
             return DownloadableFont(
                 name: self.ios.value,
                 fontFamily: webFontInfo.family,

--- a/Sources/Paywalls/PaywallFontManagerType.swift
+++ b/Sources/Paywalls/PaywallFontManagerType.swift
@@ -55,7 +55,6 @@ struct DefaultFontFileManager: FontsFileManaging {
         guard let url = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first else {
             throw CocoaError(.fileNoSuchFile)
         }
-        print("cache directory: \(url)")
         return url
     }
 }

--- a/Sources/Paywalls/PaywallFontManagerType.swift
+++ b/Sources/Paywalls/PaywallFontManagerType.swift
@@ -118,7 +118,6 @@ actor DefaultPaywallFontsManager: PaywallFontManagerType {
                 throw FontsManagerError.hashValidationError(expected: hash, actual: dataHash)
             }
 
-            print("Font: valid hash for \(remoteURL). Installing to \(destination.path)")
             try fileManager.write(data, to: destination)
         }
 

--- a/Sources/Paywalls/PaywallFontManagerType.swift
+++ b/Sources/Paywalls/PaywallFontManagerType.swift
@@ -55,6 +55,7 @@ struct DefaultFontFileManager: FontsFileManaging {
         guard let url = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first else {
             throw CocoaError(.fileNoSuchFile)
         }
+        print("cache directory: \(url)")
         return url
     }
 }
@@ -95,7 +96,8 @@ actor DefaultPaywallFontsManager: PaywallFontManagerType {
         }
     }
 
-    func installFont(from remoteURL: URL, hash: String) async throws {
+    func installFont(_ font: DownloadableFont) async throws {
+        let remoteURL = font.url
         guard let destination = self.fileURLForFontAtRemoteURL(remoteURL) else {
             return
         }
@@ -113,12 +115,14 @@ actor DefaultPaywallFontsManager: PaywallFontManagerType {
                 throw FontsManagerError.downloadError(httpStatusCode)
             }
 
-            let dataHash = data.md5String
-            guard dataHash == hash else {
-                throw FontsManagerError.hashValidationError(expected: hash, actual: dataHash)
+            let expectedHash = font.hash
+            let actualHash = data.md5String
+            guard actualHash == expectedHash else {
+                throw FontsManagerError.hashValidationError(expected: expectedHash, actual: actualHash)
             }
 
             try fileManager.write(data, to: destination)
+            Logger.debug(Strings.paywalls.font_downloaded_sucessfully(name: font.name, fontURL: remoteURL))
         }
 
         try registrar.registerFont(at: destination)
@@ -155,7 +159,7 @@ extension DefaultPaywallFontsManager.FontsManagerError: CustomStringConvertible 
         case let .registrationError(error):
             return "Font registration error: \(error?.localizedDescription ?? "Unknown error")"
         case let .hashValidationError(expected, actual):
-            return "Font download MD5 mismatch. Expected: \(expected), Actual: \(actual)"
+            return "Downloaded font file is corrupt. Hash mismatch. Expected: \(expected), Actual: \(actual)"
         }
     }
 }

--- a/Tests/UnitTests/Networking/Responses/UIConfigDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/UIConfigDecodingTests.swift
@@ -12,7 +12,7 @@
 //  Created by Josh Holtz on 12/31/24.
 
 import Nimble
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import XCTest
 
 #if !os(macOS) && !os(tvOS) // For Paywalls V2
@@ -36,7 +36,7 @@ class UIConfigDecodingTests: BaseHTTPResponseTest {
             ]))
         ]))
         expect(uiConfig.app.fonts).to(equal([
-            "primary": .init(ios: .name("SF Pro"))
+            "primary": .init(ios: UIConfig.FontInfo(name: "SF Pro"))
         ]))
 
         expect(uiConfig.localizations).to(equal([

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -12,7 +12,7 @@
 //  Created by Nacho Soto on 8/7/23.
 
 import Nimble
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import XCTest
 
 @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
@@ -193,8 +193,10 @@ final class PaywallCacheWarmingTests: TestCase {
 
         // Launch two tasks installing the same font concurrently
         let fontsConfig = UIConfig.FontsConfig(
-            ios: .name(font.name),
-            web: UIConfig.WebFontInfo(value: font.url.absoluteString, hash: font.hash)
+            ios: UIConfig.FontInfo(
+                name: font.name,
+                webFontInfo: UIConfig.WebFontInfo(url: font.url.absoluteString, hash: font.hash)
+            )
         )
 
         async let firstCall: () = cache.triggerFontDownloadIfNeeded(fontsConfig: fontsConfig)

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -207,12 +207,6 @@ final class PaywallCacheWarmingTests: TestCase {
         XCTAssertEqual(callCount, 1, "Expected only one font installation")
 
         self.logger.verifyMessageWasLogged(
-            PaywallsStrings.font_downloaded_sucessfully(name: font.name, fontURL: font.url),
-            level: .debug,
-            expectedCount: 1
-        )
-
-        self.logger.verifyMessageWasLogged(
             PaywallsStrings.font_download_already_in_progress(name: font.name, fontURL: font.url),
             level: .debug,
             expectedCount: 1

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -243,8 +243,9 @@ final class PaywallCacheWarmingTests: TestCase {
 
         let url = URL(string: "https://example.com/font.ttf")!
         mockFileManager.fileExistsAtPath = false
+        let font = DownloadableFont(name: "font-bold", fontFamily: "font", url: url, hash: hash)
 
-        try await sut.installFont(from: url, hash: hash)
+        try await sut.installFont(font)
 
         expect(mockSession.didCallDataFrom).to(beTrue())
         expect(mockFileManager.didWriteData).to(beTrue())
@@ -273,8 +274,9 @@ final class PaywallCacheWarmingTests: TestCase {
         )
 
         let url = URL(string: "https://example.com/font.ttf")!
+        let font = DownloadableFont(name: "font-bold", fontFamily: "font", url: url, hash: "expectedhash")
         do {
-            try await sut.installFont(from: url, hash: "expectedhash")
+            try await sut.installFont(font)
             fail("Expected to throw hashValidationError")
         } catch let error as DefaultPaywallFontsManager.FontsManagerError {
             guard case .hashValidationError(let expected, let actual) = error else {
@@ -311,13 +313,14 @@ final class PaywallCacheWarmingTests: TestCase {
         )
 
         let url = URL(string: "https://example.com/font.ttf")!
+        let font = DownloadableFont(name: "font-bold", fontFamily: "font", url: url, hash: hash)
 
         // First install: should download, write, register
-        try await sut.installFont(from: url, hash: hash)
+        try await sut.installFont(font)
         fileManager.fileExistsAtPath = true
 
         // Second install: should skip download/write, but still register
-        try await sut.installFont(from: url, hash: hash)
+        try await sut.installFont(font)
 
         expect(session.dataFromURLCallCount).to(equal(1))
         expect(registrar.registerFontCallCount).to(equal(2))
@@ -453,7 +456,7 @@ final actor MockFontsManager: PaywallFontManagerType {
         self.installDelayInSeconds = installDelayInSeconds
     }
 
-    func installFont(from remoteURL: URL, hash: String) async throws {
+    func installFont(_ font: RevenueCat.DownloadableFont) async throws {
         installCallCount += 1
 
         let duration = UInt64(installDelayInSeconds * 1_000_000_000)


### PR DESCRIPTION

Support new (backwards-compatible) JSON Format for `UIConfig.FontInfo`. Example:
```json
"font_id": {
    "android": {
        "family": "Good Sans",
        "hash": "1234567890qwertyuiop",
        "style": "normal",
        "type": "name",
        "url": "https://fonts.pawwalls.com/font_file.otf",
        "value": "GoodSans-Light",
        "weight": "300"
    },
    "ios": {
        "family": "Good Sans",
        "hash": "1234567890qwertyuiop",
        "style": "normal",
        "type": "name",
        "url": "https://fonts.pawwalls.com/font_file.otf",
        "value": "GoodSans-Light",
        "weight": "300"
    },
    "web": {
        "family": "Good Sans",
        "hash": "1234567890qwertyuiop",
        "style": "normal",
        "type": "name",
        "url": "https://fonts.pawwalls.com/font_file.otf",
        "weight": "300"
    }
},
```