### PR TITLE
Introduce custom actions to customer center

### DIFF
--- a/RevenueCatUI/CustomerCenter/Actions/CustomerCenter+PreferenceKeys.swift
+++ b/RevenueCatUI/CustomerCenter/Actions/CustomerCenter+PreferenceKeys.swift
@@ -93,6 +93,14 @@ extension CustomerCenterView {
             value = nextValue() ?? value
         }
     }
+
+    struct CustomActionPreferenceKey: PreferenceKey {
+        static var defaultValue: UniqueWrapper<(String, String?)>?
+        static func reduce(value: inout UniqueWrapper<(String, String?)>?,
+                           nextValue: () -> UniqueWrapper<(String, String?)>?) {
+            value = nextValue() ?? value
+        }
+    }
 }
 
 #endif

--- a/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
@@ -21,7 +21,7 @@ extension Array<CustomerCenterConfigData.HelpPath> {
     ) -> [CustomerCenterConfigData.HelpPath] {
         guard let purchaseInformation else {
             return filter {
-                $0.type == .missingPurchase
+                $0.type == .missingPurchase || $0.type == .customAction
             }
         }
 

--- a/RevenueCatUI/CustomerCenter/Actions/CustomerCenterView+Actions.swift
+++ b/RevenueCatUI/CustomerCenter/Actions/CustomerCenterView+Actions.swift
@@ -52,6 +52,10 @@ extension CustomerCenterView {
     public typealias ManagementOptionSelectedHandler =
     @MainActor @Sendable (_ managementOption: CustomerCenterActionable) -> Void
 
+    /// A closure used for notifying when a custom action is selected in the Customer Center.
+    public typealias CustomActionHandler =
+    @MainActor @Sendable (_ actionIdentifier: String, _ activePurchaseId: String?) -> Void
+
     typealias PromotionalOfferSuccessHandler = @MainActor @Sendable () -> Void
 
     typealias ChangePlansHandler = @MainActor @Sendable (_ optionId: String) -> Void
@@ -183,6 +187,19 @@ extension CustomerCenterView {
                 .onPreferenceChange(ChangePlansSelectedPreferenceKey.self) { wrapperSubscriptionGroupID in
                     if let subscriptionGroupID = wrapperSubscriptionGroupID?.value {
                         self.handler(subscriptionGroupID)
+                    }
+                }
+        }
+    }
+
+    fileprivate struct OnCustomActionModifier: ViewModifier {
+        let handler: CustomActionHandler
+
+        func body(content: Content) -> some View {
+            content
+                .onPreferenceChange(CustomActionPreferenceKey.self) { wrapper in
+                    if let (actionIdentifier, activePurchaseId) = wrapper?.value {
+                        handler(actionIdentifier, activePurchaseId)
                     }
                 }
         }
@@ -331,24 +348,11 @@ extension View {
     }
 
     /// Invokes the given closure when a management option is selected in the Customer Center.
-    /// Example:
     /// ```swift
-    ///  var body: some View {
-    ///     ContentView()
-    ///         .sheet(isPresented: self.$displayCustomerCenter) {
-    ///             CustomerCenterView()
-    ///                 .onCustomerCenterManagementOptionSelected { action in
-    ///                     switch action {
-    ///                     case is CustomerCenterManagementOption.Cancel:
-    ///                         print("Cancel action triggered")
-    ///                     case let customUrl as CustomerCenterManagementOption.CustomUrl:
-    ///                         print("Opening URL: \(customUrl.url)")
-    ///                     default:
-    ///                         print("Unknown action")
-    ///                     }
-    ///                 }
-    ///         }
-    ///  }
+    /// CustomerCenterView()
+    ///     .onCustomerCenterManagementOptionSelected { action in
+    ///         handleManagementAction(action)
+    ///     }
     /// ```
     public func onCustomerCenterManagementOptionSelected(
         _ handler: @escaping CustomerCenterView.ManagementOptionSelectedHandler
@@ -366,6 +370,19 @@ extension View {
         _ handler: @escaping CustomerCenterView.ChangePlansHandler
     ) -> some View {
         return self.modifier(CustomerCenterView.OnChangePlansSelected(handler: handler))
+    }
+
+    /// Invokes the given closure when a custom action is selected in the Customer Center.
+    /// ```swift
+    /// CustomerCenterView()
+    ///     .onCustomerCenterCustomActionSelected { actionIdentifier, activePurchaseId in
+    ///         handleCustomAction(actionIdentifier, activePurchaseId)
+    ///     }
+    /// ```
+    public func onCustomerCenterCustomActionSelected(
+        _ handler: @escaping CustomerCenterView.CustomActionHandler
+    ) -> some View {
+        return self.modifier(CustomerCenterView.OnCustomActionModifier(handler: handler))
     }
 }
 

--- a/RevenueCatUI/CustomerCenter/Data/CustomActionData.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomActionData.swift
@@ -1,0 +1,125 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomActionData.swift
+//
+//  Created by Claude on 21/07/2025.
+//
+
+import Foundation
+
+/// Data associated with a custom action selection in the Customer Center.
+/// 
+/// This struct encapsulates information about a custom action that has been triggered
+/// by a user interaction in the Customer Center. Custom actions are defined in the
+/// Customer Center configuration and allow applications to handle specialized user
+/// flows beyond the standard Customer Center actions.
+///
+/// ## Usage
+/// 
+/// Custom actions are handled through the SwiftUI view modifier:
+/// 
+/// ```swift
+/// CustomerCenterView()
+///     .onCustomerCenterCustomActionSelected { actionIdentifier, activePurchaseId in
+///         // Handle the custom action
+///         switch actionIdentifier {
+///         case "delete_user":
+///             deleteUserAccount()
+///         case "rate_app":
+///             showAppStoreRating()
+///         default:
+///             break
+///         }
+///     }
+/// ```
+public struct CustomActionData {
+
+    /// The unique identifier for the custom action.
+    /// 
+    /// This identifier is configured in the Customer Center dashboard and allows
+    /// applications to distinguish between different types of custom actions.
+    /// Common examples might include:
+    /// - `"delete_user"`
+    /// - `"rate_app"`
+    /// - `"contact_support"`
+    /// - `"view_privacy_settings"`
+    public let actionIdentifier: String
+
+    /// The product identifier of the purchase being viewed in a detail screen, if any.
+    /// 
+    /// This provides context about which specific purchase the custom action relates to.
+    /// It will be `nil` if the custom action was triggered from the general management screen
+    /// rather than from a specific purchase detail screen.
+    /// 
+    /// - When triggered from a purchase detail screen: Contains the product identifier of that purchase
+    /// - When triggered from the management screen: Will be `nil`
+    public let activePurchaseId: String?
+
+    /// Creates a new `CustomActionData` instance.
+    /// 
+    /// - Parameters:
+    ///   - actionIdentifier: The unique identifier for the custom action
+    ///   - activePurchaseId: The optional product identifier of the active purchase
+    public init(actionIdentifier: String, activePurchaseId: String?) {
+        self.actionIdentifier = actionIdentifier
+        self.activePurchaseId = activePurchaseId
+    }
+}
+
+// MARK: - Equatable
+
+extension CustomActionData: Equatable {
+
+    /// Returns a Boolean value indicating whether two `CustomActionData` instances are equal.
+    /// 
+    /// Two `CustomActionData` instances are considered equal if both their `actionIdentifier` 
+    /// and `activePurchaseId` properties are equal.
+    /// 
+    /// - Parameters:
+    ///   - lhs: A `CustomActionData` instance to compare.
+    ///   - rhs: Another `CustomActionData` instance to compare.
+    /// - Returns: `true` if the instances are equal; otherwise, `false`.
+    public static func == (lhs: CustomActionData, rhs: CustomActionData) -> Bool {
+        return lhs.actionIdentifier == rhs.actionIdentifier &&
+               lhs.activePurchaseId == rhs.activePurchaseId
+    }
+}
+
+// MARK: - Hashable
+
+extension CustomActionData: Hashable {
+
+    /// Hashes the essential components of this `CustomActionData` by feeding them into the given hasher.
+    /// 
+    /// This method combines the `actionIdentifier` and `activePurchaseId` properties 
+    /// to generate a hash value for the instance.
+    /// 
+    /// - Parameter hasher: The hasher to use when combining the components of this instance.
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(actionIdentifier)
+        hasher.combine(activePurchaseId)
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension CustomActionData: CustomStringConvertible {
+
+    /// A textual representation of this `CustomActionData` instance.
+    /// 
+    /// The description includes the action identifier and information about the 
+    /// associated purchase, if any. This is useful for debugging and logging purposes.
+    /// 
+    /// - Returns: A string describing the custom action data.
+    public var description: String {
+        let purchaseInfo = activePurchaseId.map { "purchase: \($0)" } ?? "no active purchase"
+        return "CustomActionData(actionIdentifier: \"\(actionIdentifier)\", \(purchaseInfo))"
+    }
+}

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterAction.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterAction.swift
@@ -34,5 +34,8 @@ public enum CustomerCenterAction {
     /// An option of the feedback survey has been selected
     /// - Parameter feedbackSurveyOptionId: The id of the feedback survey option selected
     case feedbackSurveyCompleted(_ feedbackSurveyOptionId: String)
+    /// A custom action has been selected
+    /// - Parameter customActionData: The data associated with the custom action
+    case customActionSelected(_ customActionData: CustomActionData)
 
 }

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterManagementOption.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterManagementOption.swift
@@ -36,4 +36,22 @@ public enum CustomerCenterManagementOption {
     /// Represents a change plans action
     public struct ChangePlans: CustomerCenterActionable {}
 
+    /// Represents a custom action
+    public struct CustomAction: CustomerCenterActionable {
+        /// The custom action identifier
+        public let actionIdentifier: String
+        /// The optional active purchase ID
+        public let activePurchaseId: String?
+
+        /// Creates a new `CustomAction` instance.
+        /// 
+        /// - Parameters:
+        ///   - actionIdentifier: The unique identifier for the custom action
+        ///   - activePurchaseId: The optional product identifier of the active purchase
+        public init(actionIdentifier: String, activePurchaseId: String?) {
+            self.actionIdentifier = actionIdentifier
+            self.activePurchaseId = activePurchaseId
+        }
+    }
+
 }

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -420,6 +420,7 @@ import Foundation
         @_spi(Internal) public let type: PathType
         @_spi(Internal) public let detail: PathDetail?
         @_spi(Internal) public let refundWindowDuration: RefundWindowDuration?
+        @_spi(Internal) public let customActionIdentifier: String?
 
         @_spi(Internal) public init(
             id: String,
@@ -428,7 +429,8 @@ import Foundation
             openMethod: OpenMethod? = nil,
             type: PathType,
             detail: PathDetail?,
-            refundWindowDuration: RefundWindowDuration? = nil
+            refundWindowDuration: RefundWindowDuration? = nil,
+            customActionIdentifier: String? = nil
         ) {
             self.id = id
             self.title = title
@@ -437,6 +439,7 @@ import Foundation
             self.type = type
             self.detail = detail
             self.refundWindowDuration = refundWindowDuration
+            self.customActionIdentifier = customActionIdentifier
         }
 
         @_spi(Internal) public enum PathDetail: Equatable {
@@ -458,6 +461,7 @@ import Foundation
             case changePlans = "CHANGE_PLANS"
             case cancel = "CANCEL"
             case customUrl = "CUSTOM_URL"
+            case customAction = "CUSTOM_ACTION"
             case unknown
 
             init(from rawValue: String) {
@@ -472,6 +476,8 @@ import Foundation
                     self = .cancel
                 case "CUSTOM_URL":
                     self = .customUrl
+                case "CUSTOM_ACTION":
+                    self = .customAction
                 default:
                     self = .unknown
                 }
@@ -804,6 +810,8 @@ extension CustomerCenterConfigData.HelpPath {
         } else {
             self.refundWindowDuration = nil
         }
+
+        self.customActionIdentifier = response.actionIdentifier
     }
 }
 

--- a/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
+++ b/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
@@ -50,6 +50,7 @@ struct CustomerCenterConfigResponse {
         let promotionalOffer: PromotionalOffer?
         let feedbackSurvey: FeedbackSurvey?
         let refundWindow: String?
+        let actionIdentifier: String?
 
         enum PathType: String {
 
@@ -58,6 +59,7 @@ struct CustomerCenterConfigResponse {
             case changePlans = "CHANGE_PLANS"
             case cancel = "CANCEL"
             case customUrl = "CUSTOM_URL"
+            case customAction = "CUSTOM_ACTION"
             case unknown
 
         }

--- a/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
@@ -15,6 +15,7 @@
 
 // swiftlint:disable file_length type_body_length function_body_length
 
+import Combine
 import Nimble
 @_spi(Internal) @testable import RevenueCat
 @_spi(Internal) @testable import RevenueCatUI
@@ -542,6 +543,145 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
                 loadPromotionalOfferUseCase.mockedPromotionalOffer?.discount.offerIdentifier
             ) == expectedOfferIdentifierInProduct
         }
+    }
+
+    func testCustomActionPathHandling() async throws {
+        let purchaseInformation = PurchaseInformation.monthlyRenewing
+        let actionWrapper = CustomerCenterActionWrapper()
+        var capturedCustomActionData: CustomActionData?
+
+        // Set up expectation to capture custom action
+        let expectation = XCTestExpectation(description: "Custom action triggered")
+
+        // Monitor the customActionSelected publisher
+        let cancellable = actionWrapper.customActionSelected
+            .sink { actionIdentifier, activePurchaseId in
+                capturedCustomActionData = CustomActionData(
+                    actionIdentifier: actionIdentifier,
+                    activePurchaseId: activePurchaseId
+                )
+                expectation.fulfill()
+            }
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: Self.managementScreen(refundWindowDuration: .forever),
+            actionWrapper: actionWrapper,
+            purchaseInformation: purchaseInformation,
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        // Create a custom action path
+        let customActionPath = CustomerCenterConfigData.HelpPath(
+            id: "custom_delete_user",
+            title: "Delete Account",
+            type: .customAction,
+            detail: nil,
+            customActionIdentifier: "delete_user"
+        )
+
+        // Call handleHelpPath with the custom action
+        await viewModel.handleHelpPath(customActionPath, withActiveProductId: purchaseInformation.productIdentifier)
+
+        // Wait for the action to be triggered
+        await fulfillment(of: [expectation], timeout: 1.0)
+
+        // Verify that the correct custom action was triggered
+        let customActionData = try XCTUnwrap(capturedCustomActionData)
+        expect(customActionData.actionIdentifier) == "delete_user"
+        expect(customActionData.activePurchaseId) == purchaseInformation.productIdentifier
+
+        cancellable.cancel()
+    }
+
+    func testCustomActionPathWithoutActionIdentifier() async throws {
+        let purchaseInformation = PurchaseInformation.monthlyRenewing
+        let actionWrapper = CustomerCenterActionWrapper()
+        var wasActionTriggered = false
+
+        // Set up expectation that should NOT be fulfilled
+        let expectation = XCTestExpectation(description: "Custom action should not be triggered")
+        expectation.isInverted = true
+
+        // Monitor the customActionSelected publisher
+        let cancellable = actionWrapper.customActionSelected
+            .sink { _, _ in
+                wasActionTriggered = true
+                expectation.fulfill() // This should not happen
+            }
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: Self.managementScreen(refundWindowDuration: .forever),
+            actionWrapper: actionWrapper,
+            purchaseInformation: purchaseInformation,
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        // Create a custom action path without action identifier
+        let customActionPath = CustomerCenterConfigData.HelpPath(
+            id: "custom_no_identifier",
+            title: "Custom Action",
+            type: .customAction,
+            detail: nil,
+            customActionIdentifier: nil
+        )
+
+        // Call handleHelpPath with the custom action - should not trigger action due to missing identifier
+        await viewModel.handleHelpPath(customActionPath, withActiveProductId: purchaseInformation.productIdentifier)
+
+        // Wait to ensure no action is triggered
+        await fulfillment(of: [expectation], timeout: 0.5)
+
+        // Verify that no custom action was triggered due to missing identifier
+        expect(wasActionTriggered) == false
+
+        cancellable.cancel()
+    }
+
+    func testCustomActionPathWithNilActivePurchaseId() async throws {
+        let actionWrapper = CustomerCenterActionWrapper()
+        var capturedCustomActionData: CustomActionData?
+
+        // Set up expectation to capture custom action
+        let expectation = XCTestExpectation(description: "Custom action triggered without purchase ID")
+
+        // Monitor the customActionSelected publisher
+        let cancellable = actionWrapper.customActionSelected
+            .sink { actionIdentifier, activePurchaseId in
+                capturedCustomActionData = CustomActionData(
+                    actionIdentifier: actionIdentifier,
+                    activePurchaseId: activePurchaseId
+                )
+                expectation.fulfill()
+            }
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: Self.managementScreen(refundWindowDuration: .forever),
+            actionWrapper: actionWrapper,
+            purchaseInformation: nil, // No purchase information
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        // Create a custom action path
+        let customActionPath = CustomerCenterConfigData.HelpPath(
+            id: "custom_rate_app",
+            title: "Rate App",
+            type: .customAction,
+            detail: nil,
+            customActionIdentifier: "rate_app"
+        )
+
+        // Call handleHelpPath without active purchase ID
+        await viewModel.handleHelpPath(customActionPath, withActiveProductId: nil)
+
+        // Wait for the action to be triggered
+        await fulfillment(of: [expectation], timeout: 1.0)
+
+        // Verify that the custom action was triggered with nil purchase ID
+        let customActionData = try XCTUnwrap(capturedCustomActionData)
+        expect(customActionData.actionIdentifier) == "rate_app"
+        expect(customActionData.activePurchaseId).to(beNil())
+
+        cancellable.cancel()
     }
 
 }

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomActionDataTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomActionDataTests.swift
@@ -1,0 +1,138 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomActionDataTests.swift
+//
+//  Created by Claude on 21/07/2025.
+//
+
+import Nimble
+@testable import RevenueCatUI
+import XCTest
+
+@available(iOS 15.0, *)
+final class CustomActionDataTests: TestCase {
+
+    func testCustomActionDataInitialization() {
+        let data = CustomActionData(
+            actionIdentifier: "delete_user",
+            activePurchaseId: "monthly_subscription"
+        )
+
+        expect(data.actionIdentifier) == "delete_user"
+        expect(data.activePurchaseId) == "monthly_subscription"
+    }
+
+    func testCustomActionDataInitializationWithNilPurchase() {
+        let data = CustomActionData(
+            actionIdentifier: "rate_app",
+            activePurchaseId: nil
+        )
+
+        expect(data.actionIdentifier) == "rate_app"
+        expect(data.activePurchaseId).to(beNil())
+    }
+
+    func testCustomActionDataEquality() {
+        let data1 = CustomActionData(actionIdentifier: "delete_user", activePurchaseId: "product1")
+        let data2 = CustomActionData(actionIdentifier: "delete_user", activePurchaseId: "product1")
+        let data3 = CustomActionData(actionIdentifier: "rate_app", activePurchaseId: "product1")
+        let data4 = CustomActionData(actionIdentifier: "delete_user", activePurchaseId: "product2")
+        let data5 = CustomActionData(actionIdentifier: "delete_user", activePurchaseId: nil)
+
+        // Test equality
+        expect(data1) == data2
+
+        // Test inequality - different action identifiers
+        expect(data1) != data3
+
+        // Test inequality - different purchase IDs
+        expect(data1) != data4
+
+        // Test inequality - nil vs non-nil purchase ID
+        expect(data1) != data5
+    }
+
+    func testCustomActionDataHashable() {
+        let data1 = CustomActionData(actionIdentifier: "delete_user", activePurchaseId: "product1")
+        let data2 = CustomActionData(actionIdentifier: "delete_user", activePurchaseId: "product1")
+        let data3 = CustomActionData(actionIdentifier: "rate_app", activePurchaseId: "product1")
+
+        // Equal objects should have equal hash values
+        expect(data1.hashValue) == data2.hashValue
+
+        // Different objects should likely have different hash values
+        expect(data1.hashValue) != data3.hashValue
+
+        // Test that CustomActionData can be used in Sets
+        let dataSet: Set<CustomActionData> = [data1, data2, data3]
+        expect(dataSet.count) == 2 // data1 and data2 are equal, so only 2 unique items
+    }
+
+    func testCustomActionDataDescription() {
+        let dataWithPurchase = CustomActionData(
+            actionIdentifier: "delete_user",
+            activePurchaseId: "monthly_sub"
+        )
+        let dataWithoutPurchase = CustomActionData(
+            actionIdentifier: "rate_app",
+            activePurchaseId: nil
+        )
+
+        expect(dataWithPurchase.description).to(contain("delete_user"))
+        expect(dataWithPurchase.description).to(contain("monthly_sub"))
+        expect(dataWithPurchase.description).to(contain("CustomActionData"))
+
+        expect(dataWithoutPurchase.description).to(contain("rate_app"))
+        expect(dataWithoutPurchase.description).to(contain("no active purchase"))
+        expect(dataWithoutPurchase.description).to(contain("CustomActionData"))
+    }
+
+    func testCustomActionDataCanBeUsedInDictionaries() {
+        let data1 = CustomActionData(actionIdentifier: "delete_user", activePurchaseId: "product1")
+        let data2 = CustomActionData(actionIdentifier: "rate_app", activePurchaseId: nil)
+
+        var actionMap: [CustomActionData: String] = [:]
+        actionMap[data1] = "Delete Account"
+        actionMap[data2] = "Rate App"
+
+        expect(actionMap[data1]) == "Delete Account"
+        expect(actionMap[data2]) == "Rate App"
+        expect(actionMap.count) == 2
+    }
+
+    func testCustomActionDataWithEmptyStrings() {
+        let data = CustomActionData(
+            actionIdentifier: "",
+            activePurchaseId: ""
+        )
+
+        expect(data.actionIdentifier) == ""
+        expect(data.activePurchaseId) == ""
+
+        // Empty strings should still work correctly
+        expect(data.description).to(contain("CustomActionData"))
+        expect(data.description).to(contain("purchase: "))
+    }
+
+    func testCustomActionDataWithLongStrings() {
+        let longActionId = String(repeating: "a", count: 1000)
+        let longPurchaseId = String(repeating: "b", count: 1000)
+
+        let data = CustomActionData(
+            actionIdentifier: longActionId,
+            activePurchaseId: longPurchaseId
+        )
+
+        expect(data.actionIdentifier) == longActionId
+        expect(data.activePurchaseId) == longPurchaseId
+        expect(data.actionIdentifier.count) == 1000
+        expect(data.activePurchaseId?.count) == 1000
+    }
+}

--- a/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
+++ b/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
@@ -283,4 +283,119 @@ class CustomerCenterConfigDataTests: TestCase {
         expect(configData.support.shouldWarnCustomerToUpdate) == true
         expect(configData.support.displayPurchaseHistoryLink) == false
     }
+
+    func testCustomActionPathConfiguration() throws {
+        let mockResponse = CustomerCenterConfigResponse(
+            customerCenter: .init(
+                appearance: .init(
+                    light: .init(accentColor: nil, textColor: nil, backgroundColor: nil,
+                                 buttonTextColor: nil, buttonBackgroundColor: nil),
+                    dark: .init(accentColor: nil, textColor: nil, backgroundColor: nil,
+                                buttonTextColor: nil, buttonBackgroundColor: nil)
+                ),
+                screens: [
+                    "MANAGEMENT": .init(
+                        title: "Management Screen",
+                        type: .management,
+                        subtitle: nil,
+                        paths: [
+                            .init(
+                                id: "custom_action_delete",
+                                title: "Delete Account",
+                                type: .customAction,
+                                url: nil,
+                                openMethod: nil,
+                                promotionalOffer: nil,
+                                feedbackSurvey: nil,
+                                refundWindow: nil,
+                                actionIdentifier: "delete_user"
+                            ),
+                            .init(
+                                id: "custom_action_rate",
+                                title: "Rate App",
+                                type: .customAction,
+                                url: nil,
+                                openMethod: nil,
+                                promotionalOffer: nil,
+                                feedbackSurvey: nil,
+                                refundWindow: nil,
+                                actionIdentifier: "rate_app"
+                            )
+                        ]
+                    )
+                ],
+                localization: .init(locale: "en_US", localizedStrings: [:]),
+                support: .init(email: "support@example.com", shouldWarnCustomerToUpdate: true,
+                               displayPurchaseHistoryLink: false, displayVirtualCurrencies: false,
+                               shouldWarnCustomersAboutMultipleSubscriptions: false),
+                changePlans: []
+            ),
+            lastPublishedAppVersion: "1.0.0",
+            itunesTrackId: nil
+        )
+
+        let configData = CustomerCenterConfigData(from: mockResponse)
+        let managementScreen = try XCTUnwrap(configData.screens[.management])
+
+        expect(managementScreen.paths.count) == 2
+
+        let deleteActionPath = managementScreen.paths.first { $0.id == "custom_action_delete" }
+        expect(deleteActionPath).toNot(beNil())
+        expect(deleteActionPath?.type) == .customAction
+        expect(deleteActionPath?.title) == "Delete Account"
+        expect(deleteActionPath?.customActionIdentifier) == "delete_user"
+
+        let rateActionPath = managementScreen.paths.first { $0.id == "custom_action_rate" }
+        expect(rateActionPath).toNot(beNil())
+        expect(rateActionPath?.type) == .customAction
+        expect(rateActionPath?.title) == "Rate App"
+        expect(rateActionPath?.customActionIdentifier) == "rate_app"
+    }
+
+    func testCustomActionPathWithoutActionIdentifier() throws {
+        let mockResponse = CustomerCenterConfigResponse(
+            customerCenter: .init(
+                appearance: .init(
+                    light: .init(accentColor: nil, textColor: nil, backgroundColor: nil,
+                                 buttonTextColor: nil, buttonBackgroundColor: nil),
+                    dark: .init(accentColor: nil, textColor: nil, backgroundColor: nil,
+                                buttonTextColor: nil, buttonBackgroundColor: nil)
+                ),
+                screens: [
+                    "MANAGEMENT": .init(
+                        title: "Management Screen",
+                        type: .management,
+                        subtitle: nil,
+                        paths: [
+                            .init(
+                                id: "custom_action_no_identifier",
+                                title: "Custom Action",
+                                type: .customAction,
+                                url: nil,
+                                openMethod: nil,
+                                promotionalOffer: nil,
+                                feedbackSurvey: nil,
+                                refundWindow: nil,
+                                actionIdentifier: nil
+                            )
+                        ]
+                    )
+                ],
+                localization: .init(locale: "en_US", localizedStrings: [:]),
+                support: .init(email: "support@example.com", shouldWarnCustomerToUpdate: true,
+                               displayPurchaseHistoryLink: false, displayVirtualCurrencies: false,
+                               shouldWarnCustomersAboutMultipleSubscriptions: false),
+                changePlans: []
+            ),
+            lastPublishedAppVersion: "1.0.0",
+            itunesTrackId: nil
+        )
+
+        let configData = CustomerCenterConfigData(from: mockResponse)
+        let managementScreen = try XCTUnwrap(configData.screens[.management])
+
+        let customActionPath = managementScreen.paths.first { $0.type == .customAction }
+        expect(customActionPath).toNot(beNil())
+        expect(customActionPath?.customActionIdentifier).to(beNil())
+    }
 }


### PR DESCRIPTION
### Motivation
This PR implements support for a new **CUSTOM_ACTION** path type in Customer Center, allowing developers to define custom actions in their configuration and handle them programmatically in their apps.

### Description
  - Added CUSTOM_ACTION path type support in customer center configuration
  - Handle `customActionIdentifier` string to identify different custom actions
  - Client determines activePurchaseId based on current context

> this is a purely additive feature that maintains full backward compatibility.


