### PR TITLE
Fix compilation error in Xcode 14

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterPurchases.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterPurchases.swift
@@ -61,12 +61,12 @@ final class CustomerCenterPurchases: CustomerCenterPurchasesType {
         promotionalOffer: PromotionalOffer?
     ) async throws -> PurchaseResultData {
         if let promotionalOffer = promotionalOffer {
-            try await Purchases.shared.purchase(
+            return try await Purchases.shared.purchase(
                 product: product,
                 promotionalOffer: promotionalOffer
             )
         } else {
-            try await Purchases.shared.purchase(product: product)
+            return try await Purchases.shared.purchase(product: product)
         }
     }
 


### PR DESCRIPTION

### Motivation
After #5512, RevenueCatUI was not building in Xcode 14 due to a missing `return` statement.

### Description
This PR adds the missing `return` to fix compilation in Xcode 14