### PR TITLE
Add missing RevenueCatUI test plans

### DIFF
--- a/Workspace.swift
+++ b/Workspace.swift
@@ -24,7 +24,8 @@ if Environment.local {
 
 var additionalFiles: [FileElement] = [
     .glob(pattern: "Global.xcconfig"),
-    .glob(pattern: "Tests/TestPlans/**/*.xctestplan")
+    .glob(pattern: "Tests/TestPlans/**/*.xctestplan"),
+    .glob(pattern: "Tests/RevenueCatUITests/TestPlans/**/*.xctestplan")
 ]
 if FileManager.default.fileExists(atPath: "Local.xcconfig") {
     additionalFiles.append(.glob(pattern: "Local.xcconfig"))


### PR DESCRIPTION
### Motivation
Just noticed that the `RevenueCatUI` test plans are not being referenced in the workspace.

### Description
- Add test plans
