### PR TITLE
Added APIs for hybrid SDKs to set presentedOfferingContext

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		16BCA37A2E4D9C0400B39E7F /* MockSimpleNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BCA3782E4D9C0400B39E7F /* MockSimpleNetworkService.swift */; };
 		16BCA37C2E4D9DD700B39E7F /* XCTestCase+Yield.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BCA37B2E4D9DD700B39E7F /* XCTestCase+Yield.swift */; };
 		16BCA38D2E4E7B5C00B39E7F /* FileRepositoryStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BCA38C2E4E7B5C00B39E7F /* FileRepositoryStrings.swift */; };
+		1DB9B2A72E57373900252D58 /* OfferingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB9B2A62E57373600252D58 /* OfferingTests.swift */; };
 		1E2F911B2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */; };
 		1E2F91722CCFA98C00BDB016 /* WebRedemptionStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2F91712CCFA98C00BDB016 /* WebRedemptionStrings.swift */; };
 		1E42CC6C2D7F1A0500E0EE8D /* CacheStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E42CC6B2D7F1A0500E0EE8D /* CacheStatus.swift */; };
@@ -1528,6 +1529,7 @@
 		16BCA3782E4D9C0400B39E7F /* MockSimpleNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSimpleNetworkService.swift; sourceTree = "<group>"; };
 		16BCA37B2E4D9DD700B39E7F /* XCTestCase+Yield.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Yield.swift"; sourceTree = "<group>"; };
 		16BCA38C2E4E7B5C00B39E7F /* FileRepositoryStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileRepositoryStrings.swift; sourceTree = "<group>"; };
+		1DB9B2A62E57373600252D58 /* OfferingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingTests.swift; sourceTree = "<group>"; };
 		1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactSupportUtilitiesTests.swift; sourceTree = "<group>"; };
 		1E2F91712CCFA98C00BDB016 /* WebRedemptionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRedemptionStrings.swift; sourceTree = "<group>"; };
 		1E42CC6B2D7F1A0500E0EE8D /* CacheStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStatus.swift; sourceTree = "<group>"; };
@@ -3265,6 +3267,7 @@
 		2DAC5F7326F13C9800C5258F /* StoreKitUnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				1DB9B2A62E57373600252D58 /* OfferingTests.swift */,
 				4FD291BC2A1E9A180098D1B9 /* StoreKit2 */,
 				571E7AD0279F2CE9003B3606 /* TestHelpers */,
 				57488C8129CB91D20000EE7E /* OfflineEntitlements */,
@@ -6476,6 +6479,7 @@
 				3543913626F90D6A00E669DF /* TrialOrIntroPriceEligibilityCheckerSK1Tests.swift in Sources */,
 				1EFA95132CDBA58F00CA5951 /* MockRedeemWebPurchaseAPI.swift in Sources */,
 				4F6E81982A81BC30006EF181 /* TestClock.swift in Sources */,
+				1DB9B2A72E57373900252D58 /* OfferingTests.swift in Sources */,
 				2D34D9D227481D9B00C05DB6 /* TrialOrIntroPriceEligibilityCheckerSK2Tests.swift in Sources */,
 				FD18BF4B2DF0DA5400140FD6 /* MockVirtualCurrencyManager.swift in Sources */,
 				FDAADFCC2BE2A5BF00BD1659 /* MockAllTransactionsProvider.swift in Sources */,

--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -52,7 +52,7 @@ extension PaywallViewConfiguration {
 
         case defaultOffering
         case offering(Offering)
-        case offeringIdentifier(String)
+        case offeringIdentifier(String, presentedOfferingContext: PresentedOfferingContext?)
 
     }
 

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -407,10 +407,11 @@ private extension PaywallView {
         case .defaultOffering:
             return try await Purchases.shared.offerings().current.orThrow(PaywallError.noCurrentOffering)
 
-        case let .offeringIdentifier(identifier):
+        case let .offeringIdentifier(identifier, presentedOfferingContext):
             return try await Purchases.shared.offerings()
                 .offering(identifier: identifier)
                 .orThrow(PaywallError.offeringNotFound(identifier: identifier))
+                .withPresentedOfferingContext(presentedOfferingContext)
         }
     }
 
@@ -423,9 +424,14 @@ private extension PaywallViewConfiguration.Content {
 
     func extractInitialOffering() -> Offering? {
         switch self {
-        case let .offering(offering): return offering
-        case .defaultOffering: return Self.loadCachedCurrentOfferingIfPossible()
-        case let .offeringIdentifier(identifier): return Self.loadCachedOfferingIfPossible(identifier: identifier)
+        case let .offering(offering):
+            return offering
+        case .defaultOffering:
+            return Self.loadCachedCurrentOfferingIfPossible()
+        case let .offeringIdentifier(identifier, presentedOfferingContextOverride):
+            return Self.loadCachedOfferingIfPossible(
+                identifier: identifier
+            )?.withPresentedOfferingContext(presentedOfferingContextOverride)
         }
     }
 

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -408,10 +408,15 @@ private extension PaywallView {
             return try await Purchases.shared.offerings().current.orThrow(PaywallError.noCurrentOffering)
 
         case let .offeringIdentifier(identifier, presentedOfferingContext):
-            return try await Purchases.shared.offerings()
+            let offering = try await Purchases.shared.offerings()
                 .offering(identifier: identifier)
                 .orThrow(PaywallError.offeringNotFound(identifier: identifier))
-                .withPresentedOfferingContext(presentedOfferingContext)
+
+            if let presentedOfferingContext {
+                return offering.withPresentedOfferingContext(presentedOfferingContext)
+            }
+
+            return offering
         }
     }
 
@@ -428,10 +433,16 @@ private extension PaywallViewConfiguration.Content {
             return offering
         case .defaultOffering:
             return Self.loadCachedCurrentOfferingIfPossible()
-        case let .offeringIdentifier(identifier, presentedOfferingContextOverride):
-            return Self.loadCachedOfferingIfPossible(
+        case let .offeringIdentifier(identifier, presentedOfferingContext):
+            let offering = Self.loadCachedOfferingIfPossible(
                 identifier: identifier
-            )?.withPresentedOfferingContext(presentedOfferingContextOverride)
+            )
+
+            if let presentedOfferingContext {
+                return offering?.withPresentedOfferingContext(presentedOfferingContext)
+            }
+
+            return offering
         }
     }
 

--- a/RevenueCatUI/UIKit/PaywallFooterViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallFooterViewController.swift
@@ -43,12 +43,28 @@ public final class PaywallFooterViewController: PaywallViewController {
     }
 
     /// Initialize a `PaywallFooterViewController` with an `Offering` identifier.
+    @available(*, deprecated, message: "use init with Offering instead")
     @objc
     public init(
         offeringIdentifier: String,
         dismissRequestedHandler: ((_ controller: PaywallViewController) -> Void)? = nil
     ) {
-        super.init(content: .offeringIdentifier(offeringIdentifier),
+        super.init(content: .offeringIdentifier(offeringIdentifier, presentedOfferingContext: nil),
+                   fonts: DefaultPaywallFontProvider(),
+                   displayCloseButton: false,
+                   shouldBlockTouchEvents: false,
+                   dismissRequestedHandler: dismissRequestedHandler)
+    }
+    
+    /// Initialize a `PaywallFooterViewController` with an `Offering` identifier and a presentedOfferingContext
+    @_spi(Internal)
+    @objc
+    public init(
+        offeringIdentifier: String,
+        presentedOfferingContext: PresentedOfferingContext? = nil,
+        dismissRequestedHandler: ((_ controller: PaywallViewController) -> Void)? = nil
+    ) {
+        super.init(content: .offeringIdentifier(offeringIdentifier, presentedOfferingContext: presentedOfferingContext),
                    fonts: DefaultPaywallFontProvider(),
                    displayCloseButton: false,
                    shouldBlockTouchEvents: false,
@@ -57,13 +73,32 @@ public final class PaywallFooterViewController: PaywallViewController {
 
     /// Initialize a `PaywallFooterViewController` with an `offeringIdentifier` and custom `fontName`.
     /// - Parameter fontName: a custom font name for this paywall. See ``CustomPaywallFontProvider``.
+    @available(*, deprecated, message: "use init with Offering instead")
     @objc
     public init(
         offeringIdentifier: String,
         fontName: String,
         dismissRequestedHandler: ((_ controller: PaywallViewController) -> Void)? = nil
     ) {
-        super.init(content: .offeringIdentifier(offeringIdentifier),
+        super.init(content: .offeringIdentifier(offeringIdentifier, presentedOfferingContext: nil),
+                   fonts: CustomPaywallFontProvider(fontName: fontName),
+                   displayCloseButton: false,
+                   shouldBlockTouchEvents: false,
+                   dismissRequestedHandler: dismissRequestedHandler)
+    }
+    
+    /// Initialize a `PaywallFooterViewController` with an `offeringIdentifier`, `presentedOfferingContext` and custom `fontName`.
+    /// - Parameter presentedOfferingContext: the context in which this offer was presented
+    /// - Parameter fontName: a custom font name for this paywall. See ``CustomPaywallFontProvider``.
+    @_spi(Internal)
+    @objc
+    public init(
+        offeringIdentifier: String,
+        presentedOfferingContext: PresentedOfferingContext? = nil,
+        fontName: String,
+        dismissRequestedHandler: ((_ controller: PaywallViewController) -> Void)? = nil
+    ) {
+        super.init(content: .offeringIdentifier(offeringIdentifier, presentedOfferingContext: presentedOfferingContext),
                    fonts: CustomPaywallFontProvider(fontName: fontName),
                    displayCloseButton: false,
                    shouldBlockTouchEvents: false,

--- a/RevenueCatUI/UIKit/PaywallFooterViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallFooterViewController.swift
@@ -55,8 +55,9 @@ public final class PaywallFooterViewController: PaywallViewController {
                    shouldBlockTouchEvents: false,
                    dismissRequestedHandler: dismissRequestedHandler)
     }
-    
-    /// Initialize a `PaywallFooterViewController` with an `Offering` identifier and a presentedOfferingContext
+
+    /// Initialize a `PaywallFooterViewController` with an `offeringIdentifier` and `presentedOfferingContext`.
+    /// - Parameter presentedOfferingContext: the context in which this offer was presented
     @_spi(Internal)
     @objc
     public init(
@@ -86,8 +87,9 @@ public final class PaywallFooterViewController: PaywallViewController {
                    shouldBlockTouchEvents: false,
                    dismissRequestedHandler: dismissRequestedHandler)
     }
-    
-    /// Initialize a `PaywallFooterViewController` with an `offeringIdentifier`, `presentedOfferingContext` and custom `fontName`.
+
+    /// Initialize a `PaywallFooterViewController` with an `offeringIdentifier`,
+    /// `presentedOfferingContext` and custom `fontName`.
     /// - Parameter presentedOfferingContext: the context in which this offer was presented
     /// - Parameter fontName: a custom font name for this paywall. See ``CustomPaywallFontProvider``.
     @_spi(Internal)

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -112,10 +112,10 @@ public class PaywallViewController: UIViewController {
             dismissRequestedHandler: dismissRequestedHandler
         )
     }
-    
+
     /// Initialize a `PaywallViewController` with an offering identifier.
     /// - Parameter offeringIdentifier: The identifier for the offering with paywall to display.
-    /// - Parameter presentedOfferingContext: Information about how the offering is presented..
+    /// - Parameter presentedOfferingContext: Information about how the offering is presented.
     /// - Parameter fonts: A ``PaywallFontProvider``.
     /// - Parameter displayCloseButton: Set this to `true` to automatically include a close button.
     /// - Parameter shouldBlockTouchEvents: Whether to interecept all touch events propagated through this VC
@@ -193,12 +193,13 @@ public class PaywallViewController: UIViewController {
     public func update(with offeringIdentifier: String) {
         self.configuration.content = .offeringIdentifier(offeringIdentifier, presentedOfferingContext: nil)
     }
-    
+
     /// - Warning: For internal use only
     @_spi(Internal)
     @objc(updateWithOfferingIdentifier:presentedOfferingContext:)
     public func update(with offeringIdentifier: String, presentedOfferingContext: PresentedOfferingContext?) {
-        self.configuration.content = .offeringIdentifier(offeringIdentifier, presentedOfferingContext: presentedOfferingContext)
+        self.configuration.content = .offeringIdentifier(offeringIdentifier,
+                                                         presentedOfferingContext: presentedOfferingContext)
     }
 
     /// - Warning: For internal use only

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -96,6 +96,7 @@ public class PaywallViewController: UIViewController {
     /// - Parameter shouldBlockTouchEvents: Whether to interecept all touch events propagated through this VC
     /// - Parameter dismissRequestedHandler: If this is not set, the paywall will close itself automatically
     /// after a successful purchase. Otherwise use this handler to handle dismissals of the paywall
+    @available(*, deprecated, message: "use init with Offering instead")
     public convenience init(
         offeringIdentifier: String,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
@@ -104,7 +105,33 @@ public class PaywallViewController: UIViewController {
         dismissRequestedHandler: ((_ controller: PaywallViewController) -> Void)? = nil
     ) {
         self.init(
-            content: .offeringIdentifier(offeringIdentifier),
+            content: .offeringIdentifier(offeringIdentifier, presentedOfferingContext: nil),
+            fonts: fonts,
+            displayCloseButton: displayCloseButton,
+            shouldBlockTouchEvents: shouldBlockTouchEvents,
+            dismissRequestedHandler: dismissRequestedHandler
+        )
+    }
+    
+    /// Initialize a `PaywallViewController` with an offering identifier.
+    /// - Parameter offeringIdentifier: The identifier for the offering with paywall to display.
+    /// - Parameter presentedOfferingContext: Information about how the offering is presented..
+    /// - Parameter fonts: A ``PaywallFontProvider``.
+    /// - Parameter displayCloseButton: Set this to `true` to automatically include a close button.
+    /// - Parameter shouldBlockTouchEvents: Whether to interecept all touch events propagated through this VC
+    /// - Parameter dismissRequestedHandler: If this is not set, the paywall will close itself automatically
+    /// after a successful purchase. Otherwise use this handler to handle dismissals of the paywall
+    @_spi(Internal)
+    public convenience init(
+        offeringIdentifier: String,
+        presentedOfferingContext: PresentedOfferingContext,
+        fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        displayCloseButton: Bool = false,
+        shouldBlockTouchEvents: Bool = false,
+        dismissRequestedHandler: ((_ controller: PaywallViewController) -> Void)? = nil
+    ) {
+        self.init(
+            content: .offeringIdentifier(offeringIdentifier, presentedOfferingContext: presentedOfferingContext),
             fonts: fonts,
             displayCloseButton: displayCloseButton,
             shouldBlockTouchEvents: shouldBlockTouchEvents,
@@ -161,9 +188,17 @@ public class PaywallViewController: UIViewController {
     }
 
     /// - Warning: For internal use only
+    @available(*, deprecated, message: "use init with Offering instead")
     @objc(updateWithOfferingIdentifier:)
     public func update(with offeringIdentifier: String) {
-        self.configuration.content = .offeringIdentifier(offeringIdentifier)
+        self.configuration.content = .offeringIdentifier(offeringIdentifier, presentedOfferingContext: nil)
+    }
+    
+    /// - Warning: For internal use only
+    @_spi(Internal)
+    @objc(updateWithOfferingIdentifier:presentedOfferingContext:)
+    public func update(with offeringIdentifier: String, presentedOfferingContext: PresentedOfferingContext?) {
+        self.configuration.content = .offeringIdentifier(offeringIdentifier, presentedOfferingContext: presentedOfferingContext)
     }
 
     /// - Warning: For internal use only

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -293,7 +293,8 @@ import Foundation
 
 @_spi(Internal)
 public extension Offering {
-    
+
+    /// Copies the Offering and sets the given `presentedOfferingContext` on all `availablePackages`
     func withPresentedOfferingContext(_ presentedOfferingContext: PresentedOfferingContext) -> Self {
         return Self(
             identifier: identifier,
@@ -305,11 +306,6 @@ public extension Offering {
             availablePackages: availablePackages.map { $0.withPresentedOfferingContext(presentedOfferingContext) },
             webCheckoutUrl: webCheckoutUrl
         )
-    }
-    
-    func withPresentedOfferingContext(_ presentedOfferingContext: PresentedOfferingContext?) -> Self {
-        guard let presentedOfferingContext else { return self }
-        return withPresentedOfferingContext(presentedOfferingContext)
     }
 }
 

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -291,6 +291,40 @@ import Foundation
 
 }
 
+@_spi(Internal)
+public extension Offering {
+    
+    func withPresentedOfferingContext(_ presentedOfferingContext: PresentedOfferingContext) -> Self {
+        return Self(
+            identifier: identifier,
+            serverDescription: serverDescription,
+            metadata: metadata,
+            paywall: paywall,
+            paywallComponents: paywallComponents,
+            draftPaywallComponents: draftPaywallComponents,
+            availablePackages: availablePackages.map { $0.withPresentedOfferingContext(presentedOfferingContext) },
+            webCheckoutUrl: webCheckoutUrl
+        )
+    }
+    
+    func withPresentedOfferingContext(_ presentedOfferingContext: PresentedOfferingContext?) -> Self {
+        guard let presentedOfferingContext else { return self }
+        return withPresentedOfferingContext(presentedOfferingContext)
+    }
+}
+
+fileprivate extension Package {
+    func withPresentedOfferingContext(_ presentedOfferingContext: PresentedOfferingContext) -> Self {
+        return Self(
+            identifier: identifier,
+            packageType: packageType,
+            storeProduct: storeProduct,
+            presentedOfferingContext: presentedOfferingContext,
+            webCheckoutUrl: webCheckoutUrl
+        )
+    }
+}
+
 extension Offering {
 
     /// - Returns: The `metadata` value associated to `key` for the expected type,

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewControllerAPI.swift
@@ -6,7 +6,7 @@
 //
 
 import RevenueCat
-import RevenueCatUI
+@_spi(Internal) import RevenueCatUI
 import SwiftUI
 
 #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
@@ -59,10 +59,15 @@ func paywallViewControllerAPI(_ delegate: Delegate,
                                                     displayCloseButton: true,
                                                     shouldBlockTouchEvents: true,
                                                     dismissRequestedHandler: dismissRequestedHandler)
-    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering", fontName: "Papyrus")
-
+    let _: UIViewController = PaywallViewController(offeringIdentifier: "offering",
+                                                    presentedOfferingContext: .init(offeringIdentifier: "offering"),
+                                                    fonts: fontProvider,
+                                                    displayCloseButton: true,
+                                                    shouldBlockTouchEvents: true,
+                                                    dismissRequestedHandler: dismissRequestedHandler)
     controller.update(with: offering!)
     controller.update(with: "offering_identifier")
+    controller.update(with: "offering_identifier", presentedOfferingContext: .init(offeringIdentifier: "offering_identifier"))
     controller.updateFont(with: "Papyrus")
 }
 
@@ -81,6 +86,13 @@ func paywallFooterViewControllerAPI(_ delegate: Delegate,
                                                           dismissRequestedHandler: dismissRequestedHandler)
     let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering",
                                                           fontName: "Papyrus",
+                                                          dismissRequestedHandler: dismissRequestedHandler)
+    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering",
+                                                          presentedOfferingContext: .init(offeringIdentifier: "offering"),
+                                                          dismissRequestedHandler: dismissRequestedHandler)
+    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering",
+                                                          presentedOfferingContext: .init(offeringIdentifier: "offering"),
+                                                          fontName: "",
                                                           dismissRequestedHandler: dismissRequestedHandler)
 }
 

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewControllerAPI.swift
@@ -6,7 +6,7 @@
 //
 
 import RevenueCat
-@_spi(Internal) import RevenueCatUI
+import RevenueCatUI
 import SwiftUI
 
 #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
@@ -59,15 +59,9 @@ func paywallViewControllerAPI(_ delegate: Delegate,
                                                     displayCloseButton: true,
                                                     shouldBlockTouchEvents: true,
                                                     dismissRequestedHandler: dismissRequestedHandler)
-    let _: UIViewController = PaywallViewController(offeringIdentifier: "offering",
-                                                    presentedOfferingContext: .init(offeringIdentifier: "offering"),
-                                                    fonts: fontProvider,
-                                                    displayCloseButton: true,
-                                                    shouldBlockTouchEvents: true,
-                                                    dismissRequestedHandler: dismissRequestedHandler)
+
     controller.update(with: offering!)
     controller.update(with: "offering_identifier")
-    controller.update(with: "offering_identifier", presentedOfferingContext: .init(offeringIdentifier: "offering_identifier"))
     controller.updateFont(with: "Papyrus")
 }
 
@@ -86,13 +80,6 @@ func paywallFooterViewControllerAPI(_ delegate: Delegate,
                                                           dismissRequestedHandler: dismissRequestedHandler)
     let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering",
                                                           fontName: "Papyrus",
-                                                          dismissRequestedHandler: dismissRequestedHandler)
-    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering",
-                                                          presentedOfferingContext: .init(offeringIdentifier: "offering"),
-                                                          dismissRequestedHandler: dismissRequestedHandler)
-    let _: UIViewController = PaywallFooterViewController(offeringIdentifier: "offering",
-                                                          presentedOfferingContext: .init(offeringIdentifier: "offering"),
-                                                          fontName: "",
                                                           dismissRequestedHandler: dismissRequestedHandler)
 }
 

--- a/Tests/StoreKitUnitTests/OfferingTests.swift
+++ b/Tests/StoreKitUnitTests/OfferingTests.swift
@@ -17,9 +17,9 @@ import XCTest
 
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 class OfferingTests: StoreKitConfigTestCase {
-    
+
     func testOfferingWithPresentedOfferingContext() async throws {
-        
+
         let monthlyProduct = try await fetchSk2Product("com.revenuecat.monthly_4.99.1_week_intro")
         let monthlyPackage = Package(
             identifier: "monthlyPackage",
@@ -30,7 +30,7 @@ class OfferingTests: StoreKitConfigTestCase {
             offeringIdentifier: "offering",
             webCheckoutUrl: nil
         )
-        
+
         let annualProduct = try await fetchSk2Product("com.revenuecat.annual_39.99.2_week_intro")
         let annualPackage = Package(
             identifier: "annualPackage",
@@ -41,7 +41,7 @@ class OfferingTests: StoreKitConfigTestCase {
             offeringIdentifier: "offering",
             webCheckoutUrl: nil
         )
-        
+
         let offering = Offering(
             identifier: "onboardingOffering",
             serverDescription: "",
@@ -51,10 +51,7 @@ class OfferingTests: StoreKitConfigTestCase {
             ],
             webCheckoutUrl: nil
         )
-        
-        // should leave the offering unchanged
-        XCTAssertEqual(offering.withPresentedOfferingContext(nil), offering)
-        
+
         let presentedOfferingContext = PresentedOfferingContext(
             offeringIdentifier: "onboardingOffering",
             placementIdentifier: "onboarding",
@@ -63,9 +60,11 @@ class OfferingTests: StoreKitConfigTestCase {
                 ruleId: "onboarding-rule-1"
             )
         )
-        
+
         // all `availablePackages` should use the given `presentedOfferingContext`
         let offeringWithPresentedOfferingContext = offering.withPresentedOfferingContext(presentedOfferingContext)
-        XCTAssert(offeringWithPresentedOfferingContext.availablePackages.allSatisfy { $0.presentedOfferingContext == presentedOfferingContext })
+        XCTAssert(offeringWithPresentedOfferingContext.availablePackages.allSatisfy {
+            $0.presentedOfferingContext == presentedOfferingContext
+        })
     }
 }

--- a/Tests/StoreKitUnitTests/OfferingTests.swift
+++ b/Tests/StoreKitUnitTests/OfferingTests.swift
@@ -1,0 +1,71 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  OfferingTests.swift
+//
+//  Created by Rick van der Linden on 21/08/2025.
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+import XCTest
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+class OfferingTests: StoreKitConfigTestCase {
+    
+    func testOfferingWithPresentedOfferingContext() async throws {
+        
+        let monthlyProduct = try await fetchSk2Product("com.revenuecat.monthly_4.99.1_week_intro")
+        let monthlyPackage = Package(
+            identifier: "monthlyPackage",
+            packageType: .monthly,
+            storeProduct: StoreProduct(
+                sk2Product: monthlyProduct
+            ),
+            offeringIdentifier: "offering",
+            webCheckoutUrl: nil
+        )
+        
+        let annualProduct = try await fetchSk2Product("com.revenuecat.annual_39.99.2_week_intro")
+        let annualPackage = Package(
+            identifier: "annualPackage",
+            packageType: .annual,
+            storeProduct: StoreProduct(
+                sk2Product: annualProduct
+            ),
+            offeringIdentifier: "offering",
+            webCheckoutUrl: nil
+        )
+        
+        let offering = Offering(
+            identifier: "onboardingOffering",
+            serverDescription: "",
+            availablePackages: [
+                monthlyPackage,
+                annualPackage
+            ],
+            webCheckoutUrl: nil
+        )
+        
+        // should leave the offering unchanged
+        XCTAssertEqual(offering.withPresentedOfferingContext(nil), offering)
+        
+        let presentedOfferingContext = PresentedOfferingContext(
+            offeringIdentifier: "onboardingOffering",
+            placementIdentifier: "onboarding",
+            targetingContext: .init(
+                revision: 1,
+                ruleId: "onboarding-rule-1"
+            )
+        )
+        
+        // all `availablePackages` should use the given `presentedOfferingContext`
+        let offeringWithPresentedOfferingContext = offering.withPresentedOfferingContext(presentedOfferingContext)
+        XCTAssert(offeringWithPresentedOfferingContext.availablePackages.allSatisfy { $0.presentedOfferingContext == presentedOfferingContext })
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
Based on PR [#2610](https://github.com/RevenueCat/purchases-android/pull/2610) for Android, adds similar internal APIs for the hybrid SDKs for iOS. Allows the hybrid SDKs to pass `PresentedOfferingContext` when launching paywalls by passing a specific offering

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
This PR implements the internal APIs, and uses the given `PresentedOfferingContext` when passing an `offeringIdentifier` from the hybrid SDKs to enrich the freshly fetched `Offering` with the given presentation context.