### PR TITLE
Replace isLifetimeSubscription for isLifetime

### DIFF
--- a/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
@@ -61,7 +61,7 @@ extension Array<CustomerCenterConfigData.HelpPath> {
 
             // can't change plans if it's not a subscription
             if $0.type == .changePlans &&
-                (!purchaseInformation.isSubscription || purchaseInformation.isLifetimeSubscription) {
+                (!purchaseInformation.isSubscription || purchaseInformation.isLifetime) {
                 return false
             }
 

--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation+Mock.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation+Mock.swift
@@ -47,7 +47,8 @@ extension PurchaseInformation {
         gracePeriodExpiresDate: Date? = nil,
         refundedAtDate: Date? = nil,
         transactionIdentifier: String? = "rc_tx_123",
-        storeTransactionIdentifier: String? = "store_tx_abc"
+        storeTransactionIdentifier: String? = "store_tx_abc",
+        isLifetime: Bool = false
     ) -> PurchaseInformation {
         return PurchaseInformation(
             title: title,
@@ -74,7 +75,8 @@ extension PurchaseInformation {
             gracePeriodExpiresDate: gracePeriodExpiresDate,
             refundedAtDate: refundedAtDate,
             transactionIdentifier: transactionIdentifier,
-            storeTransactionIdentifier: storeTransactionIdentifier
+            storeTransactionIdentifier: storeTransactionIdentifier,
+            isLifetime: isLifetime
         )
     }
 
@@ -106,7 +108,8 @@ extension PurchaseInformation {
         productIdentifier: "product_id_lifetime",
         isSubscription: true,
         expirationDate: nil,
-        renewalDate: nil
+        renewalDate: nil,
+        isLifetime: true
     )
 
     static let free = PurchaseInformation.mock(

--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -123,6 +123,9 @@ struct PurchaseInformation {
     /// Remote configured set of product ids to handle change plans flow.
     let changePlan: CustomerCenterConfigData.ChangePlan?
 
+    /// Indicates the product is lasts forever
+    let isLifetime: Bool
+
     private let dateFormatter: DateFormatter
     private let numberFormatter: NumberFormatter
 
@@ -153,7 +156,8 @@ struct PurchaseInformation {
          refundedAtDate: Date? = nil,
          transactionIdentifier: String? = nil,
          storeTransactionIdentifier: String? = nil,
-         changePlan: CustomerCenterConfigData.ChangePlan? = nil
+         changePlan: CustomerCenterConfigData.ChangePlan? = nil,
+         isLifetime: Bool = false
     ) {
         self.title = title
         self.pricePaid = pricePaid
@@ -183,6 +187,7 @@ struct PurchaseInformation {
         self.transactionIdentifier = transactionIdentifier
         self.storeTransactionIdentifier = storeTransactionIdentifier
         self.changePlan = changePlan
+        self.isLifetime = isLifetime
     }
 
     // swiftlint:disable:next function_body_length
@@ -211,6 +216,7 @@ struct PurchaseInformation {
         self.customerInfoRequestedDate = customerInfoRequestedDate
         self.managementURL = managementURL
         self.isSubscription = transaction.isSubscrition && transaction.store != .promotional
+        self.isLifetime = subscribedProduct?.productType == .nonConsumable
 
         // Use entitlement data if available, otherwise derive from transaction
         if let entitlement = entitlement {
@@ -533,10 +539,6 @@ extension PurchaseInformation {
 }
 
 extension PurchaseInformation {
-
-    var isLifetimeSubscription: Bool {
-        expirationDate == nil && isSubscription
-    }
 
     var storeLocalizationKey: CCLocalizedString {
         switch store {

--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -123,7 +123,7 @@ struct PurchaseInformation {
     /// Remote configured set of product ids to handle change plans flow.
     let changePlan: CustomerCenterConfigData.ChangePlan?
 
-    /// Indicates the product is lasts forever
+    /// Indicates the product lasts forever
     let isLifetime: Bool
 
     private let dateFormatter: DateFormatter

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
@@ -308,7 +308,7 @@ extension PurchaseInformationCardView {
             purchaseInformation: PurchaseInformation,
             localization: CustomerCenterConfigData.Localization
         ) {
-            if purchaseInformation.isLifetimeSubscription {
+            if purchaseInformation.isLifetime {
                 self = .lifetime(localization)
             } else if purchaseInformation.isExpired {
                 self = .expired(localization)

--- a/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
@@ -112,7 +112,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "Monthly Product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
         expect(subscriptionInfo.changePlan).toNot(beNil())
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .appStore
@@ -171,7 +171,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "Monthly Product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice) == .nonFree("$7.99")
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .appStore
@@ -231,7 +231,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "Monthly Product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beTrue())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .appStore
@@ -289,7 +289,7 @@ final class PurchaseInformationTests: TestCase {
         let subscriptionInfo = try XCTUnwrap(subscriptionInfoNullable)
         expect(subscriptionInfo.title) == "Monthly Product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .appStore
@@ -348,7 +348,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "Monthly Product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .appStore
@@ -393,7 +393,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "com.revenuecat.product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .playStore
@@ -438,7 +438,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "com.revenuecat.product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .playStore
@@ -483,7 +483,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "com.revenuecat.product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$6.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .playStore
@@ -529,7 +529,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "premium"
         expect(subscriptionInfo.pricePaid) == .free
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .promotional
@@ -575,7 +575,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.pricePaid) == .free
         expect(subscriptionInfo.renewalPrice).to(beNil())
         // false - no way to know if its lifetime
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .promotional
@@ -620,7 +620,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "com.revenuecat.product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .stripe
@@ -665,7 +665,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "com.revenuecat.product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .stripe
@@ -710,7 +710,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "com.revenuecat.product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .stripe
@@ -755,7 +755,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "com.revenuecat.product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice) == .nonFree("$1.99")
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .rcBilling
@@ -800,7 +800,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "com.revenuecat.product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .rcBilling
@@ -845,7 +845,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "com.revenuecat.product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .rcBilling
@@ -890,7 +890,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "com.revenuecat.product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .paddle
@@ -935,7 +935,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "com.revenuecat.product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .paddle
@@ -980,7 +980,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.title) == "com.revenuecat.product"
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
         expect(subscriptionInfo.renewalPrice).to(beNil())
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .paddle
@@ -1020,7 +1020,7 @@ final class PurchaseInformationTests: TestCase {
         )
         expect(subscriptionInfo.title) == "product_id"
         expect(subscriptionInfo.pricePaid) == .nonFree("$1.99")
-        expect(subscriptionInfo.isLifetimeSubscription).to(beFalse())
+        expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == "product_id"
         expect(subscriptionInfo.store) == .stripe


### PR DESCRIPTION
### Motivation
After discussing with @vegaro, we've realized that `isLifetimeSubscription` made no sense.

### Description
- Replace `isLifetimeSubscription` with `isLifetime`, which is true only for `nonConsumable` store products 
