### PR TITLE
Tuist: add xcconfig to PurchaseTester

### DIFF
--- a/Examples/PurchaseTester/Project.swift
+++ b/Examples/PurchaseTester/Project.swift
@@ -30,7 +30,11 @@ let allDestinations = destinations + [.appleWatch]
 let project = Project(
     name: "PurchaseTester",
     organizationName: .revenueCatOrgName,
-    settings: .project,
+    settings: .settings(
+        base: [:].automaticCodeSigning(devTeam: .revenueCatTeamID),
+        configurations: .xcconfigFileConfigurations,
+        defaultSettings: .recommended
+    ),
     targets: [
         .target(
             name: "PurchaseTester",


### PR DESCRIPTION
This PR makes it so that `tuist generate PaywallTester` includes the `global.xcconfig` file in the generated Xcode project