### PR TITLE
Package component doesn't wrap content in button if there is a purchase button inside of it

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -228,6 +228,7 @@ fileprivate extension ButtonComponentViewModel {
             component: component.stack,
             packageValidator: factory.packageValidator,
             firstImageInfo: nil,
+            purchaseButtonCollector: nil,
             localizationProvider: localizationProvider,
             uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
             offering: offering

--- a/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentViewModel.swift
@@ -23,11 +23,13 @@ class PackageComponentViewModel {
     let promotionalOfferProductCode: String?
     let package: Package?
     let stackViewModel: StackComponentViewModel
+    let hasPurchaseButton: Bool
 
     init(
         component: PaywallComponent.PackageComponent,
         offering: Offering,
-        stackViewModel: StackComponentViewModel
+        stackViewModel: StackComponentViewModel,
+        hasPurchaseButton: Bool
     ) {
         self.isSelectedByDefault = component.isSelectedByDefault
         self.promotionalOfferProductCode = component.applePromoOfferProductCode
@@ -38,6 +40,7 @@ class PackageComponentViewModel {
         }
 
         self.stackViewModel = stackViewModel
+        self.hasPurchaseButton = hasPurchaseButton
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -281,6 +281,7 @@ fileprivate extension PurchaseButtonComponentViewModel {
             component: component.stack,
             packageValidator: factory.packageValidator,
             firstImageInfo: nil,
+            purchaseButtonCollector: nil,
             localizationProvider: localizationProvider,
             uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
             offering: offering

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -17,6 +17,12 @@ import RevenueCat
 
 #if !os(macOS) && !os(tvOS) // For Paywalls V2
 
+class PurchaseButtonCollector {
+
+    var hasPurchaseButton = false
+
+}
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 // swiftlint:disable:next type_body_length
 struct ViewModelFactory {
@@ -35,6 +41,7 @@ struct ViewModelFactory {
             component: componentsConfig.stack,
             packageValidator: self.packageValidator,
             firstImageInfo: firstImageInfo,
+            purchaseButtonCollector: nil,
             localizationProvider: localizationProvider,
             uiConfigProvider: uiConfigProvider,
             offering: offering
@@ -45,6 +52,7 @@ struct ViewModelFactory {
                 component: $0.stack,
                 packageValidator: self.packageValidator,
                 firstImageInfo: nil,
+                purchaseButtonCollector: nil,
                 localizationProvider: localizationProvider,
                 uiConfigProvider: uiConfigProvider,
                 offering: offering
@@ -68,6 +76,7 @@ struct ViewModelFactory {
         component: PaywallComponent,
         packageValidator: PackageValidator,
         firstImageInfo: RootViewModel.FirstImageInfo?,
+        purchaseButtonCollector: PurchaseButtonCollector? = nil,
         offering: Offering,
         localizationProvider: LocalizationProvider,
         uiConfigProvider: UIConfigProvider
@@ -103,6 +112,7 @@ struct ViewModelFactory {
                     component: component,
                     packageValidator: packageValidator,
                     firstImageInfo: firstImageInfo,
+                    purchaseButtonCollector: purchaseButtonCollector,
                     localizationProvider: localizationProvider,
                     uiConfigProvider: uiConfigProvider,
                     offering: offering
@@ -113,6 +123,7 @@ struct ViewModelFactory {
                 component: component.stack,
                 packageValidator: packageValidator,
                 firstImageInfo: firstImageInfo,
+                purchaseButtonCollector: purchaseButtonCollector,
                 localizationProvider: localizationProvider,
                 uiConfigProvider: uiConfigProvider,
                 offering: offering
@@ -125,6 +136,7 @@ struct ViewModelFactory {
                     component: sheet.stack,
                     packageValidator: packageValidator,
                     firstImageInfo: nil,
+                    purchaseButtonCollector: purchaseButtonCollector,
                     localizationProvider: localizationProvider,
                     uiConfigProvider: uiConfigProvider,
                     offering: offering
@@ -141,19 +153,27 @@ struct ViewModelFactory {
                 )
             )
         case .package(let component):
+            // Specifically override the parent PurchaseButtonCollector so that
+            // we can see if the package has a purchase button inside of it
+            let packagePurchaseButtonCollector = PurchaseButtonCollector()
+
             let stackViewModel = try toStackViewModel(
                 component: component.stack,
                 packageValidator: packageValidator,
                 firstImageInfo: firstImageInfo,
+                purchaseButtonCollector: packagePurchaseButtonCollector,
                 localizationProvider: localizationProvider,
                 uiConfigProvider: uiConfigProvider,
                 offering: offering
             )
 
+            let hasPurchaseButton = packagePurchaseButtonCollector.hasPurchaseButton
+
             let viewModel = PackageComponentViewModel(
                 component: component,
                 offering: offering,
-                stackViewModel: stackViewModel
+                stackViewModel: stackViewModel,
+                hasPurchaseButton: hasPurchaseButton
             )
 
             if let package = viewModel.package {
@@ -167,10 +187,14 @@ struct ViewModelFactory {
 
             return .package(viewModel)
         case .purchaseButton(let component):
+            // Set hasPurchaseButton if the parent cares about it
+            purchaseButtonCollector?.hasPurchaseButton = true
+
             let stackViewModel = try toStackViewModel(
                 component: component.stack,
                 packageValidator: packageValidator,
                 firstImageInfo: firstImageInfo,
+                purchaseButtonCollector: purchaseButtonCollector,
                 localizationProvider: localizationProvider,
                 uiConfigProvider: uiConfigProvider,
                 offering: offering
@@ -189,6 +213,7 @@ struct ViewModelFactory {
                 component: component.stack,
                 packageValidator: packageValidator,
                 firstImageInfo: firstImageInfo,
+                purchaseButtonCollector: purchaseButtonCollector,
                 localizationProvider: localizationProvider,
                 uiConfigProvider: uiConfigProvider,
                 offering: offering
@@ -238,6 +263,7 @@ struct ViewModelFactory {
                 component: component.control.stack,
                 packageValidator: packageValidator,
                 firstImageInfo: firstImageInfo,
+                purchaseButtonCollector: purchaseButtonCollector,
                 localizationProvider: localizationProvider,
                 uiConfigProvider: uiConfigProvider,
                 offering: offering
@@ -284,6 +310,7 @@ struct ViewModelFactory {
                 component: tabsStackComponent,
                 packageValidator: PackageValidator(),
                 firstImageInfo: firstImageInfo,
+                purchaseButtonCollector: purchaseButtonCollector,
                 localizationProvider: localizationProvider,
                 uiConfigProvider: uiConfigProvider,
                 offering: offering
@@ -296,6 +323,7 @@ struct ViewModelFactory {
                     component: tab.stack,
                     packageValidator: tabPackageValidator,
                     firstImageInfo: firstImageInfo,
+                    purchaseButtonCollector: purchaseButtonCollector,
                     localizationProvider: localizationProvider,
                     uiConfigProvider: uiConfigProvider,
                     offering: offering
@@ -335,6 +363,7 @@ struct ViewModelFactory {
                 component: component.stack,
                 packageValidator: packageValidator,
                 firstImageInfo: firstImageInfo,
+                purchaseButtonCollector: purchaseButtonCollector,
                 localizationProvider: localizationProvider,
                 uiConfigProvider: uiConfigProvider,
                 offering: offering
@@ -360,6 +389,7 @@ struct ViewModelFactory {
                     component: stackComponent,
                     packageValidator: packageValidator,
                     firstImageInfo: firstImageInfo,
+                    purchaseButtonCollector: purchaseButtonCollector,
                     localizationProvider: localizationProvider,
                     uiConfigProvider: uiConfigProvider,
                     offering: offering
@@ -382,6 +412,7 @@ struct ViewModelFactory {
         component: PaywallComponent.StackComponent,
         packageValidator: PackageValidator,
         firstImageInfo: RootViewModel.FirstImageInfo?,
+        purchaseButtonCollector: PurchaseButtonCollector?,
         localizationProvider: LocalizationProvider,
         uiConfigProvider: UIConfigProvider,
         offering: Offering
@@ -391,6 +422,7 @@ struct ViewModelFactory {
                 component: component,
                 packageValidator: packageValidator,
                 firstImageInfo: firstImageInfo,
+                purchaseButtonCollector: purchaseButtonCollector,
                 offering: offering,
                 localizationProvider: localizationProvider,
                 uiConfigProvider: uiConfigProvider
@@ -402,6 +434,8 @@ struct ViewModelFactory {
                 component: component,
                 packageValidator: packageValidator,
                 firstImageInfo: firstImageInfo,
+                // Explicitly not looking for purchase button in badge
+                purchaseButtonCollector: nil,
                 offering: offering,
                 localizationProvider: localizationProvider,
                 uiConfigProvider: uiConfigProvider


### PR DESCRIPTION
## Summary
- Modified PackageComponentView to conditionally wrap content in a Button based on whether it contains a purchase button
- Added PurchaseButtonCollector to track presence of purchase buttons within components
- Updated ViewModelFactory to propagate purchase button detection through component hierarchy
- Package components with purchase buttons no longer get wrapped in an additional button layer

## Changes
- Added `PurchaseButtonCollector` class to track purchase button presence
- Modified `PackageComponentViewModel` to include `hasPurchaseButton` property
- Updated `PackageComponentView` to conditionally apply button wrapper based on purchase button presence
- Propagated purchase button collector through all component view model creation methods

## Test plan
- [ ] Verify packages without purchase buttons still function as clickable selectors
- [ ] Verify packages with purchase buttons don't have double button wrapping
- [ ] Test package selection behavior in various paywall configurations
- [ ] Ensure accessibility is maintained for both scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)