### PR TITLE
Dont show cancel if non-sub for customer center

### DIFF
--- a/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
@@ -68,7 +68,10 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
     }
 
     func testNonAppStoreFiltersAppStoreOnlyPaths() {
-        let purchase = PurchaseInformation.mock(store: .playStore)
+        let purchase = PurchaseInformation.mock(
+            store: .playStore,
+            isSubscription: true
+        )
 
         let viewModel = BaseManageSubscriptionViewModel(
             screen: BaseManageSubscriptionViewModelTests.default,
@@ -123,6 +126,7 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
 
     func testCancelledDoesNotShowCancelAndRefund() {
         let purchase = PurchaseInformation.mock(
+            isSubscription: true,
             isCancelled: true
         )
 


### PR DESCRIPTION
### Motivation
We've got a report that the OTPs were showing cancel. This fixes it.

### Next steps
We're going to move the PATHs to the backend, so we can address this type of issues more efficiently.