### PR TITLE
[CI] Use m1 instead of m2 executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ executors:
     macos:
       # circleci-lint: disable=unknown-xcode-version
       xcode: << parameters.xcode_version >>
-    resource_class: m2pro.medium
+    resource_class: macos.m1.medium.gen1
     environment:
       CIRCLECI_TESTS_GENERATE_SNAPSHOTS: << pipeline.parameters.generate_snapshots >>
       CIRCLECI_TESTS_GENERATE_REVENUECAT_UI_SNAPSHOTS: << pipeline.parameters.generate_revenuecatui_snapshots >>


### PR DESCRIPTION
CircleCI is having problems provisioning M2 machines

> We are currently experiencing delays starting macOS jobs on m2pro.medium and m2pro.large resource classes. We suggest customers move to m4pro.medium or m4pro.large to mitigate queue time.


https://status.circleci.com/