### PR TITLE
Add validation of Test Store API keys

### DIFF
--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -51,6 +51,8 @@ enum ConfigureStrings {
 
     case is_simulator(Bool)
 
+    case testStoreAPIKey
+
     case legacyAPIKey
 
     case invalidAPIKey
@@ -135,6 +137,11 @@ extension ConfigureStrings: LogMessage {
                 "file set up before trying to fetch products or make purchases.\n" +
                 "See https://errors.rev.cat/testing-in-simulator for more details."
                 : "Not using a simulator."
+        case .testStoreAPIKey:
+            return "Using a Test Store API key.\n" +
+            "The Test Store is for development only. Never use a Test Store API key in production. " +
+            "Test Store purchases are simulated, do not use StoreKit, and generate no revenue. " +
+            "Apps submitted with a Test Store API key will be rejected during App Review."
         case .legacyAPIKey:
             return "Looks like you're using a legacy API key.\n" +
             "This is still supported, but it's recommended to migrate to using platform-specific API key, " +

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -376,11 +376,19 @@ extension Configuration {
 
     enum APIKeyValidationResult {
         case validApplePlatform
+        case testStore
         case otherPlatforms
         case legacy
     }
 
     static func validate(apiKey: String) -> APIKeyValidationResult {
+        #if TEST_STORE
+        if apiKey.hasPrefix(testStoreKeyPrefix) {
+            // Test Store key format: "test_CtDdmbdWBySmqJeeQUTyrNxETUVkajsJ"
+            return .testStore
+        }
+        #endif // TEST_STORE
+
         if applePlatformKeyPrefixes.contains(where: { prefix in apiKey.hasPrefix(prefix) }) {
             // Apple key format: "apple_CtDdmbdWBySmqJeeQUTyrNxETUVkajsJ"
             return .validApplePlatform
@@ -396,12 +404,14 @@ extension Configuration {
     fileprivate static func verify(apiKey: String) {
         switch self.validate(apiKey: apiKey) {
         case .validApplePlatform: break
+        case .testStore: Logger.warn(Strings.configure.testStoreAPIKey)
         case .legacy: Logger.debug(Strings.configure.legacyAPIKey)
         case .otherPlatforms: Logger.error(Strings.configure.invalidAPIKey)
         }
     }
 
     private static let applePlatformKeyPrefixes: Set<String> = ["appl_", "mac_"]
+    private static let testStoreKeyPrefix = "test_"
 
 }
 

--- a/Tests/UnitTests/Purchasing/ConfigurationTests.swift
+++ b/Tests/UnitTests/Purchasing/ConfigurationTests.swift
@@ -35,6 +35,12 @@ class ConfigurationTests: TestCase {
         expect(Configuration.validate(apiKey: "swRTCezdEzjnJSxdexDNJfcfiFrMXwqZ")) == .legacy
     }
 
+    #if TEST_STORE
+    func testValidateAPIKeyWithTestStoreKey() {
+        expect(Configuration.validate(apiKey: "test_eg2t9g3098bgqqn")) == .testStore
+    }
+    #endif
+
     func testNoObserverModeWithStoreKit1() {
         let configuration = Configuration.Builder(withAPIKey: "test")
             .with(storeKitVersion: .storeKit1)


### PR DESCRIPTION
This is the first PR of a series to add support for the Test Store in the SDK.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
The SDK has to identify API keys for the Test Store to modify its behavior accordingly

### Description
Adds the validation of the Test Store API keys under the `TEST_STORE` compiler flag
