### PR TITLE
Use SwiftUI instead of UIKit to present an alert in Paywall Tester app

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/PaywallsPreview.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/PaywallsPreview.swift
@@ -35,6 +35,12 @@ struct PaywallsPreview: App {
     @State
     private var shouldShowWebPurchaseRedemptionResultAlert: Bool = false
 
+    @State
+    private var deepLinkAlertMessage: String?
+
+    @State
+    private var shouldShowDeepLinkAlert: Bool = false
+
     var body: some Scene {
         WindowGroup {
             AppContentView()
@@ -78,6 +84,13 @@ struct PaywallsPreview: App {
                         self.shouldShowWebPurchaseRedemptionResultAlert = false
                     })
                 }
+                .alert(isPresented: self.$shouldShowDeepLinkAlert) {
+                    return Alert(title: Text("Deep Link"),
+                                 message: Text(self.deepLinkAlertMessage ?? ""),
+                                 dismissButton: .cancel(Text("OK")) {
+                        self.shouldShowDeepLinkAlert = false
+                    })
+                }
                 .environmentObject(application)
         }
     }
@@ -89,7 +102,7 @@ extension PaywallsPreview {
 
     func processURL(_ url: URL) {
         if isDeepLinkTest(url) {
-            showAlert(title: "Deep Link", message: url.absoluteString)
+            showAlert(message: url.absoluteString)
         } else {
             // set to nil to trigger re-render if presenting same paywall with new data
             paywallPreviewData = nil
@@ -124,34 +137,9 @@ extension PaywallsPreview {
         return PaywallPreviewData(paywallIDToShow: paywallID, introOfferEligible: introElgibility)
     }
 
-    func showAlert(title: String, message: String) {
-        DispatchQueue.main.async {
-            guard let topVC = topMostViewController() else { return }
-
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-
-            topVC.present(alert, animated: true, completion: nil)
-        }
-    }
-
-    private func topMostViewController(controller: UIViewController? = UIApplication.shared.connectedScenes
-        .compactMap { ($0 as? UIWindowScene)?.keyWindow }
-        .first?.rootViewController) -> UIViewController? {
-
-        if let nav = controller as? UINavigationController {
-            return topMostViewController(controller: nav.visibleViewController)
-        }
-
-        if let tab = controller as? UITabBarController {
-            return topMostViewController(controller: tab.selectedViewController)
-        }
-
-        if let presented = controller?.presentedViewController {
-            return topMostViewController(controller: presented)
-        }
-
-        return controller
+    func showAlert(message: String) {
+        self.deepLinkAlertMessage = message
+        self.shouldShowDeepLinkAlert = true
     }
 
 }


### PR DESCRIPTION
### Motivation
The existing mechanism for presenting an alert will not work on macOS.

### Description
Switch from using UIKit to present an alert, to using SwiftUI.

Follow-up on https://github.com/RevenueCat/purchases-ios/pull/5238

I haven't actually been able to test this, because I cannot figure out how to get this deep link testing code to activate. I tried creating a deep link button in the Paywalls web interface, and it didn't seem to like that. @joshdholtz any advice on how to test this?

Here's the error I got:

```
Failed to open URL myscheme://deeplinktest: Error Domain=NSOSStatusErrorDomain Code=-10814 "(null)" UserInfo={_LSLine=279, _LSFunction=-[_LSDOpenClient openURL:fileHandle:options:completionHandler:]}
ERROR: Failed to open URL as deep link: myscheme://deeplinktest
```