### PR TITLE
Disable restore and sync purchases in Test Store

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -89,6 +89,10 @@ enum PurchaseStrings {
 
     case unable_to_find_root_view_controller_for_test_purchase
     case error_message_for_simulating_test_purchase_failure
+
+    // Test Store
+    case sync_purchases_test_store
+    case restore_purchases_test_store
 }
 
 extension PurchaseStrings: LogMessage {
@@ -348,6 +352,12 @@ extension PurchaseStrings: LogMessage {
 
         case .error_message_for_simulating_test_purchase_failure:
             return "Simulated test purchase failure: no real transaction occurred"
+
+        case .sync_purchases_test_store:
+            return "Syncing purchases not available in test store. Returning current CustomerInfo."
+
+        case .restore_purchases_test_store:
+            return "Restoring purchases not available in test store. Returning current CustomerInfo."
         }
     }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1505,10 +1505,10 @@ private extension PurchasesOrchestrator {
         }
     }
 
-    func syncPurchases(receiptRefreshPolicy: ReceiptRefreshPolicy,
-                       isRestore: Bool,
-                       initiationSource: ProductRequestData.InitiationSource,
-                       completion: (@Sendable (Result<CustomerInfo, PurchasesError>) -> Void)?) {
+    private func syncPurchases(receiptRefreshPolicy: ReceiptRefreshPolicy,
+                               isRestore: Bool,
+                               initiationSource: ProductRequestData.InitiationSource,
+                               completion: (@Sendable (Result<CustomerInfo, PurchasesError>) -> Void)?) {
         self.trackSyncOrRestorePurchasesStartedIfNeeded(receiptRefreshPolicy)
         let startTime = self.dateProvider.now()
         // Don't log anything unless the flag was explicitly set.

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -2082,18 +2082,6 @@ extension PurchasesOrchestrator {
             .mapError(\.asPurchasesError)
             .get()
     }
-
-    func syncPurchases(receiptRefreshPolicy: ReceiptRefreshPolicy,
-                       isRestore: Bool,
-                       initiationSource: ProductRequestData.InitiationSource) async throws -> CustomerInfo {
-        return try await Async.call { completion in
-            self.syncPurchases(receiptRefreshPolicy: receiptRefreshPolicy,
-                               isRestore: isRestore,
-                               initiationSource: initiationSource,
-                               completion: completion)
-        }
-    }
-
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -304,6 +304,17 @@ final class PurchasesOrchestrator {
     }
 
     func restorePurchases(completion: (@Sendable (Result<CustomerInfo, PurchasesError>) -> Void)?) {
+        #if TEST_STORE
+
+        if self.systemInfo.isTestStoreAPIKey {
+            Logger.debug(Strings.purchase.restore_purchases_test_store)
+            self.customerInfoManager.customerInfo(appUserID: self.appUserID, fetchPolicy: .default) { result in
+                completion?(result.mapError({ $0.asPurchasesError }))
+            }
+            return
+        }
+
+        #endif // TEST_STORE
         self.syncPurchases(receiptRefreshPolicy: .always,
                            isRestore: true,
                            initiationSource: .restore,
@@ -311,6 +322,17 @@ final class PurchasesOrchestrator {
     }
 
     func syncPurchases(completion: (@Sendable (Result<CustomerInfo, PurchasesError>) -> Void)? = nil) {
+        #if TEST_STORE
+
+        if self.systemInfo.isTestStoreAPIKey {
+            Logger.debug(Strings.purchase.sync_purchases_test_store)
+            self.customerInfoManager.customerInfo(appUserID: self.appUserID, fetchPolicy: .default) { result in
+                completion?(result.mapError({ $0.asPurchasesError }))
+            }
+            return
+        }
+
+        #endif // TEST_STORE
         self.syncPurchases(receiptRefreshPolicy: .never,
                            isRestore: allowSharingAppStoreAccount,
                            initiationSource: .restore,


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Description
This PR disables the functionality of `restorePurchases` and `syncPurchases` when using a Test Store API key. Instead, the `restorePurchases` and `syncPurchases` APIs just return the Customer Info

### Notes
All of this is implemented under the TEST_STORE compiler flag for now. Trying to restore/sync purchases still keeps the existing implementation regardless of the API key used to configure the SDK.