### PR TITLE
Remove trust-github-key from installation tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1183,7 +1183,6 @@ jobs:
       name: macos-executor
     steps:
       - checkout
-      - trust-github-key
       - install-dependencies
       - update-spm-installation-commit
       - install-dependencies:
@@ -1197,7 +1196,6 @@ jobs:
       name: macos-executor
     steps:
       - checkout
-      - trust-github-key
       - install-dependencies
       - update-spm-installation-commit
       - install-dependencies:
@@ -1211,7 +1209,6 @@ jobs:
       name: macos-executor
     steps:
       - checkout
-      - trust-github-key
       - install-dependencies
       - update-spm-installation-commit
       - install-dependencies:
@@ -1225,7 +1222,6 @@ jobs:
       name: macos-executor-large
     steps:
       - checkout
-      - trust-github-key
       - run:
           name: Upgrade Carthage
           command: |


### PR DESCRIPTION
### Motivation
We want to make sure that `installation` tests don't have access to private repositories

### Description
- Remove `trust-github-key`
