### PR TITLE
Fix dynamic type scaling for generic fonts in Paywalls

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -174,6 +174,28 @@ struct TextComponentView_Previews: PreviewProvider {
 
         platformPreview
         .previewDisplayName("Detected Platform")
+        
+        // Dynamic Type
+        TextComponentView(
+            // swiftlint:disable:next force_try
+            viewModel: try! .init(
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("This Text should be larger than normal")
+                    ]
+                ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                component: .init(
+                    text: "id_1",
+                    color: .init(light: .hex("#000000"))
+                )
+            )
+        )
+        .previewRequiredEnvironmentProperties()
+        .dynamicTypeSize(.accessibility1)
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Dynamic Type")
 
         // Markdown
         TextComponentView(

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -174,28 +174,6 @@ struct TextComponentView_Previews: PreviewProvider {
 
         platformPreview
         .previewDisplayName("Detected Platform")
-        
-        // Dynamic Type
-        TextComponentView(
-            // swiftlint:disable:next force_try
-            viewModel: try! .init(
-                localizationProvider: .init(
-                    locale: Locale.current,
-                    localizedStrings: [
-                        "id_1": .string("This Text should be larger than normal")
-                    ]
-                ),
-                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
-                component: .init(
-                    text: "id_1",
-                    color: .init(light: .hex("#000000"))
-                )
-            )
-        )
-        .previewRequiredEnvironmentProperties()
-        .dynamicTypeSize(.accessibility1)
-        .previewLayout(.sizeThatFits)
-        .previewDisplayName("Dynamic Type")
 
         // Markdown
         TextComponentView(

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -272,11 +272,17 @@ enum GenericFont: String {
     func makeFont(fontSize: CGFloat) -> Font {
         switch self {
         case .serif:
-            return Font.system(size: fontSize, weight: .regular, design: .serif)
+            return Font.system(size: UIFontMetrics.default.scaledValue(for: fontSize),
+                               weight: .regular,
+                               design: .serif)
         case .monospace:
-            return Font.system(size: fontSize, weight: .regular, design: .monospaced)
+            return Font.system(size: UIFontMetrics.default.scaledValue(for: fontSize),
+                               weight: .regular,
+                               design: .monospaced)
         case .sansSerif:
-            return Font.system(size: fontSize, weight: .regular, design: .default)
+            return Font.system(size: UIFontMetrics.default.scaledValue(for: fontSize),
+                               weight: .regular,
+                               design: .default)
         }
     }
 


### PR DESCRIPTION
### Motivation
Dynamic Type was not working when a generic font was being used in Paywalls. According to @joshdholtz, dynamic type is supposed to be supported in Paywalls.

### Description
* Update `GenericFont.makeFont` to scale the font size value according to dynamic type.

Note: I tried adding a Swift preview that would test that the scaling is being applied, so we could verify this behavior. But it appears that `UIFontMetrics.default.scaledValue` doesn't work in Swift Previews. 😞 So I'm open to other ideas on how to add testing for this behavior.
