### PR TITLE
Fix a flaky test

### DIFF
--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -701,7 +701,7 @@ class CustomerInfoManagerGetCustomerInfoTests: BaseCustomerInfoManagerTests {
                                                                      fetchPolicy: .cachedOrFetched)
 
         expect(result) == self.mockCustomerInfo
-        expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
+        await expect(self.mockBackend.invokedGetSubscriberDataCount).toEventually(equal(1))
     }
 
     func testCustomerInfoCachedOrFetchedFetchesIfNoCache() async throws {


### PR DESCRIPTION
### Motivation
The test `testCustomerInfoCachedOrFetchedReturnsFromCacheAndRefreshesIfStale()` randomly fails (e.g. see https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/29239/workflows/3f42f9f5-7af5-4da4-9eaf-a27ba60deba0/jobs/356942).

### Description
This PR attempts to fix the flakiness in the test.

### Notes
The tests checks that Customer Info is refreshed given the cache is stale when using the `.cachedOrFetched` fetch policy. Both the Customer Info refresh and the get Customer Info completion are triggered asynchronously. This means that the test condition check `expect(self.mockBackend.invokedGetSubscriberDataCount) == 1` could potentially happen **before** the Customer Info is refreshed, making the test fail.