### PR TITLE
Use Mint 0.17.5 for `run-test-ios-14` CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,8 +220,7 @@ commands:
       - when:
           condition: << parameters.install_mint_0_17_5 >>
           steps:
-            - install-brew-dependency:
-                dependency_name: "mint@0.17.5"
+            - install-mint-0_17_5
       - when:
           condition: << parameters.install_swiftlint >>
           steps:
@@ -253,6 +252,16 @@ commands:
             brew install << parameters.dependency_name >>
           environment:
             HOMEBREW_NO_INSTALL_CLEANUP: 1
+
+  install-mint-0_17_5:
+    steps:
+      - run:
+          name: Install Mint 0.17.5
+          command: |
+            git clone https://github.com/yonaskolb/Mint.git
+            cd Mint
+            git checkout 0.17.5
+            make
 
   install-xcbeautify-for-xcode14:
     description: "Installs xcbeautify using Mint"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,9 @@ commands:
       install_mint:
         type: boolean
         default: false
+      install_mint_0_17_5:
+        type: boolean
+        default: false
       install_swiftlint:
         type: boolean
         default: true
@@ -214,6 +217,11 @@ commands:
           steps:
             - install-brew-dependency:
                 dependency_name: "mint"
+      - when:
+          condition: << parameters.install_mint_0_17_5 >>
+          steps:
+            - install-brew-dependency:
+                dependency_name: "mint@0.17.5"
       - when:
           condition: << parameters.install_swiftlint >>
           steps:
@@ -906,7 +914,8 @@ jobs:
       - checkout
       - install-dependencies:
           install_xcbeautify: false
-          install_mint: true
+          # Mint 0.17.5 is required here as newer versions of Mint don't support macOS 12.
+          install_mint_0_17_5: true
           install_swiftlint: false
       - install-xcbeautify-for-xcode14
       - update-spm-installation-commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1630,91 +1630,91 @@ workflows:
         - equal:
             ["run-from-github-comments", << pipeline.parameters.GHA_Meta >>]
     jobs:
-      - backend-integration-tests-SK1:
-          context:
-            - slack-secrets-ios
-      - backend-integration-tests-SK2:
-          context:
-            - slack-secrets-ios
-      - backend-integration-tests-custom-entitlements:
-          context:
-            - slack-secrets-ios
-      - backend-integration-tests-other:
-          context:
-            - slack-secrets-ios
-      - backend-integration-tests-offline:
-          context:
-            - slack-secrets-ios
-      - build-tv-watch-and-macos:
-          context:
-            - slack-secrets-ios
-      - build-visionos:
-          context:
-            - slack-secrets-ios
-      - docs-build:
-          context:
-            - slack-secrets-ios
+      # - backend-integration-tests-SK1:
+      #     context:
+      #       - slack-secrets-ios
+      # - backend-integration-tests-SK2:
+      #     context:
+      #       - slack-secrets-ios
+      # - backend-integration-tests-custom-entitlements:
+      #     context:
+      #       - slack-secrets-ios
+      # - backend-integration-tests-other:
+      #     context:
+      #       - slack-secrets-ios
+      # - backend-integration-tests-offline:
+      #     context:
+      #       - slack-secrets-ios
+      # - build-tv-watch-and-macos:
+      #     context:
+      #       - slack-secrets-ios
+      # - build-visionos:
+      #     context:
+      #       - slack-secrets-ios
+      # - docs-build:
+      #     context:
+      #       - slack-secrets-ios
       - run-test-ios-14:
           context:
             - slack-secrets-ios
-      - run-test-ios-15:
-          context:
-            - slack-secrets-ios
-      - run-test-ios-16:
-          context:
-            - slack-secrets-ios
-      - run-test-macos:
-          context:
-            - slack-secrets-ios
-      - run-test-tvos:
-          context:
-            - slack-secrets-ios
-      - run-test-watchos:
-          context:
-            - slack-secrets-ios
-      - spm-receipt-parser:
-          context:
-            - slack-secrets-ios
-      - spm-release-build:
-          context:
-            - slack-secrets-ios
-      - spm-release-build-xcode-14:
-          context:
-            - slack-secrets-ios
-      - spm-release-build-xcode-15:
-          context:
-            - slack-secrets-ios
-      - spm-revenuecat-ui-ios-15:
-          context:
-            - slack-secrets-ios
-      - spm-revenuecat-ui-ios-16:
-          context:
-            - slack-secrets-ios
-      - spm-revenuecat-ui-watchos:
-          context:
-            - slack-secrets-ios
-      - installation-tests-cocoapods:
-          context:
-            - slack-secrets-ios
-      - installation-tests-swift-package-manager:
-          context:
-            - slack-secrets-ios
-      - installation-tests-custom-entitlement-computation-swift-package-manager:
-          context:
-            - slack-secrets-ios
-      - installation-tests-carthage:
-          context:
-            - slack-secrets-ios
-      - installation-tests-xcode-direct-integration:
-          context:
-            - slack-secrets-ios
-      - installation-tests-receipt-parser:
-          context:
-            - slack-secrets-ios
-      - api-tests:
-          context:
-            - slack-secrets-ios
-      - deploy-purchase-tester:
-          dry_run: true
-          context:
-            - slack-secrets-ios
+      # - run-test-ios-15:
+      #     context:
+      #       - slack-secrets-ios
+      # - run-test-ios-16:
+      #     context:
+      #       - slack-secrets-ios
+      # - run-test-macos:
+      #     context:
+      #       - slack-secrets-ios
+      # - run-test-tvos:
+      #     context:
+      #       - slack-secrets-ios
+      # - run-test-watchos:
+      #     context:
+      #       - slack-secrets-ios
+      # - spm-receipt-parser:
+      #     context:
+      #       - slack-secrets-ios
+      # - spm-release-build:
+      #     context:
+      #       - slack-secrets-ios
+      # - spm-release-build-xcode-14:
+      #     context:
+      #       - slack-secrets-ios
+      # - spm-release-build-xcode-15:
+      #     context:
+      #       - slack-secrets-ios
+      # - spm-revenuecat-ui-ios-15:
+      #     context:
+      #       - slack-secrets-ios
+      # - spm-revenuecat-ui-ios-16:
+      #     context:
+      #       - slack-secrets-ios
+      # - spm-revenuecat-ui-watchos:
+      #     context:
+      #       - slack-secrets-ios
+      # - installation-tests-cocoapods:
+      #     context:
+      #       - slack-secrets-ios
+      # - installation-tests-swift-package-manager:
+      #     context:
+      #       - slack-secrets-ios
+      # - installation-tests-custom-entitlement-computation-swift-package-manager:
+      #     context:
+      #       - slack-secrets-ios
+      # - installation-tests-carthage:
+      #     context:
+      #       - slack-secrets-ios
+      # - installation-tests-xcode-direct-integration:
+      #     context:
+      #       - slack-secrets-ios
+      # - installation-tests-receipt-parser:
+      #     context:
+      #       - slack-secrets-ios
+      # - api-tests:
+      #     context:
+      #       - slack-secrets-ios
+      # - deploy-purchase-tester:
+      #     dry_run: true
+      #     context:
+      #       - slack-secrets-ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1630,91 +1630,91 @@ workflows:
         - equal:
             ["run-from-github-comments", << pipeline.parameters.GHA_Meta >>]
     jobs:
-      # - backend-integration-tests-SK1:
-      #     context:
-      #       - slack-secrets-ios
-      # - backend-integration-tests-SK2:
-      #     context:
-      #       - slack-secrets-ios
-      # - backend-integration-tests-custom-entitlements:
-      #     context:
-      #       - slack-secrets-ios
-      # - backend-integration-tests-other:
-      #     context:
-      #       - slack-secrets-ios
-      # - backend-integration-tests-offline:
-      #     context:
-      #       - slack-secrets-ios
-      # - build-tv-watch-and-macos:
-      #     context:
-      #       - slack-secrets-ios
-      # - build-visionos:
-      #     context:
-      #       - slack-secrets-ios
-      # - docs-build:
-      #     context:
-      #       - slack-secrets-ios
+      - backend-integration-tests-SK1:
+          context:
+            - slack-secrets-ios
+      - backend-integration-tests-SK2:
+          context:
+            - slack-secrets-ios
+      - backend-integration-tests-custom-entitlements:
+          context:
+            - slack-secrets-ios
+      - backend-integration-tests-other:
+          context:
+            - slack-secrets-ios
+      - backend-integration-tests-offline:
+          context:
+            - slack-secrets-ios
+      - build-tv-watch-and-macos:
+          context:
+            - slack-secrets-ios
+      - build-visionos:
+          context:
+            - slack-secrets-ios
+      - docs-build:
+          context:
+            - slack-secrets-ios
       - run-test-ios-14:
           context:
             - slack-secrets-ios
-      # - run-test-ios-15:
-      #     context:
-      #       - slack-secrets-ios
-      # - run-test-ios-16:
-      #     context:
-      #       - slack-secrets-ios
-      # - run-test-macos:
-      #     context:
-      #       - slack-secrets-ios
-      # - run-test-tvos:
-      #     context:
-      #       - slack-secrets-ios
-      # - run-test-watchos:
-      #     context:
-      #       - slack-secrets-ios
-      # - spm-receipt-parser:
-      #     context:
-      #       - slack-secrets-ios
-      # - spm-release-build:
-      #     context:
-      #       - slack-secrets-ios
-      # - spm-release-build-xcode-14:
-      #     context:
-      #       - slack-secrets-ios
-      # - spm-release-build-xcode-15:
-      #     context:
-      #       - slack-secrets-ios
-      # - spm-revenuecat-ui-ios-15:
-      #     context:
-      #       - slack-secrets-ios
-      # - spm-revenuecat-ui-ios-16:
-      #     context:
-      #       - slack-secrets-ios
-      # - spm-revenuecat-ui-watchos:
-      #     context:
-      #       - slack-secrets-ios
-      # - installation-tests-cocoapods:
-      #     context:
-      #       - slack-secrets-ios
-      # - installation-tests-swift-package-manager:
-      #     context:
-      #       - slack-secrets-ios
-      # - installation-tests-custom-entitlement-computation-swift-package-manager:
-      #     context:
-      #       - slack-secrets-ios
-      # - installation-tests-carthage:
-      #     context:
-      #       - slack-secrets-ios
-      # - installation-tests-xcode-direct-integration:
-      #     context:
-      #       - slack-secrets-ios
-      # - installation-tests-receipt-parser:
-      #     context:
-      #       - slack-secrets-ios
-      # - api-tests:
-      #     context:
-      #       - slack-secrets-ios
-      # - deploy-purchase-tester:
-      #     dry_run: true
-      #     context:
-      #       - slack-secrets-ios
+      - run-test-ios-15:
+          context:
+            - slack-secrets-ios
+      - run-test-ios-16:
+          context:
+            - slack-secrets-ios
+      - run-test-macos:
+          context:
+            - slack-secrets-ios
+      - run-test-tvos:
+          context:
+            - slack-secrets-ios
+      - run-test-watchos:
+          context:
+            - slack-secrets-ios
+      - spm-receipt-parser:
+          context:
+            - slack-secrets-ios
+      - spm-release-build:
+          context:
+            - slack-secrets-ios
+      - spm-release-build-xcode-14:
+          context:
+            - slack-secrets-ios
+      - spm-release-build-xcode-15:
+          context:
+            - slack-secrets-ios
+      - spm-revenuecat-ui-ios-15:
+          context:
+            - slack-secrets-ios
+      - spm-revenuecat-ui-ios-16:
+          context:
+            - slack-secrets-ios
+      - spm-revenuecat-ui-watchos:
+          context:
+            - slack-secrets-ios
+      - installation-tests-cocoapods:
+          context:
+            - slack-secrets-ios
+      - installation-tests-swift-package-manager:
+          context:
+            - slack-secrets-ios
+      - installation-tests-custom-entitlement-computation-swift-package-manager:
+          context:
+            - slack-secrets-ios
+      - installation-tests-carthage:
+          context:
+            - slack-secrets-ios
+      - installation-tests-xcode-direct-integration:
+          context:
+            - slack-secrets-ios
+      - installation-tests-receipt-parser:
+          context:
+            - slack-secrets-ios
+      - api-tests:
+          context:
+            - slack-secrets-ios
+      - deploy-purchase-tester:
+          dry_run: true
+          context:
+            - slack-secrets-ios


### PR DESCRIPTION
### Motivation

CI for `run-test-ios-14` was failing when installing Mint
> error: 'mint-0.18.0': package 'mint-0.18.0' is using Swift tools version 5.9.0 but the installed version is 5.7.1
> Error: You are using macOS 12.
> We (and Apple) do not provide support for this old version.

### Description

Mint 0.17.5 is used in this CI job as newer versions of Mint don't support macOS 12