### PR TITLE
Tuist: prevent MagicWeather Xcode projects names clashing

### DIFF
--- a/Examples/MagicWeather/Project.swift
+++ b/Examples/MagicWeather/Project.swift
@@ -2,7 +2,7 @@ import ProjectDescription
 import ProjectDescriptionHelpers
 
 let project = Project(
-    name: "MagicWeather",
+    name: "MagicWeatherApp",
     organizationName: .revenueCatOrgName,
     settings: .appProject,
     targets: [


### PR DESCRIPTION
### Motivation
The command `tuist generate MagicWeather` generated an Xcode project named `MagicWeather.xcodeproj`, whereas that file name is already used by the MagicWeather example project meant for developers.

### Description
This PR renames the name of the Xcode project generated by `tuist generate MagicWeather` to `MagicWeatherApp.xcodeproj`.

Note that the generated `MagicWeatherApp.xcodeproj` is currently `.gitignore`d