### PR TITLE
Allow custom URL for empty screen in customer center

### DIFF
--- a/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
@@ -21,7 +21,9 @@ extension Array<CustomerCenterConfigData.HelpPath> {
     ) -> [CustomerCenterConfigData.HelpPath] {
         guard let purchaseInformation else {
             return filter {
-                $0.type == .missingPurchase || $0.type == .customAction
+                $0.type == .missingPurchase
+                    || $0.type == .customAction
+                    || $0.type == .customUrl
             }
         }
 


### PR DESCRIPTION
### Motivation
We should allow `customURL` for empty screens in customer center. The dashboard allows it.

### Description
- Allow custom URL when there's no purchase information
