### PR TITLE
Added the 'deepLinkID' property to PaywallComponentsData

### DIFF
--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
@@ -470,7 +470,8 @@ private enum ButtonWithSheetPreview {
             "close": .string("X")
         ]],
         revision: 1,
-        defaultLocaleIdentifier: "en_US"
+        defaultLocaleIdentifier: "en_US",
+        deepLinkID: "components"
     )
 }
 

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
@@ -371,7 +371,8 @@ private enum FamilySharingTogglePreview {
             "toggle_text": .string("Family Sharing?")
         ]],
         revision: 1,
-        defaultLocaleIdentifier: "en_US"
+        defaultLocaleIdentifier: "en_US",
+        deepLinkID: "components"
     )
 }
 

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
@@ -378,7 +378,8 @@ private enum MultiTierPreview {
             "tab_2_button": .string("Premium")
         ]],
         revision: 1,
-        defaultLocaleIdentifier: "en_US"
+        defaultLocaleIdentifier: "en_US",
+        deepLinkID: "components"
     )
 }
 

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/PurchaseButtonInPackagePreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/PurchaseButtonInPackagePreview.swift
@@ -301,7 +301,8 @@ private enum PurchaseButtonInPackagePreview {
             "cta_lifetime": .string("Buy Lifetime")
         ]],
         revision: 1,
-        defaultLocaleIdentifier: "en_US"
+        defaultLocaleIdentifier: "en_US",
+        deepLinkID: "components"
     )
 }
 

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -195,7 +195,8 @@ private enum Template1Preview {
             "cta_intro": .string("Claim Free Trial")
         ]],
         revision: 1,
-        defaultLocaleIdentifier: "en_US"
+        defaultLocaleIdentifier: "en_US",
+        deepLinkID: "components"
     )
 }
 

--- a/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
@@ -104,7 +104,7 @@ public struct PaywallComponentsData: Codable, Equatable, Sendable {
         case defaultLocale
         case assetBaseURL = "assetBaseUrl"
         case _revision = "revision"
-        case deepLinkID = "deep_link_id"
+        case deepLinkID = "deepLinkId"
     }
 
     public init(templateName: String,

--- a/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
@@ -88,6 +88,10 @@ public struct PaywallComponentsData: Codable, Equatable, Sendable {
     public var componentsLocalizations: [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary]
     public var defaultLocale: String
 
+    // The ID used for deeplinking
+    @_spi(Internal)
+    public let deepLinkID: String
+
     @DefaultDecodable.Zero
     internal private(set) var _revision: Int = 0
 
@@ -100,6 +104,7 @@ public struct PaywallComponentsData: Codable, Equatable, Sendable {
         case defaultLocale
         case assetBaseURL = "assetBaseUrl"
         case _revision = "revision"
+        case deepLinkID = "deep_link_id"
     }
 
     public init(templateName: String,
@@ -107,19 +112,22 @@ public struct PaywallComponentsData: Codable, Equatable, Sendable {
                 componentsConfig: ComponentsConfig,
                 componentsLocalizations: [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary],
                 revision: Int,
-                defaultLocaleIdentifier: String) {
+                defaultLocaleIdentifier: String,
+                deepLinkID: String) {
         self.templateName = templateName
         self.assetBaseURL = assetBaseURL
         self.componentsConfig = componentsConfig
         self.componentsLocalizations = componentsLocalizations
         self._revision = revision
         self.defaultLocale = defaultLocaleIdentifier
+        self.deepLinkID = deepLinkID
     }
 
 }
 
 extension PaywallComponentsData {
 
+    // swiftlint:disable:next function_body_length
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         var errors: [String: EquatableError] = [:]
@@ -174,6 +182,13 @@ extension PaywallComponentsData {
             _revision = 0
         }
 
+        do {
+            deepLinkID = try container.decode(String.self, forKey: .deepLinkID)
+        } catch {
+            errors["deep_link_id"] = .init(error)
+            deepLinkID = ""
+        }
+
         if !errors.isEmpty {
             errorInfo = errors
         }
@@ -188,6 +203,7 @@ extension PaywallComponentsData {
         try container.encode(componentsLocalizations, forKey: .componentsLocalizations)
         try container.encode(defaultLocale, forKey: .defaultLocale)
         try container.encode(_revision, forKey: ._revision)
+        try container.encode(deepLinkID, forKey: .deepLinkID)
     }
 
 }

--- a/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsWithPaywallComponents.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsWithPaywallComponents.json
@@ -11,6 +11,7 @@
                 }
             ],
             "paywall_components": {
+                "deep_link_id": "components-test1",
                 "default_locale": "en_US",
                 "revision": 3,
                 "template_name": "componentsTEST",
@@ -61,6 +62,7 @@
                 }
             ],
             "paywall_components": {
+                "deep_link_id": "components-test2",
                 "default_locale": "en_US",
                 "revision": 3,
                 "template_name": "componentsTEST",
@@ -125,6 +127,7 @@
                 }
             },
             "draft_paywall_components": {
+                "deep_link_id": "draft-components-test2",
                 "default_locale": "en_US",
                 "revision": 4,
                 "template_name": "newComponentsTEST",
@@ -199,6 +202,7 @@
                 }
             ],
             "draft_paywall_components": {
+                "deep_link_id": "draft-components-test3",
                 "default_locale": "en_US",
                 "revision": 4,
                 "template_name": "newComponentsTEST",

--- a/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
@@ -12,7 +12,7 @@
 //  Created by Antonio Pallares on 13/2/25.
 
 import Nimble
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import XCTest
 
 class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
@@ -41,6 +41,7 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
         expect(components.componentsConfig.base.stack.spacing) == 16
         expect(components.componentsConfig.base.stack.dimension) == .vertical(.center, .center)
         expect(components.componentsConfig.base.stack.components).to(haveCount(0))
+        expect(components.deepLinkID) == "components-test1"
 
         expect(offering.draftPaywallComponents) == nil
     }
@@ -61,6 +62,7 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
         expect(components.componentsConfig.base.stack.spacing) == 16
         expect(components.componentsConfig.base.stack.dimension) == .vertical(.center, .center)
         expect(components.componentsConfig.base.stack.components).to(haveCount(1))
+        expect(components.deepLinkID) == "components-test2"
 
         let draftComponents = try XCTUnwrap(offering.draftPaywallComponents)
         expect(draftComponents.templateName) == "newComponentsTEST"
@@ -70,6 +72,7 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
         expect(draftComponents.componentsConfig.base.stack.spacing) == 0
         expect(draftComponents.componentsConfig.base.stack.dimension) == .vertical(.leading, .end)
         expect(draftComponents.componentsConfig.base.stack.components).to(haveCount(1))
+        expect(draftComponents.deepLinkID) == "draft-components-test2"
     }
 
     func testDecodesPaywallComponentsWithOnlyDraftPaywallComponents() throws {
@@ -90,5 +93,6 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
         expect(draftComponents.componentsConfig.base.stack.spacing) == 0
         expect(draftComponents.componentsConfig.base.stack.dimension) == .vertical(.leading, .end)
         expect(draftComponents.componentsConfig.base.stack.components).to(haveCount(1))
+        expect(draftComponents.deepLinkID) == "draft-components-test3"
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
The  ~`id`~ `deepLinkID` of the paywall is needed in order to use universal links to link to the right paywall preview in the RC mobile app.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
Implements the ~`id`~ `deepLinkID` property on the `PaywallComponentsData` type