### PR TITLE
Add button_text to ScreenOffering

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsCardView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsCardView.swift
@@ -56,7 +56,7 @@ struct NoSubscriptionsCardView: View {
         self.init(
             title: localization[.noSubscriptionsFound],
             subtitle: localization[.tryCheckRestore],
-            subscribeTitle: localization[.buySubscrition],
+            subscribeTitle: screenOffering?.buttonText ?? localization[.buySubscrition],
             screenOffering: screenOffering,
             purchasesProvider: purchasesProvider
         )

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -734,13 +734,16 @@ import Foundation
     @_spi(Internal) public struct ScreenOffering: Equatable {
         @_spi(Internal) public let type: OfferingType
         @_spi(Internal) public let offeringId: String?
+        @_spi(Internal) public let buttonText: String?
 
         @_spi(Internal) public init(
             type: OfferingType,
-            offeringId: String?
+            offeringId: String?,
+            buttonText: String?
         ) {
             self.type = type
             self.offeringId = offeringId
+            self.buttonText = buttonText
         }
 
         @_spi(Internal) public enum OfferingType: String, Equatable {
@@ -786,13 +789,15 @@ extension CustomerCenterConfigData.Screen {
             case CustomerCenterConfigData.ScreenOffering.OfferingType.specific.rawValue:
                 return CustomerCenterConfigData.ScreenOffering(
                     type: .specific,
-                    offeringId: offering.offeringId
+                    offeringId: offering.offeringId,
+                    buttonText: offering.buttonText
                 )
 
             default:
                 return CustomerCenterConfigData.ScreenOffering(
                     type: .current,
-                    offeringId: nil
+                    offeringId: offering.offeringId,
+                    buttonText: offering.buttonText
                 )
             }
         }

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -796,7 +796,7 @@ extension CustomerCenterConfigData.Screen {
             default:
                 return CustomerCenterConfigData.ScreenOffering(
                     type: .current,
-                    offeringId: offering.offeringId,
+                    offeringId: nil,
                     buttonText: offering.buttonText
                 )
             }

--- a/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
+++ b/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
@@ -143,6 +143,7 @@ struct CustomerCenterConfigResponse {
     struct ScreenOffering {
         let type: String
         let offeringId: String?
+        let buttonText: String?
     }
 
     struct Support {


### PR DESCRIPTION
### Motivation
We want to be more explicit on how to edit the button text for the ScreenOffering.

### Description
- Add button text to ScreenOffering

> This comes already translated. For backwards compatibility, we default to the key used right now.
