### PR TITLE
Fixes API tests after changes to public API

### DIFF
--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -143,7 +143,7 @@ class Backend {
         self.customer.post(subscriberAttributes: subscriberAttributes, appUserID: appUserID, completion: completion)
     }
 
-    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    #if DEBUG
     /// Checks if the SDK should log the status of the health report to the console.
     /// - Parameter appUserID: An `appUserID` that allows the Backend to check for health report availability
     /// - Returns: Whether the health report should be reported to the console for the given `appUserID`.

--- a/Sources/Networking/InternalAPI.swift
+++ b/Sources/Networking/InternalAPI.swift
@@ -16,7 +16,7 @@ import Foundation
 class InternalAPI {
 
     typealias ResponseHandler = (BackendError?) -> Void
-    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    #if DEBUG
     typealias HealthReportResponseHandler = (Result<HealthReport, BackendError>) -> Void
     typealias HealthReportAvailabilityResponseHandler = (Result<HealthReportAvailability, BackendError>) -> Void
 
@@ -30,7 +30,7 @@ class InternalAPI {
     init(backendConfig: BackendConfiguration) {
         self.backendConfig = backendConfig
         self.healthCallbackCache = .init()
-        #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+        #if DEBUG
         self.healthReportCallbackCache = .init()
         self.healthReportAvailabilityCallbackCache = .init()
         #endif
@@ -49,7 +49,7 @@ class InternalAPI {
                                                  cacheStatus: cacheStatus)
     }
 
-    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    #if DEBUG
     func healthReportRequest(appUserID: String, completion: @escaping HealthReportResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)

--- a/Sources/Networking/Operations/HealthReportAvailabilityOperation.swift
+++ b/Sources/Networking/Operations/HealthReportAvailabilityOperation.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Pol Piella Abadia on 27/06/2025.
 
-#if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+#if DEBUG
 import Foundation
 
 final class HealthReportAvailabilityOperation: CacheableNetworkOperation {

--- a/Sources/Networking/Operations/HealthReportOperation.swift
+++ b/Sources/Networking/Operations/HealthReportOperation.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Pol Piella on 4/8/25.
 
-#if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+#if DEBUG
 import Foundation
 
 final class HealthReportOperation: CacheableNetworkOperation {

--- a/Sources/Networking/Responses/HealthReportResponse.swift
+++ b/Sources/Networking/Responses/HealthReportResponse.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Pol Piella on 4/8/25.
 
-#if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+#if DEBUG
 import Foundation
 
 enum HealthCheckStatus: String {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1874,7 +1874,7 @@ extension Purchases: InternalPurchasesType {
         }
     }
 
-    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    #if DEBUG
     internal func healthReport() async -> PurchasesDiagnostics.SDKHealthReport {
         await self.healthManager.healthReport()
     }

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1246,7 +1246,7 @@ internal protocol InternalPurchasesType: AnyObject {
     /// - Throws: `PublicError` if request failed.
     func healthRequest(signatureVerification: Bool) async throws
 
-    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    #if DEBUG
     /// Requests an in-depth report of the SDK's configuration from the server.
     /// - Throws: A `BackendError` if the request fails due to an invalid API key or connectivity issues.
     /// - Returns: A health report containing all checks performed on the server and their status.

--- a/Sources/Support/HealthReport+Validate.swift
+++ b/Sources/Support/HealthReport+Validate.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Pol Piella on 4/10/25.
 
-#if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+#if DEBUG
 extension HealthReport {
     func validate() -> PurchasesDiagnostics.SDKHealthReport {
         guard let firstFailedCheck = self.checks.first(where: { $0.status == .failed }) else {

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -230,7 +230,7 @@ extension PurchasesDiagnostics {
         }
     }
 
-    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    #if DEBUG
     /// Performs a full SDK configuration health check and throws an error if the configuration is not valid.
     /// - Important: This method can not be invoked in production builds.
     /// - Throws: ``SDKHealthError`` indicating the specific configuration issue that needs to be solved.

--- a/Sources/Support/SDKHealthManager.swift
+++ b/Sources/Support/SDKHealthManager.swift
@@ -15,7 +15,7 @@ final class SDKHealthManager: Sendable {
         self.paymentAuthorizationProvider = paymentAuthorizationProvider
     }
 
-    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    #if DEBUG
     func healthReport() async -> PurchasesDiagnostics.SDKHealthReport {
         do {
             if !paymentAuthorizationProvider.isAuthorized() {
@@ -50,7 +50,7 @@ final class SDKHealthManager: Sendable {
     #endif
 }
 
-#if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+#if DEBUG
 private enum HealthReportLogMessage: LogMessage {
     case unhealthy(error: PurchasesDiagnostics.SDKHealthError, report: PurchasesDiagnostics.SDKHealthReport)
     case healthy(report: PurchasesDiagnostics.SDKHealthReport)

--- a/Sources/Support/SDKHealthManager.swift
+++ b/Sources/Support/SDKHealthManager.swift
@@ -33,7 +33,9 @@ final class SDKHealthManager: Sendable {
             return .init(status: .unhealthy(.unknown(error)))
         }
     }
+    #endif
 
+    #if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     func logSDKHealthReportOutcome() async {
         let report = await healthReport()
         switch report.status {
@@ -50,7 +52,7 @@ final class SDKHealthManager: Sendable {
     #endif
 }
 
-#if DEBUG
+#if DEBUG && !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 private enum HealthReportLogMessage: LogMessage {
     case unhealthy(error: PurchasesDiagnostics.SDKHealthError, report: PurchasesDiagnostics.SDKHealthReport)
     case healthy(report: PurchasesDiagnostics.SDKHealthReport)


### PR DESCRIPTION
@fire-at-will realized that we made some breaking changes to the public API by mistake when adding health report logging.

The reason was that we had already shipped the new `PurchasesDiagnostics` APIs just under the `#if DEBUG` directive, so we ca not make it more restrictive now without breaking the public API.

The rest of changes (logging the health report on configure) remain under `DEBUG` and `CEC`.

This PR fixes these issues while keeping the new logging changes out of the CEC mode.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids
