### PR TITLE
Refetch offerings when preferred locale is set

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1931,6 +1931,10 @@ extension Purchases {
 
     // swiftlint:disable missing_docs
     @_spi(Internal) public func overridePreferredLocale(_ locale: String?) {
+        guard locale != self.systemInfo.preferredLocaleOverride else {
+            return
+        }
+
         self.systemInfo.overridePreferredLocale(locale)
 
         if self.overridePreferredUILocaleRateLimiter.shouldProceed() {


### PR DESCRIPTION
### Motivation

Refetch current offerings (no cache) when preferred locale is set

### Description

Use a rate limiter when attempting to fetch current offerings when setting preferred locale (2 times per minute)
