### PR TITLE
Rename subscribe to buy_subscription in customer center

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsCardView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsCardView.swift
@@ -56,7 +56,7 @@ struct NoSubscriptionsCardView: View {
         self.init(
             title: localization[.noSubscriptionsFound],
             subtitle: localization[.tryCheckRestore],
-            subscribeTitle: localization[.subscribe],
+            subscribeTitle: localization[.buySubscrition],
             screenOffering: screenOffering,
             purchasesProvider: purchasesProvider
         )

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -58,7 +58,7 @@ import Foundation
 
         @_spi(Internal) public enum CommonLocalizedString: String, Equatable {
 
-            case subscribe = "subscribe"
+            case buySubscrition = "buy_subscription"
             case copy = "copy"
             case noThanks = "no_thanks"
             case noSubscriptionsFound = "no_subscriptions_found"
@@ -175,7 +175,7 @@ import Foundation
 
             @_spi(Internal) public var defaultValue: String {
                 switch self {
-                case .subscribe:
+                case .buySubscrition:
                     return "Subscribe"
                 case .copy:
                     return "Copy"


### PR DESCRIPTION
### Motivation
I am adding a textfield in the dashboard to edit this copy directly. I noticed the key was wrong, so this renames it to match android implementation.

The feature is disabled by default, so no big deal. 
- I am thinking that Android has an integration test for this.
- I've been wanting to generate the copies automatically for a while, so I'll try to find some time to work on that.

### Description
- Rename key
