### PR TITLE
Use VCs in CustomerCenterViewModel

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -69,10 +69,6 @@ class BaseManageSubscriptionViewModel: ObservableObject {
     @Published
     private(set) var refundRequestStatus: RefundRequestStatus?
 
-    /// Virtual currencies to display. If it is set to nil, nothing will be displayed.
-    @Published
-    private(set) var virtualCurrencies: RevenueCat.VirtualCurrencies?
-
     private var error: Error?
     private let loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType
     let paths: [CustomerCenterConfigData.HelpPath]
@@ -82,7 +78,6 @@ class BaseManageSubscriptionViewModel: ObservableObject {
         screen: CustomerCenterConfigData.Screen,
         actionWrapper: CustomerCenterActionWrapper,
         purchaseInformation: PurchaseInformation? = nil,
-        virtualCurrencies: RevenueCat.VirtualCurrencies?,
         refundRequestStatus: RefundRequestStatus? = nil,
         purchasesProvider: CustomerCenterPurchasesType,
         loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType? = nil) {
@@ -95,7 +90,6 @@ class BaseManageSubscriptionViewModel: ObservableObject {
             self.loadPromotionalOfferUseCase = loadPromotionalOfferUseCase
             ?? LoadPromotionalOfferUseCase(purchasesProvider: purchasesProvider)
             self.restoreAlertType = .loading
-            self.virtualCurrencies = virtualCurrencies
         }
 
 #if os(iOS) || targetEnvironment(macCatalyst)

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -106,6 +106,10 @@ import Foundation
         ) ?? false
     }
 
+    var shouldShowVirtualCurrencies: Bool {
+        configuration?.support.displayVirtualCurrencies == true
+    }
+
     private let currentVersionFetcher: CurrentVersionFetcher
 
     internal var customerInfo: CustomerInfo?
@@ -157,11 +161,13 @@ import Foundation
     convenience init(
         activeSubscriptionPurchases: [PurchaseInformation],
         activeNonSubscriptionPurchases: [PurchaseInformation],
+        virtualCurrencies: VirtualCurrencies? = nil,
         configuration: CustomerCenterConfigData
     ) {
         self.init(actionWrapper: CustomerCenterActionWrapper(legacyActionHandler: nil))
         self.subscriptionsSection = activeSubscriptionPurchases
         self.nonSubscriptionsSection = activeNonSubscriptionPurchases
+        self.virtualCurrencies = virtualCurrencies
         self.configuration = configuration
         self.state = .success
     }
@@ -191,7 +197,7 @@ import Foundation
             try await self.loadPurchases(customerInfo: customerInfo)
             try await self.loadCustomerCenterConfig()
 
-            if self.configuration?.support.displayVirtualCurrencies == true {
+            if shouldShowVirtualCurrencies {
                 purchasesProvider.invalidateVirtualCurrenciesCache()
                 self.virtualCurrencies = try? await purchasesProvider.virtualCurrencies()
             } else {

--- a/RevenueCatUI/CustomerCenter/ViewModels/RelevantPurchasesListViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/RelevantPurchasesListViewModel.swift
@@ -46,7 +46,6 @@ final class RelevantPurchasesListViewModel: BaseManageSubscriptionViewModel {
                 screen: screen,
                 actionWrapper: actionWrapper,
                 purchaseInformation: nil,
-                virtualCurrencies: virtualCurrencies,
                 refundRequestStatus: refundRequestStatus,
                 purchasesProvider: purchasesProvider,
                 loadPromotionalOfferUseCase: loadPromotionalOfferUseCase

--- a/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
@@ -31,6 +31,7 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
     var isRefreshing: Bool = false
 
     let showPurchaseHistory: Bool
+    let showVirtualCurrencies: Bool
 
     var shouldShowContactSupport: Bool {
         purchaseInformation?.store != .appStore
@@ -49,13 +50,14 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
         customerInfoViewModel: CustomerCenterViewModel,
         screen: CustomerCenterConfigData.Screen,
         showPurchaseHistory: Bool,
+        showVirtualCurrencies: Bool,
         allowsMissingPurchaseAction: Bool,
-        virtualCurrencies: RevenueCat.VirtualCurrencies?,
         actionWrapper: CustomerCenterActionWrapper,
         purchaseInformation: PurchaseInformation? = nil,
         refundRequestStatus: RefundRequestStatus? = nil,
         purchasesProvider: CustomerCenterPurchasesType,
         loadPromotionalOfferUseCase: LoadPromotionalOfferUseCaseType? = nil) {
+            self.showVirtualCurrencies = showVirtualCurrencies
             self.showPurchaseHistory = showPurchaseHistory
             self.allowsMissingPurchaseAction = allowsMissingPurchaseAction
             self.customerInfoViewModel = customerInfoViewModel
@@ -64,7 +66,6 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
             screen: screen,
             actionWrapper: actionWrapper,
             purchaseInformation: purchaseInformation,
-            virtualCurrencies: virtualCurrencies,
             refundRequestStatus: refundRequestStatus,
             purchasesProvider: purchasesProvider,
             loadPromotionalOfferUseCase: loadPromotionalOfferUseCase
@@ -94,8 +95,8 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
         customerInfoViewModel: CustomerCenterViewModel,
         screen: CustomerCenterConfigData.Screen,
         showPurchaseHistory: Bool,
+        showVirtualCurrencies: Bool,
         allowsMissingPurchaseAction: Bool,
-        virtualCurrencies: RevenueCat.VirtualCurrencies?,
         purchaseInformation: PurchaseInformation? = nil,
         refundRequestStatus: RefundRequestStatus? = nil
     ) {
@@ -103,8 +104,8 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
             customerInfoViewModel: customerInfoViewModel,
             screen: screen,
             showPurchaseHistory: showPurchaseHistory,
+            showVirtualCurrencies: showVirtualCurrencies,
             allowsMissingPurchaseAction: allowsMissingPurchaseAction,
-            virtualCurrencies: virtualCurrencies,
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: purchaseInformation,
             refundRequestStatus: refundRequestStatus,

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -240,8 +240,8 @@ private extension CustomerCenterView {
             screen: screen,
             purchaseInformation: viewModel.subscriptionsSection.first
                 ?? viewModel.nonSubscriptionsSection.first,
-            virtualCurrencies: self.viewModel.virtualCurrencies,
             showPurchaseHistory: viewModel.shouldShowSeeAllPurchases,
+            showVirtualCurrencies: viewModel.shouldShowVirtualCurrencies,
             allowsMissingPurchaseAction: true,
             purchasesProvider: self.viewModel.purchasesProvider,
             actionWrapper: self.viewModel.actionWrapper

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -35,7 +35,7 @@ struct RelevantPurchasesListView: View {
     @Environment(\.navigationOptions)
     var navigationOptions
 
-    @ObservedObject
+    @StateObject
     private var viewModel: RelevantPurchasesListViewModel
 
     @ObservedObject
@@ -86,8 +86,8 @@ struct RelevantPurchasesListView: View {
                     customerInfoViewModel: customerInfoViewModel,
                     screen: viewModel.screen,
                     purchaseInformation: viewModel.purchaseInformation,
-                    virtualCurrencies: nil, // Don't show virtual currencies when navigated to from here
                     showPurchaseHistory: false,
+                    showVirtualCurrencies: false,
                     allowsMissingPurchaseAction: false,
                     purchasesProvider: self.viewModel.purchasesProvider,
                     actionWrapper: self.viewModel.actionWrapper
@@ -162,7 +162,9 @@ struct RelevantPurchasesListView: View {
                     .tint(colorScheme == .dark ? .white : .black)
                 }
 
-                if let virtualCurrencies = viewModel.virtualCurrencies, !virtualCurrencies.all.isEmpty {
+                if let virtualCurrencies = customerInfoViewModel.virtualCurrencies,
+                   !virtualCurrencies.all.isEmpty,
+                    customerInfoViewModel.shouldShowVirtualCurrencies {
                     VirtualCurrenciesScrollViewWithOSBackgroundSection(
                         virtualCurrencies: virtualCurrencies,
                         onSeeAllInAppCurrenciesButtonTapped: self.viewModel.displayAllInAppCurrenciesScreen

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -189,7 +189,6 @@ struct SubscriptionDetailView: View {
                         .padding(.vertical, 32)
                 }
 
-
                 if let virtualCurrencies = customerInfoViewModel.virtualCurrencies,
                    !virtualCurrencies.all.isEmpty,
                    viewModel.showVirtualCurrencies {

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -41,7 +41,7 @@ struct SubscriptionDetailView: View {
     @Environment(\.supportInformation)
     private var support
 
-    @ObservedObject
+    @StateObject
     private var viewModel: SubscriptionDetailViewModel
 
     @ObservedObject
@@ -54,8 +54,8 @@ struct SubscriptionDetailView: View {
         customerInfoViewModel: CustomerCenterViewModel,
         screen: CustomerCenterConfigData.Screen,
         purchaseInformation: PurchaseInformation?,
-        virtualCurrencies: RevenueCat.VirtualCurrencies?,
         showPurchaseHistory: Bool,
+        showVirtualCurrencies: Bool,
         allowsMissingPurchaseAction: Bool,
         purchasesProvider: CustomerCenterPurchasesType,
         actionWrapper: CustomerCenterActionWrapper) {
@@ -63,8 +63,8 @@ struct SubscriptionDetailView: View {
                 customerInfoViewModel: customerInfoViewModel,
                 screen: screen,
                 showPurchaseHistory: showPurchaseHistory,
+                showVirtualCurrencies: showVirtualCurrencies,
                 allowsMissingPurchaseAction: allowsMissingPurchaseAction,
-                virtualCurrencies: virtualCurrencies,
                 actionWrapper: actionWrapper,
                 purchaseInformation: purchaseInformation,
                 purchasesProvider: purchasesProvider)
@@ -189,12 +189,15 @@ struct SubscriptionDetailView: View {
                         .padding(.vertical, 32)
                 }
 
-                if let virtualCurrencies = viewModel.virtualCurrencies, !virtualCurrencies.all.isEmpty {
+
+                if let virtualCurrencies = customerInfoViewModel.virtualCurrencies,
+                   !virtualCurrencies.all.isEmpty,
+                   viewModel.showVirtualCurrencies {
                     VirtualCurrenciesScrollViewWithOSBackgroundSection(
                         virtualCurrencies: virtualCurrencies,
                         onSeeAllInAppCurrenciesButtonTapped: self.viewModel.displayAllInAppCurrenciesScreen
                     )
-                     Spacer().frame(height: 32)
+                    Spacer().frame(height: 32)
                 }
 
                 ActiveSubscriptionButtonsView(viewModel: viewModel)
@@ -297,8 +300,8 @@ struct SubscriptionDetailView: View {
                         ),
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
+                        showVirtualCurrencies: false,
                         allowsMissingPurchaseAction: false,
-                        virtualCurrencies: nil,
                         purchaseInformation: .monthlyRenewing,
                         refundRequestStatus: .success
                     )
@@ -320,8 +323,8 @@ struct SubscriptionDetailView: View {
                         ),
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
+                        showVirtualCurrencies: false,
                         allowsMissingPurchaseAction: false,
-                        virtualCurrencies: nil,
                         purchaseInformation: .free
                     )
                 )
@@ -342,8 +345,8 @@ struct SubscriptionDetailView: View {
                         ),
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: false,
+                        showVirtualCurrencies: false,
                         allowsMissingPurchaseAction: false,
-                        virtualCurrencies: nil,
                         purchaseInformation: .consumable
                     )
                 )
@@ -364,8 +367,8 @@ struct SubscriptionDetailView: View {
                         ),
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
+                        showVirtualCurrencies: false,
                         allowsMissingPurchaseAction: false,
-                        virtualCurrencies: nil,
                         purchaseInformation: nil
                     )
                 )
@@ -386,8 +389,8 @@ struct SubscriptionDetailView: View {
                         ),
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
+                        showVirtualCurrencies: false,
                         allowsMissingPurchaseAction: false,
-                        virtualCurrencies: nil,
                         purchaseInformation: .mock(store: .playStore, isExpired: false)
                     )
                 )
@@ -400,6 +403,7 @@ struct SubscriptionDetailView: View {
                     customerInfoViewModel: CustomerCenterViewModel(
                         activeSubscriptionPurchases: [.mock(store: .playStore, isExpired: false)],
                         activeNonSubscriptionPurchases: [],
+                        virtualCurrencies: VirtualCurrenciesFixtures.fourVirtualCurrencies,
                         configuration: .default
                     ),
                     viewModel: SubscriptionDetailViewModel(
@@ -408,8 +412,8 @@ struct SubscriptionDetailView: View {
                         ),
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
+                        showVirtualCurrencies: true,
                         allowsMissingPurchaseAction: false,
-                        virtualCurrencies: VirtualCurrenciesFixtures.fourVirtualCurrencies,
                         purchaseInformation: .mock(store: .playStore, isExpired: false)
                     )
                 )
@@ -422,6 +426,7 @@ struct SubscriptionDetailView: View {
                     customerInfoViewModel: CustomerCenterViewModel(
                         activeSubscriptionPurchases: [.mock(store: .playStore, isExpired: false)],
                         activeNonSubscriptionPurchases: [],
+                        virtualCurrencies: VirtualCurrenciesFixtures.fiveVirtualCurrencies,
                         configuration: .default
                     ),
                     viewModel: SubscriptionDetailViewModel(
@@ -430,8 +435,8 @@ struct SubscriptionDetailView: View {
                         ),
                         screen: CustomerCenterConfigData.default.screens[.management]!,
                         showPurchaseHistory: true,
+                        showVirtualCurrencies: true,
                         allowsMissingPurchaseAction: false,
-                        virtualCurrencies: VirtualCurrenciesFixtures.fiveVirtualCurrencies,
                         purchaseInformation: .mock(store: .playStore, isExpired: false)
                     )
                 )

--- a/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
@@ -45,12 +45,10 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
             screen: BaseManageSubscriptionViewModelTests.default,
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: nil,
-            virtualCurrencies: nil,
             purchasesProvider: MockCustomerCenterPurchases()
         )
 
         expect(viewModel.purchaseInformation).to(beNil())
-        expect(viewModel.virtualCurrencies).to(beNil())
         expect(viewModel.refundRequestStatus).to(beNil())
         expect(viewModel.screen).toNot(beNil())
         expect(viewModel.showRestoreAlert) == false
@@ -62,7 +60,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
             screen: BaseManageSubscriptionViewModelTests.default,
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: nil,
-            virtualCurrencies: nil,
             purchasesProvider: MockCustomerCenterPurchases()
         )
 
@@ -77,7 +74,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
             screen: BaseManageSubscriptionViewModelTests.default,
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: purchase,
-            virtualCurrencies: nil,
             purchasesProvider: MockCustomerCenterPurchases()
         )
 
@@ -92,7 +88,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
             screen: BaseManageSubscriptionViewModelTests.default,
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: purchase,
-            virtualCurrencies: nil,
             purchasesProvider: MockCustomerCenterPurchases()
         )
 
@@ -106,7 +101,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
             screen: BaseManageSubscriptionViewModelTests.default,
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: purchase,
-            virtualCurrencies: nil,
             purchasesProvider: MockCustomerCenterPurchases()
         )
 
@@ -121,7 +115,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
             screen: BaseManageSubscriptionViewModelTests.default,
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: purchase,
-            virtualCurrencies: nil,
             purchasesProvider: MockCustomerCenterPurchases())
 
         expect(viewModel.relevantPathsForPurchase.count) == 1
@@ -137,7 +130,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
             screen: BaseManageSubscriptionViewModelTests.default,
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: purchase,
-            virtualCurrencies: nil,
             purchasesProvider: MockCustomerCenterPurchases())
 
         expect(viewModel.relevantPathsForPurchase.count) == 1
@@ -153,7 +145,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
             screen: BaseManageSubscriptionViewModelTests.managementScreen(refundWindowDuration: .forever),
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: purchase,
-            virtualCurrencies: nil,
             purchasesProvider: MockCustomerCenterPurchases())
 
         expect(viewModel.relevantPathsForPurchase.count) == 3
@@ -185,7 +176,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
             screen: BaseManageSubscriptionViewModelTests.managementScreen(refundWindowDuration: .duration(oneDay)),
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: purchase,
-            virtualCurrencies: nil,
             purchasesProvider: MockCustomerCenterPurchases()
         )
 
@@ -207,7 +197,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
             screen: BaseManageSubscriptionViewModelTests.managementScreen(refundWindowDuration: .forever),
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: purchase,
-            virtualCurrencies: nil,
             purchasesProvider: MockCustomerCenterPurchases())
 
         expect(viewModel.relevantPathsForPurchase.count) == 2
@@ -229,7 +218,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
             screen: BaseManageSubscriptionViewModelTests.managementScreen(refundWindowDuration: .forever),
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: purchase,
-            virtualCurrencies: nil,
             purchasesProvider: MockCustomerCenterPurchases())
 
         expect(viewModel.relevantPathsForPurchase.count) == 2
@@ -260,7 +248,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
             screen: BaseManageSubscriptionViewModelTests.managementScreen(refundWindowDuration: .duration(oneDay)),
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: purchase,
-            virtualCurrencies: nil,
             purchasesProvider: MockCustomerCenterPurchases())
 
         expect(viewModel.relevantPathsForPurchase.count) == 3
@@ -389,7 +376,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
                 screen: PurchaseInformationFixtures.screenWithIneligiblePromo,
                 actionWrapper: CustomerCenterActionWrapper(),
                 purchaseInformation: nil,
-                virtualCurrencies: nil,
                 purchasesProvider: MockCustomerCenterPurchases(
                     customerInfo: customerInfo,
                     products: products
@@ -418,7 +404,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
             screen: BaseManageSubscriptionViewModelTests.default,
             actionWrapper: CustomerCenterActionWrapper(),
             purchaseInformation: nil,
-            virtualCurrencies: nil,
             purchasesProvider: MockCustomerCenterPurchases()
         )
 
@@ -508,7 +493,6 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
         let viewModel = BaseManageSubscriptionViewModel(screen: screen,
                                                         actionWrapper: CustomerCenterActionWrapper(),
                                                         purchaseInformation: .mock(store: .appStore, isExpired: false),
-                                                        virtualCurrencies: nil,
                                                         purchasesProvider: MockCustomerCenterPurchases(
                                                             customerInfo: customerInfo,
                                                             products: products

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -226,7 +226,7 @@ final class CustomerCenterViewModelTests: TestCase {
         expect(mockPurchases.virtualCurrenciesCallCount).to(equal(0))
     }
 
-    func testShouldShowVirtualCurrenciesTrue() {
+    func testShouldShowVirtualCurrenciesIsFalseBeforeConfigIsLoaded() async throws {
         let mockPurchases = MockCustomerCenterPurchases(
             customerInfo: CustomerInfoFixtures.customerInfoWithAppleSubscriptions,
             customerCenterConfigData: CustomerCenterConfigData.mock(displayVirtualCurrencies: true)
@@ -236,6 +236,22 @@ final class CustomerCenterViewModelTests: TestCase {
             actionWrapper: CustomerCenterActionWrapper(),
             purchasesProvider: mockPurchases
         )
+
+        expect(viewModel.shouldShowVirtualCurrencies).to(beFalse())
+    }
+
+    func testShouldShowVirtualCurrenciesTrue() async throws {
+        let mockPurchases = MockCustomerCenterPurchases(
+            customerInfo: CustomerInfoFixtures.customerInfoWithAppleSubscriptions,
+            customerCenterConfigData: CustomerCenterConfigData.mock(displayVirtualCurrencies: true)
+        )
+
+        let viewModel = CustomerCenterViewModel(
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchasesProvider: mockPurchases
+        )
+
+        await viewModel.loadScreen()
 
         expect(viewModel.shouldShowVirtualCurrencies).to(beTrue())
     }

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -1121,8 +1121,6 @@ final class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.shouldShowList).to(beTrue())
     }
 
-
-
     private func formatted(price: Decimal, currencyCode: String = "USD") -> String {
         PurchaseInformation.defaultNumberFormatter.currencyCode = currencyCode
         return PurchaseInformation.defaultNumberFormatter.string(from: price as NSNumber)!

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -226,6 +226,34 @@ final class CustomerCenterViewModelTests: TestCase {
         expect(mockPurchases.virtualCurrenciesCallCount).to(equal(0))
     }
 
+    func testShouldShowVirtualCurrenciesTrue() {
+        let mockPurchases = MockCustomerCenterPurchases(
+            customerInfo: CustomerInfoFixtures.customerInfoWithAppleSubscriptions,
+            customerCenterConfigData: CustomerCenterConfigData.mock(displayVirtualCurrencies: true)
+        )
+
+        let viewModel = CustomerCenterViewModel(
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchasesProvider: mockPurchases
+        )
+
+        expect(viewModel.shouldShowVirtualCurrencies).to(beTrue())
+    }
+
+    func testShouldShowVirtualCurrenciesFalse() {
+        let mockPurchases = MockCustomerCenterPurchases(
+            customerInfo: CustomerInfoFixtures.customerInfoWithAppleSubscriptions,
+            customerCenterConfigData: CustomerCenterConfigData.mock(displayVirtualCurrencies: false)
+        )
+
+        let viewModel = CustomerCenterViewModel(
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchasesProvider: mockPurchases
+        )
+
+        expect(viewModel.shouldShowVirtualCurrencies).to(beFalse())
+    }
+
     func testShouldShowActiveSubscription_whenUserHasOneActiveSubscriptionOneEntitlement() async throws {
         let productId = "com.revenuecat.product"
         let purchaseDate = "2022-04-12T00:03:28Z"
@@ -1092,6 +1120,8 @@ final class CustomerCenterViewModelTests: TestCase {
         )
         expect(viewModel.shouldShowList).to(beTrue())
     }
+
+
 
     private func formatted(price: Decimal, currencyCode: String = "USD") -> String {
         PurchaseInformation.defaultNumberFormatter.currencyCode = currencyCode

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
@@ -33,8 +33,8 @@ final class SubscriptionDetailViewModelTests: TestCase {
             ),
             screen: CustomerCenterConfigData.default.screens[.management]!,
             showPurchaseHistory: false,
+            showVirtualCurrencies: false,
             allowsMissingPurchaseAction: false,
-            virtualCurrencies: nil,
             purchaseInformation: .mock(store: .appStore, isExpired: false)
         )
 
@@ -59,8 +59,8 @@ final class SubscriptionDetailViewModelTests: TestCase {
                 ),
                 screen: CustomerCenterConfigData.default.screens[.management]!,
                 showPurchaseHistory: false,
+                showVirtualCurrencies: false,
                 allowsMissingPurchaseAction: true,
-                virtualCurrencies: nil,
                 purchaseInformation: .mock(store: $0, isExpired: false)
             )
 


### PR DESCRIPTION
### Description
After a discussion in the https://github.com/RevenueCat/purchases-ios/pull/5108's review, we decided to revert the change of making the view models in `RelevantPurchasesListView` and `SubscriptionDetailView` from `StateObject` to `ObservedObject`. This PR accomplishes this by using the `VirtualCurrencies` object in the `CustomerCenterViewModel` in each of those views instead of injecting it directly in the views' constructors.

**Changes:**
- Makes `RelevantPurchasesListView.viewModel` a `@StateObject` again
- Makes `SubscriptionDetailView.viewModel` a `@StateObject` again
- In both `RelevantPurchasesListView` and `SubscriptionDetailView`, reference the virtual currencies in the `CustomerCenterViewModel`

### Testing
- Updated automated tests
- Manually tested each screen that the virtual currencies are displayed on