### PR TITLE
[EXTERNAL] Adds a convenience method to set the Amplitude User ID and Amplitude Device ID (#5425) via @alpennec

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
@@ -113,6 +113,9 @@ Most features require configuring the SDK before using it.
 - ``Purchases/setMixpanelDistinctID(_:)``
 - ``Purchases/setMparticleID(_:)``
 - ``Purchases/setOnesignalID(_:)``
+- ``Attribution/setPostHogUserID(_:)``
+- ``Attribution/setAmplitudeUserID(_:)``
+- ``Attribution/setAmplitudeDeviceID(_:)``
 
 ### Advanced Configuration
 - ``Purchases/finishTransactions``

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
@@ -157,6 +157,9 @@ Or browse our iOS sample apps:
 - ``Purchases/setMixpanelDistinctID(_:)``
 - ``Purchases/setMparticleID(_:)``
 - ``Purchases/setOnesignalID(_:)``
+- ``Attribution/setPostHogUserID(_:)``
+- ``Attribution/setAmplitudeUserID(_:)``
+- ``Attribution/setAmplitudeDeviceID(_:)``
 
 ### Configuring the SDK with parameters (deprecated)
 - ``Purchases/configure(withAPIKey:appUserID:)-57pv0``

--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -341,6 +341,32 @@ public extension Attribution {
     }
 
     /**
+     * Subscriber attribute associated with the Amplitude User ID for the user.
+     * Optional for the RevenueCat Amplitude integration.
+     *
+     * #### Related Articles
+     * - [Amplitude RevenueCat Integration](https://www.revenuecat.com/docs/integrations/third-party-integrations/amplitude)
+     *
+     *- Parameter amplitudeUserID: Empty String or `nil` will delete the subscriber attribute.
+     */
+    @objc func setAmplitudeUserID(_ amplitudeUserID: String?) {
+        self.subscriberAttributesManager.setAmplitudeUserID(amplitudeUserID, appUserID: appUserID)
+    }
+
+    /**
+     * Subscriber attribute associated with the Amplitude Device ID for the user.
+     * Optional for the RevenueCat Amplitude integration.
+     *
+     * #### Related Articles
+     * - [Amplitude RevenueCat Integration](https://www.revenuecat.com/docs/integrations/third-party-integrations/amplitude)
+     *
+     *- Parameter amplitudeDeviceID: Empty String or `nil` will delete the subscriber attribute.
+     */
+    @objc func setAmplitudeDeviceID(_ amplitudeDeviceID: String?) {
+        self.subscriberAttributesManager.setAmplitudeDeviceID(amplitudeDeviceID, appUserID: appUserID)
+    }
+
+    /**
      * Subscriber attribute associated with the install media source for the user.
      *
      * #### Related Articles

--- a/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -45,6 +45,8 @@ enum ReservedSubscriberAttribute: String {
     case firebaseAppInstanceID = "$firebaseAppInstanceId"
     case tenjinAnalyticsInstallationID = "$tenjinId"
     case postHogUserID = "$posthogUserId"
+    case amplitudeUserID = "$amplitudeUserId"
+    case amplitudeDeviceID = "$amplitudeDeviceId"
 
     case mediaSource = "$mediaSource"
     case campaign = "$campaign"

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -116,6 +116,14 @@ class SubscriberAttributesManager {
         setReservedAttribute(.postHogUserID, value: postHogUserID, appUserID: appUserID)
     }
 
+    func setAmplitudeUserID(_ amplitudeUserID: String?, appUserID: String) {
+        setReservedAttribute(.amplitudeUserID, value: amplitudeUserID, appUserID: appUserID)
+    }
+
+    func setAmplitudeDeviceID(_ amplitudeDeviceID: String?, appUserID: String) {
+        setReservedAttribute(.amplitudeDeviceID, value: amplitudeDeviceID, appUserID: appUserID)
+    }
+
     func setMediaSource(_ mediaSource: String?, appUserID: String) {
         setReservedAttribute(.mediaSource, value: mediaSource, appUserID: appUserID)
     }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAttributionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAttributionAPI.m
@@ -48,6 +48,10 @@
     [a setTenjinAnalyticsInstallationID: @""];
     [a setPostHogUserID:nil];
     [a setPostHogUserID:@""];
+    [a setAmplitudeUserID:nil];
+    [a setAmplitudeUserID:@""];
+    [a setAmplitudeDeviceID:nil];
+    [a setAmplitudeDeviceID:@""];
     [a setMediaSource: nil];
     [a setMediaSource: @""];
     [a setCampaign: nil];

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AttributionAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AttributionAPI.swift
@@ -64,6 +64,12 @@ func checkAttributionAPI() {
     attribution.setPostHogUserID("")
     attribution.setPostHogUserID(nil)
 
+    attribution.setAmplitudeUserID("")
+    attribution.setAmplitudeUserID(nil)
+
+    attribution.setAmplitudeDeviceID("")
+    attribution.setAmplitudeDeviceID(nil)
+
     attribution.setMediaSource("")
     attribution.setMediaSource(nil)
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriberAttributesView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriberAttributesView.swift
@@ -46,6 +46,8 @@ struct SubscriberAttributesView: View {
         case setFirebaseAppInstanceID
         case setTenjinAnalyticsInstallationID
         case setPostHogUserID
+        case setAmplitudeUserID
+        case setAmplitudeDeviceID
     }
     
     let customerInfo: RevenueCat.CustomerInfo
@@ -161,6 +163,10 @@ struct SubscriberAttributesView: View {
                     Purchases.shared.attribution.setTenjinAnalyticsInstallationID(self.otherValue)
                 case .setPostHogUserID:
                     Purchases.shared.attribution.setPostHogUserID(self.otherValue)
+                case .setAmplitudeUserID:
+                    Purchases.shared.attribution.setAmplitudeUserID(self.otherValue)
+                case .setAmplitudeDeviceID:
+                    Purchases.shared.attribution.setAmplitudeDeviceID(self.otherValue)
                 }
             }
         }

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -459,6 +459,14 @@ extension MockPurchases: PurchasesType {
         self.unimplemented()
     }
 
+    func setAmplitudeUserID(_ amplitudeUserID: String?) {
+        self.unimplemented()
+    }
+
+    func setAmplitudeDeviceID(_ amplitudeDeviceID: String?) {
+        self.unimplemented()
+    }
+
     func collectDeviceIdentifiers() {
         self.unimplemented()
     }

--- a/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
@@ -238,6 +238,30 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
         invokedSetPostHogUserIDParametersList.append((postHogUserID, appUserID))
     }
 
+    var invokedSetAmplitudeUserID = false
+    var invokedSetAmplitudeUserIDCount = 0
+    var invokedSetAmplitudeUserIDParameters: (amplitudeUserID: String?, appUserID: String?)?
+    var invokedSetAmplitudeUserIDParametersList = [(amplitudeUserID: String?, appUserID: String?)]()
+
+    override func setAmplitudeUserID(_ amplitudeUserID: String?, appUserID: String) {
+        invokedSetAmplitudeUserID = true
+        invokedSetAmplitudeUserIDCount += 1
+        invokedSetAmplitudeUserIDParameters = (amplitudeUserID, appUserID)
+        invokedSetAmplitudeUserIDParametersList.append((amplitudeUserID, appUserID))
+    }
+
+    var invokedSetAmplitudeDeviceID = false
+    var invokedSetAmplitudeDeviceIDCount = 0
+    var invokedSetAmplitudeDeviceIDParameters: (amplitudeDeviceID: String?, appUserID: String?)?
+    var invokedSetAmplitudeDeviceIDParametersList = [(amplitudeDeviceID: String?, appUserID: String?)]()
+
+    override func setAmplitudeDeviceID(_ amplitudeDeviceID: String?, appUserID: String) {
+        invokedSetAmplitudeDeviceID = true
+        invokedSetAmplitudeDeviceIDCount += 1
+        invokedSetAmplitudeDeviceIDParameters = (amplitudeDeviceID, appUserID)
+        invokedSetAmplitudeDeviceIDParametersList.append((amplitudeDeviceID, appUserID))
+    }
+
     var invokedSetMediaSource = false
     var invokedSetMediaSourceCount = 0
     var invokedSetMediaSourceParameters: (mediaSource: String?, appUserID: String?)?

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -515,6 +515,26 @@ class PurchasesSubscriberAttributesTests: TestCase {
         (nil, purchases.appUserID)
     }
 
+    func testSetAndClearAmplitudeUserID() {
+        setupPurchases()
+        purchases.attribution.setAmplitudeUserID("amplitude")
+        purchases.attribution.setAmplitudeUserID(nil)
+        expect(self.mockSubscriberAttributesManager.invokedSetAmplitudeUserIDParametersList[0]) ==
+        ("amplitude", purchases.appUserID)
+        expect(self.mockSubscriberAttributesManager.invokedSetAmplitudeUserIDParametersList[1]) ==
+        (nil, purchases.appUserID)
+    }
+
+    func testSetAndClearAmplitudeDeviceID() {
+        setupPurchases()
+        purchases.attribution.setAmplitudeDeviceID("amplitude")
+        purchases.attribution.setAmplitudeDeviceID(nil)
+        expect(self.mockSubscriberAttributesManager.invokedSetAmplitudeDeviceIDParametersList[0]) ==
+        ("amplitude", purchases.appUserID)
+        expect(self.mockSubscriberAttributesManager.invokedSetAmplitudeDeviceIDParametersList[1]) ==
+        (nil, purchases.appUserID)
+    }
+
     func testSetAndClearMediaSource() {
         setupPurchases()
         purchases.attribution.setMediaSource("media")
@@ -727,6 +747,28 @@ class PurchasesSubscriberAttributesTests: TestCase {
         expect(self.mockSubscriberAttributesManager.invokedSetPostHogUserIDParameters?.postHogUserID) ==
         "123abc"
         expect(self.mockSubscriberAttributesManager.invokedSetPostHogUserIDParameters?.appUserID) ==
+        mockIdentityManager.currentAppUserID
+    }
+
+    func testSetAmplitudeUserIDMakesRightCalls() {
+        setupPurchases()
+
+        Purchases.shared.attribution.setAmplitudeUserID("123abc")
+        expect(self.mockSubscriberAttributesManager.invokedSetAmplitudeUserIDCount) == 1
+        expect(self.mockSubscriberAttributesManager.invokedSetAmplitudeUserIDParameters?.amplitudeUserID) ==
+        "123abc"
+        expect(self.mockSubscriberAttributesManager.invokedSetAmplitudeUserIDParameters?.appUserID) ==
+        mockIdentityManager.currentAppUserID
+    }
+
+    func testSetAmplitudeDeviceIDMakesRightCalls() {
+        setupPurchases()
+
+        Purchases.shared.attribution.setAmplitudeDeviceID("123abc")
+        expect(self.mockSubscriberAttributesManager.invokedSetAmplitudeDeviceIDCount) == 1
+        expect(self.mockSubscriberAttributesManager.invokedSetAmplitudeDeviceIDParameters?.amplitudeDeviceID) ==
+        "123abc"
+        expect(self.mockSubscriberAttributesManager.invokedSetAmplitudeDeviceIDParameters?.appUserID) ==
         mockIdentityManager.currentAppUserID
     }
 

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -1510,6 +1510,152 @@ class SubscriberAttributesManagerTests: TestCase {
         checkDeviceIdentifiersAreNotSet()
     }
     // endregion
+    // region AmplitudeUserID
+    func testSetAmplitudeUserID() throws {
+        let amplitudeUserID = "amplitudeUserID"
+
+        self.subscriberAttributesManager.setAmplitudeUserID(amplitudeUserID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$amplitudeUserId"
+        expect(receivedAttribute.value) == amplitudeUserID
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetAmplitudeUserIDSetsEmptyIfNil() throws {
+        let amplitudeUserID = "amplitudeUserID"
+
+        self.subscriberAttributesManager.setAmplitudeUserID(amplitudeUserID, appUserID: "kratos")
+        self.subscriberAttributesManager.setAmplitudeUserID(nil, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 2
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$amplitudeUserId"
+        expect(receivedAttribute.value) == ""
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetAmplitudeUserIDSkipsIfSameValue() {
+        let amplitudeUserID = "amplitudeUserID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$amplitudeUserId",
+                                                                                    value: amplitudeUserID)
+        self.subscriberAttributesManager.setAmplitudeUserID(amplitudeUserID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 0
+    }
+
+    func testSetAmplitudeUserIDOverwritesIfNewValue() throws {
+        let oldSyncTime = Date()
+        let amplitudeUserID = "amplitudeUserID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$amplitudeUserId",
+                                                                                    value: "old_id",
+                                                                                    isSynced: true,
+                                                                                    setTime: oldSyncTime)
+
+        self.subscriberAttributesManager.setAmplitudeUserID(amplitudeUserID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$amplitudeUserId"
+        expect(receivedAttribute.value) == amplitudeUserID
+        expect(receivedAttribute.isSynced) == false
+        expect(receivedAttribute.setTime) > oldSyncTime
+    }
+
+    func testSetAmplitudeUserIDDoesNotSetDeviceIdentifiers() {
+        let amplitudeUserID = "amplitudeUserID"
+        self.subscriberAttributesManager.setAmplitudeUserID(amplitudeUserID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
+
+        checkDeviceIdentifiersAreNotSet()
+    }
+    // endregion
+    // region AmplitudeDeviceID
+    func testSetAmplitudeDeviceID() throws {
+        let amplitudeDeviceID = "amplitudeDeviceID"
+
+        self.subscriberAttributesManager.setAmplitudeDeviceID(amplitudeDeviceID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$amplitudeDeviceId"
+        expect(receivedAttribute.value) == amplitudeDeviceID
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetAmplitudeDeviceIDSetsEmptyIfNil() throws {
+        let amplitudeDeviceID = "amplitudeDeviceID"
+
+        self.subscriberAttributesManager.setAmplitudeDeviceID(amplitudeDeviceID, appUserID: "kratos")
+        self.subscriberAttributesManager.setAmplitudeDeviceID(nil, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 2
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$amplitudeDeviceId"
+        expect(receivedAttribute.value) == ""
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetAmplitudeDeviceIDSkipsIfSameValue() {
+        let amplitudeDeviceID = "amplitudeDeviceID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$amplitudeDeviceId",
+                                                                                    value: amplitudeDeviceID)
+        self.subscriberAttributesManager.setAmplitudeDeviceID(amplitudeDeviceID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 0
+    }
+
+    func testSetAmplitudeDeviceIDOverwritesIfNewValue() throws {
+        let oldSyncTime = Date()
+        let amplitudeDeviceID = "amplitudeDeviceID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$amplitudeDeviceId",
+                                                                                    value: "old_id",
+                                                                                    isSynced: true,
+                                                                                    setTime: oldSyncTime)
+
+        self.subscriberAttributesManager.setAmplitudeDeviceID(amplitudeDeviceID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$amplitudeDeviceId"
+        expect(receivedAttribute.value) == amplitudeDeviceID
+        expect(receivedAttribute.isSynced) == false
+        expect(receivedAttribute.setTime) > oldSyncTime
+    }
+
+    func testSetAmplitudeDeviceIDDoesNotSetDeviceIdentifiers() {
+        let amplitudeDeviceID = "amplitudeDeviceID"
+        self.subscriberAttributesManager.setAmplitudeDeviceID(amplitudeDeviceID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
+
+        checkDeviceIdentifiersAreNotSet()
+    }
+    // endregion
     // region Media source
     func testSetMediaSource() {
         let mediaSource = "mediaSource"


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Adds a convenience method to set the Amplitude User ID ($amplitudeUserId) and Amplitude Device ID ($amplitudeDeviceId)

### Description
Adds a convenience method to set the Amplitude User ID ($amplitudeUserId) and Amplitude Device ID ($amplitudeDeviceId)