### PR TITLE
[Paywalls] Update ImageComponent max width after initial layout if it changes.

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -72,6 +72,17 @@ struct ImageComponentView: View {
                     .shadow(shadow: style.shadow,
                             shape: style.shape?.toInsettableShape())
                     .padding(style.margin)
+                    .background(
+                        GeometryReader { proxy in
+                            Color.clear
+                                .onAppear {
+                                    self.maxWidth = proxy.size.width
+                                }
+                                .onChangeOf(proxy.size.width) { newWidth in
+                                    self.maxWidth = newWidth
+                                }
+                        }
+                    )
                 } else {
                     GeometryReader { proxy in
                         Color.clear


### PR DESCRIPTION
Sometimes the size of the parent view can change after the initial layout. This can happen more often when using [PaywallViewController](https://github.com/RevenueCat/purchases-ios/blob/main/RevenueCatUI/UIKit/PaywallViewController.swift) because the `UIHostingController` can change size after being added to the parent VC and having its AutoLayout constrains set.

With this change, we still only show the image after we've received an initial max width, but we update it when it changes.

Should fix https://github.com/RevenueCat/purchases-ios/issues/5285