### PR TITLE
fix `Purchases` temporary leak when running SDK health check

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2079,15 +2079,16 @@ private extension Purchases {
 
     #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     func runHealthCheckIfInForeground() {
-        self.systemInfo.isApplicationBackgrounded { isBackgrounded in
+        self.systemInfo.isApplicationBackgrounded { [weak operationDispatcher] isBackgrounded in
             if !isBackgrounded {
-                self.operationDispatcher.dispatchOnWorkerThread {
-                    guard let availability = try? await self.backend.healthReportAvailabilityRequest(
-                        appUserID: self.appUserID
+                operationDispatcher?.dispatchOnWorkerThread { [weak self] in
+                    guard let appUserID = self?.appUserID,
+                          let availability = try? await self?.backend.healthReportAvailabilityRequest(
+                        appUserID: appUserID
                     ), availability.reportLogs else {
                         return
                     }
-                    await self.healthManager.logSDKHealthReportOutcome()
+                    await self?.healthManager.logSDKHealthReportOutcome()
                 }
             }
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2079,18 +2079,15 @@ private extension Purchases {
 
     #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     func runHealthCheckIfInForeground() {
-        self.systemInfo.isApplicationBackgrounded { [weak operationDispatcher] isBackgrounded in
-            if !isBackgrounded {
-                operationDispatcher?.dispatchOnWorkerThread { [weak self] in
-                    guard let appUserID = self?.appUserID,
-                          let availability = try? await self?.backend.healthReportAvailabilityRequest(
-                        appUserID: appUserID
-                    ), availability.reportLogs else {
-                        return
-                    }
-                    await self?.healthManager.logSDKHealthReportOutcome()
+        self.operationDispatcher.dispatchOnWorkerThread { [weak self] in
+            guard self?.systemInfo.isAppBackgroundedState == false,
+            let appUserID = self?.appUserID,
+                let availability = try? await self?.backend.healthReportAvailabilityRequest(
+                    appUserID: appUserID
+                ), availability.reportLogs else {
+                    return
                 }
-            }
+            await self?.healthManager.logSDKHealthReportOutcome()
         }
     }
     #endif


### PR DESCRIPTION
Some tests were failing due to the `runHealthCheckIfInForeground` retaining the `Purchases` instance until the health check was completed.

This PR prevents the `runHealthCheckIfInForeground` from retaining the `Purchases` instance