### PR TITLE
Display VC Name in Customer Center

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/VirtualCurrencyBalancesScreenViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/VirtualCurrencyBalancesScreenViewModel.swift
@@ -89,6 +89,7 @@ final class VirtualCurrencyBalancesScreenViewModel: ObservableObject {
         return virtualCurrencies
             .map {
                 VirtualCurrencyBalanceListRow.RowData(
+                    virtualCurrencyName: $0.value.name,
                     virtualCurrencyCode: $0.key,
                     balance: $0.value.balance
                 )

--- a/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrenciesScrollViewWithOSBackgroundSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrenciesScrollViewWithOSBackgroundSection.swift
@@ -86,6 +86,7 @@ struct VirtualCurrenciesScrollViewWithOSBackgroundSection: View {
     ) {
         let sortedCurrencies = virtualCurrencies.all.map {
             VirtualCurrencyBalanceListRow.RowData(
+                virtualCurrencyName: $0.value.name,
                 virtualCurrencyCode: $0.key,
                 balance: $0.value.balance
             )

--- a/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrencyBalanceListRow.swift
+++ b/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrencyBalanceListRow.swift
@@ -48,8 +48,13 @@ struct VirtualCurrencyBalanceListRow: View {
     struct RowData: Identifiable, Hashable {
         /// A unique identifier for the row.
         let id = UUID()
+
+        /// The virtual currency's name
+        let virtualCurrencyName: String
+
         /// The code representing the virtual currency (e.g., "GLD" for gold).
         let virtualCurrencyCode: String
+
         /// The current balance of the virtual currency.
         let balance: Int
     }
@@ -59,7 +64,7 @@ struct VirtualCurrencyBalanceListRow: View {
 
     var body: some View {
         CompatibilityLabeledContent {
-            Text(rowData.virtualCurrencyCode)
+            Text("\(rowData.virtualCurrencyName) (\(rowData.virtualCurrencyCode))")
         } content: {
             Text(rowData.balance.formatted())
         }
@@ -74,6 +79,7 @@ struct VirtualCurrencyBalanceListRow_Previews: PreviewProvider {
             List {
                 VirtualCurrencyBalanceListRow(
                     rowData: .init(
+                        virtualCurrencyName: "Gold",
                         virtualCurrencyCode: "GLD",
                         balance: 100
                     )

--- a/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrencyBalancesScreen.swift
+++ b/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrencyBalancesScreen.swift
@@ -119,10 +119,10 @@ struct VirtualCurrencyBalancesScreen_Previews: PreviewProvider {
                 VirtualCurrencyBalancesScreen(
                     viewModel: VirtualCurrencyBalancesScreenViewModel(
                         viewState: .loaded([
-                            .init(virtualCurrencyCode: "PLTNM", balance: 2000),
-                            .init(virtualCurrencyCode: "BRNZ", balance: 1000),
-                            .init(virtualCurrencyCode: "SLVR", balance: 500),
-                            .init(virtualCurrencyCode: "GLD", balance: 100)
+                            .init(virtualCurrencyName: "Platinum", virtualCurrencyCode: "PLTNM", balance: 2000),
+                            .init(virtualCurrencyName: "Bronze", virtualCurrencyCode: "BRNZ", balance: 1000),
+                            .init(virtualCurrencyName: "Silver", virtualCurrencyCode: "SLVR", balance: 500),
+                            .init(virtualCurrencyName: "Gold", virtualCurrencyCode: "GLD", balance: 100)
 
                         ]),
                         purchasesProvider: CustomerCenterPurchases()


### PR DESCRIPTION
### Description
This PR updates the iOS Customer Center to show both the virtual currency's name and code when displaying virtual currency balances so that the Customer Center's UI matches the designs.

TODO: Add Before/After screenshots