### PR TITLE
Update iOS 18.4 Simulator Warning Log Message

### DIFF
--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -160,8 +160,8 @@ extension OfferingStrings: LogMessage {
         case .known_issue_ios_18_4_simulator_products_not_found:
             return "None of the products registered in the RevenueCat dashboard could be fetched from App Store " +
             "Connect (or the StoreKit Configuration file if one is being used)." +
-            "\nThis issue is widely reported by iOS 18.4 simulator users. Try using a different iOS version with " +
-            "your simulator." +
+            "\nThis issue is widely reported by iOS 18.4 and 18.5 simulator users. Try using a different iOS " +
+            "\nversion with your simulator." +
             "\nMore information: https://rev.cat/ios-18-4-simulator-issue"
         }
     }

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -224,9 +224,9 @@ class SystemInfo {
                                                            minorVersion: 4,
                                                            patchVersion: 0)
 
-        // Conservative estimate. No Simulator iOS fix version currently known (as at 2025-04-15).
-        let firstOSVersionWithFix = OperatingSystemVersion(majorVersion: 18,
-                                                           minorVersion: 5,
+        // Resolved in iOS 26 beta 1
+        let firstOSVersionWithFix = OperatingSystemVersion(majorVersion: 26,
+                                                           minorVersion: 0,
                                                            patchVersion: 0)
 
         return SystemInfo.isRunningInSimulator

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -237,7 +237,7 @@ private extension OfferingsManager {
 
             guard products.isEmpty == false else {
                 // Check if empty products is likely caused by https://github.com/RevenueCat/purchases-ios/issues/4954
-                // There is a widely reported bug in the iOS 18.4 Simulator affecting some HTTP requests
+                // There is a widely reported bug in the iOS 18.4 and 18.5 Simulators which affects some HTTP requests
                 let showSimulatorWarning = self.systemInfo.isSubjectToKnownIssue_18_4_sim()
                 completion(.failure(Self.createErrorForEmptyResult(result.error,
                                                                    showSimulatorWarning: showSimulatorWarning)))


### PR DESCRIPTION
### Motivation
 - Update log message which warns of known iOS 18.4 and 18.5 simulator issues

### Description
 - iOS 26 beta 1 resolves issue #4954 
 - A warning message was added for iOS 18.4 simulator users (introduced in #5002)
 - Now that a fix is known, this PR updates the log message to be more specific