### PR TITLE
Use NewErrorUtils instead of RevenueCat.ErrorUtils

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2184,7 +2184,7 @@ extension Purchases {
                     completion(eligibleWinBackOffers, nil)
                 }
             } catch {
-                let publicError = RevenueCat.ErrorUtils.purchasesError(withUntypedError: error).asPublicError
+                let publicError = NewErrorUtils.purchasesError(withUntypedError: error).asPublicError
                 OperationDispatcher.dispatchOnMainActor {
                     completion(nil, publicError)
                 }


### PR DESCRIPTION
### Motivation
While working on enabling custom entitlements for tuist, I had this compilation error.

### Description
Use `NewErrorUtils` instead of `RevenueCat.ErrorUtils`

Apparently this was already a thing:

```swift

/// Necessary because `ErrorUtils` inside of `Purchases` finds the obsoleted type.
private typealias NewErrorUtils = ErrorUtils
```
