### PR TITLE
Add Purchases.cachedVirtualCurrencies

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1330,6 +1330,10 @@ public extension Purchases {
         }
     }
 
+    var cachedVirtualCurrencies: VirtualCurrencies? {
+        return self.virtualCurrencyManager.cachedVirtualCurrencies()
+    }
+
     func virtualCurrencies() async throws -> VirtualCurrencies {
         do {
             return try await self.virtualCurrencyManager.virtualCurrencies()

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -991,6 +991,15 @@ public protocol PurchasesType: AnyObject {
     func virtualCurrencies(
         completion: @escaping @Sendable (VirtualCurrencies?, PublicError?) -> Void
     )
+    
+    /**
+     * The currently cached ``VirtualCurrencies`` if one is available.
+     * This is synchronous, and therefore useful for contexts where an app needs a `VirtualCurrencies`
+     * right away without waiting for a callback, like a SwiftUI view.
+     *
+     * This allows initializing state to ensure that UI can be loaded from the very first frame.
+     */
+    var cachedVirtualCurrencies: VirtualCurrencies? { get }
 
     /**
      * Invalidates the cache for virtual currencies.

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -991,7 +991,7 @@ public protocol PurchasesType: AnyObject {
     func virtualCurrencies(
         completion: @escaping @Sendable (VirtualCurrencies?, PublicError?) -> Void
     )
-    
+
     /**
      * The currently cached ``VirtualCurrencies`` if one is available.
      * This is synchronous, and therefore useful for contexts where an app needs a `VirtualCurrencies`

--- a/Sources/Virtual Currencies/VirtualCurrencyManager.swift
+++ b/Sources/Virtual Currencies/VirtualCurrencyManager.swift
@@ -67,7 +67,7 @@ class VirtualCurrencyManager: VirtualCurrencyManagerType {
         if let cachedVirtualCurrencies = fetchCachedVirtualCurrencies(
             appUserID: appUserID,
             isAppBackgrounded: systemInfo.isAppBackgroundedState,
-            fetchEvenIfCacheIsStale: true
+            allowStaleCache: true
         ) {
             Logger.debug(Strings.virtualCurrencies.vending_from_cache)
             return cachedVirtualCurrencies
@@ -96,9 +96,9 @@ class VirtualCurrencyManager: VirtualCurrencyManagerType {
     private func fetchCachedVirtualCurrencies(
         appUserID: String,
         isAppBackgrounded: Bool,
-        fetchEvenIfCacheIsStale: Bool = false
+        allowStaleCache: Bool = false
     ) -> VirtualCurrencies? {
-        if !fetchEvenIfCacheIsStale && self.deviceCache.isVirtualCurrenciesCacheStale(
+        if !allowStaleCache && self.deviceCache.isVirtualCurrenciesCacheStale(
             appUserID: appUserID,
             isAppBackgrounded: isAppBackgrounded
         ) {

--- a/Sources/Virtual Currencies/VirtualCurrencyManager.swift
+++ b/Sources/Virtual Currencies/VirtualCurrencyManager.swift
@@ -16,6 +16,8 @@ import Foundation
 protocol VirtualCurrencyManagerType {
     func virtualCurrencies() async throws -> VirtualCurrencies
 
+    func cachedVirtualCurrencies() -> VirtualCurrencies?
+
     func invalidateVirtualCurrenciesCache()
 }
 
@@ -42,7 +44,7 @@ class VirtualCurrencyManager: VirtualCurrencyManagerType {
         let appUserID = identityManager.currentAppUserID
         let isAppBackgrounded = systemInfo.isAppBackgroundedState
 
-        if let cachedVirtualCurrencies = await fetchCachedVirtualCurrencies(
+        if let cachedVirtualCurrencies = fetchCachedVirtualCurrencies(
             appUserID: appUserID,
             isAppBackgrounded: isAppBackgrounded
         ) {
@@ -58,6 +60,20 @@ class VirtualCurrencyManager: VirtualCurrencyManagerType {
         cacheVirtualCurrencies(virtualCurrencies, appUserID: appUserID)
 
         return virtualCurrencies
+    }
+
+    func cachedVirtualCurrencies() -> VirtualCurrencies? {
+        let appUserID = identityManager.currentAppUserID
+        if let cachedVirtualCurrencies = fetchCachedVirtualCurrencies(
+            appUserID: appUserID,
+            isAppBackgrounded: systemInfo.isAppBackgroundedState,
+            fetchEvenIfCacheIsStale: true
+        ) {
+            Logger.debug(Strings.virtualCurrencies.vending_from_cache)
+            return cachedVirtualCurrencies
+        } else {
+            return nil
+        }
     }
 
     func invalidateVirtualCurrenciesCache() {
@@ -79,14 +95,15 @@ class VirtualCurrencyManager: VirtualCurrencyManagerType {
 
     private func fetchCachedVirtualCurrencies(
         appUserID: String,
-        isAppBackgrounded: Bool
-    ) async -> VirtualCurrencies? {
-        if self.deviceCache.isVirtualCurrenciesCacheStale(
+        isAppBackgrounded: Bool,
+        fetchEvenIfCacheIsStale: Bool = false
+    ) -> VirtualCurrencies? {
+        if !fetchEvenIfCacheIsStale && self.deviceCache.isVirtualCurrenciesCacheStale(
             appUserID: appUserID,
             isAppBackgrounded: isAppBackgrounded
         ) {
-            // The virtual currencies cache is stale, so
-            // return no cached virtual currencies.
+            // The virtual currencies cache is stale and we don't want to fetch stale data,
+            // so return no cached virtual currencies.
             Logger.debug(Strings.virtualCurrencies.virtual_currencies_stale_updating_from_network)
             return nil
         }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
@@ -209,6 +209,8 @@ NSURL *url;
 
     [p invalidateVirtualCurrenciesCache];
 
+    RCVirtualCurrencies * _Nullable __unused virtualCurrencies = p.cachedVirtualCurrencies;
+
 #if (TARGET_OS_IPHONE || TARGET_OS_MACCATALYST) && !TARGET_OS_TV && !TARGET_OS_WATCH
     if (@available(iOS 15.0, *)) {
         [p beginRefundRequestForProduct:@"1234" completion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
@@ -441,6 +441,9 @@ private func checkVirtualCurrenciesAPI(_ purchases: Purchases) async throws {
 
     // Invalidating Virtual Currencies Cache
     purchases.invalidateVirtualCurrenciesCache()
+
+    // Cached virtual currencies
+    let _: VirtualCurrencies? = purchases.cachedVirtualCurrencies
 }
 
 @available(*, deprecated) // Ignore deprecation warnings

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -564,4 +564,8 @@ extension MockPurchases: PurchasesSwiftType {
     func virtualCurrencies() async throws -> RevenueCat.VirtualCurrencies {
         self.unimplemented()
     }
+
+    var cachedVirtualCurrencies: VirtualCurrencies? {
+        self.unimplemented()
+    }
 }

--- a/Tests/UnitTests/Mocks/MockVirtualCurrencyManager.swift
+++ b/Tests/UnitTests/Mocks/MockVirtualCurrencyManager.swift
@@ -35,4 +35,13 @@ class MockVirtualCurrencyManager: VirtualCurrencyManagerType {
         self.invalidateVirtualCurrenciesCacheCallCount += 1
         self.invalidateVirtualCurrenciesCacheCalled = true
     }
+
+    var stubbedCachedVirtualCurrencies: VirtualCurrencies?
+    var cachedVirtualCurrenciesCallCount = 0
+    var cachedVirtualCurrenciesCalled = false
+    func cachedVirtualCurrencies() -> VirtualCurrencies? {
+        cachedVirtualCurrenciesCallCount += 1
+        cachedVirtualCurrenciesCalled = true
+        return stubbedCachedVirtualCurrencies
+    }
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesVirtualCurrenciesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesVirtualCurrenciesTests.swift
@@ -118,4 +118,25 @@ class PurchasesVirtualCurrenciesTests: BasePurchasesTests {
         expect(self.mockVirtualCurrencyManager.invalidateVirtualCurrenciesCacheCallCount).to(equal(1))
         expect(Thread.isMainThread).to(beTrue())
     }
+
+    // MARK: - cachedVirtualCurrencies Tests
+    func testCachedVirtualCurrenciesReturnsCachedVirtualCurrencies() {
+        self.mockVirtualCurrencyManager.stubbedCachedVirtualCurrencies = Self.mockVirtualCurrencies
+
+        let cachedVirtualCurrencies = self.purchases.cachedVirtualCurrencies
+        expect(cachedVirtualCurrencies).to(equal(Self.mockVirtualCurrencies))
+        expect(self.mockVirtualCurrencyManager.cachedVirtualCurrenciesCalled).to(beTrue())
+        expect(self.mockVirtualCurrencyManager.cachedVirtualCurrenciesCallCount).to(equal(1))
+        expect(Thread.isMainThread).to(beTrue())
+    }
+
+    func testCachedVirtualCurrenciesReturnsNilWhenThereAreNoCachedVirtualCurrencies() {
+        self.mockVirtualCurrencyManager.stubbedCachedVirtualCurrencies = nil
+
+        let cachedVirtualCurrencies = self.purchases.cachedVirtualCurrencies
+        expect(cachedVirtualCurrencies).to(beNil())
+        expect(self.mockVirtualCurrencyManager.cachedVirtualCurrenciesCalled).to(beTrue())
+        expect(self.mockVirtualCurrencyManager.cachedVirtualCurrenciesCallCount).to(equal(1))
+        expect(Thread.isMainThread).to(beTrue())
+    }
 }


### PR DESCRIPTION
### Description
Adds `Purchases.cachedVirtualCurrencies` as a computed property to allow developers to access the cached virtual currencies if they're present, regardless of whether the cache is stale or not.