### PR TITLE
Jzdesign/attempt to make package with button clearer

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
@@ -38,28 +38,44 @@ struct PackageComponentView: View {
 
     var body: some View {
         if let package = self.viewModel.package {
-            Button {
-                // Updating package with same variable context
-                // This will be needed when different sets of packages
-                // in different tiers
-                self.packageContext.update(
-                    package: package,
-                    variableContext: self.packageContext.variableContext
-                )
-            } label: {
+            if viewModel.isSelectable {
+                Button {
+                    // Updating package with same variable context
+                    // This will be needed when different sets of packages
+                    // in different tiers
+                    self.packageContext.update(
+                        package: package,
+                        variableContext: self.packageContext.variableContext
+                    )
+                } label: {
+                    StackComponentView(
+                        viewModel: self.viewModel.stackViewModel,
+                        onDismiss: self.onDismiss
+                    )
+                    .environment(\.componentViewState, componentViewState)
+                    // Overrides the existing PackageContext
+                    .environmentObject(PackageContext(
+                        // This is needed so text component children use this
+                        // package and not selected package for processing variables
+                        package: package,
+                        // However, reusing the same package variable context from parent
+                        variableContext: packageContext.variableContext)
+                    )
+                }
+            } else {
                 StackComponentView(
-                    viewModel: self.viewModel.stackViewModel,
-                    onDismiss: self.onDismiss
-                )
-                .environment(\.componentViewState, componentViewState)
-                // Overrides the existing PackageContext
-                .environmentObject(PackageContext(
-                    // This is needed so text component children use this
-                    // package and not selected package for processing variables
-                    package: package,
-                    // However, reusing the same package variable context from parent
-                    variableContext: packageContext.variableContext)
-                )
+                        viewModel: self.viewModel.stackViewModel,
+                        onDismiss: self.onDismiss
+                    )
+                    .environment(\.componentViewState, componentViewState)
+                    // Overrides the existing PackageContext
+                    .environmentObject(PackageContext(
+                        // This is needed so text component children use this
+                        // package and not selected package for processing variables
+                        package: package,
+                        // However, reusing the same package variable context from parent
+                        variableContext: packageContext.variableContext)
+                    )
             }
         } else {
             EmptyView()

--- a/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
@@ -36,6 +36,22 @@ struct PackageComponentView: View {
         return selectedPackage.identifier == package.identifier ? .selected : .default
     }
 
+    private func stack(_ package: Package) -> some View {
+        StackComponentView(
+            viewModel: self.viewModel.stackViewModel,
+            onDismiss: self.onDismiss
+        )
+        .environment(\.componentViewState, componentViewState)
+        // Overrides the existing PackageContext
+        .environmentObject(PackageContext(
+            // This is needed so text component children use this
+            // package and not selected package for processing variables
+            package: package,
+            // However, reusing the same package variable context from parent
+            variableContext: packageContext.variableContext)
+        )
+    }
+    
     var body: some View {
         if let package = self.viewModel.package {
             if viewModel.isSelectable {
@@ -48,34 +64,10 @@ struct PackageComponentView: View {
                         variableContext: self.packageContext.variableContext
                     )
                 } label: {
-                    StackComponentView(
-                        viewModel: self.viewModel.stackViewModel,
-                        onDismiss: self.onDismiss
-                    )
-                    .environment(\.componentViewState, componentViewState)
-                    // Overrides the existing PackageContext
-                    .environmentObject(PackageContext(
-                        // This is needed so text component children use this
-                        // package and not selected package for processing variables
-                        package: package,
-                        // However, reusing the same package variable context from parent
-                        variableContext: packageContext.variableContext)
-                    )
+                    stack(package)
                 }
             } else {
-                StackComponentView(
-                        viewModel: self.viewModel.stackViewModel,
-                        onDismiss: self.onDismiss
-                    )
-                    .environment(\.componentViewState, componentViewState)
-                    // Overrides the existing PackageContext
-                    .environmentObject(PackageContext(
-                        // This is needed so text component children use this
-                        // package and not selected package for processing variables
-                        package: package,
-                        // However, reusing the same package variable context from parent
-                        variableContext: packageContext.variableContext)
-                    )
+                stack(package)
             }
         } else {
             EmptyView()

--- a/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentViewModel.swift
@@ -19,6 +19,7 @@ import Foundation
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class PackageComponentViewModel {
 
+    let isSelectable: Bool
     let isSelectedByDefault: Bool
     let promotionalOfferProductCode: String?
     let package: Package?
@@ -29,6 +30,7 @@ class PackageComponentViewModel {
         offering: Offering,
         stackViewModel: StackComponentViewModel
     ) {
+        self.isSelectable = component.isSelectable
         self.isSelectedByDefault = component.isSelectedByDefault
         self.promotionalOfferProductCode = component.applePromoOfferProductCode
 

--- a/Sources/Paywalls/Components/PaywallPackageComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPackageComponent.swift
@@ -17,22 +17,25 @@ import Foundation
 
 public extension PaywallComponent {
 
-    final class PackageComponent: PaywallComponentBase {
+    final class PackageComponent: PaywallComponentBase, @unchecked Sendable {
 
         let type: ComponentType
         public let packageID: String
         public let isSelectedByDefault: Bool
+        public private(set) var isSelectable: Bool = true
         @_spi(Internal) public let applePromoOfferProductCode: String?
         public let stack: PaywallComponent.StackComponent
 
         public init(
             packageID: String,
+            isSelectable: Bool,
             isSelectedByDefault: Bool,
             applePromoOfferProductCode: String?,
             stack: PaywallComponent.StackComponent
         ) {
             self.type = .package
             self.packageID = packageID
+            self.isSelectable = isSelectable
             self.isSelectedByDefault = isSelectedByDefault
             self.applePromoOfferProductCode = applePromoOfferProductCode
             self.stack = stack
@@ -41,6 +44,7 @@ public extension PaywallComponent {
         public func hash(into hasher: inout Hasher) {
             hasher.combine(type)
             hasher.combine(packageID)
+            hasher.combine(isSelectable)
             hasher.combine(isSelectedByDefault)
             hasher.combine(applePromoOfferProductCode)
             hasher.combine(stack)


### PR DESCRIPTION
This is more along the lines of what I'm thinking for this kind of change. The intent is clear at initialization instead of down the chain, it's also less likely to cause grief in a Swift 6 context since we won't be modifying a reference type. 

This was a quickly thrown together, and I'm new here, so I still have to get things totally figured out with Tuist and Fastlane to  test it.