### PR TITLE
Add `@_spi` to initializers of virtual currencies APIs

### DIFF
--- a/Sources/Virtual Currencies/VirtualCurrencies.swift
+++ b/Sources/Virtual Currencies/VirtualCurrencies.swift
@@ -21,7 +21,7 @@ import Foundation
     /// `virtualCurrencies["VC_CODE"]`.
     @objc public let all: [String: VirtualCurrency]
 
-    internal init(virtualCurrencies: [String: VirtualCurrency]) {
+    @_spi(Internal) public init(virtualCurrencies: [String: VirtualCurrency]) {
         self.all = virtualCurrencies
     }
 

--- a/Sources/Virtual Currencies/VirtualCurrencies.swift
+++ b/Sources/Virtual Currencies/VirtualCurrencies.swift
@@ -21,6 +21,7 @@ import Foundation
     /// `virtualCurrencies["VC_CODE"]`.
     @objc public let all: [String: VirtualCurrency]
 
+    // swiftlint:disable:next missing_docs
     @_spi(Internal) public init(virtualCurrencies: [String: VirtualCurrency]) {
         self.all = virtualCurrencies
     }

--- a/Sources/Virtual Currencies/VirtualCurrency.swift
+++ b/Sources/Virtual Currencies/VirtualCurrency.swift
@@ -34,7 +34,7 @@ public final class VirtualCurrency: NSObject {
     /// Virtual currency description defined in the RevenueCat dashboard.
     @objc public let serverDescription: String?
 
-    internal init(
+    @_spi(Internal) public init(
         balance: Int,
         name: String,
         code: String,

--- a/Sources/Virtual Currencies/VirtualCurrency.swift
+++ b/Sources/Virtual Currencies/VirtualCurrency.swift
@@ -34,6 +34,7 @@ public final class VirtualCurrency: NSObject {
     /// Virtual currency description defined in the RevenueCat dashboard.
     @objc public let serverDescription: String?
 
+    // swiftlint:disable:next missing_docs
     @_spi(Internal) public init(
         balance: Int,
         name: String,

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -6,7 +6,7 @@
 import Nimble
 import XCTest
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 class DeviceCacheTests: TestCase {
 

--- a/Tests/UnitTests/Mocks/MockVirtualCurrencyManager.swift
+++ b/Tests/UnitTests/Mocks/MockVirtualCurrencyManager.swift
@@ -12,7 +12,7 @@
 //  Created by Will Taylor on 6/4/25.
 
 import Foundation
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 class MockVirtualCurrencyManager: VirtualCurrencyManagerType {
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesVirtualCurrenciesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesVirtualCurrenciesTests.swift
@@ -15,7 +15,7 @@ import Nimble
 import StoreKit
 import XCTest
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 @MainActor
 class PurchasesVirtualCurrenciesTests: BasePurchasesTests {

--- a/Tests/UnitTests/Virtual Currencies/VirtualCurrenciesTests.swift
+++ b/Tests/UnitTests/Virtual Currencies/VirtualCurrenciesTests.swift
@@ -12,7 +12,7 @@
 //  Created by Will Taylor on 5/21/25.
 
 import Foundation
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import XCTest
 
 final class VirtualCurrenciesTests: TestCase {

--- a/Tests/UnitTests/Virtual Currencies/VirtualCurrencyManagerTests.swift
+++ b/Tests/UnitTests/Virtual Currencies/VirtualCurrencyManagerTests.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Will Taylor on 6/4/25.
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import XCTest
 
 class VirtualCurrencyManagerTests: TestCase {

--- a/Tests/UnitTests/Virtual Currencies/VirtualCurrencyTests.swift
+++ b/Tests/UnitTests/Virtual Currencies/VirtualCurrencyTests.swift
@@ -12,7 +12,7 @@
 //  Created by Will Taylor on 6/10/25.
 
 import Foundation
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import XCTest
 
 final class VirtualCurrencyTests: TestCase {


### PR DESCRIPTION
### Motivation

Required in UI preview mode

### Description

Add `@_spi(internal) public` marker to initializers of `VirtualCurrencies` and  `VirtualCurrency`