### PR TITLE
Add missing `@_spi` to import in backend tests

### DIFF
--- a/Tests/BackendIntegrationTests/EventsManagerIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/EventsManagerIntegrationTests.swift
@@ -15,9 +15,9 @@ import Nimble
 import XCTest
 
 #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-@testable import RevenueCat_CustomEntitlementComputation
+@_spi(Internal) @testable import RevenueCat_CustomEntitlementComputation
 #else
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 #endif
 
 @MainActor


### PR DESCRIPTION
### Motivation
Some backend tests were failing after many APIs were made `@_spi` in #5270 

### Description
This PR adds the missing `@_spi` mark to an import to fix compilation of backend tests
