### PR TITLE
[v4] Add Intro Eligibility Functions to CEC Mode

### DIFF
--- a/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
+++ b/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
@@ -89,6 +89,19 @@ struct ContentView: View {
             .cornerRadius(20)
             .padding()
 
+            Button("Fetch product's intro/trial eligibility") {
+                Task<Void, Never> {
+                    await checkProductTrialIntroEligibility()
+                }
+            }
+            .font(.system(size: 20))
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.blue)
+            .cornerRadius(20)
+            .padding()
+
             .task {
                 Purchases.configureInCustomEntitlementsComputationMode(apiKey: Constants.apiKey,
                                                                        appUserID: appUserID)
@@ -227,6 +240,43 @@ struct ContentView: View {
             print("FAILED TO PURCHASE: \(error.localizedDescription)")
         }
 
+    }
+
+    func checkProductTrialIntroEligibility() async {
+        guard let offerings = self.offerings,
+              let offering = offerings.current,
+              let package = offering.availablePackages.first else {
+            print("no offerings, can't check product's eligibility")
+            return
+        }
+
+        print("Checking intro offers with the async functions.")
+        print("Checking product trial intro eligibility with async checkTrialOrIntroDiscountEligibility(product:)...")
+        let introStatus = await Purchases.shared.checkTrialOrIntroDiscountEligibility(product: package.storeProduct)
+        print("Intro status: \(introStatus)")
+
+        print("Checking product trial intro eligibility with async checkTrialOrIntroDiscountEligibility(packages:)...")
+        let introStatusDict = await Purchases.shared.checkTrialOrIntroDiscountEligibility(packages: [package])
+        print("Intro status dictionary: \(introStatusDict)")
+
+        print("Checking product trial intro eligibility with async checkTrialOrIntroDiscountEligibility(productIdentifiers:)")
+        let introStatusDict2 = await Purchases.shared.checkTrialOrIntroDiscountEligibility(
+            productIdentifiers: [package.storeProduct.productIdentifier]
+        )
+        print("Intro status dictionary: \(introStatusDict2)")
+
+        print("Checking intro offers with the completion handler functions.")
+        print("Checking product trial intro eligibility with checkTrialOrIntroDiscountEligibility(product:completion:)")
+        Purchases.shared.checkTrialOrIntroDiscountEligibility(product: package.storeProduct) { introEligibilityStatus in
+            print("Intro status: \(introEligibilityStatus)")
+
+            print("Checking checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:")
+            Purchases.shared.checkTrialOrIntroDiscountEligibility(
+                productIdentifiers: [package.storeProduct.productIdentifier]
+            ) { introStatusDict3 in
+                print("Intro status dict: \(introStatusDict3)")
+            }
+        }
     }
 
 

--- a/Sources/Misc/Concurrency/Purchases+async.swift
+++ b/Sources/Misc/Concurrency/Purchases+async.swift
@@ -172,6 +172,8 @@ extension Purchases {
         }
     }
 
+    #endif
+
     func checkTrialOrIntroductoryDiscountEligibilityAsync(_ product: StoreProduct) async
     -> IntroEligibilityStatus {
         return await withCheckedContinuation { continuation in
@@ -189,8 +191,6 @@ extension Purchases {
             }
         }
     }
-
-    #endif
 
 #if os(iOS) || os(macOS) || VISION_OS
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1028,6 +1028,8 @@ public extension Purchases {
         return try await syncPurchasesAsync()
     }
 
+    #endif
+
     @objc(checkTrialOrIntroDiscountEligibility:completion:)
     func checkTrialOrIntroDiscountEligibility(productIdentifiers: [String],
                                               completion: @escaping ([String: IntroEligibility]) -> Void) {
@@ -1062,8 +1064,6 @@ public extension Purchases {
     func checkTrialOrIntroDiscountEligibility(product: StoreProduct) async -> IntroEligibilityStatus {
         return await checkTrialOrIntroductoryDiscountEligibilityAsync(product)
     }
-
-    #endif
 
 #if os(iOS) || targetEnvironment(macCatalyst) || VISION_OS
     @available(iOS 13.4, macCatalyst 13.4, *)

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -170,15 +170,32 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: RefundRequestStatus = try await purchases.beginRefundRequest(forEntitlement: "")
         let _: RefundRequestStatus = try await purchases.beginRefundRequestForActiveEntitlement()
         #endif
+
+        let _: [String: IntroEligibility] =
+            await purchases.checkTrialOrIntroDiscountEligibility(productIdentifiers: [""])
+        let _: [Package: IntroEligibility] = await purchases.checkTrialOrIntroDiscountEligibility(packages: [pack])
+        let _: IntroEligibilityStatus = await purchases.checkTrialOrIntroDiscountEligibility(product: stp)
     } catch {}
 }
 
 func checkNonAsyncMethods(_ purchases: Purchases) {
+    let storeProduct: StoreProduct! = nil
+
     #if os(iOS)
     purchases.beginRefundRequest(forProduct: "") { (_: Result<RefundRequestStatus, PublicError>) in }
     purchases.beginRefundRequest(forEntitlement: "") { (_: Result<RefundRequestStatus, PublicError>) in }
     purchases.beginRefundRequestForActiveEntitlement { (_: Result<RefundRequestStatus, PublicError>) in }
     #endif
+
+    purchases.checkTrialOrIntroDiscountEligibility(
+        productIdentifiers: [""],
+        completion: { eligibilityDictionary in
+            let _: [String: IntroEligibility] = eligibilityDictionary
+        }
+    )
+    purchases.checkTrialOrIntroDiscountEligibility(product: storeProduct) { introEligibilityStatus in
+        let _: IntroEligibilityStatus = introEligibilityStatus
+    }
 }
 
 private func checkConfigure() -> Purchases! {


### PR DESCRIPTION
## Description
Manual backport of https://github.com/RevenueCat/purchases-ios/pull/5322 to v4. 