### PR TITLE
Potential fix for flaky test

### DIFF
--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -250,6 +250,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         self.serverDown()
 
         try await self.purchaseMonthlyProduct(allowOfflineEntitlements: true)
+        try await Task.sleep(for: .seconds(1))
         try self.testSession.forceRenewalOfSubscription(
             productIdentifier: await self.monthlyPackage.storeProduct.productIdentifier
         )

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -250,6 +250,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         self.serverDown()
 
         try await self.purchaseMonthlyProduct(allowOfflineEntitlements: true)
+        // Add 1s delay to ensure the renewal transaction has a later purchase date than the original one
         try await Task.sleep(for: .seconds(1))
         try self.testSession.forceRenewalOfSubscription(
             productIdentifier: await self.monthlyPackage.storeProduct.productIdentifier


### PR DESCRIPTION
The test `testCallToGetCustomerInfoWithPendingTransactionsPostsReceiptOnlyOnce()` is [randomly failing](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/29215/workflows/1f5c7b7a-8e15-4ee5-9554-957269d20b08/jobs/356434/tests). This PR attempts to fix it.

<details><summary>More details</summary>
<p>

The test is sometimes failing with this error:
```
OfflineStoreKitIntegrationTests.swift:262: Entitlement is not active: <EntitlementInfo: "
identifier=premium,
isActive=false,
willRenew=true,
periodType=PeriodType(rawValue: 1),
latestPurchaseDate=Optional(2025-07-17 15:45:36 +0000),
originalPurchaseDate=Optional(2025-07-17 15:45:36 +0000),
expirationDate=Optional(2025-07-17 15:45:36 +0000),
...
>
```

The error shows that the entitlement is not active while it should be active. But if you notice the dates in the log, `latestPurchaseDate` is exactly the same as `expirationDate`. This makes me think that, if the test runs fast enough, the lines
```
try await self.purchaseMonthlyProduct(allowOfflineEntitlements: true)
try self.testSession.forceRenewalOfSubscription(
    productIdentifier: await self.monthlyPackage.storeProduct.productIdentifier
)
```
can produce two transactions with the same `purchase_date` (and the first one having also the same `expires_date` as `purchase_date`). This has just happened to me when running the test locally:

> DEBUG: ℹ️ PostReceiptDataOperation: Posting receipt (source: 'queue') (note: the contents might not be up-to-date, but it will be refreshed with Apple's servers):
{...,
"in_app_purchases":[
> 
> {"transaction_id":"7","is_in_intro_offer_period":false,"original_transaction_id":"6","purchase_date":"2025-07-17T17:09:33Z","original_purchase_date":"2025-07-17T17:09:33Z","expires_date":"2025-07-17T17:10:03Z","product_id":"com.revenuecat.monthly_4.99.1_week_intro","product_type":-1,"quantity":1},
> 
> {"transaction_id":"6","is_in_intro_offer_period":true,"purchase_date":"2025-07-17T17:09:33Z","expires_date":"2025-07-17T17:09:33Z","product_id":"com.revenuecat.monthly_4.99.1_week_intro","product_type":-1,"quantity":1}
>
>],
>...}

I suspect that, because both transactions have the same `purchase_date`, the first one may be randomly picked between the two. In this case, the test then would fail because that transaction (with same `expires_date` as `purchase_date`) doesn't grant the entitlement anymore. 
This is confirmed by the test error message having `periodType=PeriodType(rawValue: 1)`, which is the `PeriodType.intro` enum case and it showing that `latestPurchaseDate` == `expirationDate`. Only the first transaction is the intro offer one.

My reasoning is that by adding 1 second delay between the two transactions will make sure that the two transactions always have a different `purchase_date`, so that the second transaction is always the one being picked as the latest one
</p>
</details>