### PR TITLE
Fix Xcode 16 compilation error

### DIFF
--- a/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
@@ -143,6 +143,7 @@ struct StorePurchaseIntent: Sendable, Equatable {
     #endif
 
     static func == (lhs: StorePurchaseIntent, rhs: StorePurchaseIntent) -> Bool {
+        // See comment in `StoreKit2PurchaseIntentType`'s `id` property below
     #if compiler(>=6.2) && !os(tvOS) && !os(watchOS) && !os(visionOS)
         if #available(iOS 18.0, macOS 15.0, *) {
             return lhs.purchaseIntent?.id == rhs.purchaseIntent?.id
@@ -181,6 +182,10 @@ protocol StoreKit2PurchaseIntentType: Equatable, Sendable {
     var offer: StoreKit.Product.SubscriptionOffer? { get }
     #endif
 
+    // Xcode 26 changed the minimum versions where StoreKit.PurchaseIntent id property is available.
+    // In Xcode 16, it was available in iOS 16.4+, macOS 14.4+
+    // In Xcode 26, it was available in iOS 18.0+, macOS 15.0+
+    // That's why we need the following workaround:
     #if compiler(>=6.2)
     @available(iOS 18.0, macOS 15.0, *)
     var id: StoreKit.Product.ID { get }

--- a/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
@@ -154,6 +154,7 @@ struct StorePurchaseIntent: Sendable, Equatable {
     #elseif compiler(>=5.10) && !os(tvOS) && !os(watchOS) && !os(visionOS)
         return lhs.purchaseIntent?.id == rhs.purchaseIntent?.id
     #else
+        // purchaseIntent is not available in compiler < 5.10
         return true
     #endif
     }

--- a/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
@@ -143,7 +143,8 @@ struct StorePurchaseIntent: Sendable, Equatable {
     #endif
 
     static func == (lhs: StorePurchaseIntent, rhs: StorePurchaseIntent) -> Bool {
-        // See comment in `StoreKit2PurchaseIntentType`'s `id` property below
+        // An explanation on why this implementation is this complicated is given in the
+        // comment in StoreKit2PurchaseIntentType's id property below
     #if compiler(>=6.2) && !os(tvOS) && !os(watchOS) && !os(visionOS)
         if #available(iOS 18.0, macOS 15.0, *) {
             return lhs.purchaseIntent?.id == rhs.purchaseIntent?.id

--- a/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
@@ -143,10 +143,16 @@ struct StorePurchaseIntent: Sendable, Equatable {
     #endif
 
     static func == (lhs: StorePurchaseIntent, rhs: StorePurchaseIntent) -> Bool {
-    #if compiler(>=5.10) && !os(tvOS) && !os(watchOS) && !os(visionOS)
+    #if compiler(>=6.2) && !os(tvOS) && !os(watchOS) && !os(visionOS)
+        if #available(iOS 18.0, macOS 15.0, *) {
+            return lhs.purchaseIntent?.id == rhs.purchaseIntent?.id
+        } else {
+            return lhs.purchaseIntent?.product.id == rhs.purchaseIntent?.product.id
+        }
+    #elseif compiler(>=5.10) && !os(tvOS) && !os(watchOS) && !os(visionOS)
         return lhs.purchaseIntent?.id == rhs.purchaseIntent?.id
     #else
-        return true
+        return lhs.purchaseIntent?.product.id == rhs.purchaseIntent?.product.id
     #endif
     }
 }
@@ -175,7 +181,12 @@ protocol StoreKit2PurchaseIntentType: Equatable, Sendable {
     var offer: StoreKit.Product.SubscriptionOffer? { get }
     #endif
 
+    #if compiler(>=6.2)
+    @available(iOS 18.0, macOS 15.0, *)
     var id: StoreKit.Product.ID { get }
+    #else
+    var id: StoreKit.Product.ID { get }
+    #endif
 }
 
 @available(iOS 16.4, macOS 14.4, *)

--- a/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2PurchaseIntentListener.swift
@@ -154,7 +154,7 @@ struct StorePurchaseIntent: Sendable, Equatable {
     #elseif compiler(>=5.10) && !os(tvOS) && !os(watchOS) && !os(visionOS)
         return lhs.purchaseIntent?.id == rhs.purchaseIntent?.id
     #else
-        return lhs.purchaseIntent?.product.id == rhs.purchaseIntent?.product.id
+        return true
     #endif
     }
 }


### PR DESCRIPTION
### Motivation
Xcode 26 Beta 1 changed the minimum versions where `StoreKit.PurchaseIntent` `id` property is available.
* In Xcode 16, it was available in iOS 16.4+, macOS 14.4+
* In Xcode 26, it was available in iOS 18.0+, macOS 15.0+

### Description
Conditionally require `id` in `StoreKit.PurchaseIntent` depending on the compiler version