### PR TITLE
Add .yield to `PaywallViewEventsFullscreenLightModeTests`

### DIFF
--- a/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
@@ -71,16 +71,21 @@ class BasePaywallViewEventsTests: TestCase {
     }
 
     func testPaywallImpressionEvent() async throws {
-        try await self.runDuringViewLifetime {}
+        try await self.runDuringViewLifetime {
+            await Task.yield()
+        }
 
-        expect(self.events).to(containElementSatisfying { $0.eventType == .impression })
+        expect(self.events)
+            .to(containElementSatisfying { $0.eventType == .impression })
 
         let event = try XCTUnwrap(self.events.first { $0.eventType == .impression })
         self.verifyEventData(event.data)
     }
 
     func testPaywallCloseEvent() async throws {
-        try await self.runDuringViewLifetime {}
+        try await self.runDuringViewLifetime {
+            await Task.yield()
+        }
         await self.waitForCloseEvent()
 
         expect(self.events).to(haveCount(2))
@@ -91,7 +96,9 @@ class BasePaywallViewEventsTests: TestCase {
     }
 
     func testCloseEventHasSameSessionID() async throws {
-        try await self.runDuringViewLifetime {}
+        try await self.runDuringViewLifetime {
+            await Task.yield()
+        }
         await self.waitForCloseEvent()
 
         expect(self.events).to(haveCount(2))
@@ -117,8 +124,12 @@ class BasePaywallViewEventsTests: TestCase {
     func testDifferentPaywallsCreateSeparateSessionIdentifiers() async throws {
         self.closeEventExpectation.expectedFulfillmentCount = 2
 
-        try await self.runDuringViewLifetime {}
-        try await self.runDuringViewLifetime {}
+        try await self.runDuringViewLifetime {
+            await Task.yield()
+        }
+        try await self.runDuringViewLifetime {
+            await Task.yield()
+        }
 
         await self.waitForCloseEvent()
 


### PR DESCRIPTION
### Motivation
Trying to fix flaky tests for `PaywallViewEventsFullscreenLightModeTests` and `PaywallViewEventsFooterDarkModeTests`

### Description
There's a sync expectation `expect(self.events).to(containElementSatisfying { $0.eventType == .impression })` that is flaky.
I'm adding a `yield` to ... that't executed right before disposing the VC 

```swift
        try await self.runDuringViewLifetime {
            await Task.yield()
        }
```


