### PR TITLE
Use a more accurate method for generating a screenshot of a UIView

### DIFF
--- a/Tests/RevenueCatUITests/PaywallsV2/TakeScreenshot.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/TakeScreenshot.swift
@@ -255,7 +255,7 @@ extension View {
 extension UIView {
   func asImage() -> UIImage {
     let renderer = UIGraphicsImageRenderer(bounds: bounds)
-    return renderer.image { rendererContext in
+    return renderer.image { _ in
         drawHierarchy(in: bounds, afterScreenUpdates: true)
     }
   }


### PR DESCRIPTION
### Motivation
Before this change, buttons (and possibly other controls) were simply not rendered in these tests on Mac Catalyst builds because they are not backed by CALayers.

### Description
Switch from CALayer.render(in:) to UIView.drawHierarchy(in:afterScreenUpdates:) for rendering paywall screenshots. This change should capture the screen render more accurately.

I'll wait until after https://github.com/RevenueCat/purchases-ios/pull/5351 is merged to merge this PR, so that we can get a clear picture of any potential iOS rendering differences that may have been introduced by this change.