### PR TITLE
Trigger promotional offer callback from `PromotionalOfferViewModel`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -641,6 +641,8 @@
 		5774F9C12805EA3000997128 /* BaseHTTPResponseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5774F9C02805EA3000997128 /* BaseHTTPResponseTest.swift */; };
 		5774F9C22805EA6900997128 /* CustomerInfoDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5774F9B92805E6E200997128 /* CustomerInfoDecodingTests.swift */; };
 		577782B52D9182A200F97EB4 /* CustomerCenterActionWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577782B42D91829D00F97EB4 /* CustomerCenterActionWrapperTests.swift */; };
+		577E58242DF86D3C0015BB60 /* PromotionalOfferViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577E58232DF86D390015BB60 /* PromotionalOfferViewModelTests.swift */; };
+		577E58262DF86F390015BB60 /* MockTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577E58252DF86F370015BB60 /* MockTransaction.swift */; };
 		578C5F2C28DB82DD00A56F02 /* PurchasesDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578C5F2B28DB82DD00A56F02 /* PurchasesDiagnostics.swift */; };
 		578D79742936A36B0042E434 /* LoggerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578D79732936A36B0042E434 /* LoggerType.swift */; };
 		578DAA482948EEAD001700FD /* Clock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578DAA472948EEAD001700FD /* Clock.swift */; };
@@ -2030,6 +2032,8 @@
 		5774F9BD2805E71100997128 /* Fixtures */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; name = Fixtures; path = Tests/UnitTests/Networking/Responses/Fixtures; sourceTree = SOURCE_ROOT; };
 		5774F9C02805EA3000997128 /* BaseHTTPResponseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseHTTPResponseTest.swift; sourceTree = "<group>"; };
 		577782B42D91829D00F97EB4 /* CustomerCenterActionWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterActionWrapperTests.swift; sourceTree = "<group>"; };
+		577E58232DF86D390015BB60 /* PromotionalOfferViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOfferViewModelTests.swift; sourceTree = "<group>"; };
+		577E58252DF86F370015BB60 /* MockTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTransaction.swift; sourceTree = "<group>"; };
 		578C5F2B28DB82DD00A56F02 /* PurchasesDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesDiagnostics.swift; sourceTree = "<group>"; };
 		578D79732936A36B0042E434 /* LoggerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerType.swift; sourceTree = "<group>"; };
 		578D79932936B0810042E434 /* LoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
@@ -3968,6 +3972,7 @@
 		3544DA6B2C2C848E00704E9D /* CustomerCenter */ = {
 			isa = PBXGroup;
 			children = (
+				577E58232DF86D390015BB60 /* PromotionalOfferViewModelTests.swift */,
 				57BB08672DD3D9EA007493E1 /* SubscriptionDetailViewModelTests.swift */,
 				57BB08632DD3BE2D007493E1 /* BaseManageSubscriptionViewModelTests.swift */,
 				576F15462DD4AB64003D8EEC /* DiscountsHandlerTests.swift */,
@@ -4493,6 +4498,7 @@
 		576F15482DD4ABB6003D8EEC /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				577E58252DF86F370015BB60 /* MockTransaction.swift */,
 				57F9726A2DC3EF9500C6E540 /* MockStoreProductDiscount.swift */,
 			);
 			path = Mocks;
@@ -7262,6 +7268,7 @@
 				038EC8232DE7A8B300786C42 /* TakeScreenshot.swift in Sources */,
 				887A633A2C1D177800E1A461 /* PaywallViewDynamicTypeTests.swift in Sources */,
 				887A633B2C1D177800E1A461 /* PaywallViewLocalizationTests.swift in Sources */,
+				577E58242DF86D3C0015BB60 /* PromotionalOfferViewModelTests.swift in Sources */,
 				887A633C2C1D177800E1A461 /* Template1ViewTests.swift in Sources */,
 				35A99C842CCB95A70074AB41 /* PurchaseInformationTests.swift in Sources */,
 				777FB4882C661C0600CD4749 /* SemanticVersionTests.swift in Sources */,
@@ -7270,6 +7277,7 @@
 				887A633E2C1D177800E1A461 /* Template3ViewTests.swift in Sources */,
 				030F918C2D55C9DC0085103F /* LocaleFinderTests.swift in Sources */,
 				887A633F2C1D177800E1A461 /* Template4ViewTests.swift in Sources */,
+				577E58262DF86F390015BB60 /* MockTransaction.swift in Sources */,
 				887A63402C1D177800E1A461 /* Template5ViewTests.swift in Sources */,
 				887A63412C1D177800E1A461 /* BaseSnapshotTest.swift in Sources */,
 				57F9726B2DC3EF9500C6E540 /* MockStoreProductDiscount.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -4626,13 +4626,6 @@
 			path = Utilities;
 			sourceTree = "<group>";
 		};
-		5798C9052DF1985700F44400 /* ManageSubscriptions */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = ManageSubscriptions;
-			sourceTree = "<group>";
-		};
 		5798C90A2DF1985700F44400 /* PurchaseHistory */ = {
 			isa = PBXGroup;
 			children = (
@@ -4647,7 +4640,6 @@
 		5798C9132DF1985700F44400 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
-				5798C9052DF1985700F44400 /* ManageSubscriptions */,
 				5798C90A2DF1985700F44400 /* PurchaseHistory */,
 				5798C90B2DF1985700F44400 /* BaseManageSubscriptionViewModel.swift */,
 				5798C90C2DF1985700F44400 /* CustomerCenterViewModel.swift */,

--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -142,36 +142,6 @@ class BaseManageSubscriptionViewModel: ObservableObject {
 
 }
 
-// MARK: - Promotional Offer Sheet Dismissal Handling
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(macOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
-extension BaseManageSubscriptionViewModel {
-
-    /// Function responsible for handling the user's action on the PromotionalOfferView
-    func handleDismissPromotionalOfferView(_ userAction: PromotionalOfferViewAction) async {
-        switch userAction {
-        case .successfullyRedeemedPromotionalOffer:
-            self.actionWrapper.handleAction(.promotionalOfferSuccess)
-        case .declinePromotionalOffer, .promotionalCodeRedemptionFailed:
-            break
-        }
-
-        // Clear the promotional offer data to dismiss the sheet
-        self.promotionalOfferData = nil
-
-        if userAction.shouldTerminateCurrentPathFlow {
-            self.loadingPath = nil
-        } else {
-            if let loadingPath = loadingPath {
-                await self.onPathSelected(path: loadingPath)
-                self.loadingPath = nil
-            }
-        }
-    }
-}
-
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)

--- a/RevenueCatUI/CustomerCenter/ViewModels/FeedbackSurveyViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/FeedbackSurveyViewModel.swift
@@ -35,7 +35,7 @@ final class FeedbackSurveyViewModel: ObservableObject {
 
     private(set) var purchasesProvider: CustomerCenterPurchasesType
     private let loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType
-    private let actionWrapper: CustomerCenterActionWrapper
+    let actionWrapper: CustomerCenterActionWrapper
 
     convenience init(feedbackSurveyData: FeedbackSurveyData,
                      purchasesProvider: CustomerCenterPurchasesType,

--- a/RevenueCatUI/CustomerCenter/ViewModels/PromotionalOfferViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/PromotionalOfferViewModel.swift
@@ -35,6 +35,7 @@ final class PromotionalOfferViewModel: ObservableObject {
 
     private var purchasesProvider: CustomerCenterPurchasesType
     private let loadPromotionalOfferUseCase: LoadPromotionalOfferUseCase
+    private let actionWrapper: CustomerCenterActionWrapper
 
     /// Callback to be called when the promotional offer is  purchased
     internal var onPromotionalOfferPurchaseFlowComplete: ((PromotionalOfferViewAction) -> Void)?
@@ -42,10 +43,12 @@ final class PromotionalOfferViewModel: ObservableObject {
     init(
         promotionalOfferData: PromotionalOfferData?,
         purchasesProvider: CustomerCenterPurchasesType,
+        actionWrapper: CustomerCenterActionWrapper,
         onPromotionalOfferPurchaseFlowComplete: ((PromotionalOfferViewAction) -> Void)? = nil
     ) {
         self.promotionalOfferData = promotionalOfferData
         self.purchasesProvider = purchasesProvider
+        self.actionWrapper = actionWrapper
         self.loadPromotionalOfferUseCase = LoadPromotionalOfferUseCase(purchasesProvider: purchasesProvider)
         self.onPromotionalOfferPurchaseFlowComplete = onPromotionalOfferPurchaseFlowComplete
     }
@@ -64,6 +67,7 @@ final class PromotionalOfferViewModel: ObservableObject {
             )
 
             Logger.debug("Purchased promotional offer: \(result)")
+            self.actionWrapper.handleAction(.promotionalOfferSuccess)
             self.onPromotionalOfferPurchaseFlowComplete?(.successfullyRedeemedPromotionalOffer(result))
         } catch {
             // swiftlint:disable:next todo

--- a/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
@@ -89,6 +89,7 @@ struct FeedbackSurveyView: View {
                     product: promotionalOfferData.product,
                     promoOfferDetails: promotionalOfferData.promoOfferDetails,
                     purchasesProvider: self.viewModel.purchasesProvider,
+                    actionWrapper: self.viewModel.actionWrapper,
                     onDismissPromotionalOfferView: { userAction in
                         Task(priority: .userInitiated) {
                             await viewModel.handleDismissPromotionalOfferView(

--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -45,6 +45,7 @@ struct PromotionalOfferView: View {
          product: StoreProduct,
          promoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer,
          purchasesProvider: CustomerCenterPurchasesType,
+         actionWrapper: CustomerCenterActionWrapper,
          onDismissPromotionalOfferView: @escaping (PromotionalOfferViewAction) -> Void
     ) {
         _viewModel = StateObject(wrappedValue: PromotionalOfferViewModel(
@@ -53,7 +54,8 @@ struct PromotionalOfferView: View {
                 product: product,
                 promoOfferDetails: promoOfferDetails
             ),
-            purchasesProvider: purchasesProvider
+            purchasesProvider: purchasesProvider,
+            actionWrapper: actionWrapper
         ))
         self.onDismissPromotionalOfferView = onDismissPromotionalOfferView
     }

--- a/Tests/RevenueCatUITests/CustomerCenter/PromotionalOfferViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/PromotionalOfferViewModelTests.swift
@@ -1,0 +1,194 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PromotionalOfferViewModelTests.swift
+//
+//  Created by Facundo Menzella on 10/6/25.
+
+import Combine
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import StoreKit
+import XCTest
+
+#if os(iOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+final class PromotionalOfferViewModelTests: TestCase {
+
+    var cancellables = Set<AnyCancellable>()
+
+    override func setUp() {
+        super.setUp()
+        cancellables = Set<AnyCancellable>()
+    }
+
+    @MainActor
+    func testActionWrapperTriggersActionOnPurchaseSuccess() async {
+        let mockPurchases = MockCustomerCenterPurchases()
+        let actionWrapper = CustomerCenterActionWrapper()
+
+        var capturedAction: PromotionalOfferViewAction?
+        let signedData = PromotionalOffer.SignedData(
+            identifier: "id",
+            keyIdentifier: "key_i",
+            nonce: UUID(),
+            signature: "a signature",
+            timestamp: 1234
+        )
+        let discount = MockStoreProductDiscount(
+            offerIdentifier: "offerIdentifier",
+            currencyCode: "usd",
+            price: 1,
+            localizedPriceString: "$1.00",
+            paymentMode: .payAsYouGo,
+            subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            numberOfPeriods: 1,
+            type: .introductory
+        )
+
+        let product = TestStoreProduct(
+            localizedTitle: "localizedTitle",
+            price: 0,
+            localizedPriceString: "",
+            productIdentifier: "productIdentifier",
+            productType: .nonRenewableSubscription,
+            localizedDescription: "localizedDescription"
+        )
+
+        mockPurchases.purchaseResult = .success(
+            (
+                transaction: nil,
+                customerInfo: CustomerInfoFixtures.customerInfoWithAmazonSubscriptions,
+                userCancelled: false
+            )
+        )
+
+        let viewModel = PromotionalOfferViewModel(
+            promotionalOfferData: PromotionalOfferData(
+                promotionalOffer: PromotionalOffer(discount: discount, signedData: signedData),
+                product: product.toStoreProduct(),
+                promoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer(
+                    iosOfferId: "offerIdentifier",
+                    eligible: true,
+                    title: "title",
+                    subtitle: "subtitle",
+                    productMapping: [:]
+                )
+            ),
+            purchasesProvider: mockPurchases,
+            actionWrapper: actionWrapper,
+            onPromotionalOfferPurchaseFlowComplete: { action in
+                capturedAction = action
+            }
+        )
+
+        var didReceivePromotionalOfferSuccess = false
+        actionWrapper.promotionalOfferSuccess
+            .sink { _ in
+                didReceivePromotionalOfferSuccess = true
+            }
+            .store(in: &cancellables)
+
+        await viewModel.purchasePromo()
+
+        expect(capturedAction!.isSuccess).to(beTrue())
+        await expect(didReceivePromotionalOfferSuccess).toEventually(beTrue())
+    }
+
+    @MainActor
+    func testOnPromotionalOfferPurchaseFlowCompleteGetsCalledOnPurchaseError() async {
+        let mockPurchases = MockCustomerCenterPurchases()
+        let actionWrapper = CustomerCenterActionWrapper()
+
+        var capturedAction: PromotionalOfferViewAction?
+        let signedData = PromotionalOffer.SignedData(
+            identifier: "id",
+            keyIdentifier: "key_i",
+            nonce: UUID(),
+            signature: "a signature",
+            timestamp: 1234
+        )
+        let discount = MockStoreProductDiscount(
+            offerIdentifier: "offerIdentifier",
+            currencyCode: "usd",
+            price: 1,
+            localizedPriceString: "$1.00",
+            paymentMode: .payAsYouGo,
+            subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            numberOfPeriods: 1,
+            type: .introductory
+        )
+
+        let product = TestStoreProduct(
+            localizedTitle: "localizedTitle",
+            price: 0,
+            localizedPriceString: "",
+            productIdentifier: "productIdentifier",
+            productType: .nonRenewableSubscription,
+            localizedDescription: "localizedDescription"
+        )
+
+        mockPurchases.purchaseResult = .failure(NSError(domain: "", code: 0))
+
+        let viewModel = PromotionalOfferViewModel(
+            promotionalOfferData: PromotionalOfferData(
+                promotionalOffer: PromotionalOffer(discount: discount, signedData: signedData),
+                product: product.toStoreProduct(),
+                promoOfferDetails: CustomerCenterConfigData.HelpPath.PromotionalOffer(
+                    iosOfferId: "offerIdentifier",
+                    eligible: true,
+                    title: "title",
+                    subtitle: "subtitle",
+                    productMapping: [:]
+                )
+            ),
+            purchasesProvider: mockPurchases,
+            actionWrapper: actionWrapper,
+            onPromotionalOfferPurchaseFlowComplete: { action in
+                capturedAction = action
+            }
+        )
+
+        await viewModel.purchasePromo()
+
+        expect(capturedAction!.isFailure).to(beTrue())
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+extension PromotionalOfferViewAction {
+
+    var isSuccess: Bool {
+        switch self {
+        case .successfullyRedeemedPromotionalOffer:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var isFailure: Bool {
+        switch self {
+        case .promotionalCodeRedemptionFailed:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+#endif

--- a/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
@@ -56,26 +56,6 @@ final class PurchaseInformationTests: TestCase {
 
     private let mockCustomerCenterStoreKitUtilities = MockCustomerCenterStoreKitUtilities()
 
-    private struct MockTransaction: Transaction {
-        let productIdentifier: String
-        let store: Store
-        let type: TransactionType
-        let isCancelled: Bool
-        let managementURL: URL?
-        let price: RevenueCat.ProductPaidPrice?
-        let displayName: String?
-        let periodType: RevenueCat.PeriodType
-        let purchaseDate: Date
-        var unsubscribeDetectedAt: Date?
-        var billingIssuesDetectedAt: Date?
-        var gracePeriodExpiresDate: Date?
-        var refundedAtDate: Date?
-        var storeIdentifier: String?
-        var identifier: String?
-        var originalPurchaseDate: Date?
-        var isSandbox: Bool
-    }
-
     func testAppleEntitlementAndSubscribedProductWithoutRenewalInfo() throws {
         let customerInfo = CustomerInfoFixtures.customerInfoWithAppleSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)

--- a/Tests/RevenueCatUITests/Mocks/MockTransaction.swift
+++ b/Tests/RevenueCatUITests/Mocks/MockTransaction.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockTransaction.swift
+//
+//  Created by Facundo Menzella on 10/6/25.
+
+import Foundation
+import RevenueCat
+@testable import RevenueCatUI
+
+struct MockTransaction: Transaction {
+    let productIdentifier: String
+    let store: Store
+    let type: TransactionType
+    let isCancelled: Bool
+    let managementURL: URL?
+    let price: RevenueCat.ProductPaidPrice?
+    let displayName: String?
+    let periodType: RevenueCat.PeriodType
+    let purchaseDate: Date
+    var unsubscribeDetectedAt: Date?
+    var billingIssuesDetectedAt: Date?
+    var gracePeriodExpiresDate: Date?
+    var refundedAtDate: Date?
+    var storeIdentifier: String?
+    var identifier: String?
+    var originalPurchaseDate: Date?
+    var isSandbox: Bool
+}


### PR DESCRIPTION
### Motivation
While working on removing internal use of preference keys, I noticed this was not being triggered.

### Description
- Move action wrapper call to `PromotionalOfferViewModel`
- delete unused `BaseManageSubscriptionViewModel.handleDismissPromotionalOfferView`
- add missing test