### PR TITLE
Extend appTarget settings to pass custom settings

### DIFF
--- a/Examples/testCustomEntitlementsComputation/Project.swift
+++ b/Examples/testCustomEntitlementsComputation/Project.swift
@@ -38,7 +38,11 @@ let project = Project(
                 .revenueCat,
                 .revenueCatUI,
             ],
-            settings: .appTarget
+            settings: .appTarget(including: [
+                    "APPLICATION_EXTENSION_API_ONLY": "YES",
+                    "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION"
+                ]
+            )
         )
     ],
 )

--- a/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation.xcodeproj/project.pbxproj
+++ b/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -234,6 +234,7 @@
 		307B9D6AEF6EED4E56F5F658 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				INFOPLIST_FILE = "Derived/InfoPlists/testCustomEntitlementsComputation-Info.plist";
@@ -248,10 +249,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-					"$(inherited)",
-					DEBUG,
-				);
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION DEBUG";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -261,6 +259,7 @@
 		3634D661A8E0A97836805213 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				INFOPLIST_FILE = "Derived/InfoPlists/testCustomEntitlementsComputation-Info.plist";
@@ -275,6 +274,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Tuist/ProjectDescriptionHelpers/Settings.swift
+++ b/Tuist/ProjectDescriptionHelpers/Settings.swift
@@ -22,13 +22,18 @@ extension Settings {
     /// This provides a standardized target settings configuration that includes:
     /// - User script sandboxing enabled for security
     /// - Essential default settings for optimal build performance
-    public static var appTarget: Settings {
+    public static func appTarget(including extra: SettingsDictionary) -> Settings {
         return .settings(
             base: [
                 "ENABLE_USER_SCRIPT_SANDBOXING": "YES"
-            ],
+            ]
+            .merging(extra),
             defaultSettings: .essential
         )
+    }
+
+    public static var appTarget: Settings {
+        return .appTarget(including: [:])
     }
 
     /// Default framework settings configuration for RevenueCat projects.


### PR DESCRIPTION
### Motivation
While going through the tuist set up once again, I noticed that `testCustomEntitlementsComputation` a project to test `RevenueCat_CustomEntitlementComputation` didn't have the settings.

### Description
- Extend `appTarget` to receive extra settingsDictionary
- Tweak `testCustomEntitlementsComputation` to include it for the only target it has
