### PR TITLE
Fix backend integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1541,6 +1541,7 @@ workflows:
       - run-revenuecat-ui-ios-17
       - run-revenuecat-ui-ios-18
       - emerge_purchases_ui_snapshot_tests
+      - backend-integration-tests-SK2
 
   create-tag:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1541,7 +1541,6 @@ workflows:
       - run-revenuecat-ui-ios-17
       - run-revenuecat-ui-ios-18
       - emerge_purchases_ui_snapshot_tests
-      - backend-integration-tests-SK2
 
   create-tag:
     when:

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1741,7 +1741,7 @@ public extension Purchases {
         showStoreMessagesAutomatically: Bool,
         diagnosticsEnabled: Bool,
         preferredLocale: String?,
-        automaticDeviceIdentifierCollectionEnabled: Bool
+        automaticDeviceIdentifierCollectionEnabled: Bool = true
     ) -> Purchases {
         return self.setDefaultInstance(
             .init(apiKey: apiKey,


### PR DESCRIPTION
### Description
Backend integration tests were failing because I missed to pass the new parameter added in #5504. This just adds a default value so we don't need to pass it in for the tests.