### PR TITLE
Update VC Caching Log Message

### DIFF
--- a/Sources/Logging/Strings/VirtualCurrencyStrings.swift
+++ b/Sources/Logging/Strings/VirtualCurrencyStrings.swift
@@ -32,7 +32,7 @@ extension VirtualCurrencyStrings: LogMessage {
         case .invalidating_virtual_currencies_cache:
             return "Invalidating VirtualCurrencies cache."
         case .no_cached_virtual_currencies:
-            return "No cached VirtualCurrencies, fetching from network."
+            return "There are no cached VirtualCurrencies."
         case .virtual_currencies_stale_updating_from_network:
             return "VirtualCurrencies cache is stale, updating from network."
         case .vending_from_cache:


### PR DESCRIPTION
### Description

iOS equivalent of https://github.com/RevenueCat/purchases-android/pull/2552

This PR updates the `VirtualCurrencyStrings.no_cached_virtual_currencies` log message from `"No cached VirtualCurrencies, fetching from network."` to `"There are no cached VirtualCurrencies."`.

The previous message implied a network fetch would occur, which isn't always the case.

There are two scenarios where this log may appear:
-  When fetching virtual currencies and the cache is not stale but contains no virtual currencies object (an edge case that shouldn't occur with normal usage).
- When accessing the cache directly using `Purchases.cachedVirtualCurrencies` and it's empty - in this case, the SDK returns nil without initiating a network fetch.

The updated message is more descriptive of what actually happens in the second scenario. In the first scenario, subsequent log messages state that the SDK is fetching VCs from the network.