### PR TITLE
Update validation of `testCanGetOfferings` StoreKit integration test

### DIFF
--- a/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
@@ -66,7 +66,6 @@
           ],
           "tos_url" : "https://revenuecat.com/tos"
         },
-        "default_locale" : "en_US",
         "localized_strings" : {
           "en_US" : {
             "call_to_action" : "Purchase for {{ sub_price_per_month }} per month",
@@ -89,7 +88,16 @@
 
         },
         "revision" : 3,
-        "template_name" : "2"
+        "template_name" : "2",
+        "zero_decimal_place_countries" : {
+          "apple" : [
+            "TWN",
+            "KAZ",
+            "MEX",
+            "PHL",
+            "THA"
+          ]
+        }
       }
     },
     {


### PR DESCRIPTION
StoreKit Integration tests have been failing for a few days. The reason is that `testCanGetOfferings()` StoreKit integration test started to fail after a server cache clean.
This PR updates the test validation to match the latest server response for the specific Get Offerings request.