### PR TITLE
Add option to disable automatic ID collection when setting attribution network IDs at configuration time

### DIFF
--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -54,6 +54,7 @@ import Foundation
     let responseVerificationMode: Signing.ResponseVerificationMode
     let showStoreMessagesAutomatically: Bool
     let preferredLocale: String?
+    let automaticDeviceIdentifierCollectionEnabled: Bool
     internal let diagnosticsEnabled: Bool
 
     private init(with builder: Builder) {
@@ -70,6 +71,7 @@ import Foundation
         self.showStoreMessagesAutomatically = builder.showStoreMessagesAutomatically
         self.diagnosticsEnabled = builder.diagnosticsEnabled
         self.preferredLocale = builder.preferredLocale
+        self.automaticDeviceIdentifierCollectionEnabled = builder.automaticDeviceIdentifierCollectionEnabled
     }
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
@@ -114,6 +116,7 @@ import Foundation
         private(set) var diagnosticsEnabled: Bool = false
         private(set) var storeKitVersion: StoreKitVersion = .default
         private(set) var preferredLocale: String?
+        private(set) var automaticDeviceIdentifierCollectionEnabled: Bool = true
 
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
@@ -296,6 +299,24 @@ import Foundation
         /// - ``StoreKitVersion``
         @objc public func with(storeKitVersion version: StoreKitVersion) -> Builder {
             self.storeKitVersion = version
+            return self
+        }
+
+        /// Set `automaticDeviceIdentifierCollectionEnabled`. This is enabled by default.
+        ///
+        /// Enable this setting to allow the collection of identifiers when setting the identifier for an
+        /// attribution network. For example, when calling``Purchases/setAdjustID(_:)``
+        /// or ``Purchases/setAppsflyerID(_:)``, the SDK would collect the device identifiers like
+        /// IDFA, IDFV or IP, if available, and send them to RevenueCat.
+        /// This is required by some attribution networks to attribute installs and re-installs.
+        ///
+        /// Enabling this setting does NOT mean we will always collect the identifiers. We will only do so when
+        /// setting an attribution network ID and the user has not limited tracking on their device.
+        ///
+        /// With this option disabled you can still collect device identifiers
+        /// by calling ``Purchases/collectDeviceIdentifiers()``
+        @objc public func with(automaticDeviceIdentifierCollectionEnabled: Bool) -> Builder {
+            self.automaticDeviceIdentifierCollectionEnabled = automaticDeviceIdentifierCollectionEnabled
             return self
         }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -296,7 +296,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                      dangerousSettings: DangerousSettings? = nil,
                      showStoreMessagesAutomatically: Bool,
                      diagnosticsEnabled: Bool = false,
-                     preferredLocale: String?
+                     preferredLocale: String?,
+                     automaticDeviceIdentifierCollectionEnabled: Bool = true,
     ) {
         if userDefaults != nil {
             Logger.debug(Strings.configure.using_custom_user_defaults)
@@ -426,17 +427,20 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         }
 
         let attributionDataMigrator = AttributionDataMigrator()
-        let subscriberAttributesManager = SubscriberAttributesManager(backend: backend,
-                                                                      deviceCache: deviceCache,
-                                                                      operationDispatcher: operationDispatcher,
-                                                                      attributionFetcher: attributionFetcher,
-                                                                      attributionDataMigrator: attributionDataMigrator)
+        let subscriberAttributesManager = SubscriberAttributesManager(
+            backend: backend,
+            deviceCache: deviceCache,
+            operationDispatcher: operationDispatcher,
+            attributionFetcher: attributionFetcher,
+            attributionDataMigrator: attributionDataMigrator,
+            automaticDeviceIdentifierCollectionEnabled: automaticDeviceIdentifierCollectionEnabled)
         let identityManager = IdentityManager(deviceCache: deviceCache,
                                               systemInfo: systemInfo,
                                               backend: backend,
                                               customerInfoManager: customerInfoManager,
                                               attributeSyncing: subscriberAttributesManager,
-                                              appUserID: appUserID)
+                                              appUserID: appUserID,
+        )
 
         let paywallEventsManager: PaywallEventsManagerType?
         do {
@@ -1468,7 +1472,8 @@ public extension Purchases {
                   dangerousSettings: configuration.dangerousSettings,
                   showStoreMessagesAutomatically: configuration.showStoreMessagesAutomatically,
                   diagnosticsEnabled: configuration.diagnosticsEnabled,
-                  preferredLocale: configuration.preferredLocale
+                  preferredLocale: configuration.preferredLocale,
+                  automaticDeviceIdentifierCollectionEnabled: configuration.automaticDeviceIdentifierCollectionEnabled,
         )
     }
 
@@ -1735,7 +1740,8 @@ public extension Purchases {
         dangerousSettings: DangerousSettings?,
         showStoreMessagesAutomatically: Bool,
         diagnosticsEnabled: Bool,
-        preferredLocale: String?
+        preferredLocale: String?,
+        automaticDeviceIdentifierCollectionEnabled: Bool,
     ) -> Purchases {
         return self.setDefaultInstance(
             .init(apiKey: apiKey,
@@ -1751,7 +1757,8 @@ public extension Purchases {
                   dangerousSettings: dangerousSettings,
                   showStoreMessagesAutomatically: showStoreMessagesAutomatically,
                   diagnosticsEnabled: diagnosticsEnabled,
-                  preferredLocale: preferredLocale)
+                  preferredLocale: preferredLocale,
+                  automaticDeviceIdentifierCollectionEnabled: automaticDeviceIdentifierCollectionEnabled)
         )
     }
 

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -20,6 +20,7 @@ class SubscriberAttributesManager {
     private let operationDispatcher: OperationDispatcher
     private let attributionFetcher: AttributionFetcher
     private let attributionDataMigrator: AttributionDataMigrator
+    private let automaticDeviceIdentifierCollectionEnabled: Bool
     private let lock = Lock()
 
     weak var delegate: SubscriberAttributesManagerDelegate?
@@ -28,12 +29,14 @@ class SubscriberAttributesManager {
          deviceCache: DeviceCache,
          operationDispatcher: OperationDispatcher,
          attributionFetcher: AttributionFetcher,
-         attributionDataMigrator: AttributionDataMigrator) {
+         attributionDataMigrator: AttributionDataMigrator,
+         automaticDeviceIdentifierCollectionEnabled: Bool = true) {
         self.backend = backend
         self.deviceCache = deviceCache
         self.operationDispatcher = operationDispatcher
         self.attributionFetcher = attributionFetcher
         self.attributionDataMigrator = attributionDataMigrator
+        self.automaticDeviceIdentifierCollectionEnabled = automaticDeviceIdentifierCollectionEnabled
     }
 
     func setAttributes(_ attributes: [String: String], appUserID: String) {
@@ -313,7 +316,9 @@ private extension SubscriberAttributesManager {
     func setAttributionID(_ attributionID: String?,
                           forNetworkID networkID: ReservedSubscriberAttribute,
                           appUserID: String) {
-        collectDeviceIdentifiers(forAppUserID: appUserID)
+        if automaticDeviceIdentifierCollectionEnabled {
+            collectDeviceIdentifiers(forAppUserID: appUserID)
+        }
         setReservedAttribute(networkID, value: attributionID, appUserID: appUserID)
     }
 

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCConfigurationAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCConfigurationAPI.m
@@ -13,7 +13,7 @@
 
 + (void)checkAPI {
     RCConfigurationBuilder *builder = [RCConfiguration builderWithAPIKey:@""];
-    RCConfiguration *config __unused = [[[[[[[[[[[[[builder withApiKey:@""]
+    RCConfiguration *config __unused = [[[[[[[[[[[[[[builder withApiKey:@""]
                                                    withPurchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat storeKitVersion:RCStoreKitVersion2]
                                                   withUserDefaults:NSUserDefaults.standardUserDefaults]
                                                  withAppUserID:@""]
@@ -25,6 +25,7 @@
                                            withUsesStoreKit2IfAvailable:false]
                                           withStoreKitVersion:RCStoreKitVersion2]
                                          withEntitlementVerificationMode:RCEntitlementVerificationModeInformational]
+                                         withAutomaticDeviceIdentifierCollectionEnabled:true]
                                         build];
 
     if (@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)) {

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/ConfigurationAPI.swift
@@ -22,6 +22,7 @@ func checkConfigurationAPI() {
         .with(platformInfo: Purchases.PlatformInfo(flavor: "", version: ""))
         .with(storeKitVersion: .default)
         .with(entitlementVerificationMode: .informational)
+        .with(automaticDeviceIdentifierCollectionEnabled: true)
 
     let _: Configuration = builder.build()
 

--- a/Tests/UnitTests/Purchasing/ConfigurationTests.swift
+++ b/Tests/UnitTests/Purchasing/ConfigurationTests.swift
@@ -115,4 +115,17 @@ class ConfigurationTests: TestCase {
         expect(configuration.storeKitVersion) == .default
     }
 
+    func testAutomaticDeviceIdentifierCollectionEnabledIsTrueByDefault() {
+        let configuration = Configuration.Builder(withAPIKey: "test")
+            .build()
+        expect(configuration.automaticDeviceIdentifierCollectionEnabled) == true
+    }
+
+    func testAutomaticDeviceIdentifierCollectionEnabledCanBeSet() {
+        let configuration = Configuration.Builder(withAPIKey: "test")
+            .with(automaticDeviceIdentifierCollectionEnabled: false)
+            .build()
+        expect(configuration.automaticDeviceIdentifierCollectionEnabled) == false
+    }
+
 }

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -42,7 +42,8 @@ class SubscriberAttributesManagerTests: TestCase {
             deviceCache: mockDeviceCache,
             operationDispatcher: MockOperationDispatcher(),
             attributionFetcher: mockAttributionFetcher,
-            attributionDataMigrator: mockAttributionDataMigrator
+            attributionDataMigrator: mockAttributionDataMigrator,
+            automaticDeviceIdentifierCollectionEnabled: true,
         )
         self.subscriberAttributeHeight = SubscriberAttribute(withKey: "height",
                                                              value: "183")
@@ -622,6 +623,24 @@ class SubscriberAttributesManagerTests: TestCase {
 
         checkDeviceIdentifiersAreSet()
     }
+
+    func testSetAdjustIDDoesNotSetDeviceIdentifiersIfOptionDisabled() {
+        self.subscriberAttributesManager = SubscriberAttributesManager(
+            backend: mockBackend,
+            deviceCache: mockDeviceCache,
+            operationDispatcher: MockOperationDispatcher(),
+            attributionFetcher: mockAttributionFetcher,
+            attributionDataMigrator: mockAttributionDataMigrator,
+            automaticDeviceIdentifierCollectionEnabled: false,
+        )
+        let adjustID = "adjustID"
+        self.subscriberAttributesManager.setAdjustID(adjustID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
+
+        checkDeviceIdentifiersAreNotSet()
+    }
     // endregion
     // region AppsflyerID
     func testSetAppsflyerID() {
@@ -694,6 +713,24 @@ class SubscriberAttributesManagerTests: TestCase {
         expect(self.mockDeviceCache.invokedStoreParametersList.count) == 5
 
         checkDeviceIdentifiersAreSet()
+    }
+
+    func testSetAppsflyerIDDoesNotSetDeviceIdentifiersIfOptionDisabled() {
+        self.subscriberAttributesManager = SubscriberAttributesManager(
+            backend: mockBackend,
+            deviceCache: mockDeviceCache,
+            operationDispatcher: MockOperationDispatcher(),
+            attributionFetcher: mockAttributionFetcher,
+            attributionDataMigrator: mockAttributionDataMigrator,
+            automaticDeviceIdentifierCollectionEnabled: false,
+        )
+        let appsflyerID = "appsflyerID"
+        self.subscriberAttributesManager.setAppsflyerID(appsflyerID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
+
+        checkDeviceIdentifiersAreNotSet()
     }
     // endregion
     // region FBAnonymousID
@@ -768,6 +805,24 @@ class SubscriberAttributesManagerTests: TestCase {
 
         checkDeviceIdentifiersAreSet()
     }
+
+    func testSetFBAnonymousIDDoesNotSetDeviceIdentifiersIfOptionDisabled() {
+        self.subscriberAttributesManager = SubscriberAttributesManager(
+            backend: mockBackend,
+            deviceCache: mockDeviceCache,
+            operationDispatcher: MockOperationDispatcher(),
+            attributionFetcher: mockAttributionFetcher,
+            attributionDataMigrator: mockAttributionDataMigrator,
+            automaticDeviceIdentifierCollectionEnabled: false,
+        )
+        let fbAnonID = "fbAnonID"
+        self.subscriberAttributesManager.setFBAnonymousID(fbAnonID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
+
+        checkDeviceIdentifiersAreNotSet()
+    }
     // endregion
     // region mParticle
     func testSetMparticleID() {
@@ -840,6 +895,24 @@ class SubscriberAttributesManagerTests: TestCase {
         expect(self.mockDeviceCache.invokedStoreParametersList.count) == 5
 
         checkDeviceIdentifiersAreSet()
+    }
+
+    func testSetMparticleIDDoesNotSetDeviceIdentifiersIfOptionDisabled() {
+        self.subscriberAttributesManager = SubscriberAttributesManager(
+            backend: mockBackend,
+            deviceCache: mockDeviceCache,
+            operationDispatcher: MockOperationDispatcher(),
+            attributionFetcher: mockAttributionFetcher,
+            attributionDataMigrator: mockAttributionDataMigrator,
+            automaticDeviceIdentifierCollectionEnabled: false,
+        )
+        let mparticleID = "mparticleID"
+        self.subscriberAttributesManager.setMparticleID(mparticleID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
+
+        checkDeviceIdentifiersAreNotSet()
     }
     // endregion
     // region OnesignalID
@@ -1205,6 +1278,24 @@ class SubscriberAttributesManagerTests: TestCase {
         expect(self.mockDeviceCache.invokedStoreParametersList.count) == 5
 
         checkDeviceIdentifiersAreSet()
+    }
+
+    func testSetKochavaDeviceIDDoesNotSetDeviceIdentifiersIfOptionDisabled() {
+        self.subscriberAttributesManager = SubscriberAttributesManager(
+            backend: mockBackend,
+            deviceCache: mockDeviceCache,
+            operationDispatcher: MockOperationDispatcher(),
+            attributionFetcher: mockAttributionFetcher,
+            attributionDataMigrator: mockAttributionDataMigrator,
+            automaticDeviceIdentifierCollectionEnabled: false,
+        )
+        let kochavaDeviceId = "kochavaDeviceID"
+        self.subscriberAttributesManager.setKochavaDeviceID(kochavaDeviceId, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
+
+        checkDeviceIdentifiersAreNotSet()
     }
     // endregion
     // region MixpanelDistinctID


### PR DESCRIPTION
### Description
iOS equivalent of https://github.com/RevenueCat/purchases-android/pull/2643

This adds a new API that can be used to disable automatic collection of device identifiers when using one of the attribution networks we support like Adjust or Appsflyer (among others). This can be set at configuration time like this:
```
let configuration = Configuration.Builder(withAPIKey: "test")
    .with(automaticDeviceIdentifierCollectionEnabled: enabled)
    .build()
Purchases.configure(configuration)
```

Note that you can still collect these identifiers with this option disabled by calling `Purchases.shared.collectDeviceIdentifiers()`