### PR TITLE
Add fallback for change plans id and only display selected

### DIFF
--- a/Examples/rc-maestro/rc-maestro/Resources/StoreKit/StoreKitConfiguration.storekit
+++ b/Examples/rc-maestro/rc-maestro/Resources/StoreKit/StoreKitConfiguration.storekit
@@ -101,7 +101,11 @@
     {
       "id" : "F7DE1690",
       "localizations" : [
-
+        {
+          "description" : "Group 1",
+          "displayName" : "Editable Group",
+          "locale" : "en_US"
+        }
       ],
       "name" : "subscription.group.1",
       "subscriptions" : [
@@ -148,7 +152,7 @@
           ],
           "displayPrice" : "1.99",
           "familyShareable" : false,
-          "groupNumber" : 1,
+          "groupNumber" : 2,
           "internalID" : "AB1B73AE",
           "introductoryOffer" : null,
           "localizations" : [
@@ -161,6 +165,34 @@
           "productID" : "maestro.monthly.tests.02",
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Product 1 [Monthly]",
+          "subscriptionGroupID" : "F7DE1690",
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "2.99",
+          "familyShareable" : false,
+          "groupNumber" : 3,
+          "internalID" : "C3CC4618",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Product 1 on yearly basis",
+              "displayName" : "Product 1 [Yearly]",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "maestro.yearly.tests.01",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "Product 1 [Yearly]",
           "subscriptionGroupID" : "F7DE1690",
           "type" : "RecurringSubscription",
           "winbackOffers" : [

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/ContentView.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/ContentView.swift
@@ -100,6 +100,7 @@ public struct ContentView: View {
          [
              "maestro.weekly.tests.01",
              "maestro.monthly.tests.02",
+             "maestro.yearly.tests.01",
              "maestro.weekly2.tests.01",
              "maestro.nonconsumable.tests.01",
              "maestro.consumable.tests.01"

--- a/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
+++ b/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
@@ -129,11 +129,12 @@ extension CustomerCenterPurchasesType {
 
     @_spi(Internal) public func body(content: Content) -> some View {
         #if swift(>=5.9)
+        let validAmountOfProducts = productIDs.count >= 2
         if #available(iOS 17.0, macOS 14.0, tvOS 17, watchOS 10.0, *),
-            productIDs.count > 2 || subscriptionGroupID != nil {
+           validAmountOfProducts || subscriptionGroupID != nil {
             content
                 .sheet(isPresented: isPresented) {
-                    if productIDs.count > 2 {
+                    if validAmountOfProducts {
                         SubscriptionStoreView(
                             productIDs: productIDs
                         )

--- a/RevenueCatUI/CustomerCenter/Extensions/PurchaseInformation+Creation.swift
+++ b/RevenueCatUI/CustomerCenter/Extensions/PurchaseInformation+Creation.swift
@@ -31,7 +31,11 @@ extension PurchaseInformation {
 
         if transaction.store == .appStore {
             if let product = await purchasesProvider.products([transaction.productIdentifier]).first {
-                let changePlan = changePlans.first(where: { product.subscriptionGroupIdentifier == $0.groupId })
+                let changePlan = changePlans
+                    .first(where: { product.subscriptionGroupIdentifier == $0.groupId })
+                ?? changePlans.first(
+                    where: { $0.products.contains(where: { $0.productId == product.productIdentifier }) }
+                )
 
                 return await PurchaseInformation.purchaseInformationUsingRenewalInfo(
                     entitlement: entitlement,

--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -225,7 +225,7 @@ extension BaseManageSubscriptionViewModel {
     var changePlanProductIDs: [String] {
         purchaseInformation?
             .changePlan
-            .map { $0.products.filter { $0.selected }.map(\.productId) }
+            .map { $0.products.filter { $0.selected }.map(\.productId) } ?? []
     }
 }
 

--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -225,7 +225,7 @@ extension BaseManageSubscriptionViewModel {
     var changePlanProductIDs: [String] {
         purchaseInformation?
             .changePlan
-            .map { $0.products.map(\.productId) } ?? []
+            .map { $0.products.filter { $0.selected }.map(\.productId) }
     }
 }
 


### PR DESCRIPTION
### Motivation
While debugging change plans, I've noticed there were some issues.

### Description
1. Add fallback to find the correct change plan to use
2. Limit productIDs to `>=2`
3. Only pick selected ones
