### PR TITLE
Remove dependency of Purchases.shared from UIConfigProvider

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -330,7 +330,12 @@ public struct PaywallView: View {
                         }
                         onRequestedDismissal()
                     },
-                    fallbackContent: .paywallV1View(dataForV1DefaultPaywall)
+                    fallbackContent: .paywallV1View(dataForV1DefaultPaywall),
+                    failedToLoadFont: { fontConfig in
+                        if Purchases.isConfigured {
+                            Purchases.shared.failedToLoadFontWithConfig(fontConfig)
+                        }
+                    }
                 )
             }
         } else {

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -105,9 +105,13 @@ struct PaywallsV2View: View {
         introEligibilityChecker: TrialOrIntroEligibilityChecker,
         showZeroDecimalPlacePrices: Bool,
         onDismiss: @escaping () -> Void,
-        fallbackContent: FallbackContent
+        fallbackContent: FallbackContent,
+        failedToLoadFont: @escaping UIConfigProvider.FailedToLoadFont
     ) {
-        let uiConfigProvider = UIConfigProvider(uiConfig: paywallComponents.uiConfig)
+        let uiConfigProvider = UIConfigProvider(
+            uiConfig: paywallComponents.uiConfig,
+            failedToLoadFont: failedToLoadFont
+        )
 
         self.paywallComponentsData = paywallComponents.data
         self.uiConfigProvider = uiConfigProvider

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
@@ -507,7 +507,8 @@ struct ButtonWithSheetPreview_Previews: PreviewProvider {
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },
-            fallbackContent: .customView(AnyView(Text("Fallback paywall")))
+            fallbackContent: .customView(AnyView(Text("Fallback paywall"))),
+            failedToLoadFont: { _ in }
         )
         .previewRequiredEnvironmentProperties()
         .previewLayout(.fixed(width: 400, height: 800))

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
@@ -395,7 +395,8 @@ struct FamilySharingTogglePreview_Previews: PreviewProvider {
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },
-            fallbackContent: .customView(AnyView(Text("Fallback paywall")))
+            fallbackContent: .customView(AnyView(Text("Fallback paywall"))),
+            failedToLoadFont: { _ in }
         )
         .previewRequiredEnvironmentProperties()
         .previewLayout(.fixed(width: 400, height: 800))

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
@@ -402,7 +402,8 @@ struct MultiTierPreview_Previews: PreviewProvider {
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },
-            fallbackContent: .customView(AnyView(Text("Fallback paywall")))
+            fallbackContent: .customView(AnyView(Text("Fallback paywall"))),
+            failedToLoadFont: { _ in }
         )
         .previewRequiredEnvironmentProperties()
         .previewLayout(.fixed(width: 400, height: 800))

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/PurchaseButtonInPackagePreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/PurchaseButtonInPackagePreview.swift
@@ -344,7 +344,8 @@ struct PurchaseButtonInPackagePreview_Previews: PreviewProvider {
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },
-            fallbackContent: .customView(AnyView(Text("Fallback paywall")))
+            fallbackContent: .customView(AnyView(Text("Fallback paywall"))),
+            failedToLoadFont: { _ in }
         )
         .previewRequiredEnvironmentProperties()
         .previewLayout(.fixed(width: 400, height: 800))

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -223,7 +223,8 @@ struct Template1Preview_Previews: PreviewProvider {
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },
-            fallbackContent: .customView(AnyView(Text("Fallback paywall")))
+            fallbackContent: .customView(AnyView(Text("Fallback paywall"))),
+            failedToLoadFont: { _ in }
         )
         .previewRequiredEnvironmentProperties()
         .previewLayout(.fixed(width: 400, height: 800))

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -74,7 +74,6 @@ struct UIConfigProvider {
         guard let customFont = UIFont(name: fontName, size: fontSize) else {
             Logger.warning("Custom font '\(fontName)' could not be loaded. Falling back to system font.")
             self.failedToLoadFont?(fontsConfig)
-//            self.purchases.failedToLoadFontWithConfig(fontsConfig)
             return nil
         }
 

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -19,12 +19,14 @@ import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct UIConfigProvider {
-    private let uiConfig: UIConfig
-    private let purchases: PaywallPurchasesType
+    typealias FailedToLoadFont = (_ fontConfig: UIConfig.FontsConfig) -> Void
 
-    init(uiConfig: UIConfig, purchases: PaywallPurchasesType = Purchases.shared) {
+    private let uiConfig: UIConfig
+    private let failedToLoadFont: FailedToLoadFont?
+
+    init(uiConfig: UIConfig, failedToLoadFont: FailedToLoadFont? = nil) {
         self.uiConfig = uiConfig
-        self.purchases = purchases
+        self.failedToLoadFont = failedToLoadFont
     }
 
     var variableConfig: UIConfig.VariableConfig {
@@ -71,7 +73,8 @@ struct UIConfigProvider {
 
         guard let customFont = UIFont(name: fontName, size: fontSize) else {
             Logger.warning("Custom font '\(fontName)' could not be loaded. Falling back to system font.")
-            self.purchases.failedToLoadFontWithConfig(fontsConfig)
+            self.failedToLoadFont?(fontsConfig)
+//            self.purchases.failedToLoadFontWithConfig(fontsConfig)
             return nil
         }
 


### PR DESCRIPTION
### Motivation

Fix failing cross platform validation screenshots

### Description

`UIConfigProvider` required that `Purchases.shared` be configured but some of the paywalls tests (like the screenshot taker) doesn't do that

Removed dependency of `Purchases.shared` from within Paywalls v2 and replaced it with a function that is passed into `PaywallsV2View`
