### PR TITLE
fix non-renewable appstore PATHs for customer center

### DIFF
--- a/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
@@ -43,11 +43,11 @@ extension Array<CustomerCenterConfigData.HelpPath> {
 
             if $0.type == .cancel {
                 // don't show cancel if there's no URL
-                if isNonAppStorePurchase && purchaseInformation.managementURL == nil {
-                     return false
+                if isNonAppStorePurchase {
+                    return purchaseInformation.managementURL != nil
                 }
 
-                return purchaseInformation.isSubscription
+                return purchaseInformation.isAppStoreRenewableSubscription
                     && !purchaseInformation.isCancelled
                     && purchaseInformation.renewalDate != nil
             }
@@ -62,9 +62,10 @@ extension Array<CustomerCenterConfigData.HelpPath> {
             let refundWindowIsValid = $0.refundWindowDuration?.isWithin(purchaseInformation) ?? true
 
             // can't change plans if it's not a subscription
-            if $0.type == .changePlans &&
-                (!purchaseInformation.isSubscription || purchaseInformation.isLifetime) {
-                return false
+            if $0.type == .changePlans {
+                if !purchaseInformation.isAppStoreRenewableSubscription || purchaseInformation.isLifetime {
+                    return false
+                }
             }
 
             return (!isRefund || isRefundEligible) && refundWindowIsValid

--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation+Mock.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation+Mock.swift
@@ -29,6 +29,7 @@ extension PurchaseInformation {
         productIdentifier: String = "com.revenuecat.pro",
         store: Store = .appStore,
         isSubscription: Bool = false,
+        productType: StoreProduct.ProductType? = nil,
         isTrial: Bool = false,
         isCancelled: Bool = false,
         isExpired: Bool = false,
@@ -57,6 +58,7 @@ extension PurchaseInformation {
             productIdentifier: productIdentifier,
             store: store,
             isSubscription: isSubscription,
+            productType: productType,
             isTrial: isTrial,
             isCancelled: isCancelled,
             isExpired: isExpired,
@@ -85,18 +87,19 @@ extension PurchaseInformation {
         renewalPrice: .nonFree("$4.99"),
         store: .appStore,
         isSubscription: true,
+        productType: .autoRenewableSubscription,
         isCancelled: false,
         expirationDate: nil,
         renewalDate: Self.defaulRenewalDate
     )
 
     static let expired = PurchaseInformation.mock(
-
         pricePaid: .nonFree("$4.99"),
         renewalPrice: .nonFree("$4.99"),
         productIdentifier: "product_id_expired",
         store: .appStore,
         isSubscription: true,
+        productType: .autoRenewableSubscription,
         isExpired: true,
         expirationDate: Self.defaultExpirationDate,
         renewalDate: nil
@@ -107,6 +110,7 @@ extension PurchaseInformation {
         pricePaid: .nonFree("$4.99"),
         productIdentifier: "product_id_lifetime",
         isSubscription: true,
+        productType: .nonConsumable,
         expirationDate: nil,
         renewalDate: nil,
         isLifetime: true
@@ -130,6 +134,7 @@ extension PurchaseInformation {
         productIdentifier: "product_id",
         store: .appStore,
         isSubscription: false,
+        productType: .consumable,
         isExpired: false,
         isSandbox: false,
         managementURL: URL(string: "https://www.revenuecat.com"),

--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -40,8 +40,11 @@ struct PurchaseInformation {
     /// The store from which the purchase was made (e.g., App Store, Play Store).
     let store: Store
 
-    /// Indicates whether the purchase is a subscription or not.
+    /// Indicates whether the purchase is a subscription (renewable or non-renewable).
     let isSubscription: Bool
+
+    /// The product type from StoreKit (autoRenewableSubscription, nonRenewableSubscription, etc.)
+    let productType: StoreProduct.ProductType?
 
     /// Indicates whether the purchase is under a trial period.
     /// - `true` for purchases within the trial period.
@@ -135,6 +138,7 @@ struct PurchaseInformation {
          productIdentifier: String,
          store: Store,
          isSubscription: Bool,
+         productType: StoreProduct.ProductType?,
          isTrial: Bool,
          isCancelled: Bool,
          isExpired: Bool,
@@ -165,6 +169,7 @@ struct PurchaseInformation {
         self.productIdentifier = productIdentifier
         self.store = store
         self.isSubscription = isSubscription
+        self.productType = productType
         self.isTrial = isTrial
         self.isCancelled = isCancelled
         self.isSandbox = isSandbox
@@ -215,7 +220,10 @@ struct PurchaseInformation {
 
         self.customerInfoRequestedDate = customerInfoRequestedDate
         self.managementURL = managementURL
-        self.isSubscription = transaction.isSubscrition && transaction.store != .promotional
+        self.isSubscription = transaction.isSubscrition
+            && transaction.store != .promotional
+        self.productType = subscribedProduct?.productType
+
         self.isLifetime = subscribedProduct?.productType == .nonConsumable
 
         // Use entitlement data if available, otherwise derive from transaction
@@ -318,6 +326,7 @@ extension PurchaseInformation: Hashable {
         hasher.combine(productIdentifier)
         hasher.combine(store)
         hasher.combine(isSubscription)
+        hasher.combine(productType)
         hasher.combine(isCancelled)
         hasher.combine(latestPurchaseDate)
         hasher.combine(customerInfoRequestedDate)
@@ -539,6 +548,10 @@ extension PurchaseInformation {
 }
 
 extension PurchaseInformation {
+
+    var isAppStoreRenewableSubscription: Bool {
+        return productType == .autoRenewableSubscription && store == .appStore
+    }
 
     var storeLocalizationKey: CCLocalizedString {
         switch store {

--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -220,7 +220,7 @@ struct PurchaseInformation {
 
         self.customerInfoRequestedDate = customerInfoRequestedDate
         self.managementURL = managementURL
-        self.isSubscription = transaction.isSubscrition
+        self.isSubscription = transaction.isSubscription
             && transaction.store != .promotional
         self.productType = subscribedProduct?.productType
 

--- a/RevenueCatUI/CustomerCenter/Data/Transaction.swift
+++ b/RevenueCatUI/CustomerCenter/Data/Transaction.swift
@@ -32,7 +32,7 @@ protocol Transaction {
     var identifier: String? { get }
     var isSandbox: Bool { get }
     var originalPurchaseDate: Date? { get }
-    var isSubscrition: Bool { get }
+    var isSubscription: Bool { get }
 }
 
 enum TransactionType {
@@ -75,7 +75,7 @@ enum TransactionType {
         nil
     }
 
-    var isSubscrition: Bool {
+    var isSubscription: Bool {
         true
     }
 }
@@ -126,7 +126,7 @@ extension NonSubscriptionTransaction: Transaction {
         nil
     }
 
-    var isSubscrition: Bool {
+    var isSubscription: Bool {
         false
     }
 }

--- a/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
@@ -90,7 +90,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: false
+            isSubscription: false
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -152,7 +152,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfoNullable = await PurchaseInformation.purchaseInformationUsingRenewalInfo(
@@ -211,7 +211,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfoNullable = await PurchaseInformation.purchaseInformationUsingRenewalInfo(
@@ -271,7 +271,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfoNullable = await PurchaseInformation.purchaseInformationUsingRenewalInfo(
@@ -329,7 +329,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfoNullable = await PurchaseInformation.purchaseInformationUsingRenewalInfo(
@@ -375,7 +375,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -420,7 +420,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -465,7 +465,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -510,7 +510,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -556,7 +556,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -602,7 +602,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -647,7 +647,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -692,7 +692,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -737,7 +737,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -782,7 +782,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -827,7 +827,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -872,7 +872,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -917,7 +917,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -962,7 +962,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -1004,7 +1004,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(
@@ -1047,7 +1047,7 @@ final class PurchaseInformationTests: TestCase {
             periodType: .normal,
             purchaseDate: Date(),
             isSandbox: false,
-            isSubscrition: true
+            isSubscription: true
         )
 
         let subscriptionInfo = try XCTUnwrap(

--- a/Tests/RevenueCatUITests/Mocks/MockTransaction.swift
+++ b/Tests/RevenueCatUITests/Mocks/MockTransaction.swift
@@ -33,5 +33,5 @@ struct MockTransaction: Transaction {
     var identifier: String?
     var originalPurchaseDate: Date?
     var isSandbox: Bool
-    var isSubscrition: Bool
+    var isSubscription: Bool
 }


### PR DESCRIPTION
### Motivation
We've got a zendesk report for a non-renewable appstore transaction. We were showing CANCEL, even though it's not cancellable. This also applies for change plans.

### Description
- Store productType only for appstore products
- Update PATH logic
