### PR TITLE
Fix VirtualCurrencyBalancesScreen Preview on Catalyst (Optimized For Mac)

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrencyBalancesScreen.swift
+++ b/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrencyBalancesScreen.swift
@@ -102,7 +102,7 @@ struct VirtualCurrencyBalancesScreen_Previews: PreviewProvider {
 
     static var previews: some View {
         if #available(iOS 15.0, *) {
-            NavigationView {
+            CompatibilityNavigationStack {
                 VirtualCurrencyBalancesScreen(
                     viewModel: VirtualCurrencyBalancesScreenViewModel(
                         viewState: .loaded([]),
@@ -115,7 +115,7 @@ struct VirtualCurrencyBalancesScreen_Previews: PreviewProvider {
             }
             .previewDisplayName("Loaded With 0 VC Balances")
 
-            NavigationView {
+            CompatibilityNavigationStack {
                 VirtualCurrencyBalancesScreen(
                     viewModel: VirtualCurrencyBalancesScreenViewModel(
                         viewState: .loaded([
@@ -133,7 +133,7 @@ struct VirtualCurrencyBalancesScreen_Previews: PreviewProvider {
             }
             .previewDisplayName("Loaded with 4 VC Balances")
 
-            NavigationView {
+            CompatibilityNavigationStack {
                 VirtualCurrencyBalancesScreen(
                     viewModel: VirtualCurrencyBalancesScreenViewModel(
                         viewState: .error,


### PR DESCRIPTION
### Description
This PR fixes the VirtualCurrencyBalancesScreen preview for Catalyst (Optimized For Mac). We were previously wrapping the previews in a `NavigationStack` to show the navigation title in the previews, but on Catalyst (Optimized For Mac), this displayed the view in a sidebar. This PR fixes that issue by instead wrapping the `VirtualCurrencyBalancesScreen` in a `CompatibilityNavigationStack`, which doesn't use the sidebar on Catalyst (Optimized For Mac).

I've tested this in a Catalyst (Optimized For Mac) app, and the screen looks just fine, so this issue only affected the previews.