### PR TITLE
Enable markdown in paywalls in iOS 15 and watchOS 8

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -75,7 +75,7 @@ private struct NonLocalizedMarkdownText: View {
 
     var markdownText: AttributedString? {
         #if swift(>=5.7)
-        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
             return try? AttributedString(
                 markdown: self.text,
                 // We want to only process inline markdown, preserving line feeds in the original text.

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -75,15 +75,11 @@ private struct NonLocalizedMarkdownText: View {
 
     var markdownText: AttributedString? {
         #if swift(>=5.7)
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-            return try? AttributedString(
-                markdown: self.text,
-                // We want to only process inline markdown, preserving line feeds in the original text.
-                options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnly)
-            )
-        } else {
-            return nil
-        }
+        return try? AttributedString(
+            markdown: self.text,
+            // We want to only process inline markdown, preserving line feeds in the original text.
+            options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnly)
+        )
         #else
         return nil
         #endif


### PR DESCRIPTION
### Motivation

We got a report of markdown in paywalls not being rendered correctly in iOS 15

### Description

This PR enables markdown in `TextComponentView` for iOS 15 and watchOS 8.