### PR TITLE
Renamed isActive to isExpired in PurchaseInformation

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation+Mock.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation+Mock.swift
@@ -31,7 +31,7 @@ extension PurchaseInformation {
         isLifetime: Bool = false,
         isTrial: Bool = false,
         isCancelled: Bool = false,
-        isActive: Bool = true,
+        isExpired: Bool = false,
         isSandbox: Bool = true,
         latestPurchaseDate: Date = Self.defaultLatestPurchaseDate,
         originalPurchaseDate: Date? = Self.defaultOriginalPurchaseDate,
@@ -58,7 +58,7 @@ extension PurchaseInformation {
             isLifetime: isLifetime,
             isTrial: isTrial,
             isCancelled: isCancelled,
-            isActive: isActive,
+            isExpired: isExpired,
             isSandbox: isSandbox,
             latestPurchaseDate: latestPurchaseDate,
             originalPurchaseDate: originalPurchaseDate,
@@ -92,7 +92,7 @@ extension PurchaseInformation {
         productIdentifier: "product_id_expired",
         store: .appStore,
         isLifetime: false,
-        isActive: false,
+        isExpired: true,
         expirationDate: nil,
         renewalDate: nil
     )
@@ -112,7 +112,7 @@ extension PurchaseInformation {
         renewalPrice: .nonFree("$4.99"),
         productIdentifier: "product_id_free",
         isTrial: true,
-        isActive: true,
+        isExpired: false,
         expirationDate: nil,
         renewalDate: nil
     )
@@ -124,7 +124,7 @@ extension PurchaseInformation {
         productIdentifier: "product_id",
         store: .appStore,
         isLifetime: true,
-        isActive: true,
+        isExpired: false,
         isSandbox: false,
         managementURL: URL(string: "https://www.revenuecat.com"),
         expirationDate: nil,

--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -68,10 +68,10 @@ struct PurchaseInformation {
     /// resubscriptions by lapsed subscribers. `nil` for non-subscriptions
     let originalPurchaseDate: Date?
 
-    /// Indicates whether the purchased subscription is active
+    /// Indicates whether the purchased subscription is expired
     ///
-    /// Note: `true` for non-subscriptions
-    let isActive: Bool
+    /// Note: `false` for non-subscriptions
+    let isExpired: Bool
 
     /// The fetch date of this CustomerInfo. (a.k.a. CustomerInfo.requestedDate)
     let customerInfoRequestedDate: Date
@@ -133,7 +133,7 @@ struct PurchaseInformation {
          isLifetime: Bool,
          isTrial: Bool,
          isCancelled: Bool,
-         isActive: Bool,
+         isExpired: Bool,
          isSandbox: Bool,
          latestPurchaseDate: Date,
          originalPurchaseDate: Date?,
@@ -162,7 +162,7 @@ struct PurchaseInformation {
         self.isTrial = isTrial
         self.isCancelled = isCancelled
         self.isSandbox = isSandbox
-        self.isActive = isActive
+        self.isExpired = isExpired
         self.latestPurchaseDate = latestPurchaseDate
         self.originalPurchaseDate = originalPurchaseDate
         self.customerInfoRequestedDate = customerInfoRequestedDate
@@ -216,7 +216,7 @@ struct PurchaseInformation {
             self.renewalDate = entitlement.willRenew ? entitlement.expirationDate : nil
             self.periodType = entitlement.periodType
             self.ownershipType = entitlement.ownershipType
-            self.isActive = entitlement.isActive
+            self.isExpired = !entitlement.isActive
             self.unsubscribeDetectedAt = entitlement.unsubscribeDetectedAt
             self.billingIssuesDetectedAt = entitlement.billingIssueDetectedAt
             self.gracePeriodExpiresDate = nil
@@ -233,12 +233,12 @@ struct PurchaseInformation {
                 self.expirationDate = expiresDate
                 self.renewalDate = willRenew ? expiresDate : nil
                 self.ownershipType = ownershipType
-                self.isActive = isActive
+                self.isExpired = !isActive
 
             case .nonSubscription:
                 self.isLifetime = true
                 self.isTrial = false
-                self.isActive = true
+                self.isExpired = false
                 self.renewalDate = nil
                 self.expirationDate = nil
                 self.ownershipType = nil

--- a/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseInformation+History.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/PurchaseHistory/PurchaseInformation+History.swift
@@ -33,7 +33,7 @@ extension PurchaseInformation {
         var items: [PurchaseDetailItem] = []
         items.append(.paidPrice(pricePaidString(localizations: localization)))
         items.append(.status(
-            isActive ? .active : .inactive
+            isExpired ? .inactive : .active
         ))
 
         let dateFormatter = PurchaseInformation.defaultDateFormatter

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
@@ -98,13 +98,13 @@ struct PurchaseInformationCardView: View {
         self.storeTitle = localization[purchaseInformation.store.localizationKey]
         self.showChevron = showChevron
 
-        if !purchaseInformation.isActive {
+        if purchaseInformation.isExpired {
             self.badge = .expired(localization)
         } else if purchaseInformation.isCancelled {
             self.badge = .cancelled(localization)
         } else if purchaseInformation.isTrial, purchaseInformation.pricePaid == .free {
             self.badge = .freeTrial(localization)
-        } else if purchaseInformation.isActive {
+        } else if purchaseInformation.renewalDate != nil || purchaseInformation.expirationDate != nil {
             self.badge = .active(localization)
         } else {
             self.badge = nil

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -246,12 +246,12 @@ struct RelevantPurchasesListView_Previews: PreviewProvider {
         let purchases = [
             PurchaseInformation.mock(
                 store: .amazon,
-                isActive: true,
+                isExpired: false,
                 renewalDate: PurchaseInformation.defaulRenewalDate
             ),
             PurchaseInformation.mock(
                 store: .appStore,
-                isActive: true
+                isExpired: false
             ),
             .free
         ]

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -329,7 +329,7 @@ struct SubscriptionDetailView: View {
             CompatibilityNavigationStack {
                 SubscriptionDetailView(
                     customerInfoViewModel: CustomerCenterViewModel(
-                        activeSubscriptionPurchases: [.mock(store: .playStore, isActive: true)],
+                        activeSubscriptionPurchases: [.mock(store: .playStore, isExpired: false)],
                         activeNonSubscriptionPurchases: [],
                         configuration: .default
                     ),
@@ -340,7 +340,7 @@ struct SubscriptionDetailView: View {
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
                         allowsMissingPurchaseAction: false,
-                        purchaseInformation: .mock(store: .playStore, isActive: true)
+                        purchaseInformation: .mock(store: .playStore, isExpired: false)
                     )
                 )
             }

--- a/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
@@ -468,7 +468,7 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
         let screen = PurchaseInformationFixtures.screenWithPromo(offerID: offerIdentifierInJSON)
         let viewModel = BaseManageSubscriptionViewModel(screen: screen,
                                                         actionWrapper: CustomerCenterActionWrapper(),
-                                                        purchaseInformation: .mock(store: .appStore, isActive: true),
+                                                        purchaseInformation: .mock(store: .appStore, isExpired: false),
                                                         purchasesProvider: MockCustomerCenterPurchases(
                                                             customerInfo: customerInfo,
                                                             products: products

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
@@ -34,7 +34,7 @@ final class SubscriptionDetailViewModelTests: TestCase {
             screen: CustomerCenterConfigData.default.screens[.management]!,
             showPurchaseHistory: false,
             allowsMissingPurchaseAction: false,
-            purchaseInformation: .mock(store: .appStore, isActive: true)
+            purchaseInformation: .mock(store: .appStore, isExpired: false)
         )
 
         expect(viewModelAppStore.shouldShowContactSupport).to(beFalse())
@@ -59,7 +59,7 @@ final class SubscriptionDetailViewModelTests: TestCase {
                 screen: CustomerCenterConfigData.default.screens[.management]!,
                 showPurchaseHistory: false,
                 allowsMissingPurchaseAction: true,
-                purchaseInformation: .mock(store: $0, isActive: true)
+                purchaseInformation: .mock(store: $0, isExpired: false)
             )
 
             expect(viewModelOther.shouldShowContactSupport).to(beTrue())


### PR DESCRIPTION
### Motivation
We're working on refining `PurchaseInformation`

### Description
`isActive` does not make much sense for non subscriptions, so we're renaming it to `isExpired` instead.
