### PR TITLE
Tuist: fix compilation of RevenueCat and RevenueCatUI projects in visionOS

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Settings.swift
+++ b/Tuist/ProjectDescriptionHelpers/Settings.swift
@@ -41,7 +41,9 @@ extension Settings {
             base: [
                 "CODE_SIGNING_ALLOWED": "NO",
                 "CODE_SIGNING_REQUIRED": "NO",
-                "CODE_SIGN_IDENTITY": ""
+                "CODE_SIGN_IDENTITY": "",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xros*]": "VISION_OS",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xrsimulator*]": "VISION_OS"
             ]
         )
     }


### PR DESCRIPTION
This PR adds the `VISION_OS` compiler flag to the tuist-generated projects for RevenueCat and RevenueCatUI, fixing the compilation in visionOS.

### Notes
1. We still cannot use `#if os(visionOS)` since we're executing tests in older versions of Xcode that don't recognize `visionOS` (see #2989)
2. I tried using `.swiftActiveCompilationConditions`, but it looks like it doesn't support applying the conditions conditionally per platform (as we need the `VISION_OS` flag only in visionOS)