### PR TITLE
Paywall video component model creation -- Not views, just models

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		16DA8EC92E4EE24100283940 /* JsonLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DA8EC82E4EE24100283940 /* JsonLoader.swift */; };
 		16DA8ECD2E4EE33700283940 /* ImageComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DA8ECC2E4EE33700283940 /* ImageComponentTests.swift */; };
 		16DA8EDF2E4F6A6600283940 /* PaywallVideoComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DA8EDE2E4F6A6600283940 /* PaywallVideoComponent.swift */; };
+		16DA8EF42E4F7A2500283940 /* VideoComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DA8EF32E4F7A2500283940 /* VideoComponentTests.swift */; };
 		1E2F911B2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */; };
 		1E2F91722CCFA98C00BDB016 /* WebRedemptionStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2F91712CCFA98C00BDB016 /* WebRedemptionStrings.swift */; };
 		1E42CC6C2D7F1A0500E0EE8D /* CacheStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E42CC6B2D7F1A0500E0EE8D /* CacheStatus.swift */; };
@@ -1510,6 +1511,7 @@
 		16DA8EC82E4EE24100283940 /* JsonLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonLoader.swift; sourceTree = "<group>"; };
 		16DA8ECC2E4EE33700283940 /* ImageComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageComponentTests.swift; sourceTree = "<group>"; };
 		16DA8EDE2E4F6A6600283940 /* PaywallVideoComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallVideoComponent.swift; sourceTree = "<group>"; };
+		16DA8EF32E4F7A2500283940 /* VideoComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoComponentTests.swift; sourceTree = "<group>"; };
 		1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactSupportUtilitiesTests.swift; sourceTree = "<group>"; };
 		1E2F91712CCFA98C00BDB016 /* WebRedemptionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRedemptionStrings.swift; sourceTree = "<group>"; };
 		1E42CC6B2D7F1A0500E0EE8D /* CacheStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStatus.swift; sourceTree = "<group>"; };
@@ -3068,6 +3070,7 @@
 				038213DA2DD4979A003C02C3 /* PurchaseButtonComponentTests.swift */,
 				2C8EC6DE2CCD27A100D6CCF8 /* PartialComponentTests.swift */,
 				16DA8ECC2E4EE33700283940 /* ImageComponentTests.swift */,
+				16DA8EF32E4F7A2500283940 /* VideoComponentTests.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -7083,6 +7086,7 @@
 				2DDF41E624F6F5DC005BC22D /* MockSK1Product.swift in Sources */,
 				351B51BA26D450E800BD2BD7 /* ProductRequestDataExtensions.swift in Sources */,
 				57E6C27E29723F9E001AFE98 /* SigningTests.swift in Sources */,
+				16DA8EF42E4F7A2500283940 /* VideoComponentTests.swift in Sources */,
 				574A2F3F282D75E300150D40 /* OfferingsDecodingTests.swift in Sources */,
 				35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift in Sources */,
 				03A98D322D2441B8009BCA61 /* PaywallDataDecodingTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -55,6 +55,8 @@
 		03F446262D2FE1510046129A /* MaskShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */; };
 		03F446552D303E350046129A /* PaddingPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446542D303E350046129A /* PaddingPropertyTests.swift */; };
 		03F446572D303FA10046129A /* CornerRadiusesPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446562D303FA10046129A /* CornerRadiusesPropertyTests.swift */; };
+		16DA8EC92E4EE24100283940 /* JsonLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DA8EC82E4EE24100283940 /* JsonLoader.swift */; };
+		16DA8ECD2E4EE33700283940 /* ImageComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DA8ECC2E4EE33700283940 /* ImageComponentTests.swift */; };
 		1E2F911B2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */; };
 		1E2F91722CCFA98C00BDB016 /* WebRedemptionStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2F91712CCFA98C00BDB016 /* WebRedemptionStrings.swift */; };
 		1E42CC6C2D7F1A0500E0EE8D /* CacheStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E42CC6B2D7F1A0500E0EE8D /* CacheStatus.swift */; };
@@ -1504,6 +1506,8 @@
 		03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskShapePropertyTests.swift; sourceTree = "<group>"; };
 		03F446542D303E350046129A /* PaddingPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingPropertyTests.swift; sourceTree = "<group>"; };
 		03F446562D303FA10046129A /* CornerRadiusesPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerRadiusesPropertyTests.swift; sourceTree = "<group>"; };
+		16DA8EC82E4EE24100283940 /* JsonLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonLoader.swift; sourceTree = "<group>"; };
+		16DA8ECC2E4EE33700283940 /* ImageComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageComponentTests.swift; sourceTree = "<group>"; };
 		1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactSupportUtilitiesTests.swift; sourceTree = "<group>"; };
 		1E2F91712CCFA98C00BDB016 /* WebRedemptionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRedemptionStrings.swift; sourceTree = "<group>"; };
 		1E42CC6B2D7F1A0500E0EE8D /* CacheStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStatus.swift; sourceTree = "<group>"; };
@@ -2710,6 +2714,10 @@
 		FECF627761D375C8431EB866 /* StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProduct.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		16DA8ECF2E4EE5F200283940 /* JSON */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = JSON; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		2DAC5F6F26F13C9800C5258F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -2925,6 +2933,13 @@
 			path = Properties;
 			sourceTree = "<group>";
 		};
+		16DA8EC72E4EE22A00283940 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		1E8A60402CDBD73E0034ACF3 /* WebPurchaseRedemption */ = {
 			isa = PBXGroup;
 			children = (
@@ -3040,6 +3055,9 @@
 		2C8EC6AD2CCBD33800D6CCF8 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				16DA8ECF2E4EE5F200283940 /* JSON */,
+				16DA8EC82E4EE24100283940 /* JsonLoader.swift */,
+				16DA8EC72E4EE22A00283940 /* Helpers */,
 				03F446222D2FE0B90046129A /* Properties */,
 				03F446202D2F73210046129A /* StackComponentTests.swift */,
 				03C7305A2D35985500297FEC /* TextComponentTests.swift */,
@@ -3047,6 +3065,7 @@
 				2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */,
 				038213DA2DD4979A003C02C3 /* PurchaseButtonComponentTests.swift */,
 				2C8EC6DE2CCD27A100D6CCF8 /* PartialComponentTests.swift */,
+				16DA8ECC2E4EE33700283940 /* ImageComponentTests.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -5840,6 +5859,9 @@
 				2DC5622124EC63430031F69B /* PBXTargetDependency */,
 				2DFF6C55270CA11400ECAFAB /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				16DA8ECF2E4EE5F200283940 /* JSON */,
+			);
 			name = UnitTests;
 			packageProductDependencies = (
 				2D803F6226F144830069D717 /* Nimble */,
@@ -6952,6 +6974,7 @@
 				FD18BF4C2DF0DA5400140FD6 /* MockVirtualCurrencyManager.swift in Sources */,
 				B300E4C026D4371200B22262 /* SKPaymentTransactionExtensionsTests.swift in Sources */,
 				2DDF41C924F6F4C3005BC22D /* UInt8+ExtensionsTests.swift in Sources */,
+				16DA8ECD2E4EE33700283940 /* ImageComponentTests.swift in Sources */,
 				2D4D6AF524F717B800B656BE /* ContainerFactory.swift in Sources */,
 				75A0E7922E3D205C00A60BD5 /* MockTestStorePurchaseUI.swift in Sources */,
 				4F2A91D82B05675B00FED622 /* MockStoreMessagesHelper.swift in Sources */,
@@ -7153,6 +7176,7 @@
 				574A2F4F282D7B9E00150D40 /* PostOfferDecodingTests.swift in Sources */,
 				2DDF41CE24F6F4C3005BC22D /* InAppPurchaseBuilderTests.swift in Sources */,
 				573A10DB2800AF4700F976E5 /* PurchaseErrorTests.swift in Sources */,
+				16DA8EC92E4EE24100283940 /* JsonLoader.swift in Sources */,
 				FDC892D22CCAD0EE000AEB9F /* MockStoreKit2PurchaseIntentListener.swift in Sources */,
 				1EFA950D2CDB6B6500CA5951 /* BackendPostRedeemWebPurchaseTests.swift in Sources */,
 				35C05DC82BC8510000109308 /* DiagnosticsTrackerTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		03F446572D303FA10046129A /* CornerRadiusesPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446562D303FA10046129A /* CornerRadiusesPropertyTests.swift */; };
 		16DA8EC92E4EE24100283940 /* JsonLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DA8EC82E4EE24100283940 /* JsonLoader.swift */; };
 		16DA8ECD2E4EE33700283940 /* ImageComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DA8ECC2E4EE33700283940 /* ImageComponentTests.swift */; };
+		16DA8EDF2E4F6A6600283940 /* PaywallVideoComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DA8EDE2E4F6A6600283940 /* PaywallVideoComponent.swift */; };
 		1E2F911B2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */; };
 		1E2F91722CCFA98C00BDB016 /* WebRedemptionStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2F91712CCFA98C00BDB016 /* WebRedemptionStrings.swift */; };
 		1E42CC6C2D7F1A0500E0EE8D /* CacheStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E42CC6B2D7F1A0500E0EE8D /* CacheStatus.swift */; };
@@ -1508,6 +1509,7 @@
 		03F446562D303FA10046129A /* CornerRadiusesPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerRadiusesPropertyTests.swift; sourceTree = "<group>"; };
 		16DA8EC82E4EE24100283940 /* JsonLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonLoader.swift; sourceTree = "<group>"; };
 		16DA8ECC2E4EE33700283940 /* ImageComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageComponentTests.swift; sourceTree = "<group>"; };
+		16DA8EDE2E4F6A6600283940 /* PaywallVideoComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallVideoComponent.swift; sourceTree = "<group>"; };
 		1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactSupportUtilitiesTests.swift; sourceTree = "<group>"; };
 		1E2F91712CCFA98C00BDB016 /* WebRedemptionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRedemptionStrings.swift; sourceTree = "<group>"; };
 		1E42CC6B2D7F1A0500E0EE8D /* CacheStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStatus.swift; sourceTree = "<group>"; };
@@ -5473,6 +5475,7 @@
 		88AD010B2C740CF400AA1F2B /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				16DA8EDE2E4F6A6600283940 /* PaywallVideoComponent.swift */,
 				03C730F22D35F13F00297FEC /* PaywallV2CacheWarming.swift */,
 				2CC791612CC0493600FBE120 /* Common */,
 				7707A94B2CAD93AC006E0313 /* PaywallButtonComponent.swift */,
@@ -6787,6 +6790,7 @@
 				B34605CC279A6E380031CA74 /* LogInOperation.swift in Sources */,
 				4FFFE6C42AA9464100B2955C /* PaywallEventsManager.swift in Sources */,
 				4F8929192A65EF3000A91EA2 /* EnsureNonEmptyCollectionDecodable.swift in Sources */,
+				16DA8EDF2E4F6A6600283940 /* PaywallVideoComponent.swift in Sources */,
 				35F82BB626A9B8040051DF03 /* AttributionDataMigrator.swift in Sources */,
 				4F5F47082AA91F8A005649D8 /* HealthOperation.swift in Sources */,
 				4FEF41AB2B4F2F3400CD699F /* MapAppStoreDetector.swift in Sources */,

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PaywallComponentViewModel.swift
@@ -37,7 +37,7 @@ enum PaywallComponentViewModel {
     case tabControlToggle(TabControlToggleComponentViewModel)
 
     case carousel(CarouselComponentViewModel)
-
+    case video(VideoComponentViewModel)
 }
 
 #endif

--- a/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
@@ -28,6 +28,8 @@ public enum PaywallComponent: Codable, Sendable, Hashable, Equatable {
 
     case carousel(CarouselComponent)
 
+    case video(VideoComponent)
+
     public enum ComponentType: String, Codable, Sendable {
 
         case text
@@ -46,6 +48,7 @@ public enum PaywallComponent: Codable, Sendable, Hashable, Equatable {
         case tabControlToggle = "tab_control_toggle"
 
         case carousel
+        case video
 
     }
 
@@ -113,6 +116,9 @@ extension PaywallComponent {
             try component.encode(to: encoder)
         case .carousel(let component):
             try container.encode(ComponentType.carousel, forKey: .type)
+            try component.encode(to: encoder)
+        case .video(let component):
+            try container.encode(ComponentType.video, forKey: .type)
             try component.encode(to: encoder)
         }
     }
@@ -195,6 +201,8 @@ extension PaywallComponent {
             return .tabControlToggle(try TabControlToggleComponent(from: decoder))
         case .carousel:
             return .carousel(try CarouselComponent(from: decoder))
+        case .video:
+            return .video(try VideoComponent(from: decoder))
         }
     }
 

--- a/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
@@ -45,6 +45,34 @@ public extension PaywallComponent {
         public let heicLowRes: URL
     }
 
+    struct ThemeVideoUrls: Codable, Sendable, Hashable, Equatable {
+
+        public init(light: VideoUrls, dark: VideoUrls? = nil) {
+            self.light = light
+            self.dark = dark
+        }
+
+        public let light: VideoUrls
+        public let dark: VideoUrls?
+
+    }
+
+    struct VideoUrls: Codable, Sendable, Hashable, Equatable {
+
+        public init(width: Int, height: Int, url: URL, urlLowRes: URL? = nil) {
+            self.width = width
+            self.height = height
+            self.url = url
+            self.urlLowRes = urlLowRes
+        }
+
+        public let width: Int
+        public let height: Int
+        public let url: URL
+        public let urlLowRes: URL?
+
+    }
+
     struct GradientPoint: Codable, Sendable, Hashable, Equatable {
 
         public let color: ColorHex

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -87,6 +87,8 @@ extension PaywallComponentsData.PaywallComponentsConfig {
                 urls += carousel.pages.flatMap({ stack in
                     self.collectAllImageURLs(in: stack)
                 })
+            case .video:
+                assert(false, "failure: video support in progress")
             }
         }
 

--- a/Sources/Paywalls/Components/PaywallVideoComponent.swift
+++ b/Sources/Paywalls/Components/PaywallVideoComponent.swift
@@ -25,10 +25,10 @@ extension PaywallComponent {
         public let source: ThemeVideoUrls
         public let fallbackSource: ThemeImageUrls?
         public let visible: Bool?
-        public let videoID: String
         public let showControls: Bool
         public let autoplay: Bool
         public let loop: Bool
+        public let muteAudio: Bool
         public let size: Size
         public let fitMode: FitMode
         public let maskShape: MaskShape?
@@ -44,10 +44,10 @@ extension PaywallComponent {
             visible: Bool? = nil,
             source: ThemeVideoUrls,
             fallbackSource: ThemeImageUrls? = nil,
-            videoID: String,
             showControls: Bool = false,
             autoplay: Bool = true,
             loop: Bool = true,
+            muteAudio: Bool = true,
             size: Size = .init(width: .fill, height: .fit),
             fitMode: FitMode = .fit,
             maskShape: MaskShape? = nil,
@@ -62,10 +62,10 @@ extension PaywallComponent {
             self.source = source
             self.fallbackSource = fallbackSource
             self.visible = visible
-            self.videoID = videoID
             self.showControls = showControls
             self.autoplay = autoplay
             self.loop = loop
+            self.muteAudio = muteAudio
             self.size = size
             self.fitMode = fitMode
             self.maskShape = maskShape
@@ -80,10 +80,10 @@ extension PaywallComponent {
         public func hash(into hasher: inout Hasher) {
             hasher.combine(type)
             hasher.combine(visible)
-            hasher.combine(videoID)
             hasher.combine(showControls)
             hasher.combine(autoplay)
             hasher.combine(loop)
+            hasher.combine(muteAudio)
             hasher.combine(size)
             hasher.combine(fitMode)
             hasher.combine(maskShape)
@@ -100,10 +100,10 @@ extension PaywallComponent {
         public static func == (lhs: VideoComponent, rhs: VideoComponent) -> Bool {
             return lhs.type == rhs.type &&
             lhs.visible == rhs.visible &&
-            lhs.videoID == rhs.videoID &&
             lhs.showControls == rhs.showControls &&
             lhs.autoplay == rhs.autoplay &&
             lhs.loop == rhs.loop &&
+            lhs.muteAudio == rhs.muteAudio &&
             lhs.size == rhs.size &&
             lhs.fitMode == rhs.fitMode &&
             lhs.maskShape == rhs.maskShape &&
@@ -123,10 +123,10 @@ extension PaywallComponent {
         public let source: ThemeVideoUrls?
         public let fallbackSource: ThemeImageUrls?
         public let visible: Bool?
-        public let videoID: String?
         public let showControls: Bool?
         public let autoplay: Bool?
         public let loop: Bool?
+        public let muteAudio: Bool?
         public let size: Size?
         public let fitMode: FitMode?
         public let maskShape: MaskShape?
@@ -140,10 +140,10 @@ extension PaywallComponent {
             source: ThemeVideoUrls? = nil,
             fallbackSource: ThemeImageUrls? = nil,
             visible: Bool? = true,
-            videoID: String? = nil,
             showControls: Bool? = nil,
             autoplay: Bool? = nil,
             loop: Bool? = nil,
+            muteAudio: Bool? = nil,
             size: Size? = nil,
             fitMode: FitMode? = nil,
             maskShape: MaskShape? = nil,
@@ -156,10 +156,10 @@ extension PaywallComponent {
             self.source = source
             self.fallbackSource = fallbackSource
             self.visible = visible
-            self.videoID = videoID
             self.showControls = showControls
             self.autoplay = autoplay
             self.loop = loop
+            self.muteAudio = muteAudio
             self.size = size
             self.fitMode = fitMode
             self.maskShape = maskShape
@@ -174,10 +174,10 @@ extension PaywallComponent {
             hasher.combine(source)
             hasher.combine(fallbackSource)
             hasher.combine(visible)
-            hasher.combine(videoID)
             hasher.combine(showControls)
             hasher.combine(autoplay)
             hasher.combine(loop)
+            hasher.combine(muteAudio)
             hasher.combine(size)
             hasher.combine(fitMode)
             hasher.combine(maskShape)
@@ -190,10 +190,10 @@ extension PaywallComponent {
 
         public static func == (lhs: PartialVideoComponent, rhs: PartialVideoComponent) -> Bool {
             return lhs.visible == rhs.visible &&
-            lhs.videoID == rhs.videoID &&
             lhs.showControls == rhs.showControls &&
             lhs.autoplay == rhs.autoplay &&
             lhs.loop == rhs.loop &&
+            lhs.muteAudio == rhs.muteAudio &&
             lhs.size == rhs.size &&
             lhs.fitMode == rhs.fitMode &&
             lhs.maskShape == rhs.maskShape &&

--- a/Sources/Paywalls/Components/PaywallVideoComponent.swift
+++ b/Sources/Paywalls/Components/PaywallVideoComponent.swift
@@ -1,0 +1,209 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallVideoComponent.swift
+//
+//  Created by Jacob Zivan Rakidzich on 8/11/25.
+//
+// swiftlint:disable missing_docs
+
+import Foundation
+
+extension PaywallComponent {
+
+    // Need to add source with the urls
+
+    public final class VideoComponent: PaywallComponentBase {
+
+        let type: ComponentType
+        public let source: ThemeVideoUrls
+        public let fallbackSource: ThemeImageUrls?
+        public let visible: Bool?
+        public let videoID: String
+        public let showControls: Bool
+        public let autoplay: Bool
+        public let loop: Bool
+        public let size: Size
+        public let fitMode: FitMode
+        public let maskShape: MaskShape?
+        public let colorOverlay: ColorScheme?
+        public let padding: Padding?
+        public let margin: Padding?
+        public let border: Border?
+        public let shadow: Shadow?
+
+        public let overrides: ComponentOverrides<PartialVideoComponent>?
+
+        public init(
+            visible: Bool? = nil,
+            source: ThemeVideoUrls,
+            fallbackSource: ThemeImageUrls? = nil,
+            videoID: String,
+            showControls: Bool = false,
+            autoplay: Bool = true,
+            loop: Bool = true,
+            size: Size = .init(width: .fill, height: .fit),
+            fitMode: FitMode = .fit,
+            maskShape: MaskShape? = nil,
+            colorOverlay: ColorScheme? = nil,
+            padding: Padding? = nil,
+            margin: Padding? = nil,
+            border: Border? = nil,
+            shadow: Shadow? = nil,
+            overrides: ComponentOverrides<PartialVideoComponent>? = nil
+        ) {
+            self.type = .video
+            self.source = source
+            self.fallbackSource = fallbackSource
+            self.visible = visible
+            self.videoID = videoID
+            self.showControls = showControls
+            self.autoplay = autoplay
+            self.loop = loop
+            self.size = size
+            self.fitMode = fitMode
+            self.maskShape = maskShape
+            self.colorOverlay = colorOverlay
+            self.padding = padding
+            self.margin = margin
+            self.border = border
+            self.shadow = shadow
+            self.overrides = overrides
+        }
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(type)
+            hasher.combine(visible)
+            hasher.combine(videoID)
+            hasher.combine(showControls)
+            hasher.combine(autoplay)
+            hasher.combine(loop)
+            hasher.combine(size)
+            hasher.combine(fitMode)
+            hasher.combine(maskShape)
+            hasher.combine(colorOverlay)
+            hasher.combine(padding)
+            hasher.combine(margin)
+            hasher.combine(border)
+            hasher.combine(shadow)
+            hasher.combine(overrides)
+            hasher.combine(source)
+            hasher.combine(fallbackSource)
+        }
+
+        public static func == (lhs: VideoComponent, rhs: VideoComponent) -> Bool {
+            return lhs.type == rhs.type &&
+            lhs.visible == rhs.visible &&
+            lhs.videoID == rhs.videoID &&
+            lhs.showControls == rhs.showControls &&
+            lhs.autoplay == rhs.autoplay &&
+            lhs.loop == rhs.loop &&
+            lhs.size == rhs.size &&
+            lhs.fitMode == rhs.fitMode &&
+            lhs.maskShape == rhs.maskShape &&
+            lhs.colorOverlay == rhs.colorOverlay &&
+            lhs.padding == rhs.padding &&
+            lhs.margin == rhs.margin &&
+            lhs.border == rhs.border &&
+            lhs.shadow == rhs.shadow &&
+            lhs.overrides == rhs.overrides &&
+            lhs.fallbackSource == rhs.fallbackSource &&
+            lhs.source == rhs.source
+        }
+    }
+
+    public final class PartialVideoComponent: PaywallPartialComponent {
+
+        public let source: ThemeVideoUrls?
+        public let fallbackSource: ThemeImageUrls?
+        public let visible: Bool?
+        public let videoID: String?
+        public let showControls: Bool?
+        public let autoplay: Bool?
+        public let loop: Bool?
+        public let size: Size?
+        public let fitMode: FitMode?
+        public let maskShape: MaskShape?
+        public let colorOverlay: ColorScheme?
+        public let padding: Padding?
+        public let margin: Padding?
+        public let border: Border?
+        public let shadow: Shadow?
+
+        public init(
+            source: ThemeVideoUrls? = nil,
+            fallbackSource: ThemeImageUrls? = nil,
+            visible: Bool? = true,
+            videoID: String? = nil,
+            showControls: Bool? = nil,
+            autoplay: Bool? = nil,
+            loop: Bool? = nil,
+            size: Size? = nil,
+            fitMode: FitMode? = nil,
+            maskShape: MaskShape? = nil,
+            colorOverlay: ColorScheme? = nil,
+            padding: Padding? = nil,
+            margin: Padding? = nil,
+            border: Border? = nil,
+            shadow: Shadow? = nil
+        ) {
+            self.source = source
+            self.fallbackSource = fallbackSource
+            self.visible = visible
+            self.videoID = videoID
+            self.showControls = showControls
+            self.autoplay = autoplay
+            self.loop = loop
+            self.size = size
+            self.fitMode = fitMode
+            self.maskShape = maskShape
+            self.colorOverlay = colorOverlay
+            self.padding = padding
+            self.margin = margin
+            self.border = border
+            self.shadow = shadow
+        }
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(source)
+            hasher.combine(fallbackSource)
+            hasher.combine(visible)
+            hasher.combine(videoID)
+            hasher.combine(showControls)
+            hasher.combine(autoplay)
+            hasher.combine(loop)
+            hasher.combine(size)
+            hasher.combine(fitMode)
+            hasher.combine(maskShape)
+            hasher.combine(colorOverlay)
+            hasher.combine(padding)
+            hasher.combine(margin)
+            hasher.combine(border)
+            hasher.combine(shadow)
+        }
+
+        public static func == (lhs: PartialVideoComponent, rhs: PartialVideoComponent) -> Bool {
+            return lhs.visible == rhs.visible &&
+            lhs.videoID == rhs.videoID &&
+            lhs.showControls == rhs.showControls &&
+            lhs.autoplay == rhs.autoplay &&
+            lhs.loop == rhs.loop &&
+            lhs.size == rhs.size &&
+            lhs.fitMode == rhs.fitMode &&
+            lhs.maskShape == rhs.maskShape &&
+            lhs.colorOverlay == rhs.colorOverlay &&
+            lhs.padding == rhs.padding &&
+            lhs.margin == rhs.margin &&
+            lhs.border == rhs.border &&
+            lhs.shadow == rhs.shadow &&
+            lhs.fallbackSource == rhs.fallbackSource &&
+            lhs.source == rhs.source
+        }
+    }
+}

--- a/Tests/UnitTests/Paywalls/Components/ImageComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/ImageComponentTests.swift
@@ -33,6 +33,11 @@ class ImageComponentTests: TestCase {
             "https://assets.pawwalls.com/1151049_1732039548.png"
         )
         XCTAssertNil(image.source.dark)
+        XCTAssertNotNil(image.colorOverlay)
+        XCTAssertEqual(image.fitMode, PaywallComponent.FitMode.fill)
+        XCTAssertNotNil(image.maskShape)
+        XCTAssertNotNil(image.shadow)
+        XCTAssertNotNil(image.size)
         XCTAssertEqual(image, image2)
 
     }

--- a/Tests/UnitTests/Paywalls/Components/ImageComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/ImageComponentTests.swift
@@ -1,0 +1,39 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ImageComponentTests.swift
+//
+//  Created by Jacob Zivan Rakidzich on 8/14/25.
+
+import Foundation
+@testable import RevenueCat
+import XCTest
+
+class ImageComponentTests: TestCase {
+
+    func testCodable() throws {
+        let jsonData = try JsonLoader.data(for: "ImageComponent")
+
+        // Validate decoding works
+        let image = try JSONDecoder.default
+            .decode(PaywallComponent.ImageComponent.self, from: jsonData)
+
+        // validate encoding
+        let image2 = try image.encodeAndDecode()
+
+        // Validate some data
+        XCTAssertEqual(
+            image.source.light.original.absoluteString,
+            "https://assets.pawwalls.com/1151049_1732039548.png"
+        )
+        XCTAssertNil(image.source.dark)
+        XCTAssertEqual(image, image2)
+
+    }
+}

--- a/Tests/UnitTests/Paywalls/Components/JSON/ImageComponent.json
+++ b/Tests/UnitTests/Paywalls/Components/JSON/ImageComponent.json
@@ -5,12 +5,6 @@
       "value": "primary"
     }
   },
-  "corner_radiuses": {
-    "bottom_leading": 5,
-    "bottom_trailing": 6,
-    "top_leading": 7,
-    "top_trailing": 8
-  },
   "fit_mode": "fill",
   "id": "P0Tzh3p6d3",
   "mask_shape": {

--- a/Tests/UnitTests/Paywalls/Components/JSON/ImageComponent.json
+++ b/Tests/UnitTests/Paywalls/Components/JSON/ImageComponent.json
@@ -1,0 +1,61 @@
+{
+  "color_overlay": {
+    "light": {
+      "type": "alias",
+      "value": "primary"
+    }
+  },
+  "corner_radiuses": {
+    "bottom_leading": 5,
+    "bottom_trailing": 6,
+    "top_leading": 7,
+    "top_trailing": 8
+  },
+  "fit_mode": "fill",
+  "id": "P0Tzh3p6d3",
+  "mask_shape": {
+    "corners": {
+      "bottom_leading": 1,
+      "bottom_trailing": 2,
+      "top_leading": 3,
+      "top_trailing": 4
+    },
+    "type": "rectangle"
+  },
+  "name": "",
+  "override_source_lid": "abc123",
+  "shadow": {
+    "color": {
+      "light": {
+        "type": "alias",
+        "value": "tertiary"
+      }
+    },
+    "radius": 20.1,
+    "x": 23.6,
+    "y": 45.2
+  },
+  "size": {
+    "height": {
+      "type": "fit",
+      "value": null
+    },
+    "width": {
+      "type": "fill",
+      "value": null
+    }
+  },
+  "source": {
+    "light": {
+      "heic": "https://assets.pawwalls.com/1151049_1732039548.heic",
+      "heic_low_res": "https://assets.pawwalls.com/1151049_low_res_1732039548.heic",
+      "height": 200,
+      "original": "https://assets.pawwalls.com/1151049_1732039548.png",
+      "webp": "https://assets.pawwalls.com/1151049_1732039548.webp",
+      "webp_low_res": "https://assets.pawwalls.com/1151049_low_res_1732039548.webp",
+      "width": 400
+    }
+  },
+  "type": "image",
+  "visible": false
+}

--- a/Tests/UnitTests/Paywalls/Components/JSON/VideoComponent.json
+++ b/Tests/UnitTests/Paywalls/Components/JSON/VideoComponent.json
@@ -6,12 +6,6 @@
       "value": "primary"
     }
   },
-  "corner_radiuses": {
-    "bottom_leading": 5,
-    "bottom_trailing": 6,
-    "top_leading": 7,
-    "top_trailing": 8
-  },
   "fallback_source": {
     "light": {
       "heic": "https://assets.pawwalls.com/1151049_1732039548.heic",

--- a/Tests/UnitTests/Paywalls/Components/JSON/VideoComponent.json
+++ b/Tests/UnitTests/Paywalls/Components/JSON/VideoComponent.json
@@ -1,0 +1,72 @@
+{
+  "autoplay": true,
+  "color_overlay": {
+    "light": {
+      "type": "alias",
+      "value": "primary"
+    }
+  },
+  "corner_radiuses": {
+    "bottom_leading": 5,
+    "bottom_trailing": 6,
+    "top_leading": 7,
+    "top_trailing": 8
+  },
+  "fallback_source": {
+    "light": {
+      "heic": "https://assets.pawwalls.com/1151049_1732039548.heic",
+      "heic_low_res": "https://assets.pawwalls.com/1151049_low_res_1732039548.heic",
+      "height": 200,
+      "original": "https://assets.pawwalls.com/1151049_1732039548.png",
+      "webp": "https://assets.pawwalls.com/1151049_1732039548.webp",
+      "webp_low_res": "https://assets.pawwalls.com/1151049_low_res_1732039548.webp",
+      "width": 400
+    }
+  },
+  "fit_mode": "fill",
+  "id": "P0Tzh3p6d3",
+  "loop": true,
+  "mask_shape": {
+    "corners": {
+      "bottom_leading": 1,
+      "bottom_trailing": 2,
+      "top_leading": 3,
+      "top_trailing": 4
+    },
+    "type": "rectangle"
+  },
+  "mute_audio": true,
+  "name": "",
+  "override_source_lid": "abc123",
+  "shadow": {
+    "color": {
+      "light": {
+        "type": "alias",
+        "value": "tertiary"
+      }
+    },
+    "radius": 20.1,
+    "x": 23.6,
+    "y": 45.2
+  },
+  "show_controls": false,
+  "size": {
+    "height": {
+      "type": "fit",
+      "value": null
+    },
+    "width": {
+      "type": "fill",
+      "value": null
+    }
+  },
+  "source": {
+    "light": {
+      "height": 400,
+      "ulr_low_res": "https://videos.pexels.com/video-files/5532767/5532767-uhd_1440_2732_25fps.mp4",
+      "url": "https://videos.pexels.com/video-files/5532767/5532767-uhd_1440_2732_25fps.mp4",
+      "width": 200
+    }
+  },
+  "type": "video"
+}

--- a/Tests/UnitTests/Paywalls/Components/JsonLoader.swift
+++ b/Tests/UnitTests/Paywalls/Components/JsonLoader.swift
@@ -1,0 +1,37 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  JsonLoader.swift
+//
+//  Created by Jacob Zivan Rakidzich on 8/14/25.
+
+import Foundation
+import XCTest
+
+enum JsonLoader {
+    private class BundleToken { }
+
+    static func data(
+        for fileName: String,
+        in subDirectory: String = "JSON",
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> Data {
+        let url = try XCTUnwrap(
+            URL(fileURLWithPath: String(describing: file))
+                        .deletingLastPathComponent()
+                        .appendingPathComponent(subDirectory)
+                        .appendingPathComponent(fileName + ".json"),
+            "Could not find file with name: '\(fileName).json'",
+            file: file,
+            line: line
+        )
+        return try XCTUnwrap(Data(contentsOf: url), file: file, line: line)
+    }
+}

--- a/Tests/UnitTests/Paywalls/Components/JsonLoader.swift
+++ b/Tests/UnitTests/Paywalls/Components/JsonLoader.swift
@@ -15,7 +15,6 @@ import Foundation
 import XCTest
 
 enum JsonLoader {
-    private class BundleToken { }
 
     static func data(
         for fileName: String,

--- a/Tests/UnitTests/Paywalls/Components/VideoComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/VideoComponentTests.swift
@@ -1,0 +1,48 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  VideoComponentTests.swift
+//
+//  Created by Jacob Zivan Rakidzich on 8/15/25.
+
+import Foundation
+@testable import RevenueCat
+import XCTest
+
+class VideoComponentTests: TestCase {
+
+    func testCodable() throws {
+        let jsonData = try JsonLoader.data(for: "VideoComponent")
+
+        // Validate decoding works
+        let video: PaywallComponent.VideoComponent = try JSONDecoder.default
+            .decode(PaywallComponent.VideoComponent.self, from: jsonData)
+
+        // validate encoding
+        let video2 = try video.encodeAndDecode()
+
+        // Validate some data
+        XCTAssertEqual(
+            video.source.light.url.absoluteString,
+            "https://videos.pexels.com/video-files/5532767/5532767-uhd_1440_2732_25fps.mp4"
+        )
+        XCTAssertNil(video.source.dark)
+        XCTAssertNotNil(video.colorOverlay)
+        XCTAssertNotNil(video.fallbackSource)
+        XCTAssertEqual(video.fitMode, PaywallComponent.FitMode.fill)
+        XCTAssertTrue(video.loop)
+        XCTAssertNotNil(video.maskShape)
+        XCTAssertTrue(video.muteAudio)
+        XCTAssertNotNil(video.shadow)
+        XCTAssertFalse(video.showControls)
+        XCTAssertNotNil(video.size)
+        XCTAssertEqual(video, video2)
+
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

In an effort to support more paywall features, we are developing a video component. This PR is to set up the models that will be used to drive the view layer. It will tie together with #5477 in an upcoming PR to create the views

### Description

This creates the VideoComponent model and all its sub models, as well as unit tests the codable functionality. The image component is quite similar to the video component, so I used that as a reference, and while I was at it, I added some codable tests for that as well.
