### PR TITLE
Bug Fix: Ensure onRestoreCompleted callback is triggered when no subscriptions are found

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -114,10 +114,11 @@ struct ButtonComponentView: View {
         let (customerInfo, success) = try await self.purchaseHandler.restorePurchases()
         if success {
             Logger.debug(Strings.restored_purchases)
-            self.purchaseHandler.setRestored(customerInfo)
         } else {
             Logger.debug(Strings.restore_purchases_with_empty_result)
         }
+
+        self.purchaseHandler.setRestored(customerInfo)
     }
 
     private func navigateTo(destination: ButtonComponentViewModel.Destination) {


### PR DESCRIPTION
The `onRestoreCompleted` callback is not being triggered when a user attempts to restore purchases but has no active subscriptions. This occurs because the current implementation in `ButtonComponentView.swift` only calls `setRestored(customerInfo)` when the restore operation returns `success: true` (indicating active subscriptions were found). This creates inconsistent behavior where users with no subscriptions don't receive proper feedback after a restore attempt.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
this is a fix for issue #5026 

Related:
- https://community.revenuecat.com/sdks-51/restorecompleted-restorefailure-doesn-t-trigger-in-paywallfooter-4313
- https://community.revenuecat.com/sdks-51/restore-purchases-not-working-with-revenuecatui-onrestorecompleted-modifier-not-triggering-6470

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
