### PR TITLE
Fix paywall locale receiving UN M.49 standard localization

### DIFF
--- a/RevenueCatUI/Templates/V2/Localizations/LocaleFinder.swift
+++ b/RevenueCatUI/Templates/V2/Localizations/LocaleFinder.swift
@@ -42,6 +42,14 @@ extension Dictionary where Key == String {
             return exactMatch
         }
 
+        // Last resort: matching language and script converting dictionary keys to language and script as well
+        // This covers cases where dictionary keys contain the UN M.49 standard. For example:
+        // If locale = "es_MX" and dictionary key = "es_419" (both have rc_languageAndScript = "es-Latn")
+        if let onlyLanguageAndScriptIdentifier = locale.rc_languageAndScript,
+           let match = self.valueForLanguageAndScript(onlyLanguageAndScriptIdentifier) {
+            return match
+        }
+
         return nil
     }
 
@@ -53,6 +61,16 @@ extension Dictionary where Key == String {
         // For cases like zh-Hans and zh-Hant
         let underscoreLocaleIdentifier = localeIdentifier.replacingOccurrences(of: "-", with: "_")
         return self[underscoreLocaleIdentifier]
+    }
+
+    private func valueForLanguageAndScript(_ languageAndScript: String) -> Value? {
+        guard let matchKey = self.keys.lazy.first(where: {
+            let keyLocale = Locale(identifier: $0)
+            return keyLocale.rc_languageAndScript == languageAndScript
+        }) else {
+            return nil
+        }
+        return self[matchKey]
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Localizations/LocaleFinder.swift
+++ b/RevenueCatUI/Templates/V2/Localizations/LocaleFinder.swift
@@ -31,23 +31,21 @@ extension Dictionary where Key == String {
         }
 
         // For matching language and script without region
-        if let onlyLanguageAndScriptIdentifier = locale.rc_languageAndScript,
-           let exactMatch = self.valueForLocaleString(onlyLanguageAndScriptIdentifier) {
-            return exactMatch
+        if let onlyLanguageAndScriptIdentifier = locale.rc_languageAndScript {
+            if let exactMatch = self.valueForLocaleString(onlyLanguageAndScriptIdentifier) {
+                return exactMatch
+            } else if let match = self.valueForLanguageAndScript(onlyLanguageAndScriptIdentifier) {
+                // Matching language and script converting dictionary keys to language and script as well
+                // This covers cases where dictionary keys contain the UN M.49 standard. For example:
+                // If locale = "es_MX" and dictionary key = "es_419" (both have rc_languageAndScript = "es-Latn")
+                return match
+            }
         }
 
         // For matching language without script or region
         if let onlyLanguageIdentifier = locale.rc_languageCode,
            let exactMatch = self.valueForLocaleString(onlyLanguageIdentifier) {
             return exactMatch
-        }
-
-        // Last resort: matching language and script converting dictionary keys to language and script as well
-        // This covers cases where dictionary keys contain the UN M.49 standard. For example:
-        // If locale = "es_MX" and dictionary key = "es_419" (both have rc_languageAndScript = "es-Latn")
-        if let onlyLanguageAndScriptIdentifier = locale.rc_languageAndScript,
-           let match = self.valueForLanguageAndScript(onlyLanguageAndScriptIdentifier) {
-            return match
         }
 
         return nil

--- a/Tests/RevenueCatUITests/PaywallsV2/LocaleFinderTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/LocaleFinderTests.swift
@@ -132,4 +132,16 @@ class LocaleFinderTest: TestCase {
         expect(foundLocalizations).to(equal(Self.expectedTranslations))
     }
 
+    func test_es_MX_Matches_es_419_ByLanguageAndScript() {
+        let localizations = [
+            "es_419": Self.expectedTranslations,
+            "es": ["wrong": "this is es"]
+        ]
+
+        let locale = Locale(identifier: "es_MX")
+
+        // This tests that "es_MX" matches "es_419" due to both sharing the same language and script ("es-Latn")
+        let foundLocalizations = localizations.findLocale(locale)
+        expect(foundLocalizations).to(equal(Self.expectedTranslations))
+    }
 }


### PR DESCRIPTION
### Motivation
Found a bug where displaying a paywall with the only Spanish localization being `"es_MX"` would not show some localization strings (device region: Spain, preferred languages: es, en_US)
<img src="https://github.com/user-attachments/assets/d354aa2d-cd0b-4b9a-86c9-86b66fd6bf0d" width="200">

### Description
In this case, the server's `ui_config.localization` contains `"es_419"` (UN M.49 standard for the Latin America and the Caribbean region) but no `"es_MX"`. With the existing implementation, the SDK was not able to match `"es_MX"` with `"es_419"`.

This PR adds an extra step when trying to find the matching locale from `UIConfig.localizations`. As a last resort, it tries to find a key in `ui_config.localization` with matching language and script.