### PR TITLE
Add Danger rule to avoid submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "upstream/paywall-preview-resources"]
-	path = upstream/paywall-preview-resources
-	url = git@github.com:RevenueCat/paywall-preview-resources.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "upstream/paywall-preview-resources"]
+	path = upstream/paywall-preview-resources
+	url = git@github.com:RevenueCat/paywall-preview-resources.git

--- a/Dangerfile
+++ b/Dangerfile
@@ -3,5 +3,5 @@ danger.import_dangerfile(github: 'RevenueCat/Dangerfile')
 # Check for submodules
 submodules = `git submodule status`.strip
 if !submodules.empty?
-  fail("This repository should not contain any submodules. Please remove them.")
+  fail("This repository should not contain any submodules. When using Swift Package Manager, developers will get a resolution error because SPM cannot access private submodules.")
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,1 +1,7 @@
 danger.import_dangerfile(github: 'RevenueCat/Dangerfile')
+
+# Check for submodules
+submodules = `git submodule status`.strip
+if !submodules.empty?
+  fail("This repository should not contain any submodules. Please remove them.")
+end


### PR DESCRIPTION
### Motivation
Preventing adding git submodules in the future (which cause SPM not to be able to allow the dependency when the submodule is private)

### Description
Adds a danger rule that fails if it detects a submodule in the repository