### PR TITLE
Dont be explicit on store for paddle, web, rcBilling, external

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -524,13 +524,11 @@ extension PurchaseInformation {
         case .appStore: return .storeAppStore
         case .macAppStore: return .storeMacAppStore
         case .playStore: return .storePlayStore
-        case .stripe: return .storeStripe
         case .promotional: return .cardStorePromotional
         case .amazon: return .storeAmazon
-        case .rcBilling: return .storeRCBilling
-        case .external: return .storeExternal
-        case .paddle: return .storePaddle
         case .unknownStore: return .storeUnknownStore
+        case .paddle, .stripe, .rcBilling, .external:
+            return .storeWeb
         }
     }
 }

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -146,6 +146,7 @@ import Foundation
             case storeExternal = "store_external"
             case storeUnknownStore = "store_unknown"
             case storePaddle = "store_paddle"
+            case storeWeb = "store_web"
             case debugHeaderTitle = "Debug"
             case youMayHaveDuplicatedSubscriptionsTitle = "you_may_have_duplicated_subscriptions_title"
             case youMayHaveDuplicatedSubscriptionsSubtitle = "you_may_have_duplicated_subscriptions_subtitle"
@@ -352,6 +353,8 @@ import Foundation
                     return "Unknown Store"
                 case .storePaddle:
                     return "Paddle"
+                case .storeWeb:
+                    return "Web"
                 case .debugHeaderTitle:
                     return "Debug"
                 case .youMayHaveDuplicatedSubscriptionsTitle:


### PR DESCRIPTION
### Motivation
We've been discussing not exposing these as different stores.

### Description
- Use storeWeb instead of each store key.
