### PR TITLE
Make TrialOrIntroEligibilityChecker @_spi public

### DIFF
--- a/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker.swift
+++ b/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker.swift
@@ -13,6 +13,7 @@
 
 import Foundation
 import RevenueCat
+import Combine
 
 @_spi(Internal) public final class TrialOrIntroEligibilityChecker: ObservableObject {
 

--- a/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker.swift
+++ b/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker.swift
@@ -14,9 +14,9 @@
 import Foundation
 import RevenueCat
 
-final class TrialOrIntroEligibilityChecker: ObservableObject {
+@_spi(Internal) public final class TrialOrIntroEligibilityChecker: ObservableObject {
 
-    typealias Checker = @Sendable ([Package]) async -> [Package: IntroEligibilityStatus]
+    @_spi(Internal) public typealias Checker = @Sendable ([Package]) async -> [Package: IntroEligibilityStatus]
 
     /// `false` if this `TrialOrIntroEligibilityChecker` is not backend by a configured `Purchases`instance.
     let isConfigured: Bool
@@ -31,7 +31,7 @@ final class TrialOrIntroEligibilityChecker: ObservableObject {
     }
 
     /// Creates an instance with a custom checker, useful for testing or previews.
-    init(isConfigured: Bool = true, checker: @escaping Checker) {
+    @_spi(Internal) public init(isConfigured: Bool = true, checker: @escaping Checker) {
         self.isConfigured = isConfigured
         self.checker = checker
     }

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -123,7 +123,7 @@ public struct PaywallView: View {
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
         useDraftPaywall: Bool,
-        introEligibility: TrialOrIntroEligibilityChecker = .default(),
+        introEligibility: TrialOrIntroEligibilityChecker? = nil,
         performPurchase: PerformPurchase? = nil,
         performRestore: PerformRestore? = nil
     ) {

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -123,6 +123,7 @@ public struct PaywallView: View {
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
         useDraftPaywall: Bool,
+        introEligibility: TrialOrIntroEligibilityChecker = .default(),
         performPurchase: PerformPurchase? = nil,
         performRestore: PerformRestore? = nil
     ) {
@@ -134,6 +135,7 @@ public struct PaywallView: View {
                 fonts: fonts,
                 displayCloseButton: displayCloseButton,
                 useDraftPaywall: useDraftPaywall,
+                introEligibility: introEligibility,
                 purchaseHandler: purchaseHandler
             )
         )


### PR DESCRIPTION
In order to allow previewing intro trials in Paywall Previews in the RC app, we need to allow the app to inject its own `TrialOrIntroEligibilityChecker`. That's why we're making `TrialOrIntroEligibilityChecker` `@_spi` public
