### PR TITLE
Fix PurchaseTester crash in Mac Catalyst

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -89,7 +89,7 @@ struct HomeView: View {
                                 Text(policy.label).tag(policy)
                             }
                         }
-                        #if os(iOS)
+                        #if os(iOS) && !targetEnvironment(macCatalyst)
                         .pickerStyle(WheelPickerStyle())
                         .frame(height: 80)
                         #endif


### PR DESCRIPTION
This PR fixes the a crash in the PurchaseTester crashing that was happening when running in Mac Catalyst after the Configure screen due to an issue with Picker APIs
> _TtC7SwiftUIP33_6F6D7FC252FF6BD4B4AE026DA1B1779815UIKitPickerView is not supported when running Catalyst apps in the Mac idiom. See UIBehavioralStyle for possible alternatives.

