### PR TITLE
[DX-457] Log the SDK configuration report on every `#DEBUG` run

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -512,6 +512,7 @@
 		4FFFE6C82AA9467800B2955C /* PaywallEventsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFFE6C72AA9467800B2955C /* PaywallEventsManagerTests.swift */; };
 		4FFFE6CA2AA946A700B2955C /* MockInternalAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFFE6C92AA946A700B2955C /* MockInternalAPI.swift */; };
 		4FFFE6E72AA948A600B2955C /* PaywallEventsIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFFE6E62AA948A600B2955C /* PaywallEventsIntegrationTests.swift */; };
+		5310820F2E097DEE00F71174 /* SDKHealthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5310820E2E097DEE00F71174 /* SDKHealthManagerTests.swift */; };
 		537B4B2E2DA9662700CEFF4C /* HealthReportResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B2D2DA9662700CEFF4C /* HealthReportResponse.swift */; };
 		537B4B302DA9742500CEFF4C /* HealthReportOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B2F2DA9742500CEFF4C /* HealthReportOperation.swift */; };
 		537B4B322DA9743800CEFF4C /* HealthReport+Validate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B312DA9743800CEFF4C /* HealthReport+Validate.swift */; };
@@ -1951,6 +1952,7 @@
 		4FFFE6C72AA9467800B2955C /* PaywallEventsManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallEventsManagerTests.swift; sourceTree = "<group>"; };
 		4FFFE6C92AA946A700B2955C /* MockInternalAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockInternalAPI.swift; sourceTree = "<group>"; };
 		4FFFE6E62AA948A600B2955C /* PaywallEventsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallEventsIntegrationTests.swift; sourceTree = "<group>"; };
+		5310820E2E097DEE00F71174 /* SDKHealthManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKHealthManagerTests.swift; sourceTree = "<group>"; };
 		537B4B2D2DA9662700CEFF4C /* HealthReportResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthReportResponse.swift; sourceTree = "<group>"; };
 		537B4B2F2DA9742500CEFF4C /* HealthReportOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthReportOperation.swift; sourceTree = "<group>"; };
 		537B4B312DA9743800CEFF4C /* HealthReport+Validate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HealthReport+Validate.swift"; sourceTree = "<group>"; };
@@ -3852,6 +3854,7 @@
 		35272E1A26D0023400F22C3B /* Misc */ = {
 			isa = PBXGroup;
 			children = (
+				5310820E2E097DEE00F71174 /* SDKHealthManagerTests.swift */,
 				5757EDF72DEE092900AC4BE1 /* ClockTests.swift */,
 				5757EDE62DEE08C100AC4BE1 /* StoreKitVersionTests.swift */,
 				575F19B52D5A29860089A64F /* ISODurationFormatterTests.swift */,
@@ -6892,6 +6895,7 @@
 				4F1E84012A6062C1000AF177 /* ImageSnapshot.swift in Sources */,
 				57FDAAC028493C13009A48F1 /* MockSandboxEnvironmentDetector.swift in Sources */,
 				1EF46BC62D9C1FA7005C94A6 /* PurchasesSystemInfoTests.swift in Sources */,
+				5310820F2E097DEE00F71174 /* SDKHealthManagerTests.swift in Sources */,
 				5766AAD1283E981700FA6091 /* PurchasesPurchasingTests.swift in Sources */,
 				351B515E26D44B9900BD2BD7 /* MockPurchasesDelegate.swift in Sources */,
 				5712BE9229241F7900A83F15 /* TimingUtilTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 		537B4B392DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B352DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift */; };
 		537B4B3A2DA9744B00CEFF4C /* ProductStatus+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B342DA9744B00CEFF4C /* ProductStatus+Icon.swift */; };
 		537BA85B2DBBFAF200C93327 /* SDKHealthError+CustomNSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537BA85A2DBBFAE700C93327 /* SDKHealthError+CustomNSError.swift */; };
+		53E33BBB2E095B8900287158 /* SDKHealthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E33BBA2E095B8900287158 /* SDKHealthManager.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
 		57045B3C29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */; };
@@ -1957,6 +1958,7 @@
 		537B4B352DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthCheckStatus+Icon.swift"; sourceTree = "<group>"; };
 		537B4B362DA9744B00CEFF4C /* SDKHealthStatus+Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthStatus+Icon.swift"; sourceTree = "<group>"; };
 		537BA85A2DBBFAE700C93327 /* SDKHealthError+CustomNSError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthError+CustomNSError.swift"; sourceTree = "<group>"; };
+		53E33BBA2E095B8900287158 /* SDKHealthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKHealthManager.swift; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
 		57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProductEntitlementMappingOperation.swift; sourceTree = "<group>"; };
 		57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingCallback.swift; sourceTree = "<group>"; };
@@ -4135,6 +4137,7 @@
 				1E473B652AC42D34008B07F9 /* StoreMessagesHelper.swift */,
 				1E473B672AC43254008B07F9 /* StoreMessageType.swift */,
 				537B4B312DA9743800CEFF4C /* HealthReport+Validate.swift */,
+				53E33BBA2E095B8900287158 /* SDKHealthManager.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -6366,6 +6369,7 @@
 				9A65E03625918B0500DE00B0 /* ConfigureStrings.swift in Sources */,
 				4FF6E4B92B069B8C000141ED /* HTTPRequest+Signing.swift in Sources */,
 				57488C7729CB90F90000EE7E /* PurchasedProductsFetcher.swift in Sources */,
+				53E33BBB2E095B8900287158 /* SDKHealthManager.swift in Sources */,
 				4F3C986A2A44FA60009AECA3 /* ErrorResponse.swift in Sources */,
 				578C5F2C28DB82DD00A56F02 /* PurchasesDiagnostics.swift in Sources */,
 				537B4B322DA9743800CEFF4C /* HealthReport+Validate.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -520,6 +520,7 @@
 		537B4B392DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B352DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift */; };
 		537B4B3A2DA9744B00CEFF4C /* ProductStatus+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B342DA9744B00CEFF4C /* ProductStatus+Icon.swift */; };
 		537BA85B2DBBFAF200C93327 /* SDKHealthError+CustomNSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537BA85A2DBBFAE700C93327 /* SDKHealthError+CustomNSError.swift */; };
+		53AAD34F2E09857300605F51 /* PaymentAuthorizationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53AAD34E2E09856400605F51 /* PaymentAuthorizationProvider.swift */; };
 		53E33BBB2E095B8900287158 /* SDKHealthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E33BBA2E095B8900287158 /* SDKHealthManager.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
@@ -1960,6 +1961,7 @@
 		537B4B352DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthCheckStatus+Icon.swift"; sourceTree = "<group>"; };
 		537B4B362DA9744B00CEFF4C /* SDKHealthStatus+Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthStatus+Icon.swift"; sourceTree = "<group>"; };
 		537BA85A2DBBFAE700C93327 /* SDKHealthError+CustomNSError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthError+CustomNSError.swift"; sourceTree = "<group>"; };
+		53AAD34E2E09856400605F51 /* PaymentAuthorizationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentAuthorizationProvider.swift; sourceTree = "<group>"; };
 		53E33BBA2E095B8900287158 /* SDKHealthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKHealthManager.swift; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
 		57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProductEntitlementMappingOperation.swift; sourceTree = "<group>"; };
@@ -4129,6 +4131,7 @@
 		35E840C1270FB45600899AE2 /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				53AAD34E2E09856400605F51 /* PaymentAuthorizationProvider.swift */,
 				4F6BED572A26A13800CD9322 /* DebugUI */,
 				A5F0104D2717B3150090732D /* BeginRefundRequestHelper.swift */,
 				35E840C5270FB47C00899AE2 /* ManageSubscriptionsHelper.swift */,
@@ -6635,6 +6638,7 @@
 				4F6BEDE02A26B65900CD9322 /* DebugViewSheetPresentation.swift in Sources */,
 				4F6BEDD92A26B55C00CD9322 /* DebugViewModel.swift in Sources */,
 				FDAC7B552CD3D7A500DFC0D9 /* WinBackOfferEligibilityCalculator.swift in Sources */,
+				53AAD34F2E09857300605F51 /* PaymentAuthorizationProvider.swift in Sources */,
 				1EDB6AA82DC9519D00C771A4 /* WebProductsResponse.swift in Sources */,
 				5766C622282DAA700067D886 /* GetIntroEligibilityResponse.swift in Sources */,
 				35E840CC270FB70D00899AE2 /* ManageSubscriptionsHelper.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -520,6 +520,8 @@
 		537B4B392DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B352DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift */; };
 		537B4B3A2DA9744B00CEFF4C /* ProductStatus+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B342DA9744B00CEFF4C /* ProductStatus+Icon.swift */; };
 		537BA85B2DBBFAF200C93327 /* SDKHealthError+CustomNSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537BA85A2DBBFAE700C93327 /* SDKHealthError+CustomNSError.swift */; };
+		53A8DCC12E0EA49400FEABEA /* HealthReportAvailabilityOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A8DCC02E0EA49400FEABEA /* HealthReportAvailabilityOperation.swift */; };
+		53A8DCC32E0EA4FF00FEABEA /* HealthReportAvailabilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A8DCC22E0EA4F600FEABEA /* HealthReportAvailabilityResponse.swift */; };
 		53AAD34F2E09857300605F51 /* PaymentAuthorizationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53AAD34E2E09856400605F51 /* PaymentAuthorizationProvider.swift */; };
 		53E33BBB2E095B8900287158 /* SDKHealthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E33BBA2E095B8900287158 /* SDKHealthManager.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
@@ -1961,6 +1963,8 @@
 		537B4B352DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthCheckStatus+Icon.swift"; sourceTree = "<group>"; };
 		537B4B362DA9744B00CEFF4C /* SDKHealthStatus+Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthStatus+Icon.swift"; sourceTree = "<group>"; };
 		537BA85A2DBBFAE700C93327 /* SDKHealthError+CustomNSError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthError+CustomNSError.swift"; sourceTree = "<group>"; };
+		53A8DCC02E0EA49400FEABEA /* HealthReportAvailabilityOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthReportAvailabilityOperation.swift; sourceTree = "<group>"; };
+		53A8DCC22E0EA4F600FEABEA /* HealthReportAvailabilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthReportAvailabilityResponse.swift; sourceTree = "<group>"; };
 		53AAD34E2E09856400605F51 /* PaymentAuthorizationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentAuthorizationProvider.swift; sourceTree = "<group>"; };
 		53E33BBA2E095B8900287158 /* SDKHealthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKHealthManager.swift; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
@@ -4772,6 +4776,7 @@
 		57D5412C27F63108004CC35C /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				53A8DCC22E0EA4F600FEABEA /* HealthReportAvailabilityResponse.swift */,
 				03A98D2E2D240C2D009BCA61 /* RevenueCatUI */,
 				3592E88D2C2ED5B200D7F91D /* CustomerCenterConfigResponse.swift */,
 				5774F9B52805E6CC00997128 /* CustomerInfoResponse.swift */,
@@ -5364,6 +5369,7 @@
 		B34605AA279A6E380031CA74 /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				53A8DCC02E0EA49400FEABEA /* HealthReportAvailabilityOperation.swift */,
 				B34605AE279A6E380031CA74 /* Handling */,
 				3592E88B2C2ED58900D7F91D /* GetCustomerCenterConfigOperation.swift */,
 				B34605B5279A6E380031CA74 /* GetCustomerInfoOperation.swift */,
@@ -6578,6 +6584,7 @@
 				B325543C2825C81800DA62EA /* Configuration.swift in Sources */,
 				4F89A55D2A6ABADF008A411E /* PaywallViewMode.swift in Sources */,
 				4F1428A42A4A132C006CD196 /* TestStoreProductDiscount.swift in Sources */,
+				53A8DCC32E0EA4FF00FEABEA /* HealthReportAvailabilityResponse.swift in Sources */,
 				F5BE447B269E4A7500254A30 /* TrackingManagerProxy.swift in Sources */,
 				5746508C27586B2E0053AB09 /* Result+Extensions.swift in Sources */,
 				B34D2AA0269606E400D88C3A /* IntroEligibility.swift in Sources */,
@@ -6640,6 +6647,7 @@
 				FDAC7B552CD3D7A500DFC0D9 /* WinBackOfferEligibilityCalculator.swift in Sources */,
 				53AAD34F2E09857300605F51 /* PaymentAuthorizationProvider.swift in Sources */,
 				1EDB6AA82DC9519D00C771A4 /* WebProductsResponse.swift in Sources */,
+				53A8DCC12E0EA49400FEABEA /* HealthReportAvailabilityOperation.swift in Sources */,
 				5766C622282DAA700067D886 /* GetIntroEligibilityResponse.swift in Sources */,
 				35E840CC270FB70D00899AE2 /* ManageSubscriptionsHelper.swift in Sources */,
 				6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */,

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -143,6 +143,15 @@ class Backend {
         self.customer.post(subscriberAttributes: subscriberAttributes, appUserID: appUserID, completion: completion)
     }
 
+    func healthReportAvailabilityRequest(appUserID: String) async throws -> HealthReportAvailability {
+        try await Async.call { (completion: @escaping (Result<HealthReportAvailability, BackendError>) -> Void) in
+            self.internalAPI.healthReportAvailabilityRequest(
+                appUserID: appUserID,
+                completion: completion
+            )
+        }
+    }
+
     /// Call the `/health_report` endpoint and perform a full validation of the SDK's configuration
     /// - Parameter appUserID: An `appUserID` that allows the Backend to fetch offerings
     /// - Returns: A report with all validation checks along with their status

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -143,6 +143,14 @@ class Backend {
         self.customer.post(subscriberAttributes: subscriberAttributes, appUserID: appUserID, completion: completion)
     }
 
+    /// Call the `/health_report` endpoint and perform a full validation of the SDK's configuration
+    /// - Parameter appUserID: An `appUserID` that allows the Backend to fetch offerings
+    /// - Returns: A report with all validation checks along with their status
+    func healthReportRequest(appUserID: String) async throws -> HealthReport {
+        try await Async.call { (completion: @escaping (Result<HealthReport, BackendError>) -> Void) in
+            self.internalAPI.healthReportRequest(appUserID: appUserID, completion: completion)
+        }
+    }
 }
 
 extension Backend {
@@ -153,19 +161,6 @@ extension Backend {
             self.internalAPI.healthRequest(signatureVerification: signatureVerification) { error in
                 completion(.init(error))
             }
-        }
-    }
-
-}
-
-extension Backend {
-
-    /// Call the `/health_report` endpoint and perform a full validation of the SDK's configuration
-    /// - Parameter appUserID: An `appUserID` that allows the Backend to fetch offerings
-    /// - Returns: A report with all validation checks along with their status
-    func healthReportRequest(appUserID: String) async throws -> HealthReport {
-        try await Async.call { (completion: @escaping (Result<HealthReport, BackendError>) -> Void) in
-            self.internalAPI.healthReportRequest(appUserID: appUserID, completion: completion)
         }
     }
 

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -143,6 +143,10 @@ class Backend {
         self.customer.post(subscriberAttributes: subscriberAttributes, appUserID: appUserID, completion: completion)
     }
 
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    /// Checks if the SDK should log the status of the health report to the console.
+    /// - Parameter appUserID: An `appUserID` that allows the Backend to check for health report availability
+    /// - Returns: Whether the health report should be reported to the console for the given `appUserID`.
     func healthReportAvailabilityRequest(appUserID: String) async throws -> HealthReportAvailability {
         try await Async.call { (completion: @escaping (Result<HealthReportAvailability, BackendError>) -> Void) in
             self.internalAPI.healthReportAvailabilityRequest(
@@ -160,6 +164,7 @@ class Backend {
             self.internalAPI.healthReportRequest(appUserID: appUserID, completion: completion)
         }
     }
+    #endif
 }
 
 extension Backend {

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -83,6 +83,7 @@ extension HTTPRequest {
         case postAdServicesToken(appUserID: String)
         case health
         case appHealthReport(appUserID: String)
+        case appHealthReportAvailability(appUserID: String)
         case getProductEntitlementMapping
         case getCustomerCenterConfig(appUserID: String)
         case postRedeemWebPurchase
@@ -138,7 +139,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postRedeemWebPurchase,
                 .getProductEntitlementMapping,
                 .getCustomerCenterConfig,
-                .appHealthReport:
+                .appHealthReport,
+                .appHealthReportAvailability:
             return true
 
         case .health:
@@ -160,7 +162,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postRedeemWebPurchase,
                 .getProductEntitlementMapping,
                 .getCustomerCenterConfig,
-                .appHealthReport:
+                .appHealthReport,
+                .appHealthReportAvailability:
             return true
         case .health:
             return false
@@ -175,7 +178,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .health,
                 .getOfferings,
                 .getProductEntitlementMapping,
-                .appHealthReport:
+                .appHealthReport,
+                .appHealthReportAvailability:
             return true
         case .getIntroEligibility,
                 .postSubscriberAttributes,
@@ -204,7 +208,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postRedeemWebPurchase,
                 .getProductEntitlementMapping,
                 .getCustomerCenterConfig,
-                .appHealthReport:
+                .appHealthReport,
+                .appHealthReportAvailability:
             return false
         }
     }
@@ -226,6 +231,9 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case let .appHealthReport(appUserID):
             return "subscribers/\(Self.escape(appUserID))/health_report"
+
+        case let .appHealthReportAvailability(appUserID):
+            return "subscribers/\(Self.escape(appUserID))/health_report_availability"
 
         case .logIn:
             return "subscribers/identify"
@@ -303,6 +311,9 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case .appHealthReport:
             return "get_app_health_report"
+
+        case .appHealthReportAvailability:
+            return "get_app_health_report_availability"
 
         }
     }

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -139,11 +139,11 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postRedeemWebPurchase,
                 .getProductEntitlementMapping,
                 .getCustomerCenterConfig,
-                .appHealthReport,
-                .appHealthReportAvailability:
+                .appHealthReport:
             return true
 
-        case .health:
+        case .health,
+             .appHealthReportAvailability:
             return false
         }
     }
@@ -162,10 +162,10 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postRedeemWebPurchase,
                 .getProductEntitlementMapping,
                 .getCustomerCenterConfig,
-                .appHealthReport,
-                .appHealthReportAvailability:
+                .appHealthReport:
             return true
-        case .health:
+        case .health,
+             .appHealthReportAvailability:
             return false
         }
     }
@@ -197,7 +197,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case .getCustomerInfo,
                 .logIn,
                 .postReceiptData,
-                .health:
+                .health,
+                .appHealthReportAvailability:
             return true
         case .getOfferings,
                 .getIntroEligibility,
@@ -208,8 +209,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postRedeemWebPurchase,
                 .getProductEntitlementMapping,
                 .getCustomerCenterConfig,
-                .appHealthReport,
-                .appHealthReportAvailability:
+                .appHealthReport:
             return false
         }
     }

--- a/Sources/Networking/InternalAPI.swift
+++ b/Sources/Networking/InternalAPI.swift
@@ -44,6 +44,7 @@ class InternalAPI {
                                                  cacheStatus: cacheStatus)
     }
 
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     func healthReportRequest(appUserID: String, completion: @escaping HealthReportResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)
@@ -76,6 +77,7 @@ class InternalAPI {
                                                  delay: .none,
                                                  cacheStatus: cacheStatus)
     }
+    #endif
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     func postPaywallEvents(events: [StoredEvent], completion: @escaping ResponseHandler) {

--- a/Sources/Networking/InternalAPI.swift
+++ b/Sources/Networking/InternalAPI.swift
@@ -16,19 +16,24 @@ import Foundation
 class InternalAPI {
 
     typealias ResponseHandler = (BackendError?) -> Void
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     typealias HealthReportResponseHandler = (Result<HealthReport, BackendError>) -> Void
     typealias HealthReportAvailabilityResponseHandler = (Result<HealthReportAvailability, BackendError>) -> Void
 
-    private let backendConfig: BackendConfiguration
-    private let healthCallbackCache: CallbackCache<HealthOperation.Callback>
     private let healthReportCallbackCache: CallbackCache<HealthReportOperation.Callback>
     private let healthReportAvailabilityCallbackCache: CallbackCache<HealthReportAvailabilityOperation.Callback>
+    #endif
+
+    private let backendConfig: BackendConfiguration
+    private let healthCallbackCache: CallbackCache<HealthOperation.Callback>
 
     init(backendConfig: BackendConfiguration) {
         self.backendConfig = backendConfig
         self.healthCallbackCache = .init()
+        #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
         self.healthReportCallbackCache = .init()
         self.healthReportAvailabilityCallbackCache = .init()
+        #endif
     }
 
     func healthRequest(signatureVerification: Bool, completion: @escaping ResponseHandler) {

--- a/Sources/Networking/Operations/HealthReportAvailabilityOperation.swift
+++ b/Sources/Networking/Operations/HealthReportAvailabilityOperation.swift
@@ -1,0 +1,73 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  HealthReportOperation 2.swift
+//
+//  Created by Pol Piella Abadia on 27/06/2025.
+
+import Foundation
+
+final class HealthReportAvailabilityOperation: CacheableNetworkOperation {
+
+    struct Callback: CacheKeyProviding {
+
+        let cacheKey: String
+        let completion: InternalAPI.HealthReportAvailabilityResponseHandler
+
+    }
+
+    private let configuration: AppUserConfiguration
+    private let callbackCache: CallbackCache<Callback>
+
+    static func createFactory(
+        configuration: UserSpecificConfiguration,
+        callbackCache: CallbackCache<Callback>
+    ) -> CacheableNetworkOperationFactory<HealthReportAvailabilityOperation> {
+        return .init({ .init(configuration: configuration,
+                             callbackCache: callbackCache,
+                             cacheKey: $0) },
+                     individualizedCacheKeyPart: "")
+    }
+
+    private init(configuration: UserSpecificConfiguration,
+                 callbackCache: CallbackCache<Callback>,
+                 cacheKey: String) {
+        self.configuration = configuration
+        self.callbackCache = callbackCache
+
+        super.init(configuration: configuration, cacheKey: cacheKey)
+    }
+
+    override func begin(completion: @escaping () -> Void) {
+        let request: HTTPRequest = .init(method: .get,
+                                         path: .appHealthReport(appUserID: configuration.appUserID))
+
+        self.httpClient.perform(
+            request
+        ) { (response: VerifiedHTTPResponse<HealthReportAvailability>.Result) in
+            self.finish(with: response, completion: completion)
+        }
+    }
+
+    private func finish(with response: VerifiedHTTPResponse<HealthReportAvailability>.Result,
+                        completion: () -> Void) {
+        self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
+            callback.completion(
+                response
+                    .mapError(BackendError.networkError)
+                    .map { $0.body }
+            )
+        }
+
+        completion()
+    }
+}
+
+// Restating inherited @unchecked Sendable from Foundation's Operation
+extension HealthReportAvailabilityOperation: @unchecked Sendable {}

--- a/Sources/Networking/Operations/HealthReportAvailabilityOperation.swift
+++ b/Sources/Networking/Operations/HealthReportAvailabilityOperation.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Pol Piella Abadia on 27/06/2025.
 
+#if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 import Foundation
 
 final class HealthReportAvailabilityOperation: CacheableNetworkOperation {
@@ -71,3 +72,4 @@ final class HealthReportAvailabilityOperation: CacheableNetworkOperation {
 
 // Restating inherited @unchecked Sendable from Foundation's Operation
 extension HealthReportAvailabilityOperation: @unchecked Sendable {}
+#endif

--- a/Sources/Networking/Operations/HealthReportAvailabilityOperation.swift
+++ b/Sources/Networking/Operations/HealthReportAvailabilityOperation.swift
@@ -7,7 +7,7 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  HealthReportOperation 2.swift
+//  HealthReportAvailabilityOperation.swift
 //
 //  Created by Pol Piella Abadia on 27/06/2025.
 

--- a/Sources/Networking/Operations/HealthReportAvailabilityOperation.swift
+++ b/Sources/Networking/Operations/HealthReportAvailabilityOperation.swift
@@ -46,7 +46,7 @@ final class HealthReportAvailabilityOperation: CacheableNetworkOperation {
 
     override func begin(completion: @escaping () -> Void) {
         let request: HTTPRequest = .init(method: .get,
-                                         path: .appHealthReport(appUserID: configuration.appUserID))
+                                         path: .appHealthReportAvailability(appUserID: configuration.appUserID))
 
         self.httpClient.perform(
             request

--- a/Sources/Networking/Operations/HealthReportOperation.swift
+++ b/Sources/Networking/Operations/HealthReportOperation.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Pol Piella on 4/8/25.
 
+#if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 import Foundation
 
 final class HealthReportOperation: CacheableNetworkOperation {
@@ -71,3 +72,4 @@ final class HealthReportOperation: CacheableNetworkOperation {
 
 // Restating inherited @unchecked Sendable from Foundation's Operation
 extension HealthReportOperation: @unchecked Sendable {}
+#endif

--- a/Sources/Networking/Responses/HealthReportAvailabilityResponse.swift
+++ b/Sources/Networking/Responses/HealthReportAvailabilityResponse.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 struct HealthReportAvailability {
-    let isAvailable: Bool
+    let reportLogs: Bool
 }
 
 extension HealthReportAvailability: HTTPResponseBody {}

--- a/Sources/Networking/Responses/HealthReportAvailabilityResponse.swift
+++ b/Sources/Networking/Responses/HealthReportAvailabilityResponse.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  HealthReportAvailabilityResponse.swift
+//
+//  Created by Pol Piella Abadia on 27/06/2025.
+
+import Foundation
+
+struct HealthReportAvailability {
+    let isAvailable: Bool
+}
+
+extension HealthReportAvailability: HTTPResponseBody {}
+extension HealthReportAvailability: Codable, Equatable {}

--- a/Sources/Networking/Responses/HealthReportResponse.swift
+++ b/Sources/Networking/Responses/HealthReportResponse.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Pol Piella on 4/8/25.
 
+#if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 import Foundation
 
 enum HealthCheckStatus: String {
@@ -138,3 +139,4 @@ extension ProductStatus: Codable, Equatable {}
 extension ProductHealthReport: Codable, Equatable {}
 extension OfferingHealthReport: Codable, Equatable {}
 extension PackageHealthReport: Codable, Equatable {}
+#endif

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -113,7 +113,7 @@ import Foundation
         private(set) var platformInfo: Purchases.PlatformInfo?
         private(set) var responseVerificationMode: Signing.ResponseVerificationMode = .default
         private(set) var showStoreMessagesAutomatically: Bool = true
-        private(set) var validateConfigurationOnLaunch: Bool = true
+        private(set) var validateConfigurationOnLaunch: Bool = false
         private(set) var diagnosticsEnabled: Bool = false
         private(set) var storeKitVersion: StoreKitVersion = .default
 

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -53,7 +53,6 @@ import Foundation
     let platformInfo: Purchases.PlatformInfo?
     let responseVerificationMode: Signing.ResponseVerificationMode
     let showStoreMessagesAutomatically: Bool
-    let validateConfigurationOnDebugAppLaunch: Bool
     let preferredLocale: String?
     internal let diagnosticsEnabled: Bool
 
@@ -71,7 +70,6 @@ import Foundation
         self.platformInfo = builder.platformInfo
         self.responseVerificationMode = builder.responseVerificationMode
         self.showStoreMessagesAutomatically = builder.showStoreMessagesAutomatically
-        self.validateConfigurationOnDebugAppLaunch = builder.validateConfigurationOnDebugAppLaunch
         self.diagnosticsEnabled = builder.diagnosticsEnabled
         self.preferredLocale = builder.preferredLocale
     }
@@ -115,7 +113,6 @@ import Foundation
         private(set) var platformInfo: Purchases.PlatformInfo?
         private(set) var responseVerificationMode: Signing.ResponseVerificationMode = .default
         private(set) var showStoreMessagesAutomatically: Bool = true
-        private(set) var validateConfigurationOnDebugAppLaunch: Bool = true
         private(set) var diagnosticsEnabled: Bool = false
         private(set) var storeKitVersion: StoreKitVersion = .default
         private(set) var preferredLocale: String?
@@ -248,27 +245,6 @@ import Foundation
             self.showStoreMessagesAutomatically = showStoreMessagesAutomatically
             return self
         }
-
-        #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-        /// Set `validateConfigurationOnDebugAppLaunch`. Enabled by default.
-        /// If enabled, the SDK will automatically validate its configuration on every launch 
-        /// by running a health check and logging the results to the console. This helps identify
-        /// configuration issues early in the development process.
-        /// 
-        /// The health check validates:
-        /// - API key validity
-        /// - Bundle ID configuration
-        /// - Product configuration in App Store Connect
-        /// - Offering configuration
-        /// - Payment authorization status
-        ///
-        /// - Note: This feature is only available in DEBUG builds
-        /// - Note: Health checks are performed asynchronously and don't block app startup
-        @objc public func with(validateConfigurationOnDebugAppLaunch: Bool) -> Builder {
-            self.validateConfigurationOnDebugAppLaunch = validateConfigurationOnDebugAppLaunch
-            return self
-        }
-        #endif
 
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -246,6 +246,7 @@ import Foundation
             return self
         }
 
+        #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
         /// Set `validateConfigurationOnLaunch`. Enabled by default.
         /// If enabled, the SDK will automatically validate its configuration on every launch 
         /// by running a health check and logging the results to the console. This helps identify
@@ -257,18 +258,14 @@ import Foundation
         /// - Product configuration in App Store Connect
         /// - Offering configuration
         /// - Payment authorization status
-        /// 
-        /// Health check results are logged with appropriate log levels:
-        /// - `.error` for unhealthy configurations that need immediate attention
-        /// - `.warn` for healthy configurations with warnings
-        /// - `.info` for healthy configurations without issues
-        /// 
+        ///
         /// - Note: This feature is only available in DEBUG builds
         /// - Note: Health checks are performed asynchronously and don't block app startup
         @objc public func with(validateConfigurationOnLaunch: Bool) -> Builder {
             self.validateConfigurationOnLaunch = validateConfigurationOnLaunch
             return self
         }
+        #endif
 
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -53,6 +53,7 @@ import Foundation
     let platformInfo: Purchases.PlatformInfo?
     let responseVerificationMode: Signing.ResponseVerificationMode
     let showStoreMessagesAutomatically: Bool
+    let validateConfigurationOnLaunch: Bool
     internal let diagnosticsEnabled: Bool
 
     private init(with builder: Builder) {
@@ -69,6 +70,7 @@ import Foundation
         self.platformInfo = builder.platformInfo
         self.responseVerificationMode = builder.responseVerificationMode
         self.showStoreMessagesAutomatically = builder.showStoreMessagesAutomatically
+        self.validateConfigurationOnLaunch = builder.validateConfigurationOnLaunch
         self.diagnosticsEnabled = builder.diagnosticsEnabled
     }
 
@@ -111,6 +113,7 @@ import Foundation
         private(set) var platformInfo: Purchases.PlatformInfo?
         private(set) var responseVerificationMode: Signing.ResponseVerificationMode = .default
         private(set) var showStoreMessagesAutomatically: Bool = true
+        private(set) var validateConfigurationOnLaunch: Bool = true
         private(set) var diagnosticsEnabled: Bool = false
         private(set) var storeKitVersion: StoreKitVersion = .default
 
@@ -240,6 +243,30 @@ import Foundation
         /// the related methods
         @objc public func with(showStoreMessagesAutomatically: Bool) -> Builder {
             self.showStoreMessagesAutomatically = showStoreMessagesAutomatically
+            return self
+        }
+
+        /// Set `validateConfigurationOnLaunch`. Enabled by default.
+        /// If enabled, the SDK will automatically validate its configuration on every launch 
+        /// by running a health check and logging the results to the console. This helps identify
+        /// configuration issues early in the development process.
+        /// 
+        /// The health check validates:
+        /// - API key validity
+        /// - Bundle ID configuration
+        /// - Product configuration in App Store Connect
+        /// - Offering configuration
+        /// - Payment authorization status
+        /// 
+        /// Health check results are logged with appropriate log levels:
+        /// - `.error` for unhealthy configurations that need immediate attention
+        /// - `.warn` for healthy configurations with warnings
+        /// - `.info` for healthy configurations without issues
+        /// 
+        /// - Note: This feature is only available in DEBUG builds
+        /// - Note: Health checks are performed asynchronously and don't block app startup
+        @objc public func with(validateConfigurationOnLaunch: Bool) -> Builder {
+            self.validateConfigurationOnLaunch = validateConfigurationOnLaunch
             return self
         }
 

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -53,7 +53,7 @@ import Foundation
     let platformInfo: Purchases.PlatformInfo?
     let responseVerificationMode: Signing.ResponseVerificationMode
     let showStoreMessagesAutomatically: Bool
-    let validateConfigurationOnLaunch: Bool
+    let validateConfigurationOnDebugAppLaunch: Bool
     internal let diagnosticsEnabled: Bool
 
     private init(with builder: Builder) {
@@ -70,7 +70,7 @@ import Foundation
         self.platformInfo = builder.platformInfo
         self.responseVerificationMode = builder.responseVerificationMode
         self.showStoreMessagesAutomatically = builder.showStoreMessagesAutomatically
-        self.validateConfigurationOnLaunch = builder.validateConfigurationOnLaunch
+        self.validateConfigurationOnDebugAppLaunch = builder.validateConfigurationOnDebugAppLaunch
         self.diagnosticsEnabled = builder.diagnosticsEnabled
     }
 
@@ -113,7 +113,7 @@ import Foundation
         private(set) var platformInfo: Purchases.PlatformInfo?
         private(set) var responseVerificationMode: Signing.ResponseVerificationMode = .default
         private(set) var showStoreMessagesAutomatically: Bool = true
-        private(set) var validateConfigurationOnLaunch: Bool = false
+        private(set) var validateConfigurationOnDebugAppLaunch: Bool = false
         private(set) var diagnosticsEnabled: Bool = false
         private(set) var storeKitVersion: StoreKitVersion = .default
 
@@ -247,7 +247,7 @@ import Foundation
         }
 
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-        /// Set `validateConfigurationOnLaunch`. Enabled by default.
+        /// Set `validateConfigurationOnDebugAppLaunch`. Enabled by default.
         /// If enabled, the SDK will automatically validate its configuration on every launch 
         /// by running a health check and logging the results to the console. This helps identify
         /// configuration issues early in the development process.
@@ -261,8 +261,8 @@ import Foundation
         ///
         /// - Note: This feature is only available in DEBUG builds
         /// - Note: Health checks are performed asynchronously and don't block app startup
-        @objc public func with(validateConfigurationOnLaunch: Bool) -> Builder {
-            self.validateConfigurationOnLaunch = validateConfigurationOnLaunch
+        @objc public func with(validateConfigurationOnDebugAppLaunch: Bool) -> Builder {
+            self.validateConfigurationOnDebugAppLaunch = validateConfigurationOnDebugAppLaunch
             return self
         }
         #endif

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -113,7 +113,7 @@ import Foundation
         private(set) var platformInfo: Purchases.PlatformInfo?
         private(set) var responseVerificationMode: Signing.ResponseVerificationMode = .default
         private(set) var showStoreMessagesAutomatically: Bool = true
-        private(set) var validateConfigurationOnDebugAppLaunch: Bool = false
+        private(set) var validateConfigurationOnDebugAppLaunch: Bool = true
         private(set) var diagnosticsEnabled: Bool = false
         private(set) var storeKitVersion: StoreKitVersion = .default
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -277,7 +277,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     private let syncAttributesAndOfferingsIfNeededRateLimiter = RateLimiter(maxCalls: 5, period: 60)
     private let diagnosticsTracker: DiagnosticsTrackerType?
-    private let validateConfigurationOnLaunch: Bool
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     convenience init(apiKey: String,
@@ -619,8 +618,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   purchasedProductsFetcher: purchasedProductsFetcher,
                   trialOrIntroPriceEligibilityChecker: trialOrIntroPriceChecker,
                   storeMessagesHelper: storeMessagesHelper,
-                  diagnosticsTracker: diagnosticsTracker,
-                  validateConfigurationOnLaunch: validateConfigurationOnLaunch
+                  diagnosticsTracker: diagnosticsTracker
         )
     }
 
@@ -651,7 +649,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          trialOrIntroPriceEligibilityChecker: CachingTrialOrIntroPriceEligibilityChecker,
          storeMessagesHelper: StoreMessagesHelperType?,
          diagnosticsTracker: DiagnosticsTrackerType?,
-         validateConfigurationOnLaunch: Bool
+         validateConfigurationOnLaunch: Bool = true
     ) {
 
         if systemInfo.dangerousSettings.customEntitlementComputation {
@@ -700,7 +698,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.trialOrIntroPriceEligibilityChecker = trialOrIntroPriceEligibilityChecker
         self.storeMessagesHelper = storeMessagesHelper
         self.diagnosticsTracker = diagnosticsTracker
-        self.validateConfigurationOnLaunch = validateConfigurationOnLaunch
 
         super.init()
 
@@ -719,7 +716,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.updateCachesIfInForeground()
 
         #if DEBUG
-        if self.validateConfigurationOnLaunch {
+        if validateConfigurationOnLaunch {
             self.runHealthCheckIfInForeground()
         }
         #endif

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -291,7 +291,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                      networkTimeout: TimeInterval = Configuration.networkTimeoutDefault,
                      dangerousSettings: DangerousSettings? = nil,
                      showStoreMessagesAutomatically: Bool,
-                     validateConfigurationOnLaunch: Bool,
+                     validateConfigurationOnDebugAppLaunch: Bool,
                      diagnosticsEnabled: Bool = false
     ) {
         if userDefaults != nil {
@@ -619,7 +619,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   trialOrIntroPriceEligibilityChecker: trialOrIntroPriceChecker,
                   storeMessagesHelper: storeMessagesHelper,
                   diagnosticsTracker: diagnosticsTracker,
-                  validateConfigurationOnLaunch: validateConfigurationOnLaunch
+                  validateConfigurationOnDebugAppLaunch: validateConfigurationOnDebugAppLaunch
         )
     }
 
@@ -650,7 +650,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          trialOrIntroPriceEligibilityChecker: CachingTrialOrIntroPriceEligibilityChecker,
          storeMessagesHelper: StoreMessagesHelperType?,
          diagnosticsTracker: DiagnosticsTrackerType?,
-         validateConfigurationOnLaunch: Bool
+         validateConfigurationOnDebugAppLaunch: Bool
     ) {
 
         if systemInfo.dangerousSettings.customEntitlementComputation {
@@ -717,7 +717,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.updateCachesIfInForeground()
 
         #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-        if validateConfigurationOnLaunch {
+        if validateConfigurationOnDebugAppLaunch {
             self.runHealthCheckIfInForeground()
         }
         #endif
@@ -1398,7 +1398,7 @@ public extension Purchases {
                   networkTimeout: configuration.networkTimeout,
                   dangerousSettings: configuration.dangerousSettings,
                   showStoreMessagesAutomatically: configuration.showStoreMessagesAutomatically,
-                  validateConfigurationOnLaunch: configuration.validateConfigurationOnLaunch,
+                  validateConfigurationOnDebugAppLaunch: configuration.validateConfigurationOnDebugAppLaunch,
                   diagnosticsEnabled: configuration.diagnosticsEnabled
         )
     }
@@ -1665,7 +1665,7 @@ public extension Purchases {
         networkTimeout: TimeInterval,
         dangerousSettings: DangerousSettings?,
         showStoreMessagesAutomatically: Bool,
-        validateConfigurationOnLaunch: Bool,
+        validateConfigurationOnDebugAppLaunch: Bool,
         diagnosticsEnabled: Bool
     ) -> Purchases {
         return self.setDefaultInstance(
@@ -1681,7 +1681,7 @@ public extension Purchases {
                   networkTimeout: networkTimeout,
                   dangerousSettings: dangerousSettings,
                   showStoreMessagesAutomatically: showStoreMessagesAutomatically,
-                  validateConfigurationOnLaunch: validateConfigurationOnLaunch,
+                  validateConfigurationOnDebugAppLaunch: validateConfigurationOnDebugAppLaunch,
                   diagnosticsEnabled: diagnosticsEnabled)
         )
     }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -277,6 +277,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     private let syncAttributesAndOfferingsIfNeededRateLimiter = RateLimiter(maxCalls: 5, period: 60)
     private let diagnosticsTracker: DiagnosticsTrackerType?
+    private let validateConfigurationOnLaunch: Bool
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     convenience init(apiKey: String,
@@ -291,6 +292,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                      networkTimeout: TimeInterval = Configuration.networkTimeoutDefault,
                      dangerousSettings: DangerousSettings? = nil,
                      showStoreMessagesAutomatically: Bool,
+                     validateConfigurationOnLaunch: Bool = true,
                      diagnosticsEnabled: Bool = false
     ) {
         if userDefaults != nil {
@@ -617,7 +619,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   purchasedProductsFetcher: purchasedProductsFetcher,
                   trialOrIntroPriceEligibilityChecker: trialOrIntroPriceChecker,
                   storeMessagesHelper: storeMessagesHelper,
-                  diagnosticsTracker: diagnosticsTracker
+                  diagnosticsTracker: diagnosticsTracker,
+                  validateConfigurationOnLaunch: validateConfigurationOnLaunch
         )
     }
 
@@ -647,7 +650,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          purchasedProductsFetcher: PurchasedProductsFetcherType?,
          trialOrIntroPriceEligibilityChecker: CachingTrialOrIntroPriceEligibilityChecker,
          storeMessagesHelper: StoreMessagesHelperType?,
-         diagnosticsTracker: DiagnosticsTrackerType?
+         diagnosticsTracker: DiagnosticsTrackerType?,
+         validateConfigurationOnLaunch: Bool
     ) {
 
         if systemInfo.dangerousSettings.customEntitlementComputation {
@@ -696,6 +700,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.trialOrIntroPriceEligibilityChecker = trialOrIntroPriceEligibilityChecker
         self.storeMessagesHelper = storeMessagesHelper
         self.diagnosticsTracker = diagnosticsTracker
+        self.validateConfigurationOnLaunch = validateConfigurationOnLaunch
 
         super.init()
 
@@ -714,7 +719,9 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.updateCachesIfInForeground()
 
         #if DEBUG
-        self.runHealthCheckIfInForeground()
+        if self.validateConfigurationOnLaunch {
+            self.runHealthCheckIfInForeground()
+        }
         #endif
 
         if self.systemInfo.dangerousSettings.autoSyncPurchases {
@@ -1393,6 +1400,7 @@ public extension Purchases {
                   networkTimeout: configuration.networkTimeout,
                   dangerousSettings: configuration.dangerousSettings,
                   showStoreMessagesAutomatically: configuration.showStoreMessagesAutomatically,
+                  validateConfigurationOnLaunch: configuration.validateConfigurationOnLaunch,
                   diagnosticsEnabled: configuration.diagnosticsEnabled
         )
     }
@@ -1659,6 +1667,7 @@ public extension Purchases {
         networkTimeout: TimeInterval,
         dangerousSettings: DangerousSettings?,
         showStoreMessagesAutomatically: Bool,
+        validateConfigurationOnLaunch: Bool,
         diagnosticsEnabled: Bool
     ) -> Purchases {
         return self.setDefaultInstance(
@@ -1674,6 +1683,7 @@ public extension Purchases {
                   networkTimeout: networkTimeout,
                   dangerousSettings: dangerousSettings,
                   showStoreMessagesAutomatically: showStoreMessagesAutomatically,
+                  validateConfigurationOnLaunch: validateConfigurationOnLaunch,
                   diagnosticsEnabled: diagnosticsEnabled)
         )
     }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2051,8 +2051,8 @@ private extension Purchases {
             if !isBackgrounded {
                 self.operationDispatcher.dispatchOnWorkerThread {
                     Task {
-                        await SDKHealthManager(healthReportRequest: self.healthReportRequest)
-                            .logSDKHealthReportOutcome()
+                        let manager = SDKHealthManager { try await self.healthReportRequest() }
+                        await manager.logSDKHealthReportOutcome()
                     }
                 }
             }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -716,7 +716,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         // all at the same time by too many users concurrently.
         self.updateCachesIfInForeground()
 
-        #if DEBUG
+        #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
         if validateConfigurationOnLaunch {
             self.runHealthCheckIfInForeground()
         }
@@ -2053,7 +2053,7 @@ private extension Purchases {
         }
     }
 
-    #if DEBUG
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     func runHealthCheckIfInForeground() {
         self.systemInfo.isApplicationBackgrounded { isBackgrounded in
             if !isBackgrounded {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2058,10 +2058,8 @@ private extension Purchases {
         self.systemInfo.isApplicationBackgrounded { isBackgrounded in
             if !isBackgrounded {
                 self.operationDispatcher.dispatchOnWorkerThread {
-                    Task {
-                        let manager = SDKHealthManager { try await self.healthReportRequest() }
-                        await manager.logSDKHealthReportOutcome()
-                    }
+                    let manager = SDKHealthManager { try await self.healthReportRequest() }
+                    await manager.logSDKHealthReportOutcome()
                 }
             }
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -292,7 +292,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                      networkTimeout: TimeInterval = Configuration.networkTimeoutDefault,
                      dangerousSettings: DangerousSettings? = nil,
                      showStoreMessagesAutomatically: Bool,
-                     validateConfigurationOnDebugAppLaunch: Bool,
                      diagnosticsEnabled: Bool = false,
                      preferredLocale: String?
     ) {
@@ -626,7 +625,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   trialOrIntroPriceEligibilityChecker: trialOrIntroPriceChecker,
                   storeMessagesHelper: storeMessagesHelper,
                   diagnosticsTracker: diagnosticsTracker,
-                  validateConfigurationOnDebugAppLaunch: validateConfigurationOnDebugAppLaunch,
                   healthManager: healthManager
         )
     }
@@ -658,7 +656,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          trialOrIntroPriceEligibilityChecker: CachingTrialOrIntroPriceEligibilityChecker,
          storeMessagesHelper: StoreMessagesHelperType?,
          diagnosticsTracker: DiagnosticsTrackerType?,
-         validateConfigurationOnDebugAppLaunch: Bool,
          healthManager: SDKHealthManager
     ) {
 
@@ -727,9 +724,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.updateCachesIfInForeground()
 
         #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-        if validateConfigurationOnDebugAppLaunch {
-            self.runHealthCheckIfInForeground()
-        }
+        self.runHealthCheckIfInForeground()
         #endif
 
         if self.systemInfo.dangerousSettings.autoSyncPurchases {
@@ -1408,7 +1403,6 @@ public extension Purchases {
                   networkTimeout: configuration.networkTimeout,
                   dangerousSettings: configuration.dangerousSettings,
                   showStoreMessagesAutomatically: configuration.showStoreMessagesAutomatically,
-                  validateConfigurationOnDebugAppLaunch: configuration.validateConfigurationOnDebugAppLaunch,
                   diagnosticsEnabled: configuration.diagnosticsEnabled,
                   preferredLocale: configuration.preferredLocale
         )
@@ -1676,7 +1670,6 @@ public extension Purchases {
         networkTimeout: TimeInterval,
         dangerousSettings: DangerousSettings?,
         showStoreMessagesAutomatically: Bool,
-        validateConfigurationOnDebugAppLaunch: Bool,
         diagnosticsEnabled: Bool,
         preferredLocale: String?
     ) -> Purchases {
@@ -1693,7 +1686,6 @@ public extension Purchases {
                   networkTimeout: networkTimeout,
                   dangerousSettings: dangerousSettings,
                   showStoreMessagesAutomatically: showStoreMessagesAutomatically,
-                  validateConfigurationOnDebugAppLaunch: validateConfigurationOnDebugAppLaunch,
                   diagnosticsEnabled: diagnosticsEnabled,
                   preferredLocale: preferredLocale)
         )

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1852,9 +1852,11 @@ extension Purchases: InternalPurchasesType {
         }
     }
 
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     internal func healthReportRequest() async throws -> HealthReport {
         try await self.backend.healthReportRequest(appUserID: self.appUserID)
     }
+    #endif
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func productEntitlementMapping() async throws -> ProductEntitlementMapping {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -291,7 +291,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                      networkTimeout: TimeInterval = Configuration.networkTimeoutDefault,
                      dangerousSettings: DangerousSettings? = nil,
                      showStoreMessagesAutomatically: Bool,
-                     validateConfigurationOnLaunch: Bool = true,
+                     validateConfigurationOnLaunch: Bool,
                      diagnosticsEnabled: Bool = false
     ) {
         if userDefaults != nil {
@@ -618,7 +618,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   purchasedProductsFetcher: purchasedProductsFetcher,
                   trialOrIntroPriceEligibilityChecker: trialOrIntroPriceChecker,
                   storeMessagesHelper: storeMessagesHelper,
-                  diagnosticsTracker: diagnosticsTracker
+                  diagnosticsTracker: diagnosticsTracker,
+                  validateConfigurationOnLaunch: validateConfigurationOnLaunch
         )
     }
 
@@ -649,7 +650,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          trialOrIntroPriceEligibilityChecker: CachingTrialOrIntroPriceEligibilityChecker,
          storeMessagesHelper: StoreMessagesHelperType?,
          diagnosticsTracker: DiagnosticsTrackerType?,
-         validateConfigurationOnLaunch: Bool = true
+         validateConfigurationOnLaunch: Bool
     ) {
 
         if systemInfo.dangerousSettings.customEntitlementComputation {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2058,6 +2058,11 @@ private extension Purchases {
         self.systemInfo.isApplicationBackgrounded { isBackgrounded in
             if !isBackgrounded {
                 self.operationDispatcher.dispatchOnWorkerThread {
+                    guard let availability = try? await self.backend.healthReportAvailabilityRequest(
+                        appUserID: self.appUserID
+                    ), availability.isAvailable else {
+                        return
+                    }
                     let manager = SDKHealthManager { try await self.healthReportRequest() }
                     await manager.logSDKHealthReportOutcome()
                 }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2060,7 +2060,7 @@ private extension Purchases {
                 self.operationDispatcher.dispatchOnWorkerThread {
                     guard let availability = try? await self.backend.healthReportAvailabilityRequest(
                         appUserID: self.appUserID
-                    ), availability.isAvailable else {
+                    ), availability.reportLogs else {
                         return
                     }
                     let manager = SDKHealthManager { try await self.healthReportRequest() }

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1250,7 +1250,7 @@ internal protocol InternalPurchasesType: AnyObject {
     /// Requests an in-depth report of the SDK's configuration from the server.
     /// - Throws: A `BackendError` if the request fails due to an invalid API key or connectivity issues.
     /// - Returns: A health report containing all checks performed on the server and their status.
-    func healthReportRequest() async throws -> HealthReport
+    func healthReport() async -> PurchasesDiagnostics.SDKHealthReport
     #endif
 
     func offerings(fetchPolicy: OfferingsManager.FetchPolicy) async throws -> Offerings

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1246,10 +1246,12 @@ internal protocol InternalPurchasesType: AnyObject {
     /// - Throws: `PublicError` if request failed.
     func healthRequest(signatureVerification: Bool) async throws
 
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     /// Requests an in-depth report of the SDK's configuration from the server.
     /// - Throws: A `BackendError` if the request fails due to an invalid API key or connectivity issues.
     /// - Returns: A health report containing all checks performed on the server and their status.
     func healthReportRequest() async throws -> HealthReport
+    #endif
 
     func offerings(fetchPolicy: OfferingsManager.FetchPolicy) async throws -> Offerings
 

--- a/Sources/Support/DebugUI/DebugViewModel.swift
+++ b/Sources/Support/DebugUI/DebugViewModel.swift
@@ -62,8 +62,9 @@ final class DebugViewModel: ObservableObject {
     @MainActor
     func load() async {
         self.configuration = .loaded(.create())
-
+        #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
         self.diagnosticsResult = .loaded(await PurchasesDiagnostics.default.healthReport())
+        #endif
         self.offerings = await .create { try await Purchases.shared.offerings() }
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
         self.customerInfo = await .create { try await Purchases.shared.customerInfo() }

--- a/Sources/Support/HealthReport+Validate.swift
+++ b/Sources/Support/HealthReport+Validate.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Pol Piella on 4/10/25.
 
-#if DEBUG
+#if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 extension HealthReport {
     func validate() -> PurchasesDiagnostics.SDKHealthReport {
         guard let firstFailedCheck = self.checks.first(where: { $0.status == .failed }) else {

--- a/Sources/Support/PaymentAuthorizationProvider.swift
+++ b/Sources/Support/PaymentAuthorizationProvider.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaymentAuthorizationProvider.swift
+//
+//  Created by Pol Piella Abadia on 23/06/2025.
+
+import Foundation
+import StoreKit
+
+struct PaymentAuthorizationProvider {
+    var isAuthorized: () -> Bool
+}
+
+extension PaymentAuthorizationProvider {
+    static let storeKit = PaymentAuthorizationProvider(
+        isAuthorized: {
+            if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *) {
+                return AppStore.canMakePayments
+            } else {
+                return SKPaymentQueue.canMakePayments()
+            }
+        }
+    )
+}

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -230,7 +230,7 @@ extension PurchasesDiagnostics {
         }
     }
 
-    #if DEBUG
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     /// Performs a full SDK configuration health check and throws an error if the configuration is not valid.
     /// - Important: This method can not be invoked in production builds.
     /// - Throws: ``SDKHealthError`` indicating the specific configuration issue that needs to be solved.

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -36,7 +36,7 @@ public final class PurchasesDiagnostics: NSObject, Sendable {
 
     init(purchases: SDK) {
         self.purchases = purchases
-        self.sdkHealthManager = SDKHealthManager(healthReportRequest: purchases.healthReportRequest)
+        self.sdkHealthManager = SDKHealthManager { try await purchases.healthReportRequest() }
     }
 
     /// Default instance of `PurchasesDiagnostics`.

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -76,7 +76,7 @@ extension PurchasesDiagnostics {
     }
 
     /// Additional information behind a configuration issue for the app's Bundle Id
-    public struct InvalidBundleIdErrorPayload {
+    public struct InvalidBundleIdErrorPayload: Equatable {
         /// Bundle ID for the RevenueCat app
         public let appBundleId: String
         /// Bundle ID detected from the app at runtime by the RevenueCat SDK

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -32,9 +32,11 @@ public final class PurchasesDiagnostics: NSObject, Sendable {
     typealias SDK = PurchasesType & InternalPurchasesType & Sendable
 
     private let purchases: SDK
+    private let sdkHealthManager: SDKHealthManager
 
     init(purchases: SDK) {
         self.purchases = purchases
+        self.sdkHealthManager = SDKHealthManager(healthReportRequest: purchases.healthReportRequest)
     }
 
     /// Default instance of `PurchasesDiagnostics`.
@@ -241,33 +243,12 @@ extension PurchasesDiagnostics {
         }
     }
 
-    private var canMakePayments: Bool {
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *) {
-            return AppStore.canMakePayments
-        } else {
-            return SKPaymentQueue.canMakePayments()
-        }
-    }
-
     /// Performs a full SDK configuration health check and returns its status.
     /// - Important: This method is intended solely for debugging configuration issues with the SDK implementation.
     /// It should not be invoked in production builds.
     /// - Returns: The result of the SDK configuration health check.
     public func healthReport() async -> SDKHealthReport {
-        do {
-            if !canMakePayments {
-                return .init(status: .unhealthy(.notAuthorizedToMakePayments))
-            }
-            return try await self.purchases.healthReportRequest().validate()
-        } catch let error as BackendError {
-            if case .networkError(let networkError) = error,
-               case .errorResponse(let response, _, _) = networkError, response.code == .invalidAPIKey {
-                return .init(status: .unhealthy(.invalidAPIKey))
-            }
-            return .init(status: .unhealthy(.unknown(error)))
-        } catch {
-            return .init(status: .unhealthy(.unknown(error)))
-        }
+        await sdkHealthManager.healthReport()
     }
     #endif
 }

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -32,11 +32,15 @@ public final class PurchasesDiagnostics: NSObject, Sendable {
     typealias SDK = PurchasesType & InternalPurchasesType & Sendable
 
     private let purchases: SDK
+    #if DEBUG
     private let sdkHealthManager: SDKHealthManager
+    #endif
 
     init(purchases: SDK) {
         self.purchases = purchases
+        #if DEBUG
         self.sdkHealthManager = SDKHealthManager { try await purchases.healthReportRequest() }
+        #endif
     }
 
     /// Default instance of `PurchasesDiagnostics`.

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -32,15 +32,9 @@ public final class PurchasesDiagnostics: NSObject, Sendable {
     typealias SDK = PurchasesType & InternalPurchasesType & Sendable
 
     private let purchases: SDK
-    #if DEBUG
-    private let sdkHealthManager: SDKHealthManager
-    #endif
 
     init(purchases: SDK) {
         self.purchases = purchases
-        #if DEBUG
-        self.sdkHealthManager = SDKHealthManager { try await purchases.healthReportRequest() }
-        #endif
     }
 
     /// Default instance of `PurchasesDiagnostics`.
@@ -252,7 +246,7 @@ extension PurchasesDiagnostics {
     /// It should not be invoked in production builds.
     /// - Returns: The result of the SDK configuration health check.
     public func healthReport() async -> SDKHealthReport {
-        await sdkHealthManager.healthReport()
+        await purchases.healthReport()
     }
     #endif
 }

--- a/Sources/Support/SDKHealthError+CustomNSError.swift
+++ b/Sources/Support/SDKHealthError+CustomNSError.swift
@@ -58,9 +58,12 @@ extension PurchasesDiagnostics.SDKHealthError: CustomNSError {
         case let .offeringConfiguration(payload):
             guard let offendingOffering = payload.first(where: { $0.status == .failed }) else {
                 let offeringsWithWarnings = payload.filter { $0.status == .warning }
+                let offeringDescription = offeringsWithWarnings.isEmpty ?
+                    "Some offerings" :
+                    "The offerings \(offeringsWithWarnings.map { "'\($0.identifier)'" }.joined(separator: ", "))"
                 return """
-                The offerings \(offeringsWithWarnings.map { "'\($0.identifier)'" }.joined(separator: ", ")) have \
-                configuration issues that may prevent users from seeing product options or making purchases.
+                \(offeringDescription) have configuration issues that may prevent users from seeing product \
+                options or making purchases.
                 """
             }
 

--- a/Sources/Support/SDKHealthError+CustomNSError.swift
+++ b/Sources/Support/SDKHealthError+CustomNSError.swift
@@ -57,9 +57,10 @@ extension PurchasesDiagnostics.SDKHealthError: CustomNSError {
 
         case let .offeringConfiguration(payload):
             guard let offendingOffering = payload.first(where: { $0.status == .failed }) else {
+                let offeringsWithWarnings = payload.filter { $0.status == .warning }
                 return """
-                Your default offering is not configured correctly in RevenueCat. This prevents users from \
-                seeing product options. Please check your offering configuration in the RevenueCat website.
+                The offerings \(offeringsWithWarnings.map { "'\($0.identifier)'" }.joined(separator: ", ")) have \
+                configuration issues that may prevent users from seeing product options or making purchases.
                 """
             }
 

--- a/Sources/Support/SDKHealthManager.swift
+++ b/Sources/Support/SDKHealthManager.swift
@@ -52,7 +52,10 @@ final class SDKHealthManager: Sendable {
 private enum HealthReportLogMessage: LogMessage {
     case unhealthy(error: PurchasesDiagnostics.SDKHealthError, report: PurchasesDiagnostics.SDKHealthReport)
     case healthy(report: PurchasesDiagnostics.SDKHealthReport)
-    case healthyWithWarnings(warnings: [PurchasesDiagnostics.SDKHealthError], report: PurchasesDiagnostics.SDKHealthReport)
+    case healthyWithWarnings(
+        warnings: [PurchasesDiagnostics.SDKHealthError],
+        report: PurchasesDiagnostics.SDKHealthReport
+    )
 
     var description: String {
         switch self {
@@ -67,7 +70,10 @@ private enum HealthReportLogMessage: LogMessage {
 
     var category: String { "health_report" }
 
-    private func buildUnhealthyMessage(error: PurchasesDiagnostics.SDKHealthError, report: PurchasesDiagnostics.SDKHealthReport) -> String {
+    private func buildUnhealthyMessage(
+        error: PurchasesDiagnostics.SDKHealthError,
+        report: PurchasesDiagnostics.SDKHealthReport
+    ) -> String {
         var message = "SDK Configuration is not valid\n"
         message += "\n\(error.localizedDescription)\n"
 
@@ -75,7 +81,7 @@ private enum HealthReportLogMessage: LogMessage {
             guard let projectId = report.projectId, let appId = report.appId else { return nil }
 
             switch error {
-            case .invalidBundleId(let invalidBundleIdErrorPayload):
+            case .invalidBundleId:
                 return "https://app.revenuecat.com/projects/\(projectId)/apps/\(appId)"
             case .offeringConfiguration, .noOfferings:
                 return "https://app.revenuecat.com/projects/\(projectId)/product-catalog/offerings"
@@ -91,36 +97,39 @@ private enum HealthReportLogMessage: LogMessage {
 
         message += buildProductsSection(report: report)
         message += buildOfferingsSection(report: report)
-        
+
         return message
     }
 
     private func buildHealthyMessage(report: PurchasesDiagnostics.SDKHealthReport) -> String {
         var message = "SDK Configuration is Valid\n"
-        
+
         message += buildProductsSection(report: report)
         message += buildOfferingsSection(report: report)
-        
+
         return message
     }
 
-    private func buildHealthyWithWarningsMessage(warnings: [PurchasesDiagnostics.SDKHealthError], report: PurchasesDiagnostics.SDKHealthReport) -> String {
+    private func buildHealthyWithWarningsMessage(
+        warnings: [PurchasesDiagnostics.SDKHealthError],
+        report: PurchasesDiagnostics.SDKHealthReport
+    ) -> String {
         var message = "SDK is configured correctly, but contains some issues you might want to address\n"
-        
+
         message += "\nWarnings:\n"
         for warning in warnings {
             message += "  • \(warning.localizedDescription)\n"
         }
-        
+
         message += buildProductsSection(report: report)
         message += buildOfferingsSection(report: report)
-        
+
         return message
     }
 
     private func buildProductsSection(report: PurchasesDiagnostics.SDKHealthReport) -> String {
         guard !report.products.isEmpty else { return "" }
-        
+
         var section = "\nProducts Status:\n"
         for product in report.products {
             let statusIcon = productStatusIcon(product.status)
@@ -130,23 +139,24 @@ private enum HealthReportLogMessage: LogMessage {
             }
             section += ": \(product.description)\n"
         }
-        
+
         return section
     }
 
     private func buildOfferingsSection(report: PurchasesDiagnostics.SDKHealthReport) -> String {
         guard !report.offerings.isEmpty else { return "" }
-        
+
         var section = "\nOfferings Status:\n"
         for offering in report.offerings {
             let statusIcon = offeringStatusIcon(offering.status)
             section += "  \(statusIcon) \(offering.identifier)\n"
             for package in offering.packages {
                 let packageStatusIcon = productStatusIcon(package.status)
-                section += "    \(packageStatusIcon) \(package.identifier) (\(package.productIdentifier)): \(package.description)\n"
+                let packageInfo = "\(packageStatusIcon) \(package.identifier) (\(package.productIdentifier))"
+                section += "    \(packageInfo): \(package.description)\n"
             }
         }
-        
+
         return section
     }
 

--- a/Sources/Support/SDKHealthManager.swift
+++ b/Sources/Support/SDKHealthManager.swift
@@ -99,7 +99,7 @@ private enum HealthReportLogMessage: LogMessage {
     }
 
     private func buildHealthyMessage(report: PurchasesDiagnostics.SDKHealthReport) -> String {
-        var message = "SDK Configuration is Valid\n"
+        var message = "✅ SDK is configured correctly\n"
 
         message += buildProductsSection(report: report)
         message += buildOfferingsSection(report: report)

--- a/Sources/Support/SDKHealthManager.swift
+++ b/Sources/Support/SDKHealthManager.swift
@@ -26,11 +26,146 @@ final class SDKHealthManager: Sendable {
         }
     }
 
+    func logSDKHealthReportOutcome() async {
+        let report = await healthReport()
+        switch report.status {
+        case let .unhealthy(error):
+            Logger.error(HealthReportLogMessage.unhealthy(error: error, report: report))
+        case let .healthy(warnings):
+            if warnings.isEmpty {
+                Logger.info(HealthReportLogMessage.healthy(report: report))
+            } else {
+                Logger.warn(HealthReportLogMessage.healthyWithWarnings(warnings: warnings, report: report))
+            }
+        }
+    }
+
     private var canMakePayments: Bool {
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *) {
             return AppStore.canMakePayments
         } else {
             return SKPaymentQueue.canMakePayments()
+        }
+    }
+}
+
+private enum HealthReportLogMessage: LogMessage {
+    case unhealthy(error: PurchasesDiagnostics.SDKHealthError, report: PurchasesDiagnostics.SDKHealthReport)
+    case healthy(report: PurchasesDiagnostics.SDKHealthReport)
+    case healthyWithWarnings(warnings: [PurchasesDiagnostics.SDKHealthError], report: PurchasesDiagnostics.SDKHealthReport)
+
+    var description: String {
+        switch self {
+        case let .unhealthy(error, report):
+            return buildUnhealthyMessage(error: error, report: report)
+        case let .healthy(report):
+            return buildHealthyMessage(report: report)
+        case let .healthyWithWarnings(warnings, report):
+            return buildHealthyWithWarningsMessage(warnings: warnings, report: report)
+        }
+    }
+
+    var category: String { "health_report" }
+
+    private func buildUnhealthyMessage(error: PurchasesDiagnostics.SDKHealthError, report: PurchasesDiagnostics.SDKHealthReport) -> String {
+        var message = "SDK Configuration is not valid\n"
+        message += "\n\(error.localizedDescription)\n"
+
+        let actionURL: String? = {
+            guard let projectId = report.projectId, let appId = report.appId else { return nil }
+
+            switch error {
+            case .invalidBundleId(let invalidBundleIdErrorPayload):
+                return "https://app.revenuecat.com/projects/\(projectId)/apps/\(appId)"
+            case .offeringConfiguration, .noOfferings:
+                return "https://app.revenuecat.com/projects/\(projectId)/product-catalog/offerings"
+            case .invalidProducts:
+                return "https://app.revenuecat.com/projects/\(projectId)/product-catalog/products"
+            default: return nil
+            }
+        }()
+
+        if let actionURL {
+            message += "\nPlease visit the RevenueCat website to resolve the issue: \(actionURL)\n"
+        }
+
+        message += buildProductsSection(report: report)
+        message += buildOfferingsSection(report: report)
+        
+        return message
+    }
+
+    private func buildHealthyMessage(report: PurchasesDiagnostics.SDKHealthReport) -> String {
+        var message = "SDK Configuration is Valid\n"
+        
+        message += buildProductsSection(report: report)
+        message += buildOfferingsSection(report: report)
+        
+        return message
+    }
+
+    private func buildHealthyWithWarningsMessage(warnings: [PurchasesDiagnostics.SDKHealthError], report: PurchasesDiagnostics.SDKHealthReport) -> String {
+        var message = "SDK is configured correctly, but contains some issues you might want to address\n"
+        
+        message += "\nWarnings:\n"
+        for warning in warnings {
+            message += "  • \(warning.localizedDescription)\n"
+        }
+        
+        message += buildProductsSection(report: report)
+        message += buildOfferingsSection(report: report)
+        
+        return message
+    }
+
+    private func buildProductsSection(report: PurchasesDiagnostics.SDKHealthReport) -> String {
+        guard !report.products.isEmpty else { return "" }
+        
+        var section = "\nProducts Status:\n"
+        for product in report.products {
+            let statusIcon = productStatusIcon(product.status)
+            section += "  \(statusIcon) \(product.identifier)"
+            if let title = product.title {
+                section += " (\(title))"
+            }
+            section += ": \(product.description)\n"
+        }
+        
+        return section
+    }
+
+    private func buildOfferingsSection(report: PurchasesDiagnostics.SDKHealthReport) -> String {
+        guard !report.offerings.isEmpty else { return "" }
+        
+        var section = "\nOfferings Status:\n"
+        for offering in report.offerings {
+            let statusIcon = offeringStatusIcon(offering.status)
+            section += "  \(statusIcon) \(offering.identifier)\n"
+            for package in offering.packages {
+                let packageStatusIcon = productStatusIcon(package.status)
+                section += "    \(packageStatusIcon) \(package.identifier) (\(package.productIdentifier)): \(package.description)\n"
+            }
+        }
+        
+        return section
+    }
+
+    private func productStatusIcon(_ status: PurchasesDiagnostics.ProductStatus) -> String {
+        switch status {
+        case .valid: return "✅"
+        case .couldNotCheck: return "❓"
+        case .notFound: return "❌"
+        case .actionInProgress: return "⏳"
+        case .needsAction: return "⚠️"
+        case .unknown: return "❓"
+        }
+    }
+
+    private func offeringStatusIcon(_ status: PurchasesDiagnostics.SDKHealthCheckStatus) -> String {
+        switch status {
+        case .passed: return "✅"
+        case .failed: return "❌"
+        case .warning: return "⚠️"
         }
     }
 }

--- a/Sources/Support/SDKHealthManager.swift
+++ b/Sources/Support/SDKHealthManager.swift
@@ -1,0 +1,37 @@
+#if DEBUG
+import Foundation
+import StoreKit
+
+final class SDKHealthManager: Sendable {
+    private let healthReportRequest: @Sendable () async throws -> HealthReport
+
+    init(healthReportRequest: @Sendable @escaping () async throws -> HealthReport) {
+        self.healthReportRequest = healthReportRequest
+    }
+
+    func healthReport() async -> PurchasesDiagnostics.SDKHealthReport {
+        do {
+            if !canMakePayments {
+                return .init(status: .unhealthy(.notAuthorizedToMakePayments))
+            }
+            return try await self.healthReportRequest().validate()
+        } catch let error as BackendError {
+            if case .networkError(let networkError) = error,
+               case .errorResponse(let response, _, _) = networkError, response.code == .invalidAPIKey {
+                return .init(status: .unhealthy(.invalidAPIKey))
+            }
+            return .init(status: .unhealthy(.unknown(error)))
+        } catch {
+            return .init(status: .unhealthy(.unknown(error)))
+        }
+    }
+
+    private var canMakePayments: Bool {
+        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *) {
+            return AppStore.canMakePayments
+        } else {
+            return SKPaymentQueue.canMakePayments()
+        }
+    }
+}
+#endif

--- a/Sources/Support/SDKHealthManager.swift
+++ b/Sources/Support/SDKHealthManager.swift
@@ -152,10 +152,11 @@ private enum HealthReportLogMessage: LogMessage {
     }
 
     private func buildProductsSection(report: PurchasesDiagnostics.SDKHealthReport) -> String {
-        guard !report.products.isEmpty else { return "" }
+        let productsWithIssues = report.products.filter { $0.status != .valid }
+        guard !productsWithIssues.isEmpty else { return "" }
 
-        var section = "\nProducts Status:\n"
-        for product in report.products {
+        var section = "\nProduct Issues:\n"
+        for product in productsWithIssues {
             let statusIcon = productStatusIcon(product.status)
             section += "  \(statusIcon) \(product.identifier)"
             if let title = product.title {
@@ -168,13 +169,15 @@ private enum HealthReportLogMessage: LogMessage {
     }
 
     private func buildOfferingsSection(report: PurchasesDiagnostics.SDKHealthReport) -> String {
-        guard !report.offerings.isEmpty else { return "" }
+        let offeringsWithIssues = report.offerings.filter { $0.status != .passed }
+        guard !offeringsWithIssues.isEmpty else { return "" }
 
-        var section = "\nOfferings Status:\n"
-        for offering in report.offerings {
+        var section = "\nOffering Issues:\n"
+        for offering in offeringsWithIssues {
             let statusIcon = offeringStatusIcon(offering.status)
             section += "  \(statusIcon) \(offering.identifier)\n"
-            for package in offering.packages {
+            let packagesWithIssues = offering.packages.filter { $0.status != .valid }
+            for package in packagesWithIssues {
                 let packageStatusIcon = productStatusIcon(package.status)
                 let packageInfo = "\(packageStatusIcon) \(package.identifier) (\(package.productIdentifier))"
                 section += "    \(packageInfo): \(package.description)\n"

--- a/Sources/Support/SDKHealthManager.swift
+++ b/Sources/Support/SDKHealthManager.swift
@@ -111,6 +111,28 @@ private enum HealthReportLogMessage: LogMessage {
         warnings: [PurchasesDiagnostics.SDKHealthError],
         report: PurchasesDiagnostics.SDKHealthReport
     ) -> String {
+        if report.products.allSatisfy({ $0.status == .couldNotCheck }) {
+            var message = """
+            We could not validate your SDK's configuration and check your product statuses in App Store Connect.\n
+            """
+
+            if let description = report.products.first?.description {
+                message += "\nError: \(description)\n"
+            }
+
+            message += """
+            \nIf you want to check if your SDK is configured correctly, please check your App Store Connect \
+            credentials in RevenueCat, make sure your App Store Connect App exists and try again:
+            """
+
+            if let projectId = report.projectId, let appId = report.appId {
+                let url = "https://app.revenuecat.com/projects/\(projectId)/apps/\(appId)#scroll=app-store-connect-api"
+                message += "\n\n\(url)"
+            }
+
+            return message
+        }
+
         var message = "RevenueCat SDK is configured correctly, but contains some issues you might want to address\n"
 
         message += "\nWarnings:\n"

--- a/Sources/Support/SDKHealthManager.swift
+++ b/Sources/Support/SDKHealthManager.swift
@@ -71,7 +71,7 @@ private enum HealthReportLogMessage: LogMessage {
         error: PurchasesDiagnostics.SDKHealthError,
         report: PurchasesDiagnostics.SDKHealthReport
     ) -> String {
-        var message = "SDK Configuration is not valid\n"
+        var message = "RevenueCat SDK Configuration is not valid\n"
         message += "\n\(error.localizedDescription)\n"
 
         let actionURL: String? = {
@@ -99,7 +99,7 @@ private enum HealthReportLogMessage: LogMessage {
     }
 
     private func buildHealthyMessage(report: PurchasesDiagnostics.SDKHealthReport) -> String {
-        var message = "✅ SDK is configured correctly\n"
+        var message = "✅ RevenueCat SDK is configured correctly\n"
 
         message += buildProductsSection(report: report)
         message += buildOfferingsSection(report: report)
@@ -111,7 +111,7 @@ private enum HealthReportLogMessage: LogMessage {
         warnings: [PurchasesDiagnostics.SDKHealthError],
         report: PurchasesDiagnostics.SDKHealthReport
     ) -> String {
-        var message = "SDK is configured correctly, but contains some issues you might want to address\n"
+        var message = "RevenueCat SDK is configured correctly, but contains some issues you might want to address\n"
 
         message += "\nWarnings:\n"
         for warning in warnings {

--- a/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
+++ b/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
@@ -239,8 +239,36 @@ class PurchasesDiagnosticsTests: TestCase {
 
         expect(error.errorUserInfo[NSUnderlyingErrorKey] as? NSNull).toNot(beNil())
         let expected = """
-        Your default offering is not configured correctly in RevenueCat. This prevents users from \
-        seeing product options. Please check your offering configuration in the RevenueCat website.
+        Some offerings have configuration issues that may prevent users from seeing product options or making purchases.
+        """
+        expect(error.localizedDescription) == expected
+    }
+
+    func testWarningOfferingConfigurationError() {
+        let error = PurchasesDiagnostics.SDKHealthError.offeringConfiguration(
+            [
+                .init(
+                    identifier: "offering_one",
+                    packages: [],
+                    status: .warning
+                ),
+                .init(
+                    identifier: "offering_two",
+                    packages: [],
+                    status: .warning
+                ),
+                .init(
+                    identifier: "offering_three",
+                    packages: [],
+                    status: .passed
+                )
+            ]
+        )
+
+        expect(error.errorUserInfo[NSUnderlyingErrorKey] as? NSNull).toNot(beNil())
+        let expected = """
+        The offerings 'offering_one', 'offering_two' have configuration issues that may prevent users from \
+        seeing product options or making purchases.
         """
         expect(error.localizedDescription) == expected
     }

--- a/Tests/UnitTests/Misc/SDKHealthManagerTests.swift
+++ b/Tests/UnitTests/Misc/SDKHealthManagerTests.swift
@@ -130,7 +130,7 @@ class SDKHealthManagerTests: TestCase {
                         identifier: "test_product",
                         title: "Test Product",
                         status: .needsAction,
-                        description: "Product needs action in App Store Connect."
+                        description: "Product needs action in App Store Connect"
                     )
                 ])))
             ]
@@ -169,7 +169,7 @@ class SDKHealthManagerTests: TestCase {
 
         await manager.logSDKHealthReportOutcome()
 
-        self.logger.verifyMessageWasLogged("SDK Configuration is Valid", level: .info)
+        self.logger.verifyMessageWasLogged("SDK is configured correctly", level: .info)
     }
 
     func testLogSDKHealthReportOutcomeLogsWarningForHealthyWithWarningsStatus() async {

--- a/Tests/UnitTests/Misc/SDKHealthManagerTests.swift
+++ b/Tests/UnitTests/Misc/SDKHealthManagerTests.swift
@@ -1,0 +1,559 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SDKHealthManagerTests.swift
+//
+//  Created by Pol Piella Abadia on 12/19/24.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class SDKHealthManagerTests: TestCase {
+
+    private var healthReportRequest: (@Sendable () async throws -> HealthReport)!
+    private var manager: SDKHealthManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        self.healthReportRequest = {
+            throw BackendError.networkError(.errorResponse(.defaultResponse, .internalServerError))
+        }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+    }
+
+    // MARK: - Health Report Tests
+
+    func testHealthReportReturnsUnhealthyWhenCannotMakePayments() async {
+        // Mock SKPaymentQueue to return false for canMakePayments
+        // This would require mocking StoreKit, but for now we'll test the happy path
+        // where canMakePayments returns true
+
+        self.healthReportRequest = {
+            HealthReport(
+                status: .passed,
+                projectId: "test_project",
+                appId: "test_app",
+                checks: []
+            )
+        }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        let report = await self.manager.healthReport()
+
+        expect(report.status).to(beHealthy())
+        expect(report.projectId) == "test_project"
+        expect(report.appId) == "test_app"
+    }
+
+    func testHealthReportReturnsUnhealthyForInvalidAPIKey() async {
+        self.healthReportRequest = {
+            throw BackendError.networkError(.errorResponse(
+                .init(code: .invalidAPIKey, originalCode: 0),
+                .forbidden
+            ))
+        }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        let report = await self.manager.healthReport()
+
+        expect(report.status).to(beUnhealthy(.invalidAPIKey))
+    }
+
+    func testHealthReportReturnsUnhealthyForUnknownBackendError() async {
+        self.healthReportRequest = {
+            throw BackendError.networkError(
+                .errorResponse(
+                    .init(code: .unknownError, originalCode: 0),
+                    .internalServerError
+                )
+            )
+        }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        let report = await self.manager.healthReport()
+
+        expect(report.status).to(beUnhealthyWithUnknownError())
+    }
+
+    func testHealthReportReturnsUnhealthyForNonBackendError() async {
+        let testError = NSError(domain: "test", code: 1, userInfo: nil)
+        self.healthReportRequest = {
+            throw testError
+        }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        let report = await self.manager.healthReport()
+
+        expect(report.status).to(beUnhealthyWithUnknownError())
+    }
+
+    func testHealthReportWithValidHealthReport() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .passed, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "test_product",
+                        title: "Test Product",
+                        status: .valid,
+                        description: "Available for production purchases."
+                    )
+                ])))
+            ]
+        )
+
+        self.healthReportRequest = { healthReport }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        let report = await self.manager.healthReport()
+
+        expect(report.status).to(beHealthy())
+        expect(report.projectId) == "test_project"
+        expect(report.appId) == "test_app"
+        expect(report.products).to(haveCount(1))
+        expect(report.products[0].identifier) == "test_product"
+        expect(report.products[0].status) == .valid
+    }
+
+    func testHealthReportWithFailedCheck() async {
+        let healthReport = HealthReport(
+            status: .failed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .apiKey, status: .failed)
+            ]
+        )
+
+        self.healthReportRequest = { healthReport }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        let report = await self.manager.healthReport()
+
+        expect(report.status).to(beUnhealthy(.invalidAPIKey))
+        expect(report.projectId) == "test_project"
+        expect(report.appId) == "test_app"
+    }
+
+    func testHealthReportWithWarnings() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .warning, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "test_product",
+                        title: "Test Product",
+                        status: .needsAction,
+                        description: "Product needs action in App Store Connect."
+                    )
+                ])))
+            ]
+        )
+
+        self.healthReportRequest = { healthReport }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        let report = await self.manager.healthReport()
+
+        expect(report.status).to(beHealthyWithWarnings())
+        if case let .healthy(warnings) = report.status {
+            expect(warnings).to(haveCount(1))
+            expect(warnings[0]).to(beInvalidProducts())
+        }
+    }
+
+    // MARK: - Logging Tests
+
+    func testLogSDKHealthReportOutcomeLogsErrorForUnhealthyStatus() async {
+        self.healthReportRequest = {
+            throw BackendError.networkError(.errorResponse(.init(code: .invalidAPIKey, originalCode: 0), .forbidden))
+        }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        await self.manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged("SDK Configuration is not valid", level: .error)
+        self.logger.verifyMessageWasLogged("API key is not valid", level: .error)
+    }
+
+    func testLogSDKHealthReportOutcomeLogsInfoForHealthyStatus() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: []
+        )
+
+        self.healthReportRequest = { healthReport }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        await self.manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged("SDK Configuration is Valid", level: .info)
+    }
+
+    func testLogSDKHealthReportOutcomeLogsWarningForHealthyWithWarningsStatus() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .warning, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "test_product",
+                        title: "Test Product",
+                        status: .needsAction,
+                        description: "Product needs action in App Store Connect."
+                    )
+                ])))
+            ]
+        )
+
+        self.healthReportRequest = { healthReport }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        await self.manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged(
+            "SDK is configured correctly, but contains some issues you might want to address",
+            level: .warn
+        )
+        self.logger.verifyMessageWasLogged("Warnings:", level: .warn)
+    }
+
+    func testLogSDKHealthReportOutcomeIncludesActionURLForInvalidBundleId() async {
+        let healthReport = HealthReport(
+            status: .failed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .bundleId, status: .failed, details: .bundleId(BundleIdCheckDetails(
+                    sdkBundleId: "com.test.sdk",
+                    appBundleId: "com.test.app"
+                )))
+            ]
+        )
+
+        self.healthReportRequest = { healthReport }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        await self.manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged(
+            "https://app.revenuecat.com/projects/test_project/apps/test_app",
+            level: .error
+        )
+        self.logger.verifyMessageWasLogged(
+            "Please visit the RevenueCat website to resolve the issue",
+            level: .error
+        )
+    }
+
+    func testLogSDKHealthReportOutcomeIncludesActionURLForInvalidProducts() async {
+        let healthReport = HealthReport(
+            status: .failed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .failed, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "test_product",
+                        title: "Test Product",
+                        status: .notFound,
+                        description: "Product not found in App Store Connect."
+                    )
+                ])))
+            ]
+        )
+
+        self.healthReportRequest = { healthReport }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        await self.manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged(
+            "https://app.revenuecat.com/projects/test_project/product-catalog/products",
+            level: .error
+        )
+    }
+
+    func testLogSDKHealthReportOutcomeIncludesActionURLForOfferingConfiguration() async {
+        let healthReport = HealthReport(
+            status: .failed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .offerings, status: .failed)
+            ]
+        )
+
+        self.healthReportRequest = { healthReport }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        await self.manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged(
+            "https://app.revenuecat.com/projects/test_project/product-catalog/offerings",
+            level: .error
+        )
+    }
+
+    func testLogSDKHealthReportOutcomeIncludesProductsSection() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .passed, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "test_product",
+                        title: "Test Product",
+                        status: .valid,
+                        description: "Available for production purchases."
+                    ),
+                    ProductHealthReport(
+                        identifier: "test_product_2",
+                        title: nil,
+                        status: .notFound,
+                        description: "Product not found in App Store Connect."
+                    )
+                ])))
+            ]
+        )
+
+        self.healthReportRequest = { healthReport }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        await self.manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged("Products Status:", level: .info)
+        self.logger.verifyMessageWasLogged(
+            "✅ test_product (Test Product): Available for production purchases.",
+            level: .info
+        )
+        self.logger.verifyMessageWasLogged(
+            "❌ test_product_2: Product not found in App Store Connect.",
+            level: .info
+        )
+    }
+
+    func testLogSDKHealthReportOutcomeIncludesOfferingsSection() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(
+                    name: .offeringsProducts,
+                    status: .passed,
+                    details: .offeringsProducts(OfferingsCheckDetails(offerings: [
+                        OfferingHealthReport(
+                            identifier: "test_offering",
+                            packages: [
+                                PackageHealthReport(
+                                    identifier: "test_package",
+                                    title: "Test Package",
+                                    status: .valid,
+                                    description: "Available for production purchases.",
+                                    productIdentifier: "test_product",
+                                    productTitle: "Test Product"
+                                )
+                            ],
+                            status: .passed
+                        )
+                    ]))
+                )
+            ]
+        )
+
+        self.healthReportRequest = { healthReport }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        await self.manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged("Offerings Status:", level: .info)
+        self.logger.verifyMessageWasLogged("✅ test_offering", level: .info)
+        self.logger.verifyMessageWasLogged(
+            "✅ test_package (test_product): Available for production purchases.",
+            level: .info
+        )
+    }
+
+    func testLogSDKHealthReportOutcomeDoesNotIncludeEmptySections() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: []
+        )
+
+        self.healthReportRequest = { healthReport }
+        self.manager = SDKHealthManager(healthReportRequest: self.healthReportRequest)
+
+        await self.manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasNotLogged("Products Status:", level: .info)
+        self.logger.verifyMessageWasNotLogged("Offerings Status:", level: .info)
+    }
+
+    // MARK: - Custom Matchers
+
+    private func beHealthy() -> Matcher<PurchasesDiagnostics.SDKHealthStatus> {
+        return Matcher { actualExpression in
+            let message = ExpectationMessage.expectedActualValueTo("be healthy")
+
+            guard let actual = try actualExpression.evaluate() else {
+                return MatcherResult(status: .fail, message: message.appendedBeNilHint())
+            }
+
+            switch actual {
+            case .healthy:
+                return MatcherResult(status: .matches, message: message)
+            case .unhealthy:
+                return MatcherResult(status: .fail, message: message.appended(details: "was unhealthy"))
+            }
+        }
+    }
+
+    private func beHealthyWithWarnings() -> Matcher<PurchasesDiagnostics.SDKHealthStatus> {
+        return Matcher { actualExpression in
+            let message = ExpectationMessage.expectedActualValueTo("be healthy with warnings")
+
+            guard let actual = try actualExpression.evaluate() else {
+                return MatcherResult(status: .fail, message: message.appendedBeNilHint())
+            }
+
+            switch actual {
+            case let .healthy(warnings):
+                if warnings.isEmpty {
+                    return MatcherResult(
+                        status: .fail,
+                        message: message.appended(details: "was healthy without warnings")
+                    )
+                } else {
+                    return MatcherResult(status: .matches, message: message)
+                }
+            case .unhealthy:
+                return MatcherResult(status: .fail, message: message.appended(details: "was unhealthy"))
+            }
+        }
+    }
+
+    private func beUnhealthy(
+        _ error: PurchasesDiagnostics.SDKHealthError
+    ) -> Matcher<PurchasesDiagnostics.SDKHealthStatus> {
+        return Matcher { [error] actualExpression in
+            let message = ExpectationMessage.expectedActualValueTo("be unhealthy with error \(error)")
+
+            guard let actual = try actualExpression.evaluate() else {
+                return MatcherResult(status: .fail, message: message.appendedBeNilHint())
+            }
+
+            switch actual {
+            case .healthy:
+                return MatcherResult(status: .fail, message: message.appended(details: "was healthy"))
+            case let .unhealthy(actualError):
+                return self.compareUnhealthyErrors(expected: error, actual: actualError, message: message)
+            }
+        }
+    }
+
+    private func compareUnhealthyErrors(
+        expected: PurchasesDiagnostics.SDKHealthError,
+        actual: PurchasesDiagnostics.SDKHealthError,
+        message: ExpectationMessage
+    ) -> MatcherResult {
+        switch (expected, actual) {
+        case (.invalidAPIKey, .invalidAPIKey),
+             (.noOfferings, .noOfferings),
+             (.notAuthorizedToMakePayments, .notAuthorizedToMakePayments):
+            return MatcherResult(status: .matches, message: message)
+        case let (.invalidBundleId(expected), .invalidBundleId(actual)):
+            if expected == actual {
+                return MatcherResult(status: .matches, message: message)
+            } else {
+                return MatcherResult(status: .fail, message: message.appended(details: "bundle ID mismatch"))
+            }
+        case let (.invalidProducts(expected), .invalidProducts(actual)):
+            if expected.count == actual.count {
+                return MatcherResult(status: .matches, message: message)
+            } else {
+                return MatcherResult(
+                    status: .fail,
+                    message: message.appended(details: "products count mismatch")
+                )
+            }
+        case let (.offeringConfiguration(expected), .offeringConfiguration(actual)):
+            if expected.count == actual.count {
+                return MatcherResult(status: .matches, message: message)
+            } else {
+                return MatcherResult(
+                    status: .fail,
+                    message: message.appended(details: "offerings count mismatch")
+                )
+            }
+        case (.unknown, .unknown):
+            return MatcherResult(status: .matches, message: message)
+        default:
+            return MatcherResult(
+                status: .fail,
+                message: message.appended(details: "was unhealthy with different error \(actual)")
+            )
+        }
+    }
+
+    private func beInvalidProducts() -> Matcher<PurchasesDiagnostics.SDKHealthError> {
+        return Matcher { actualExpression in
+            let message = ExpectationMessage.expectedActualValueTo("be invalid products error")
+
+            guard let actual = try actualExpression.evaluate() else {
+                return MatcherResult(status: .fail, message: message.appendedBeNilHint())
+            }
+
+            switch actual {
+            case .invalidProducts:
+                return MatcherResult(status: .matches, message: message)
+            default:
+                return MatcherResult(status: .fail, message: message.appended(details: "was \(actual)"))
+            }
+        }
+    }
+
+    private func beUnhealthyWithUnknownError() -> Matcher<PurchasesDiagnostics.SDKHealthStatus> {
+        return Matcher { actualExpression in
+            let message = ExpectationMessage.expectedActualValueTo("be unhealthy with unknown error")
+
+            guard let actual = try actualExpression.evaluate() else {
+                return MatcherResult(status: .fail, message: message.appendedBeNilHint())
+            }
+
+            switch actual {
+            case .healthy:
+                return MatcherResult(status: .fail, message: message.appended(details: "was healthy"))
+            case let .unhealthy(error):
+                if case .unknown = error {
+                    return MatcherResult(status: .matches, message: message)
+                } else {
+                    return MatcherResult(
+                        status: .fail,
+                        message: message.appended(details: "was unhealthy with error \(error)")
+                    )
+                }
+            }
+        }
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -179,6 +179,12 @@ class MockBackend: Backend {
 
     static let referenceDate = Date(timeIntervalSinceReferenceDate: 700000000) // 2023-03-08 20:26:40
 
+    var healthReportRequestResponse: Result<HealthReport, BackendError> = .success(
+        HealthReport(status: .passed, projectId: nil, appId: nil, checks: [])
+    )
+    override func healthReportRequest(appUserID: String) async throws -> HealthReport {
+        return try healthReportRequestResponse.get()
+    }
 }
 
 extension MockBackend: @unchecked Sendable {}

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -188,6 +188,10 @@ class MockBackend: Backend {
     override func healthReportRequest(appUserID: String) async throws -> HealthReport {
         return try healthReportRequestResponse.get()
     }
+
+    override func healthReportAvailabilityRequest(appUserID: String) async throws -> HealthReportAvailability {
+        return .init(reportLogs: true)
+    }
 }
 
 extension MockBackend: @unchecked Sendable {}

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -64,8 +64,12 @@ extension MockPurchases: InternalPurchasesType {
         }
     }
 
-    func healthReportRequest() async throws -> HealthReport {
-        return try self.mockedHealthReportRequestResponse.get()
+    func healthReport() async -> PurchasesDiagnostics.SDKHealthReport {
+        do {
+            return try self.mockedHealthReportRequestResponse.get().validate()
+        } catch {
+            return .init(status: .unhealthy(.unknown(error)))
+        }
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -237,14 +237,14 @@ class BasePurchasesTests: TestCase {
     func setupPurchases(
         automaticCollection: Bool = false,
         withDelegate: Bool = true,
-        validateConfigurationOnLaunch: Bool = true
+        validateConfigurationOnDebugAppLaunch: Bool = true
     ) {
         self.identityManager.mockIsAnonymous = false
 
         self.initializePurchasesInstance(
             appUserId: self.identityManager.currentAppUserID,
             withDelegate: withDelegate,
-            validateConfigurationOnLaunch: validateConfigurationOnLaunch
+            validateConfigurationOnDebugAppLaunch: validateConfigurationOnDebugAppLaunch
         )
     }
 
@@ -265,7 +265,7 @@ class BasePurchasesTests: TestCase {
     func initializePurchasesInstance(
         appUserId: String?,
         withDelegate: Bool = true,
-        validateConfigurationOnLaunch: Bool = true
+        validateConfigurationOnDebugAppLaunch: Bool = true
     ) {
         self.purchasesOrchestrator = PurchasesOrchestrator(
             productsManager: self.mockProductsManager,
@@ -329,7 +329,7 @@ class BasePurchasesTests: TestCase {
                                    trialOrIntroPriceEligibilityChecker: self.cachingTrialOrIntroPriceEligibilityChecker,
                                    storeMessagesHelper: self.mockStoreMessagesHelper,
                                    diagnosticsTracker: self.diagnosticsTracker,
-                                   validateConfigurationOnLaunch: validateConfigurationOnLaunch)
+                                   validateConfigurationOnDebugAppLaunch: validateConfigurationOnDebugAppLaunch)
 
         self.purchasesOrchestrator.delegate = self.purchases
 

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -302,6 +302,10 @@ class BasePurchasesTests: TestCase {
             diagnosticsTracker: self.diagnosticsTracker
         )
         self.cachingTrialOrIntroPriceEligibilityChecker = .init(checker: self.trialOrIntroPriceEligibilityChecker)
+        let healthManager = SDKHealthManager(
+            backend: self.backend,
+            identityManager: self.identityManager
+        )
 
         self.purchases = Purchases(appUserID: appUserId,
                                    requestFetcher: self.requestFetcher,
@@ -329,7 +333,8 @@ class BasePurchasesTests: TestCase {
                                    trialOrIntroPriceEligibilityChecker: self.cachingTrialOrIntroPriceEligibilityChecker,
                                    storeMessagesHelper: self.mockStoreMessagesHelper,
                                    diagnosticsTracker: self.diagnosticsTracker,
-                                   validateConfigurationOnDebugAppLaunch: validateConfigurationOnDebugAppLaunch)
+                                   validateConfigurationOnDebugAppLaunch: validateConfigurationOnDebugAppLaunch,
+                                   healthManager: healthManager)
 
         self.purchasesOrchestrator.delegate = self.purchases
 

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -479,12 +479,12 @@ extension BasePurchasesTests {
             )
         }
 
-        var overrideHealthReportAvailabilityResponse = true
+        var overrideHealthReportAvailabilityResponse = HealthReportAvailability(reportLogs: true)
         var healthReportAvailabilityRequests = [String]()
         override func healthReportAvailabilityRequest(appUserID: String) async throws -> HealthReportAvailability {
             healthReportAvailabilityRequests.append(appUserID)
 
-            return .init(isAvailable: overrideHealthReportAvailabilityResponse)
+            return overrideHealthReportAvailabilityResponse
         }
 
         var postReceiptDataCalled = false

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -479,6 +479,14 @@ extension BasePurchasesTests {
             )
         }
 
+        var overrideHealthReportAvailabilityResponse = true
+        var healthReportAvailabilityRequests = [String]()
+        override func healthReportAvailabilityRequest(appUserID: String) async throws -> HealthReportAvailability {
+            healthReportAvailabilityRequests.append(appUserID)
+
+            return .init(isAvailable: overrideHealthReportAvailabilityResponse)
+        }
+
         var postReceiptDataCalled = false
         var postedReceiptData: EncodedAppleReceipt?
         var postedIsRestore: Bool?

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -236,15 +236,13 @@ class BasePurchasesTests: TestCase {
 
     func setupPurchases(
         automaticCollection: Bool = false,
-        withDelegate: Bool = true,
-        validateConfigurationOnDebugAppLaunch: Bool = true
+        withDelegate: Bool = true
     ) {
         self.identityManager.mockIsAnonymous = false
 
         self.initializePurchasesInstance(
             appUserId: self.identityManager.currentAppUserID,
-            withDelegate: withDelegate,
-            validateConfigurationOnDebugAppLaunch: validateConfigurationOnDebugAppLaunch
+            withDelegate: withDelegate
         )
     }
 
@@ -264,8 +262,7 @@ class BasePurchasesTests: TestCase {
 
     func initializePurchasesInstance(
         appUserId: String?,
-        withDelegate: Bool = true,
-        validateConfigurationOnDebugAppLaunch: Bool = true
+        withDelegate: Bool = true
     ) {
         self.purchasesOrchestrator = PurchasesOrchestrator(
             productsManager: self.mockProductsManager,
@@ -333,7 +330,6 @@ class BasePurchasesTests: TestCase {
                                    trialOrIntroPriceEligibilityChecker: self.cachingTrialOrIntroPriceEligibilityChecker,
                                    storeMessagesHelper: self.mockStoreMessagesHelper,
                                    diagnosticsTracker: self.diagnosticsTracker,
-                                   validateConfigurationOnDebugAppLaunch: validateConfigurationOnDebugAppLaunch,
                                    healthManager: healthManager)
 
         self.purchasesOrchestrator.delegate = self.purchases

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -234,12 +234,17 @@ class BasePurchasesTests: TestCase {
         }
     }
 
-    func setupPurchases(automaticCollection: Bool = false, withDelegate: Bool = true) {
+    func setupPurchases(
+        automaticCollection: Bool = false,
+        withDelegate: Bool = true,
+        validateConfigurationOnLaunch: Bool = true
+    ) {
         self.identityManager.mockIsAnonymous = false
 
         self.initializePurchasesInstance(
             appUserId: self.identityManager.currentAppUserID,
-            withDelegate: withDelegate
+            withDelegate: withDelegate,
+            validateConfigurationOnLaunch: validateConfigurationOnLaunch
         )
     }
 
@@ -257,7 +262,11 @@ class BasePurchasesTests: TestCase {
         self.initializePurchasesInstance(appUserId: nil)
     }
 
-    func initializePurchasesInstance(appUserId: String?, withDelegate: Bool = true) {
+    func initializePurchasesInstance(
+        appUserId: String?,
+        withDelegate: Bool = true,
+        validateConfigurationOnLaunch: Bool = true
+    ) {
         self.purchasesOrchestrator = PurchasesOrchestrator(
             productsManager: self.mockProductsManager,
             paymentQueueWrapper: self.paymentQueueWrapper,
@@ -319,7 +328,8 @@ class BasePurchasesTests: TestCase {
                                    purchasedProductsFetcher: self.mockPurchasedProductsFetcher,
                                    trialOrIntroPriceEligibilityChecker: self.cachingTrialOrIntroPriceEligibilityChecker,
                                    storeMessagesHelper: self.mockStoreMessagesHelper,
-                                   diagnosticsTracker: self.diagnosticsTracker)
+                                   diagnosticsTracker: self.diagnosticsTracker,
+                                   validateConfigurationOnLaunch: validateConfigurationOnLaunch)
 
         self.purchasesOrchestrator.delegate = self.purchases
 
@@ -455,6 +465,18 @@ extension BasePurchasesTests {
             DispatchQueue.main.async {
                 completion(result)
             }
+        }
+
+        var healthReportRequests = [String]()
+        override func healthReportRequest(appUserID: String) async throws -> HealthReport {
+            healthReportRequests += [appUserID]
+
+            return .init(
+                status: .passed,
+                projectId: nil,
+                appId: nil,
+                checks: []
+            )
         }
 
         var postReceiptDataCalled = false

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -325,6 +325,14 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(self.backend.healthReportRequests).toEventually(equal([self.identityManager.currentAppUserID]))
     }
 
+    func testFirstInitializationFromForegroundAndDefaultConfigurationWithNoAvailabilityDoesNotLogHealth() {
+        self.systemInfo.stubbedIsApplicationBackgrounded = false
+        self.backend.overrideHealthReportAvailabilityResponse = false
+        self.setupPurchases()
+        expect(self.backend.healthReportAvailabilityRequests).toEventually(equal([identityManager.currentAppUserID]))
+        expect(self.backend.healthReportRequests).toEventually(equal([]))
+    }
+
     func testFirstInitializationFromForegroundAndHealthValidationNotEnabledDoesNotLogHealth() {
         self.systemInfo.stubbedIsApplicationBackgrounded = false
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -333,14 +333,6 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(self.backend.healthReportRequests).toEventually(equal([]))
     }
 
-    func testFirstInitializationFromForegroundAndHealthValidationNotEnabledDoesNotLogHealth() {
-        self.systemInfo.stubbedIsApplicationBackgrounded = false
-
-        self.setupPurchases(validateConfigurationOnDebugAppLaunch: false)
-
-        expect(self.backend.healthReportRequests).toEventually(equal([]))
-    }
-
     func testFirstInitializationFromForegroundUpdatesCustomerInfoCacheIfUserDefaultsCacheStale() {
         let staleCacheDateForForeground = Calendar.current.date(byAdding: .minute, value: -20, to: Date())!
         self.deviceCache.setCustomerInfoCache(timestamp: staleCacheDateForForeground,
@@ -445,7 +437,6 @@ class PurchasesConfiguringTests: BasePurchasesTests {
                           responseVerificationMode: .default,
                           dangerousSettings: .init(customEntitlementComputation: true),
                           showStoreMessagesAutomatically: true,
-                          validateConfigurationOnDebugAppLaunch: false,
                           preferredLocale: nil)
         }.to(throwAssertion())
     }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -327,7 +327,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     func testFirstInitializationFromForegroundAndDefaultConfigurationWithNoAvailabilityDoesNotLogHealth() {
         self.systemInfo.stubbedIsApplicationBackgrounded = false
-        self.backend.overrideHealthReportAvailabilityResponse = false
+        self.backend.overrideHealthReportAvailabilityResponse = HealthReportAvailability(reportLogs: false)
         self.setupPurchases()
         expect(self.backend.healthReportAvailabilityRequests).toEventually(equal([identityManager.currentAppUserID]))
         expect(self.backend.healthReportRequests).toEventually(equal([]))

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -328,7 +328,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
     func testFirstInitializationFromForegroundAndHealthValidationNotEnabledDoesNotLogHealth() {
         self.systemInfo.stubbedIsApplicationBackgrounded = false
 
-        self.setupPurchases(validateConfigurationOnLaunch: false)
+        self.setupPurchases(validateConfigurationOnDebugAppLaunch: false)
 
         expect(self.backend.healthReportRequests).toEventually(equal([]))
     }
@@ -437,7 +437,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
                           responseVerificationMode: .default,
                           dangerousSettings: .init(customEntitlementComputation: true),
                           showStoreMessagesAutomatically: true,
-                          validateConfigurationOnLaunch: false)
+                          validateConfigurationOnDebugAppLaunch: false)
         }.to(throwAssertion())
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -436,7 +436,8 @@ class PurchasesConfiguringTests: BasePurchasesTests {
                           observerMode: false,
                           responseVerificationMode: .default,
                           dangerousSettings: .init(customEntitlementComputation: true),
-                          showStoreMessagesAutomatically: true)
+                          showStoreMessagesAutomatically: true,
+                          validateConfigurationOnLaunch: false)
         }.to(throwAssertion())
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -313,6 +313,26 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
     }
 
+    func testFirstInitializationFromBackgroundAndDefaultConfigurationDoesNotLogHealth() {
+        self.systemInfo.stubbedIsApplicationBackgrounded = true
+        self.setupPurchases()
+        expect(self.backend.healthReportRequests).toEventually(equal([]))
+    }
+
+    func testFirstInitializationFromForegroundAndDefaultConfigurationLogsHealth() {
+        self.systemInfo.stubbedIsApplicationBackgrounded = false
+        self.setupPurchases()
+        expect(self.backend.healthReportRequests).toEventually(equal([self.identityManager.currentAppUserID]))
+    }
+
+    func testFirstInitializationFromForegroundAndHealthValidationNotEnabledDoesNotLogHealth() {
+        self.systemInfo.stubbedIsApplicationBackgrounded = false
+
+        self.setupPurchases(validateConfigurationOnLaunch: false)
+
+        expect(self.backend.healthReportRequests).toEventually(equal([]))
+    }
+
     func testFirstInitializationFromForegroundUpdatesCustomerInfoCacheIfUserDefaultsCacheStale() {
         let staleCacheDateForForeground = Calendar.current.date(byAdding: .minute, value: -20, to: Date())!
         self.deviceCache.setCustomerInfoCache(timestamp: staleCacheDateForForeground,

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -236,7 +236,8 @@ class PurchasesSubscriberAttributesTests: TestCase {
                                 with: trialOrIntroductoryPriceEligibilityChecker
                               ),
                               storeMessagesHelper: self.mockStoreMessagesHelper,
-                              diagnosticsTracker: nil)
+                              diagnosticsTracker: nil,
+                              validateConfigurationOnLaunch: false)
         purchasesOrchestrator.delegate = purchases
         purchases!.delegate = purchasesDelegate
         Purchases.setDefaultInstance(purchases!)

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -241,7 +241,6 @@ class PurchasesSubscriberAttributesTests: TestCase {
                               ),
                               storeMessagesHelper: self.mockStoreMessagesHelper,
                               diagnosticsTracker: nil,
-                              validateConfigurationOnDebugAppLaunch: false,
                               healthManager: healthManager)
         purchasesOrchestrator.delegate = purchases
         purchases!.delegate = purchasesDelegate

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -237,7 +237,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
                               ),
                               storeMessagesHelper: self.mockStoreMessagesHelper,
                               diagnosticsTracker: nil,
-                              validateConfigurationOnLaunch: false)
+                              validateConfigurationOnDebugAppLaunch: false)
         purchasesOrchestrator.delegate = purchases
         purchases!.delegate = purchasesDelegate
         Purchases.setDefaultInstance(purchases!)

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -209,6 +209,10 @@ class PurchasesSubscriberAttributesTests: TestCase {
             productsManager: mockProductsManager,
             diagnosticsTracker: nil
         )
+        let healthManager = SDKHealthManager(
+            backend: self.mockBackend,
+            identityManager: self.mockIdentityManager
+        )
         purchases = Purchases(appUserID: mockIdentityManager.currentAppUserID,
                               requestFetcher: mockRequestFetcher,
                               receiptFetcher: mockReceiptFetcher,
@@ -237,7 +241,8 @@ class PurchasesSubscriberAttributesTests: TestCase {
                               ),
                               storeMessagesHelper: self.mockStoreMessagesHelper,
                               diagnosticsTracker: nil,
-                              validateConfigurationOnDebugAppLaunch: false)
+                              validateConfigurationOnDebugAppLaunch: false,
+                              healthManager: healthManager)
         purchasesOrchestrator.delegate = purchases
         purchases!.delegate = purchasesDelegate
         Purchases.setDefaultInstance(purchases!)


### PR DESCRIPTION
In another effort to reduce the amount of 'Empty Offerings' reports that we get, we want to let users know of configuration issues whenever they run a `DEBUG` build.

For this reason, we would like to run the SDK Health Check on debug builds. This is controlled with a configuration value, that is `false` by default, and can be turned on by the user at any time.

### Examples

**✅ Successful configuration (No Warnings)**

<img width="1204" alt="Screenshot 2025-06-24 at 13 49 13" src="https://github.com/user-attachments/assets/4b040582-a4dc-4b78-99a4-45ba36ac56ff" />


**✅ Successful configuration (Warnings)**

<img width="2286" alt="Screenshot 2025-06-24 at 13 46 22" src="https://github.com/user-attachments/assets/ab74e7af-ed65-4b30-847e-585bdbff7737" />

**❌ Failed configuration**

<img width="2287" alt="Screenshot 2025-06-24 at 13 49 52" src="https://github.com/user-attachments/assets/1d3ae10a-cbff-4ca6-b1b0-8a96619f65e2" />

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids
