### PR TITLE
Tuist: fix some setup issues

### DIFF
--- a/Projects/RevenueCat/Project.swift
+++ b/Projects/RevenueCat/Project.swift
@@ -22,7 +22,8 @@ let allDeploymentTargets: DeploymentTargets = .multiplatform(
     iOS: "13.0",
     macOS: "11.0",
     watchOS: "7.0",
-    tvOS: "14.0"
+    tvOS: "14.0",
+    visionOS: "1.3"
 )
 
 // MARK: - Project Definition

--- a/Tuist/ProjectDescriptionHelpers/Settings.swift
+++ b/Tuist/ProjectDescriptionHelpers/Settings.swift
@@ -42,9 +42,9 @@ extension Settings {
                 "CODE_SIGNING_ALLOWED": "NO",
                 "CODE_SIGNING_REQUIRED": "NO",
                 "CODE_SIGN_IDENTITY": "",
-                "SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xros*]": "VISION_OS",
-                "SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xrsimulator*]": "VISION_OS"
-            ]
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xros*]": "$(inherited) VISION_OS",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xrsimulator*]": "$(inherited) VISION_OS"
+            ],
         )
     }
 }

--- a/Tuist/ProjectDescriptionHelpers/Settings.swift
+++ b/Tuist/ProjectDescriptionHelpers/Settings.swift
@@ -45,6 +45,7 @@ extension Settings {
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xros*]": "$(inherited) VISION_OS",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=xrsimulator*]": "$(inherited) VISION_OS"
             ],
+            configurations: .xcconfigFileConfigurations
         )
     }
 }


### PR DESCRIPTION
This PR fixes some issues we had with tuist-generated projects:
* `SWIFT_ACTIVE_COMPILATION_CONDITIONS` from xcconfig files were not being propagated to framework targets (e.g. RevenueCat and RevenueCatUI)
* `SWIFT_ACTIVE_COMPILATION_CONDITIONS` from xcconfig files were not being propagated to the visionOS platforms
* Running apps in visionOS would not work due to the minimum deployment version for visionOS not being correctly set
