### PR TITLE
Fix one flaky unit test

### DIFF
--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -86,7 +86,8 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
 
     func testCustomerInfoIsOnlyFetchedOnceOnAppLaunch() async throws {
         // 1. Make sure any existing customer info requests finish
-        _ = try? await purchases.customerInfo(fetchPolicy: .fromCacheOnly)
+        var customerInfoIterator = try? purchases.customerInfoStream.makeAsyncIterator()
+        _ = await customerInfoIterator?.next()
 
         // 2. Verify only one CustomerInfo request was done
         try self.logger.verifyMessageWasLogged(


### PR DESCRIPTION
Test `testCustomerInfoIsOnlyFetchedOnceOnAppLaunch()` was flaky because this line
```swift
// 1. Make sure any existing customer info requests finish
_ = try? await purchases.customerInfo(fetchPolicy: .fromCacheOnly)
```
did not really cause the test to wait for the existing customer info requests finish. The reason is that the code path of `fetchPolicy: .fromCacheOnly` does not consider any existing requests; it just returns the customer info from the cache.

Instead, the test now does the following:
```swift
var customerInfoIterator = try? purchases.customerInfoStream.makeAsyncIterator()
_ = await customerInfoIterator?.next()
```
which makes sure that execution is only continued once a `CustomerInfo` valued is received (i.e. after the existing customer info request finishes)