### PR TITLE
[DX-457] Re-apply Health SDK logging on app launch

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -512,6 +512,7 @@
 		4FFFE6C82AA9467800B2955C /* PaywallEventsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFFE6C72AA9467800B2955C /* PaywallEventsManagerTests.swift */; };
 		4FFFE6CA2AA946A700B2955C /* MockInternalAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFFE6C92AA946A700B2955C /* MockInternalAPI.swift */; };
 		4FFFE6E72AA948A600B2955C /* PaywallEventsIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFFE6E62AA948A600B2955C /* PaywallEventsIntegrationTests.swift */; };
+		5310820F2E097DEE00F71174 /* SDKHealthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5310820E2E097DEE00F71174 /* SDKHealthManagerTests.swift */; };
 		537B4B2E2DA9662700CEFF4C /* HealthReportResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B2D2DA9662700CEFF4C /* HealthReportResponse.swift */; };
 		537B4B302DA9742500CEFF4C /* HealthReportOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B2F2DA9742500CEFF4C /* HealthReportOperation.swift */; };
 		537B4B322DA9743800CEFF4C /* HealthReport+Validate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B312DA9743800CEFF4C /* HealthReport+Validate.swift */; };
@@ -519,6 +520,10 @@
 		537B4B392DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B352DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift */; };
 		537B4B3A2DA9744B00CEFF4C /* ProductStatus+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B4B342DA9744B00CEFF4C /* ProductStatus+Icon.swift */; };
 		537BA85B2DBBFAF200C93327 /* SDKHealthError+CustomNSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537BA85A2DBBFAE700C93327 /* SDKHealthError+CustomNSError.swift */; };
+		53A8DCC12E0EA49400FEABEA /* HealthReportAvailabilityOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A8DCC02E0EA49400FEABEA /* HealthReportAvailabilityOperation.swift */; };
+		53A8DCC32E0EA4FF00FEABEA /* HealthReportAvailabilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A8DCC22E0EA4F600FEABEA /* HealthReportAvailabilityResponse.swift */; };
+		53AAD34F2E09857300605F51 /* PaymentAuthorizationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53AAD34E2E09856400605F51 /* PaymentAuthorizationProvider.swift */; };
+		53E33BBB2E095B8900287158 /* SDKHealthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E33BBA2E095B8900287158 /* SDKHealthManager.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
 		57045B3C29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */; };
@@ -1953,6 +1958,7 @@
 		4FFFE6C72AA9467800B2955C /* PaywallEventsManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallEventsManagerTests.swift; sourceTree = "<group>"; };
 		4FFFE6C92AA946A700B2955C /* MockInternalAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockInternalAPI.swift; sourceTree = "<group>"; };
 		4FFFE6E62AA948A600B2955C /* PaywallEventsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallEventsIntegrationTests.swift; sourceTree = "<group>"; };
+		5310820E2E097DEE00F71174 /* SDKHealthManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKHealthManagerTests.swift; sourceTree = "<group>"; };
 		537B4B2D2DA9662700CEFF4C /* HealthReportResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthReportResponse.swift; sourceTree = "<group>"; };
 		537B4B2F2DA9742500CEFF4C /* HealthReportOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthReportOperation.swift; sourceTree = "<group>"; };
 		537B4B312DA9743800CEFF4C /* HealthReport+Validate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HealthReport+Validate.swift"; sourceTree = "<group>"; };
@@ -1960,6 +1966,10 @@
 		537B4B352DA9744B00CEFF4C /* SDKHealthCheckStatus+Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthCheckStatus+Icon.swift"; sourceTree = "<group>"; };
 		537B4B362DA9744B00CEFF4C /* SDKHealthStatus+Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthStatus+Icon.swift"; sourceTree = "<group>"; };
 		537BA85A2DBBFAE700C93327 /* SDKHealthError+CustomNSError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SDKHealthError+CustomNSError.swift"; sourceTree = "<group>"; };
+		53A8DCC02E0EA49400FEABEA /* HealthReportAvailabilityOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthReportAvailabilityOperation.swift; sourceTree = "<group>"; };
+		53A8DCC22E0EA4F600FEABEA /* HealthReportAvailabilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthReportAvailabilityResponse.swift; sourceTree = "<group>"; };
+		53AAD34E2E09856400605F51 /* PaymentAuthorizationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentAuthorizationProvider.swift; sourceTree = "<group>"; };
+		53E33BBA2E095B8900287158 /* SDKHealthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKHealthManager.swift; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
 		57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProductEntitlementMappingOperation.swift; sourceTree = "<group>"; };
 		57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingCallback.swift; sourceTree = "<group>"; };
@@ -3856,6 +3866,7 @@
 		35272E1A26D0023400F22C3B /* Misc */ = {
 			isa = PBXGroup;
 			children = (
+				5310820E2E097DEE00F71174 /* SDKHealthManagerTests.swift */,
 				5757EDF72DEE092900AC4BE1 /* ClockTests.swift */,
 				5757EDE62DEE08C100AC4BE1 /* StoreKitVersionTests.swift */,
 				575F19B52D5A29860089A64F /* ISODurationFormatterTests.swift */,
@@ -4130,6 +4141,7 @@
 		35E840C1270FB45600899AE2 /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				53AAD34E2E09856400605F51 /* PaymentAuthorizationProvider.swift */,
 				4F6BED572A26A13800CD9322 /* DebugUI */,
 				A5F0104D2717B3150090732D /* BeginRefundRequestHelper.swift */,
 				35E840C5270FB47C00899AE2 /* ManageSubscriptionsHelper.swift */,
@@ -4141,6 +4153,7 @@
 				1E473B652AC42D34008B07F9 /* StoreMessagesHelper.swift */,
 				1E473B672AC43254008B07F9 /* StoreMessageType.swift */,
 				537B4B312DA9743800CEFF4C /* HealthReport+Validate.swift */,
+				53E33BBA2E095B8900287158 /* SDKHealthManager.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -4769,6 +4782,7 @@
 		57D5412C27F63108004CC35C /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				53A8DCC22E0EA4F600FEABEA /* HealthReportAvailabilityResponse.swift */,
 				03A98D2E2D240C2D009BCA61 /* RevenueCatUI */,
 				3592E88D2C2ED5B200D7F91D /* CustomerCenterConfigResponse.swift */,
 				5774F9B52805E6CC00997128 /* CustomerInfoResponse.swift */,
@@ -5362,6 +5376,7 @@
 		B34605AA279A6E380031CA74 /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				53A8DCC02E0EA49400FEABEA /* HealthReportAvailabilityOperation.swift */,
 				B34605AE279A6E380031CA74 /* Handling */,
 				3592E88B2C2ED58900D7F91D /* GetCustomerCenterConfigOperation.swift */,
 				B34605B5279A6E380031CA74 /* GetCustomerInfoOperation.swift */,
@@ -6374,6 +6389,7 @@
 				9A65E03625918B0500DE00B0 /* ConfigureStrings.swift in Sources */,
 				4FF6E4B92B069B8C000141ED /* HTTPRequest+Signing.swift in Sources */,
 				57488C7729CB90F90000EE7E /* PurchasedProductsFetcher.swift in Sources */,
+				53E33BBB2E095B8900287158 /* SDKHealthManager.swift in Sources */,
 				4F3C986A2A44FA60009AECA3 /* ErrorResponse.swift in Sources */,
 				578C5F2C28DB82DD00A56F02 /* PurchasesDiagnostics.swift in Sources */,
 				537B4B322DA9743800CEFF4C /* HealthReport+Validate.swift in Sources */,
@@ -6576,6 +6592,7 @@
 				B325543C2825C81800DA62EA /* Configuration.swift in Sources */,
 				4F89A55D2A6ABADF008A411E /* PaywallViewMode.swift in Sources */,
 				4F1428A42A4A132C006CD196 /* TestStoreProductDiscount.swift in Sources */,
+				53A8DCC32E0EA4FF00FEABEA /* HealthReportAvailabilityResponse.swift in Sources */,
 				F5BE447B269E4A7500254A30 /* TrackingManagerProxy.swift in Sources */,
 				5746508C27586B2E0053AB09 /* Result+Extensions.swift in Sources */,
 				B34D2AA0269606E400D88C3A /* IntroEligibility.swift in Sources */,
@@ -6636,7 +6653,9 @@
 				4F6BEDE02A26B65900CD9322 /* DebugViewSheetPresentation.swift in Sources */,
 				4F6BEDD92A26B55C00CD9322 /* DebugViewModel.swift in Sources */,
 				FDAC7B552CD3D7A500DFC0D9 /* WinBackOfferEligibilityCalculator.swift in Sources */,
+				53AAD34F2E09857300605F51 /* PaymentAuthorizationProvider.swift in Sources */,
 				1EDB6AA82DC9519D00C771A4 /* WebProductsResponse.swift in Sources */,
+				53A8DCC12E0EA49400FEABEA /* HealthReportAvailabilityOperation.swift in Sources */,
 				5766C622282DAA700067D886 /* GetIntroEligibilityResponse.swift in Sources */,
 				35E840CC270FB70D00899AE2 /* ManageSubscriptionsHelper.swift in Sources */,
 				6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */,
@@ -6897,6 +6916,7 @@
 				4F1E84012A6062C1000AF177 /* ImageSnapshot.swift in Sources */,
 				57FDAAC028493C13009A48F1 /* MockSandboxEnvironmentDetector.swift in Sources */,
 				1EF46BC62D9C1FA7005C94A6 /* PurchasesSystemInfoTests.swift in Sources */,
+				5310820F2E097DEE00F71174 /* SDKHealthManagerTests.swift in Sources */,
 				5766AAD1283E981700FA6091 /* PurchasesPurchasingTests.swift in Sources */,
 				351B515E26D44B9900BD2BD7 /* MockPurchasesDelegate.swift in Sources */,
 				5712BE9229241F7900A83F15 /* TimingUtilTests.swift in Sources */,

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -143,6 +143,28 @@ class Backend {
         self.customer.post(subscriberAttributes: subscriberAttributes, appUserID: appUserID, completion: completion)
     }
 
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    /// Checks if the SDK should log the status of the health report to the console.
+    /// - Parameter appUserID: An `appUserID` that allows the Backend to check for health report availability
+    /// - Returns: Whether the health report should be reported to the console for the given `appUserID`.
+    func healthReportAvailabilityRequest(appUserID: String) async throws -> HealthReportAvailability {
+        try await Async.call { (completion: @escaping (Result<HealthReportAvailability, BackendError>) -> Void) in
+            self.internalAPI.healthReportAvailabilityRequest(
+                appUserID: appUserID,
+                completion: completion
+            )
+        }
+    }
+
+    /// Call the `/health_report` endpoint and perform a full validation of the SDK's configuration
+    /// - Parameter appUserID: An `appUserID` that allows the Backend to fetch offerings
+    /// - Returns: A report with all validation checks along with their status
+    func healthReportRequest(appUserID: String) async throws -> HealthReport {
+        try await Async.call { (completion: @escaping (Result<HealthReport, BackendError>) -> Void) in
+            self.internalAPI.healthReportRequest(appUserID: appUserID, completion: completion)
+        }
+    }
+    #endif
 }
 
 extension Backend {
@@ -153,19 +175,6 @@ extension Backend {
             self.internalAPI.healthRequest(signatureVerification: signatureVerification) { error in
                 completion(.init(error))
             }
-        }
-    }
-
-}
-
-extension Backend {
-
-    /// Call the `/health_report` endpoint and perform a full validation of the SDK's configuration
-    /// - Parameter appUserID: An `appUserID` that allows the Backend to fetch offerings
-    /// - Returns: A report with all validation checks along with their status
-    func healthReportRequest(appUserID: String) async throws -> HealthReport {
-        try await Async.call { (completion: @escaping (Result<HealthReport, BackendError>) -> Void) in
-            self.internalAPI.healthReportRequest(appUserID: appUserID, completion: completion)
         }
     }
 

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -83,6 +83,7 @@ extension HTTPRequest {
         case postAdServicesToken(appUserID: String)
         case health
         case appHealthReport(appUserID: String)
+        case appHealthReportAvailability(appUserID: String)
         case getProductEntitlementMapping
         case getCustomerCenterConfig(appUserID: String)
         case postRedeemWebPurchase
@@ -141,7 +142,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .appHealthReport:
             return true
 
-        case .health:
+        case .health,
+             .appHealthReportAvailability:
             return false
         }
     }
@@ -162,7 +164,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .getCustomerCenterConfig,
                 .appHealthReport:
             return true
-        case .health:
+        case .health,
+             .appHealthReportAvailability:
             return false
         }
     }
@@ -175,7 +178,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .health,
                 .getOfferings,
                 .getProductEntitlementMapping,
-                .appHealthReport:
+                .appHealthReport,
+                .appHealthReportAvailability:
             return true
         case .getIntroEligibility,
                 .postSubscriberAttributes,
@@ -193,7 +197,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case .getCustomerInfo,
                 .logIn,
                 .postReceiptData,
-                .health:
+                .health,
+                .appHealthReportAvailability:
             return true
         case .getOfferings,
                 .getIntroEligibility,
@@ -226,6 +231,9 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case let .appHealthReport(appUserID):
             return "subscribers/\(Self.escape(appUserID))/health_report"
+
+        case let .appHealthReportAvailability(appUserID):
+            return "subscribers/\(Self.escape(appUserID))/health_report_availability"
 
         case .logIn:
             return "subscribers/identify"
@@ -303,6 +311,9 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case .appHealthReport:
             return "get_app_health_report"
+
+        case .appHealthReportAvailability:
+            return "get_app_health_report_availability"
 
         }
     }

--- a/Sources/Networking/InternalAPI.swift
+++ b/Sources/Networking/InternalAPI.swift
@@ -16,16 +16,24 @@ import Foundation
 class InternalAPI {
 
     typealias ResponseHandler = (BackendError?) -> Void
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     typealias HealthReportResponseHandler = (Result<HealthReport, BackendError>) -> Void
+    typealias HealthReportAvailabilityResponseHandler = (Result<HealthReportAvailability, BackendError>) -> Void
+
+    private let healthReportCallbackCache: CallbackCache<HealthReportOperation.Callback>
+    private let healthReportAvailabilityCallbackCache: CallbackCache<HealthReportAvailabilityOperation.Callback>
+    #endif
 
     private let backendConfig: BackendConfiguration
     private let healthCallbackCache: CallbackCache<HealthOperation.Callback>
-    private let healthReportCallbackCache: CallbackCache<HealthReportOperation.Callback>
 
     init(backendConfig: BackendConfiguration) {
         self.backendConfig = backendConfig
         self.healthCallbackCache = .init()
+        #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
         self.healthReportCallbackCache = .init()
+        self.healthReportAvailabilityCallbackCache = .init()
+        #endif
     }
 
     func healthRequest(signatureVerification: Bool, completion: @escaping ResponseHandler) {
@@ -41,6 +49,7 @@ class InternalAPI {
                                                  cacheStatus: cacheStatus)
     }
 
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     func healthReportRequest(appUserID: String, completion: @escaping HealthReportResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)
@@ -53,6 +62,27 @@ class InternalAPI {
                                                  delay: .none,
                                                  cacheStatus: cacheStatus)
     }
+
+    func healthReportAvailabilityRequest(
+        appUserID: String,
+        completion: @escaping HealthReportAvailabilityResponseHandler
+    ) {
+        let config = NetworkOperation.UserSpecificConfiguration(
+            httpClient: self.backendConfig.httpClient,
+            appUserID: appUserID
+        )
+        let factory = HealthReportAvailabilityOperation.createFactory(
+            configuration: config,
+            callbackCache: self.healthReportAvailabilityCallbackCache
+        )
+        let callback = HealthReportAvailabilityOperation.Callback(cacheKey: factory.cacheKey, completion: completion)
+        let cacheStatus = self.healthReportAvailabilityCallbackCache.add(callback)
+
+        self.backendConfig.addCacheableOperation(with: factory,
+                                                 delay: .none,
+                                                 cacheStatus: cacheStatus)
+    }
+    #endif
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     func postPaywallEvents(events: [StoredEvent], completion: @escaping ResponseHandler) {

--- a/Sources/Networking/Operations/HealthReportAvailabilityOperation.swift
+++ b/Sources/Networking/Operations/HealthReportAvailabilityOperation.swift
@@ -7,19 +7,19 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  HealthReportOperation.swift
+//  HealthReportAvailabilityOperation.swift
 //
-//  Created by Pol Piella on 4/8/25.
+//  Created by Pol Piella Abadia on 27/06/2025.
 
 #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 import Foundation
 
-final class HealthReportOperation: CacheableNetworkOperation {
+final class HealthReportAvailabilityOperation: CacheableNetworkOperation {
 
     struct Callback: CacheKeyProviding {
 
         let cacheKey: String
-        let completion: InternalAPI.HealthReportResponseHandler
+        let completion: InternalAPI.HealthReportAvailabilityResponseHandler
 
     }
 
@@ -29,7 +29,7 @@ final class HealthReportOperation: CacheableNetworkOperation {
     static func createFactory(
         configuration: UserSpecificConfiguration,
         callbackCache: CallbackCache<Callback>
-    ) -> CacheableNetworkOperationFactory<HealthReportOperation> {
+    ) -> CacheableNetworkOperationFactory<HealthReportAvailabilityOperation> {
         return .init({ .init(configuration: configuration,
                              callbackCache: callbackCache,
                              cacheKey: $0) },
@@ -47,16 +47,16 @@ final class HealthReportOperation: CacheableNetworkOperation {
 
     override func begin(completion: @escaping () -> Void) {
         let request: HTTPRequest = .init(method: .get,
-                                         path: .appHealthReport(appUserID: configuration.appUserID))
+                                         path: .appHealthReportAvailability(appUserID: configuration.appUserID))
 
         self.httpClient.perform(
             request
-        ) { (response: VerifiedHTTPResponse<HealthReport>.Result) in
+        ) { (response: VerifiedHTTPResponse<HealthReportAvailability>.Result) in
             self.finish(with: response, completion: completion)
         }
     }
 
-    private func finish(with response: VerifiedHTTPResponse<HealthReport>.Result,
+    private func finish(with response: VerifiedHTTPResponse<HealthReportAvailability>.Result,
                         completion: () -> Void) {
         self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
             callback.completion(
@@ -71,5 +71,5 @@ final class HealthReportOperation: CacheableNetworkOperation {
 }
 
 // Restating inherited @unchecked Sendable from Foundation's Operation
-extension HealthReportOperation: @unchecked Sendable {}
+extension HealthReportAvailabilityOperation: @unchecked Sendable {}
 #endif

--- a/Sources/Networking/Responses/HealthReportAvailabilityResponse.swift
+++ b/Sources/Networking/Responses/HealthReportAvailabilityResponse.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  HealthReportAvailabilityResponse.swift
+//
+//  Created by Pol Piella Abadia on 27/06/2025.
+
+import Foundation
+
+struct HealthReportAvailability {
+    let reportLogs: Bool
+}
+
+extension HealthReportAvailability: HTTPResponseBody {}
+extension HealthReportAvailability: Codable, Equatable {}

--- a/Sources/Networking/Responses/HealthReportResponse.swift
+++ b/Sources/Networking/Responses/HealthReportResponse.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Pol Piella on 4/8/25.
 
+#if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 import Foundation
 
 enum HealthCheckStatus: String {
@@ -138,3 +139,4 @@ extension ProductStatus: Codable, Equatable {}
 extension ProductHealthReport: Codable, Equatable {}
 extension OfferingHealthReport: Codable, Equatable {}
 extension PackageHealthReport: Codable, Equatable {}
+#endif

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2079,6 +2079,16 @@ private extension Purchases {
 
     #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     func runHealthCheckIfInForeground() {
+        // This is a workaround and needs to be fixed at some point. Explanation:
+        // The StoreKit integration tests are very time sensitive and set very
+        // short expiry times for most products. This results in flakiness, which
+        // is further aggravated by the fact that the health check adds an extra async
+        // method and thus an extra delay.
+        // To avoid this, we skip the health check when running integration tests.
+        // This is not ideal, and we should consider making the tests more resilient
+        // in the future.
+        guard !ProcessInfo.isRunningIntegrationTests else { return }
+
         self.operationDispatcher.dispatchOnWorkerThread { [weak self] in
             guard self?.systemInfo.isAppBackgroundedState == false,
             let appUserID = self?.appUserID,

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1246,10 +1246,12 @@ internal protocol InternalPurchasesType: AnyObject {
     /// - Throws: `PublicError` if request failed.
     func healthRequest(signatureVerification: Bool) async throws
 
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     /// Requests an in-depth report of the SDK's configuration from the server.
     /// - Throws: A `BackendError` if the request fails due to an invalid API key or connectivity issues.
     /// - Returns: A health report containing all checks performed on the server and their status.
-    func healthReportRequest() async throws -> HealthReport
+    func healthReport() async -> PurchasesDiagnostics.SDKHealthReport
+    #endif
 
     func offerings(fetchPolicy: OfferingsManager.FetchPolicy) async throws -> Offerings
 

--- a/Sources/Support/DebugUI/DebugViewModel.swift
+++ b/Sources/Support/DebugUI/DebugViewModel.swift
@@ -62,8 +62,9 @@ final class DebugViewModel: ObservableObject {
     @MainActor
     func load() async {
         self.configuration = .loaded(.create())
-
+        #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
         self.diagnosticsResult = .loaded(await PurchasesDiagnostics.default.healthReport())
+        #endif
         self.offerings = await .create { try await Purchases.shared.offerings() }
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
         self.customerInfo = await .create { try await Purchases.shared.customerInfo() }

--- a/Sources/Support/HealthReport+Validate.swift
+++ b/Sources/Support/HealthReport+Validate.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Pol Piella on 4/10/25.
 
-#if DEBUG
+#if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 extension HealthReport {
     func validate() -> PurchasesDiagnostics.SDKHealthReport {
         guard let firstFailedCheck = self.checks.first(where: { $0.status == .failed }) else {

--- a/Sources/Support/PaymentAuthorizationProvider.swift
+++ b/Sources/Support/PaymentAuthorizationProvider.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaymentAuthorizationProvider.swift
+//
+//  Created by Pol Piella Abadia on 23/06/2025.
+
+import Foundation
+import StoreKit
+
+struct PaymentAuthorizationProvider {
+    var isAuthorized: () -> Bool
+}
+
+extension PaymentAuthorizationProvider {
+    static let storeKit = PaymentAuthorizationProvider(
+        isAuthorized: {
+            if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *) {
+                return AppStore.canMakePayments
+            } else {
+                return SKPaymentQueue.canMakePayments()
+            }
+        }
+    )
+}

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -74,7 +74,7 @@ extension PurchasesDiagnostics {
     }
 
     /// Additional information behind a configuration issue for the app's Bundle Id
-    public struct InvalidBundleIdErrorPayload {
+    public struct InvalidBundleIdErrorPayload: Equatable {
         /// Bundle ID for the RevenueCat app
         public let appBundleId: String
         /// Bundle ID detected from the app at runtime by the RevenueCat SDK
@@ -230,7 +230,7 @@ extension PurchasesDiagnostics {
         }
     }
 
-    #if DEBUG
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     /// Performs a full SDK configuration health check and throws an error if the configuration is not valid.
     /// - Important: This method can not be invoked in production builds.
     /// - Throws: ``SDKHealthError`` indicating the specific configuration issue that needs to be solved.
@@ -241,33 +241,12 @@ extension PurchasesDiagnostics {
         }
     }
 
-    private var canMakePayments: Bool {
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *) {
-            return AppStore.canMakePayments
-        } else {
-            return SKPaymentQueue.canMakePayments()
-        }
-    }
-
     /// Performs a full SDK configuration health check and returns its status.
     /// - Important: This method is intended solely for debugging configuration issues with the SDK implementation.
     /// It should not be invoked in production builds.
     /// - Returns: The result of the SDK configuration health check.
     public func healthReport() async -> SDKHealthReport {
-        do {
-            if !canMakePayments {
-                return .init(status: .unhealthy(.notAuthorizedToMakePayments))
-            }
-            return try await self.purchases.healthReportRequest().validate()
-        } catch let error as BackendError {
-            if case .networkError(let networkError) = error,
-               case .errorResponse(let response, _, _) = networkError, response.code == .invalidAPIKey {
-                return .init(status: .unhealthy(.invalidAPIKey))
-            }
-            return .init(status: .unhealthy(.unknown(error)))
-        } catch {
-            return .init(status: .unhealthy(.unknown(error)))
-        }
+        await purchases.healthReport()
     }
     #endif
 }

--- a/Sources/Support/SDKHealthError+CustomNSError.swift
+++ b/Sources/Support/SDKHealthError+CustomNSError.swift
@@ -57,9 +57,13 @@ extension PurchasesDiagnostics.SDKHealthError: CustomNSError {
 
         case let .offeringConfiguration(payload):
             guard let offendingOffering = payload.first(where: { $0.status == .failed }) else {
+                let offeringsWithWarnings = payload.filter { $0.status == .warning }
+                let offeringDescription = offeringsWithWarnings.isEmpty ?
+                    "Some offerings" :
+                    "The offerings \(offeringsWithWarnings.map { "'\($0.identifier)'" }.joined(separator: ", "))"
                 return """
-                Your default offering is not configured correctly in RevenueCat. This prevents users from \
-                seeing product options. Please check your offering configuration in the RevenueCat website.
+                \(offeringDescription) have configuration issues that may prevent users from seeing product \
+                options or making purchases.
                 """
             }
 

--- a/Sources/Support/SDKHealthManager.swift
+++ b/Sources/Support/SDKHealthManager.swift
@@ -1,0 +1,209 @@
+import Foundation
+
+final class SDKHealthManager: Sendable {
+    private let backend: Backend
+    private let identityManager: IdentityManager
+    private let paymentAuthorizationProvider: PaymentAuthorizationProvider
+
+    init(
+        backend: Backend,
+        identityManager: IdentityManager,
+        paymentAuthorizationProvider: PaymentAuthorizationProvider = .storeKit
+    ) {
+        self.backend = backend
+        self.identityManager = identityManager
+        self.paymentAuthorizationProvider = paymentAuthorizationProvider
+    }
+
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    func healthReport() async -> PurchasesDiagnostics.SDKHealthReport {
+        do {
+            if !paymentAuthorizationProvider.isAuthorized() {
+                return .init(status: .unhealthy(.notAuthorizedToMakePayments))
+            }
+            let appUserID = self.identityManager.currentAppUserID
+            return try await self.backend.healthReportRequest(appUserID: appUserID).validate()
+        } catch let error as BackendError {
+            if case .networkError(let networkError) = error,
+               case .errorResponse(let response, _, _) = networkError, response.code == .invalidAPIKey {
+                return .init(status: .unhealthy(.invalidAPIKey))
+            }
+            return .init(status: .unhealthy(.unknown(error)))
+        } catch {
+            return .init(status: .unhealthy(.unknown(error)))
+        }
+    }
+
+    func logSDKHealthReportOutcome() async {
+        let report = await healthReport()
+        switch report.status {
+        case let .unhealthy(error):
+            Logger.error(HealthReportLogMessage.unhealthy(error: error, report: report))
+        case let .healthy(warnings):
+            if warnings.isEmpty {
+                Logger.info(HealthReportLogMessage.healthy(report: report))
+            } else {
+                Logger.warn(HealthReportLogMessage.healthyWithWarnings(warnings: warnings, report: report))
+            }
+        }
+    }
+    #endif
+}
+
+#if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+private enum HealthReportLogMessage: LogMessage {
+    case unhealthy(error: PurchasesDiagnostics.SDKHealthError, report: PurchasesDiagnostics.SDKHealthReport)
+    case healthy(report: PurchasesDiagnostics.SDKHealthReport)
+    case healthyWithWarnings(
+        warnings: [PurchasesDiagnostics.SDKHealthError],
+        report: PurchasesDiagnostics.SDKHealthReport
+    )
+
+    var description: String {
+        switch self {
+        case let .unhealthy(error, report):
+            return buildUnhealthyMessage(error: error, report: report)
+        case let .healthy(report):
+            return buildHealthyMessage(report: report)
+        case let .healthyWithWarnings(warnings, report):
+            return buildHealthyWithWarningsMessage(warnings: warnings, report: report)
+        }
+    }
+
+    var category: String { "health_report" }
+
+    private func buildUnhealthyMessage(
+        error: PurchasesDiagnostics.SDKHealthError,
+        report: PurchasesDiagnostics.SDKHealthReport
+    ) -> String {
+        var message = "RevenueCat SDK Configuration is not valid\n"
+        message += "\n\(error.localizedDescription)\n"
+
+        let actionURL: String? = {
+            guard let projectId = report.projectId, let appId = report.appId else { return nil }
+
+            switch error {
+            case .invalidBundleId:
+                return "https://app.revenuecat.com/projects/\(projectId)/apps/\(appId)"
+            case .offeringConfiguration, .noOfferings:
+                return "https://app.revenuecat.com/projects/\(projectId)/product-catalog/offerings"
+            case .invalidProducts:
+                return "https://app.revenuecat.com/projects/\(projectId)/product-catalog/products"
+            default: return nil
+            }
+        }()
+
+        if let actionURL {
+            message += "\nPlease visit the RevenueCat website to resolve the issue: \(actionURL)\n"
+        }
+
+        message += buildProductsSection(report: report)
+        message += buildOfferingsSection(report: report)
+
+        return message
+    }
+
+    private func buildHealthyMessage(report: PurchasesDiagnostics.SDKHealthReport) -> String {
+        var message = "✅ RevenueCat SDK is configured correctly\n"
+
+        message += buildProductsSection(report: report)
+        message += buildOfferingsSection(report: report)
+
+        return message
+    }
+
+    private func buildHealthyWithWarningsMessage(
+        warnings: [PurchasesDiagnostics.SDKHealthError],
+        report: PurchasesDiagnostics.SDKHealthReport
+    ) -> String {
+        if report.products.allSatisfy({ $0.status == .couldNotCheck }) {
+            var message = """
+            We could not validate your SDK's configuration and check your product statuses in App Store Connect.\n
+            """
+
+            if let description = report.products.first?.description {
+                message += "\nError: \(description)\n"
+            }
+
+            message += """
+            \nIf you want to check if your SDK is configured correctly, please check your App Store Connect \
+            credentials in RevenueCat, make sure your App Store Connect App exists and try again:
+            """
+
+            if let projectId = report.projectId, let appId = report.appId {
+                let url = "https://app.revenuecat.com/projects/\(projectId)/apps/\(appId)#scroll=app-store-connect-api"
+                message += "\n\n\(url)"
+            }
+
+            return message
+        }
+
+        var message = "RevenueCat SDK is configured correctly, but contains some issues you might want to address\n"
+
+        message += "\nWarnings:\n"
+        for warning in warnings {
+            message += "  • \(warning.localizedDescription)\n"
+        }
+
+        message += buildProductsSection(report: report)
+        message += buildOfferingsSection(report: report)
+
+        return message
+    }
+
+    private func buildProductsSection(report: PurchasesDiagnostics.SDKHealthReport) -> String {
+        let productsWithIssues = report.products.filter { $0.status != .valid }
+        guard !productsWithIssues.isEmpty else { return "" }
+
+        var section = "\nProduct Issues:\n"
+        for product in productsWithIssues {
+            let statusIcon = productStatusIcon(product.status)
+            section += "  \(statusIcon) \(product.identifier)"
+            if let title = product.title {
+                section += " (\(title))"
+            }
+            section += ": \(product.description)\n"
+        }
+
+        return section
+    }
+
+    private func buildOfferingsSection(report: PurchasesDiagnostics.SDKHealthReport) -> String {
+        let offeringsWithIssues = report.offerings.filter { $0.status != .passed }
+        guard !offeringsWithIssues.isEmpty else { return "" }
+
+        var section = "\nOffering Issues:\n"
+        for offering in offeringsWithIssues {
+            let statusIcon = offeringStatusIcon(offering.status)
+            section += "  \(statusIcon) \(offering.identifier)\n"
+            let packagesWithIssues = offering.packages.filter { $0.status != .valid }
+            for package in packagesWithIssues {
+                let packageStatusIcon = productStatusIcon(package.status)
+                let packageInfo = "\(packageStatusIcon) \(package.identifier) (\(package.productIdentifier))"
+                section += "    \(packageInfo): \(package.description)\n"
+            }
+        }
+
+        return section
+    }
+
+    private func productStatusIcon(_ status: PurchasesDiagnostics.ProductStatus) -> String {
+        switch status {
+        case .valid: return "✅"
+        case .couldNotCheck: return "❓"
+        case .notFound: return "❌"
+        case .actionInProgress: return "⏳"
+        case .needsAction: return "⚠️"
+        case .unknown: return "❓"
+        }
+    }
+
+    private func offeringStatusIcon(_ status: PurchasesDiagnostics.SDKHealthCheckStatus) -> String {
+        switch status {
+        case .passed: return "✅"
+        case .failed: return "❌"
+        case .warning: return "⚠️"
+        }
+    }
+}
+#endif

--- a/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
+++ b/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
@@ -239,8 +239,36 @@ class PurchasesDiagnosticsTests: TestCase {
 
         expect(error.errorUserInfo[NSUnderlyingErrorKey] as? NSNull).toNot(beNil())
         let expected = """
-        Your default offering is not configured correctly in RevenueCat. This prevents users from \
-        seeing product options. Please check your offering configuration in the RevenueCat website.
+        Some offerings have configuration issues that may prevent users from seeing product options or making purchases.
+        """
+        expect(error.localizedDescription) == expected
+    }
+
+    func testWarningOfferingConfigurationError() {
+        let error = PurchasesDiagnostics.SDKHealthError.offeringConfiguration(
+            [
+                .init(
+                    identifier: "offering_one",
+                    packages: [],
+                    status: .warning
+                ),
+                .init(
+                    identifier: "offering_two",
+                    packages: [],
+                    status: .warning
+                ),
+                .init(
+                    identifier: "offering_three",
+                    packages: [],
+                    status: .passed
+                )
+            ]
+        )
+
+        expect(error.errorUserInfo[NSUnderlyingErrorKey] as? NSNull).toNot(beNil())
+        let expected = """
+        The offerings 'offering_one', 'offering_two' have configuration issues that may prevent users from \
+        seeing product options or making purchases.
         """
         expect(error.localizedDescription) == expected
     }

--- a/Tests/UnitTests/Misc/SDKHealthManagerTests.swift
+++ b/Tests/UnitTests/Misc/SDKHealthManagerTests.swift
@@ -1,0 +1,962 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SDKHealthManagerTests.swift
+//
+//  Created by Pol Piella Abadia on 12/19/24.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class SDKHealthManagerTests: TestCase {
+    func testHealthReportReturnsUnhealthyWhenCannotMakePayments() async {
+        let manager = makeSUT(backendResponse: .success(
+            HealthReport(
+                status: .passed,
+                projectId: "test_project",
+                appId: "test_app",
+                checks: []
+            )
+        ), canMakePayments: false)
+
+        let report = await manager.healthReport()
+
+        expect(report.status).to(beUnhealthy(.notAuthorizedToMakePayments))
+    }
+
+    func testHealthReportReturnsUnhealthyForInvalidAPIKey() async {
+        let manager = makeSUT(backendResponse: .failure(BackendError.networkError(.errorResponse(
+            .init(code: .invalidAPIKey, originalCode: 0),
+            .forbidden
+        ))))
+
+        let report = await manager.healthReport()
+
+        expect(report.status).to(beUnhealthy(.invalidAPIKey))
+    }
+
+    func testHealthReportReturnsUnhealthyForUnknownBackendError() async {
+        let manager = makeSUT(backendResponse: .failure(BackendError.networkError(
+            .errorResponse(
+                .init(code: .unknownError, originalCode: 0),
+                .internalServerError
+            )
+        )))
+
+        let report = await manager.healthReport()
+
+        expect(report.status).to(beUnhealthyWithUnknownError())
+    }
+
+    func testHealthReportReturnsUnhealthyForNonBackendError() async {
+        let manager = makeSUT(backendResponse: .failure(BackendError.networkError(.errorResponse(
+            .init(code: .unknownError, originalCode: 0),
+            .internalServerError
+        ))))
+
+        let report = await manager.healthReport()
+
+        expect(report.status).to(beUnhealthyWithUnknownError())
+    }
+
+    func testHealthReportWithValidHealthReport() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .passed, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "test_product",
+                        title: "Test Product",
+                        status: .valid,
+                        description: "Available for production purchases."
+                    )
+                ])))
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        let report = await manager.healthReport()
+
+        expect(report.status).to(beHealthy())
+        expect(report.projectId) == "test_project"
+        expect(report.appId) == "test_app"
+        expect(report.products).to(haveCount(1))
+        expect(report.products[0].identifier) == "test_product"
+        expect(report.products[0].status) == .valid
+    }
+
+    func testHealthReportWithFailedCheck() async {
+        let healthReport = HealthReport(
+            status: .failed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .apiKey, status: .failed)
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        let report = await manager.healthReport()
+
+        expect(report.status).to(beUnhealthy(.invalidAPIKey))
+        expect(report.projectId) == "test_project"
+        expect(report.appId) == "test_app"
+    }
+
+    func testHealthReportWithWarnings() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .warning, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "test_product",
+                        title: "Test Product",
+                        status: .needsAction,
+                        description: "Product needs action in App Store Connect"
+                    )
+                ])))
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        let report = await manager.healthReport()
+
+        expect(report.status).to(beHealthyWithWarnings())
+        if case let .healthy(warnings) = report.status {
+            expect(warnings).to(haveCount(1))
+            expect(warnings[0]).to(beInvalidProducts())
+        }
+    }
+
+    func testLogSDKHealthReportOutcomeLogsErrorForUnhealthyStatus() async {
+        let manager = makeSUT(
+            backendResponse: .failure(
+                BackendError.networkError(
+                    .errorResponse(.init(code: .invalidAPIKey, originalCode: 0), .forbidden)
+                )
+            )
+        )
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged("SDK Configuration is not valid", level: .error)
+        self.logger.verifyMessageWasLogged("API key is not valid", level: .error)
+    }
+
+    func testLogSDKHealthReportOutcomeLogsInfoForHealthyStatus() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: []
+        )
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged("SDK is configured correctly", level: .info)
+    }
+
+    func testLogSDKHealthReportOutcomeLogsWarningForHealthyWithWarningsStatus() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .warning, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "test_product",
+                        title: "Test Product",
+                        status: .needsAction,
+                        description: "Product needs action in App Store Connect."
+                    )
+                ])))
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged(
+            "SDK is configured correctly, but contains some issues you might want to address",
+            level: .warn
+        )
+        self.logger.verifyMessageWasLogged("Warnings:", level: .warn)
+    }
+
+    func testLogSDKHealthReportOutcomeIncludesActionURLForInvalidBundleId() async {
+        let healthReport = HealthReport(
+            status: .failed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .bundleId, status: .failed, details: .bundleId(BundleIdCheckDetails(
+                    sdkBundleId: "com.test.sdk",
+                    appBundleId: "com.test.app"
+                )))
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged(
+            "https://app.revenuecat.com/projects/test_project/apps/test_app",
+            level: .error
+        )
+        self.logger.verifyMessageWasLogged(
+            "Please visit the RevenueCat website to resolve the issue",
+            level: .error
+        )
+    }
+
+    func testLogSDKHealthReportOutcomeIncludesActionURLForInvalidProducts() async {
+        let healthReport = HealthReport(
+            status: .failed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .failed, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "test_product",
+                        title: "Test Product",
+                        status: .notFound,
+                        description: "Product not found in App Store Connect."
+                    )
+                ])))
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged(
+            "https://app.revenuecat.com/projects/test_project/product-catalog/products",
+            level: .error
+        )
+    }
+
+    func testLogSDKHealthReportOutcomeIncludesActionURLForOfferingConfiguration() async {
+        let healthReport = HealthReport(
+            status: .failed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .offerings, status: .failed)
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged(
+            "https://app.revenuecat.com/projects/test_project/product-catalog/offerings",
+            level: .error
+        )
+    }
+
+    func testLogSDKHealthReportOutcomeIncludesProductIssuesSection() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .passed, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "test_product",
+                        title: "Test Product",
+                        status: .valid,
+                        description: "Available for production purchases."
+                    ),
+                    ProductHealthReport(
+                        identifier: "test_product_2",
+                        title: nil,
+                        status: .notFound,
+                        description: "Product not found in App Store Connect."
+                    ),
+                    ProductHealthReport(
+                        identifier: "test_product_3",
+                        title: "Test Product 3",
+                        status: .needsAction,
+                        description: "Product needs action in App Store Connect."
+                    )
+                ])))
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged("Product Issues:", level: .info)
+        self.logger.verifyMessageWasNotLogged(
+            "✅ test_product (Test Product): Available for production purchases.",
+            level: .info
+        )
+        self.logger.verifyMessageWasLogged(
+            "❌ test_product_2: Product not found in App Store Connect.",
+            level: .info
+        )
+        self.logger.verifyMessageWasLogged(
+            """
+            ⚠️ test_product_3 (Test Product 3): This product's status (Product needs action in App Store Connect.) \
+            requires you to take action in App Store Connect before using it in production purchases.
+            """,
+            level: .info
+        )
+    }
+
+    func testLogSDKHealthReportOutcomeIncludesOfferingIssuesSection() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(
+                    name: .offeringsProducts,
+                    status: .passed,
+                    details: .offeringsProducts(OfferingsCheckDetails(offerings: [
+                        OfferingHealthReport(
+                            identifier: "test_offering",
+                            packages: [
+                                PackageHealthReport(
+                                    identifier: "test_package",
+                                    title: "Test Package",
+                                    status: .valid,
+                                    description: "Available for production purchases.",
+                                    productIdentifier: "test_product",
+                                    productTitle: "Test Product"
+                                ),
+                                PackageHealthReport(
+                                    identifier: "test_package_2",
+                                    title: "Test Package 2",
+                                    status: .notFound,
+                                    description: "Package not found in App Store Connect.",
+                                    productIdentifier: "test_product_2",
+                                    productTitle: "Test Product 2"
+                                )
+                            ],
+                            status: .warning
+                        ),
+                        OfferingHealthReport(
+                            identifier: "test_offering_2",
+                            packages: [
+                                PackageHealthReport(
+                                    identifier: "test_package_3",
+                                    title: "Test Package 3",
+                                    status: .needsAction,
+                                    description: "Package needs action in App Store Connect.",
+                                    productIdentifier: "test_product_3",
+                                    productTitle: "Test Product 3"
+                                )
+                            ],
+                            status: .warning
+                        )
+                    ]))
+                )
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged("Offering Issues:", level: .info)
+        self.logger.verifyMessageWasNotLogged("✅ test_offering", level: .info)
+        self.logger.verifyMessageWasNotLogged(
+            "✅ test_package (test_product): Available for production purchases.",
+            level: .info
+        )
+        self.logger.verifyMessageWasLogged("⚠️ test_offering_2", level: .info)
+        self.logger.verifyMessageWasLogged(
+            """
+            ❌ test_package_2 (test_product_2): Product not found in App Store Connect. You need to create a product \
+            with identifier: 'test_product_2' in App Store Connect to use it for production purchases.
+            """,
+            level: .info
+        )
+        self.logger.verifyMessageWasLogged(
+            """
+            ⚠️ test_package_3 (test_product_3): This product's status (Package needs action in App Store Connect.) \
+            requires you to take action in App Store Connect before using it in production purchases.
+            """,
+            level: .info
+        )
+    }
+
+    func testLogSDKHealthReportOutcomeDoesNotIncludeEmptySections() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: []
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasNotLogged("Product Issues:", level: .info)
+        self.logger.verifyMessageWasNotLogged("Offering Issues:", level: .info)
+    }
+
+    func testLogSDKHealthReportOutcomeLogsSpecialMessageWhenNoAppStoreConnectCredentials() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .warning, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "test_product_1",
+                        title: "Test Product 1",
+                        status: .couldNotCheck,
+                        description: "Could not validate product status due to App Store Connect API issues"
+                    ),
+                    ProductHealthReport(
+                        identifier: "test_product_2",
+                        title: "Test Product 2",
+                        status: .couldNotCheck,
+                        description: "Could not validate product status due to App Store Connect API issues"
+                    )
+                ])))
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged(
+            "We could not validate your SDK's configuration and check your product statuses in App Store Connect.",
+            level: .warn
+        )
+        self.logger.verifyMessageWasLogged(
+            "Error: Could not validate product status due to App Store Connect API issues",
+            level: .warn
+        )
+        self.logger.verifyMessageWasLogged(
+            """
+            If you want to check if your SDK is configured correctly, please check your App Store Connect \
+            credentials in RevenueCat, make sure your App Store Connect App exists and try again:
+            """,
+            level: .warn
+        )
+        self.logger.verifyMessageWasLogged(
+            "https://app.revenuecat.com/projects/test_project/apps/test_app#scroll=app-store-connect-api",
+            level: .warn
+        )
+    }
+
+    func testLogSDKHealthReportOutcomeLogsNoAppStoreCredentialsWarningWithNoProjectAndAppId() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: nil,
+            appId: nil,
+            checks: [
+                HealthCheck(name: .products, status: .warning, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "test_product_1",
+                        title: "Test Product 1",
+                        status: .couldNotCheck,
+                        description: "Could not validate product status due to App Store Connect API issues"
+                    ),
+                    ProductHealthReport(
+                        identifier: "test_product_2",
+                        title: "Test Product 2",
+                        status: .couldNotCheck,
+                        description: "Could not validate product status due to App Store Connect API issues"
+                    )
+                ])))
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged(
+            "We could not validate your SDK's configuration and check your product statuses in App Store Connect.",
+            level: .warn
+        )
+        self.logger.verifyMessageWasLogged(
+            "Error: Could not validate product status due to App Store Connect API issues",
+            level: .warn
+        )
+        self.logger.verifyMessageWasLogged(
+            """
+            If you want to check if your SDK is configured correctly, please check your App Store Connect \
+            credentials in RevenueCat, make sure your App Store Connect App exists and try again:
+            """,
+            level: .warn
+        )
+        self.logger.verifyMessageWasNotLogged("https://app.revenuecat.com/projects/", level: .warn)
+    }
+
+    func testLogSDKHealthReportOutcomeDoesNotIncludeValidProducts() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .passed, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "valid_product_1",
+                        title: "Valid Product 1",
+                        status: .valid,
+                        description: "Available for production purchases."
+                    ),
+                    ProductHealthReport(
+                        identifier: "valid_product_2",
+                        title: "Valid Product 2",
+                        status: .valid,
+                        description: "Available for production purchases."
+                    )
+                ])))
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasNotLogged("Product Issues:", level: .info)
+        self.logger.verifyMessageWasNotLogged("valid_product_1", level: .info)
+        self.logger.verifyMessageWasNotLogged("valid_product_2", level: .info)
+    }
+
+    func testLogSDKHealthReportOutcomeDoesNotIncludeValidOfferings() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(
+                    name: .offeringsProducts,
+                    status: .passed,
+                    details: .offeringsProducts(OfferingsCheckDetails(offerings: [
+                        OfferingHealthReport(
+                            identifier: "valid_offering",
+                            packages: [
+                                PackageHealthReport(
+                                    identifier: "valid_package",
+                                    title: "Valid Package",
+                                    status: .valid,
+                                    description: "Available for production purchases.",
+                                    productIdentifier: "valid_product",
+                                    productTitle: "Valid Product"
+                                )
+                            ],
+                            status: .passed
+                        )
+                    ]))
+                )
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasNotLogged("Offering Issues:", level: .info)
+        self.logger.verifyMessageWasNotLogged("valid_offering", level: .info)
+        self.logger.verifyMessageWasNotLogged("valid_package", level: .info)
+    }
+
+    func testLogSDKHealthReportOutcomeDoesNotIncludeValidOfferingMessages() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(
+                    name: .offeringsProducts,
+                    status: .passed,
+                    details: .offeringsProducts(OfferingsCheckDetails(offerings: [
+                        OfferingHealthReport(
+                            identifier: "test_offering",
+                            packages: [
+                                PackageHealthReport(
+                                    identifier: "valid_package",
+                                    title: "Valid Package",
+                                    status: .valid,
+                                    description: "Available for production purchases.",
+                                    productIdentifier: "valid_product",
+                                    productTitle: "Valid Product"
+                                ),
+                                PackageHealthReport(
+                                    identifier: "invalid_package",
+                                    title: "Invalid Package",
+                                    status: .notFound,
+                                    description: "Package not found in App Store Connect.",
+                                    productIdentifier: "invalid_product",
+                                    productTitle: "Invalid Product"
+                                )
+                            ],
+                            status: .passed
+                        )
+                    ]))
+                )
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasNotLogged("valid_package", level: .info)
+    }
+
+    func testLogSDKHealthReportOutcomeIncludesAllProductStatusesExceptValid() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .passed, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "valid_product",
+                        title: "Valid Product",
+                        status: .valid,
+                        description: "Available for production purchases."
+                    ),
+                    ProductHealthReport(
+                        identifier: "not_found_product",
+                        title: "Not Found Product",
+                        status: .notFound,
+                        description: "Product not found in App Store Connect."
+                    ),
+                    ProductHealthReport(
+                        identifier: "needs_action_product",
+                        title: "Needs Action Product",
+                        status: .needsAction,
+                        description: "Product needs action in App Store Connect."
+                    ),
+                    ProductHealthReport(
+                        identifier: "action_in_progress_product",
+                        title: "Action In Progress Product",
+                        status: .actionInProgress,
+                        description: "Action in progress for this product."
+                    ),
+                    ProductHealthReport(
+                        identifier: "could_not_check_product",
+                        title: "Could Not Check Product",
+                        status: .couldNotCheck,
+                        description: "Could not validate product status."
+                    ),
+                    ProductHealthReport(
+                        identifier: "unknown_product",
+                        title: "Unknown Product",
+                        status: .unknown,
+                        description: "Unknown product status."
+                    )
+                ])))
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged("Product Issues:", level: .info)
+        self.logger.verifyMessageWasNotLogged("valid_product", level: .info)
+        self.logger.verifyMessageWasLogged("❌ not_found_product", level: .info)
+        self.logger.verifyMessageWasLogged("⚠️ needs_action_product", level: .info)
+        self.logger.verifyMessageWasLogged("⏳ action_in_progress_product", level: .info)
+        self.logger.verifyMessageWasLogged("❓ could_not_check_product", level: .info)
+        self.logger.verifyMessageWasLogged("❓ unknown_product", level: .info)
+    }
+
+    func testLogSDKHealthReportOutcomeIncludesAllOfferingStatusesExceptPassed() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(
+                    name: .offeringsProducts,
+                    status: .passed,
+                    details: .offeringsProducts(OfferingsCheckDetails(offerings: [
+                        OfferingHealthReport(
+                            identifier: "passed_offering",
+                            packages: [],
+                            status: .passed
+                        ),
+                        OfferingHealthReport(
+                            identifier: "failed_offering",
+                            packages: [],
+                            status: .failed
+                        ),
+                        OfferingHealthReport(
+                            identifier: "warning_offering",
+                            packages: [],
+                            status: .warning
+                        )
+                    ]))
+                )
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged("Offering Issues:", level: .info)
+        self.logger.verifyMessageWasNotLogged("passed_offering", level: .info)
+        self.logger.verifyMessageWasLogged("❌ failed_offering", level: .info)
+        self.logger.verifyMessageWasLogged("⚠️ warning_offering", level: .info)
+    }
+
+    func testLogSDKHealthReportOutcomeShowsCleanMessageWhenAllProductsAndOfferingsAreValid() async {
+        let healthReport = HealthReport(
+            status: .passed,
+            projectId: "test_project",
+            appId: "test_app",
+            checks: [
+                HealthCheck(name: .products, status: .passed, details: .products(ProductsCheckDetails(products: [
+                    ProductHealthReport(
+                        identifier: "valid_product",
+                        title: "Valid Product",
+                        status: .valid,
+                        description: "Available for production purchases."
+                    )
+                ]))),
+                HealthCheck(
+                    name: .offeringsProducts,
+                    status: .passed,
+                    details: .offeringsProducts(OfferingsCheckDetails(offerings: [
+                        OfferingHealthReport(
+                            identifier: "valid_offering",
+                            packages: [
+                                PackageHealthReport(
+                                    identifier: "valid_package",
+                                    title: "Valid Package",
+                                    status: .valid,
+                                    description: "Available for production purchases.",
+                                    productIdentifier: "valid_product",
+                                    productTitle: "Valid Product"
+                                )
+                            ],
+                            status: .passed
+                        )
+                    ]))
+                )
+            ]
+        )
+
+        let manager = makeSUT(backendResponse: .success(healthReport))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasLogged("✅ RevenueCat SDK is configured correctly", level: .info)
+        self.logger.verifyMessageWasNotLogged("Product Issues:", level: .info)
+        self.logger.verifyMessageWasNotLogged("Offering Issues:", level: .info)
+    }
+}
+
+// MARK: - Builder Methods
+
+fileprivate extension SDKHealthManagerTests {
+    private func makeSUT(
+        backendResponse: Result<HealthReport, BackendError>,
+        canMakePayments: Bool = true,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> SDKHealthManager {
+        let backend = MockBackend()
+        backend.healthReportRequestResponse = backendResponse
+        let manager = SDKHealthManager(
+            backend: backend,
+            identityManager: MockIdentityManager(mockAppUserID: "app_user_id", mockDeviceCache: .init()),
+            paymentAuthorizationProvider: .mock(canMakePayments: canMakePayments)
+        )
+
+        addTeardownBlock { [weak manager] in
+            XCTAssertNil(
+                manager,
+                file: file,
+                line: line
+            )
+        }
+
+        return manager
+    }
+}
+
+// MARK: - Custom Matchers
+
+fileprivate extension SDKHealthManagerTests {
+    private func beHealthy() -> Matcher<PurchasesDiagnostics.SDKHealthStatus> {
+        return Matcher { actualExpression in
+            let message = ExpectationMessage.expectedActualValueTo("be healthy")
+
+            guard let actual = try actualExpression.evaluate() else {
+                return MatcherResult(status: .fail, message: message.appendedBeNilHint())
+            }
+
+            switch actual {
+            case .healthy:
+                return MatcherResult(status: .matches, message: message)
+            case .unhealthy:
+                return MatcherResult(status: .fail, message: message.appended(details: "was unhealthy"))
+            }
+        }
+    }
+
+    private func beHealthyWithWarnings() -> Matcher<PurchasesDiagnostics.SDKHealthStatus> {
+        return Matcher { actualExpression in
+            let message = ExpectationMessage.expectedActualValueTo("be healthy with warnings")
+
+            guard let actual = try actualExpression.evaluate() else {
+                return MatcherResult(status: .fail, message: message.appendedBeNilHint())
+            }
+
+            switch actual {
+            case let .healthy(warnings):
+                if warnings.isEmpty {
+                    return MatcherResult(
+                        status: .fail,
+                        message: message.appended(details: "was healthy without warnings")
+                    )
+                } else {
+                    return MatcherResult(status: .matches, message: message)
+                }
+            case .unhealthy:
+                return MatcherResult(status: .fail, message: message.appended(details: "was unhealthy"))
+            }
+        }
+    }
+
+    private func beUnhealthy(
+        _ error: PurchasesDiagnostics.SDKHealthError
+    ) -> Matcher<PurchasesDiagnostics.SDKHealthStatus> {
+        return Matcher { [error] actualExpression in
+            let message = ExpectationMessage.expectedActualValueTo("be unhealthy with error \(error)")
+
+            guard let actual = try actualExpression.evaluate() else {
+                return MatcherResult(status: .fail, message: message.appendedBeNilHint())
+            }
+
+            switch actual {
+            case .healthy:
+                return MatcherResult(status: .fail, message: message.appended(details: "was healthy"))
+            case let .unhealthy(actualError):
+                return self.compareUnhealthyErrors(expected: error, actual: actualError, message: message)
+            }
+        }
+    }
+
+    private func compareUnhealthyErrors(
+        expected: PurchasesDiagnostics.SDKHealthError,
+        actual: PurchasesDiagnostics.SDKHealthError,
+        message: ExpectationMessage
+    ) -> MatcherResult {
+        switch (expected, actual) {
+        case (.invalidAPIKey, .invalidAPIKey),
+             (.noOfferings, .noOfferings),
+             (.notAuthorizedToMakePayments, .notAuthorizedToMakePayments):
+            return MatcherResult(status: .matches, message: message)
+        case let (.invalidBundleId(expected), .invalidBundleId(actual)):
+            if expected == actual {
+                return MatcherResult(status: .matches, message: message)
+            } else {
+                return MatcherResult(status: .fail, message: message.appended(details: "bundle ID mismatch"))
+            }
+        case let (.invalidProducts(expected), .invalidProducts(actual)):
+            if expected.count == actual.count {
+                return MatcherResult(status: .matches, message: message)
+            } else {
+                return MatcherResult(
+                    status: .fail,
+                    message: message.appended(details: "products count mismatch")
+                )
+            }
+        case let (.offeringConfiguration(expected), .offeringConfiguration(actual)):
+            if expected.count == actual.count {
+                return MatcherResult(status: .matches, message: message)
+            } else {
+                return MatcherResult(
+                    status: .fail,
+                    message: message.appended(details: "offerings count mismatch")
+                )
+            }
+        case (.unknown, .unknown):
+            return MatcherResult(status: .matches, message: message)
+        default:
+            return MatcherResult(
+                status: .fail,
+                message: message.appended(details: "was unhealthy with different error \(actual)")
+            )
+        }
+    }
+
+    private func beInvalidProducts() -> Matcher<PurchasesDiagnostics.SDKHealthError> {
+        return Matcher { actualExpression in
+            let message = ExpectationMessage.expectedActualValueTo("be invalid products error")
+
+            guard let actual = try actualExpression.evaluate() else {
+                return MatcherResult(status: .fail, message: message.appendedBeNilHint())
+            }
+
+            switch actual {
+            case .invalidProducts:
+                return MatcherResult(status: .matches, message: message)
+            default:
+                return MatcherResult(status: .fail, message: message.appended(details: "was \(actual)"))
+            }
+        }
+    }
+
+    private func beUnhealthyWithUnknownError() -> Matcher<PurchasesDiagnostics.SDKHealthStatus> {
+        return Matcher { actualExpression in
+            let message = ExpectationMessage.expectedActualValueTo("be unhealthy with unknown error")
+
+            guard let actual = try actualExpression.evaluate() else {
+                return MatcherResult(status: .fail, message: message.appendedBeNilHint())
+            }
+
+            switch actual {
+            case .healthy:
+                return MatcherResult(status: .fail, message: message.appended(details: "was healthy"))
+            case let .unhealthy(error):
+                if case .unknown = error {
+                    return MatcherResult(status: .matches, message: message)
+                } else {
+                    return MatcherResult(
+                        status: .fail,
+                        message: message.appended(details: "was unhealthy with error \(error)")
+                    )
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Mocks
+
+fileprivate extension PaymentAuthorizationProvider {
+    static func mock(canMakePayments: Bool = true) -> PaymentAuthorizationProvider {
+        return PaymentAuthorizationProvider(
+            isAuthorized: { canMakePayments }
+        )
+    }
+}

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -182,6 +182,16 @@ class MockBackend: Backend {
 
     static let referenceDate = Date(timeIntervalSinceReferenceDate: 700000000) // 2023-03-08 20:26:40
 
+    var healthReportRequestResponse: Result<HealthReport, BackendError> = .success(
+        HealthReport(status: .passed, projectId: nil, appId: nil, checks: [])
+    )
+    override func healthReportRequest(appUserID: String) async throws -> HealthReport {
+        return try healthReportRequestResponse.get()
+    }
+
+    override func healthReportAvailabilityRequest(appUserID: String) async throws -> HealthReportAvailability {
+        return .init(reportLogs: true)
+    }
 }
 
 extension MockBackend: @unchecked Sendable {}

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -64,8 +64,12 @@ extension MockPurchases: InternalPurchasesType {
         }
     }
 
-    func healthReportRequest() async throws -> HealthReport {
-        return try self.mockedHealthReportRequestResponse.get()
+    func healthReport() async -> PurchasesDiagnostics.SDKHealthReport {
+        do {
+            return try self.mockedHealthReportRequestResponse.get().validate()
+        } catch {
+            return .init(status: .unhealthy(.unknown(error)))
+        }
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -234,7 +234,10 @@ class BasePurchasesTests: TestCase {
         }
     }
 
-    func setupPurchases(automaticCollection: Bool = false, withDelegate: Bool = true) {
+    func setupPurchases(
+        automaticCollection: Bool = false,
+        withDelegate: Bool = true
+    ) {
         self.identityManager.mockIsAnonymous = false
 
         self.initializePurchasesInstance(
@@ -257,7 +260,10 @@ class BasePurchasesTests: TestCase {
         self.initializePurchasesInstance(appUserId: nil)
     }
 
-    func initializePurchasesInstance(appUserId: String?, withDelegate: Bool = true) {
+    func initializePurchasesInstance(
+        appUserId: String?,
+        withDelegate: Bool = true
+    ) {
         self.purchasesOrchestrator = PurchasesOrchestrator(
             productsManager: self.mockProductsManager,
             paymentQueueWrapper: self.paymentQueueWrapper,
@@ -293,6 +299,10 @@ class BasePurchasesTests: TestCase {
             diagnosticsTracker: self.diagnosticsTracker
         )
         self.cachingTrialOrIntroPriceEligibilityChecker = .init(checker: self.trialOrIntroPriceEligibilityChecker)
+        let healthManager = SDKHealthManager(
+            backend: self.backend,
+            identityManager: self.identityManager
+        )
 
         self.purchases = Purchases(appUserID: appUserId,
                                    requestFetcher: self.requestFetcher,
@@ -319,7 +329,8 @@ class BasePurchasesTests: TestCase {
                                    purchasedProductsFetcher: self.mockPurchasedProductsFetcher,
                                    trialOrIntroPriceEligibilityChecker: self.cachingTrialOrIntroPriceEligibilityChecker,
                                    storeMessagesHelper: self.mockStoreMessagesHelper,
-                                   diagnosticsTracker: self.diagnosticsTracker)
+                                   diagnosticsTracker: self.diagnosticsTracker,
+                                   healthManager: healthManager)
 
         self.purchasesOrchestrator.delegate = self.purchases
 
@@ -455,6 +466,26 @@ extension BasePurchasesTests {
             DispatchQueue.main.async {
                 completion(result)
             }
+        }
+
+        var healthReportRequests = [String]()
+        override func healthReportRequest(appUserID: String) async throws -> HealthReport {
+            healthReportRequests += [appUserID]
+
+            return .init(
+                status: .passed,
+                projectId: nil,
+                appId: nil,
+                checks: []
+            )
+        }
+
+        var overrideHealthReportAvailabilityResponse = HealthReportAvailability(reportLogs: true)
+        var healthReportAvailabilityRequests = [String]()
+        override func healthReportAvailabilityRequest(appUserID: String) async throws -> HealthReportAvailability {
+            healthReportAvailabilityRequests.append(appUserID)
+
+            return overrideHealthReportAvailabilityResponse
         }
 
         var postReceiptDataCalled = false

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -313,6 +313,26 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
     }
 
+    func testFirstInitializationFromBackgroundAndDefaultConfigurationDoesNotLogHealth() {
+        self.systemInfo.stubbedIsApplicationBackgrounded = true
+        self.setupPurchases()
+        expect(self.backend.healthReportRequests).toEventually(equal([]))
+    }
+
+    func testFirstInitializationFromForegroundAndDefaultConfigurationLogsHealth() {
+        self.systemInfo.stubbedIsApplicationBackgrounded = false
+        self.setupPurchases()
+        expect(self.backend.healthReportRequests).toEventually(equal([self.identityManager.currentAppUserID]))
+    }
+
+    func testFirstInitializationFromForegroundAndDefaultConfigurationWithNoAvailabilityDoesNotLogHealth() {
+        self.systemInfo.stubbedIsApplicationBackgrounded = false
+        self.backend.overrideHealthReportAvailabilityResponse = HealthReportAvailability(reportLogs: false)
+        self.setupPurchases()
+        expect(self.backend.healthReportAvailabilityRequests).toEventually(equal([identityManager.currentAppUserID]))
+        expect(self.backend.healthReportRequests).toEventually(equal([]))
+    }
+
     func testFirstInitializationFromForegroundUpdatesCustomerInfoCacheIfUserDefaultsCacheStale() {
         let staleCacheDateForForeground = Calendar.current.date(byAdding: .minute, value: -20, to: Date())!
         self.deviceCache.setCustomerInfoCache(timestamp: staleCacheDateForForeground,

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -209,6 +209,10 @@ class PurchasesSubscriberAttributesTests: TestCase {
             productsManager: mockProductsManager,
             diagnosticsTracker: nil
         )
+        let healthManager = SDKHealthManager(
+            backend: self.mockBackend,
+            identityManager: self.mockIdentityManager
+        )
         purchases = Purchases(appUserID: mockIdentityManager.currentAppUserID,
                               requestFetcher: mockRequestFetcher,
                               receiptFetcher: mockReceiptFetcher,
@@ -236,7 +240,8 @@ class PurchasesSubscriberAttributesTests: TestCase {
                                 with: trialOrIntroductoryPriceEligibilityChecker
                               ),
                               storeMessagesHelper: self.mockStoreMessagesHelper,
-                              diagnosticsTracker: nil)
+                              diagnosticsTracker: nil,
+                              healthManager: healthManager)
         purchasesOrchestrator.delegate = purchases
         purchases!.delegate = purchasesDelegate
         Purchases.setDefaultInstance(purchases!)


### PR DESCRIPTION
We recently had to revert the changes as we noticed some signature verification warnings and some increased flakiness in the Backend Integration tests.

These issues have now been addressed:
- Changed the signature verification from the `health_report_availability` endpoint: https://github.com/RevenueCat/khepri/pull/13783
- The unit test flakiness was not caused by the Health SDK, but they were aggravated by introducing more asynchronous behaviour. @ajpallares recently fixed the flakiness for the existing unit test: https://github.com/RevenueCat/purchases-ios/pull/5356

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids
