### PR TITLE
Post receipt in for purchases in Test Store

### DIFF
--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -258,6 +258,13 @@ private extension TransactionPoster {
 
     func fetchEncodedReceipt(transaction: StoreTransactionType,
                              completion: @escaping (Result<EncodedAppleReceipt, BackendError>) -> Void) {
+        #if SIMULATED_STORE
+        if systemInfo.isSimulatedStoreAPIKey {
+            let purchaseToken = transaction.jwsRepresentation ?? ""
+            completion(.success(.jws(purchaseToken)))
+            return
+        }
+        #endif
         if systemInfo.storeKitVersion.isStoreKit2EnabledAndAvailable,
            let jwsRepresentation = transaction.jwsRepresentation {
             if transaction.environment == .xcode, #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {

--- a/Sources/Purchasing/SimulatedStore/SimulatedStorePurchaseHandler.swift
+++ b/Sources/Purchasing/SimulatedStore/SimulatedStorePurchaseHandler.swift
@@ -83,13 +83,13 @@ actor SimulatedStorePurchaseHandler: SimulatedStorePurchaseHandlerType {
 
     private func createStoreTransaction(product: TestStoreProduct) async -> StoreTransaction {
         let purchaseDate = Date()
-        let transactionId = "test_\(purchaseDate.millisecondsSince1970)_\(UUID().uuidString)"
+        let purchaseToken = "test_\(purchaseDate.millisecondsSince1970)_\(UUID().uuidString)"
         let storefront = await Storefront.currentStorefront
         let simulatedStoreTransaction = SimulatedStoreTransaction(productIdentifier: product.productIdentifier,
                                                                   purchaseDate: purchaseDate,
-                                                                  transactionIdentifier: transactionId,
+                                                                  transactionIdentifier: purchaseToken,
                                                                   storefront: storefront,
-                                                                  jwsRepresentation: nil)
+                                                                  jwsRepresentation: purchaseToken)
         return StoreTransaction(simulatedStoreTransaction)
     }
 

--- a/Sources/Purchasing/SimulatedStore/SimulatedStorePurchaseHandler.swift
+++ b/Sources/Purchasing/SimulatedStore/SimulatedStorePurchaseHandler.swift
@@ -30,6 +30,7 @@ protocol SimulatedStorePurchaseHandlerType: AnyObject, Sendable {
 actor SimulatedStorePurchaseHandler: SimulatedStorePurchaseHandlerType {
 
     private let purchaseUI: SimulatedStorePurchaseUI
+    private let dateProvider: DateProvider
 
     private var currentPurchaseTask: Task<TestPurchaseResult, Never>?
     private var purchaseInProgress: Bool {
@@ -38,11 +39,13 @@ actor SimulatedStorePurchaseHandler: SimulatedStorePurchaseHandlerType {
 
     init(systemInfo: SystemInfo) {
         self.purchaseUI = DefaultSimulatedStorePurchaseUI(systemInfo: systemInfo)
+        self.dateProvider = DateProvider()
     }
 
     // For testing purposes
-    init(purchaseUI: SimulatedStorePurchaseUI) {
+    init(purchaseUI: SimulatedStorePurchaseUI, dateProvider: DateProvider) {
         self.purchaseUI = purchaseUI
+        self.dateProvider = dateProvider
     }
 
     #if SIMULATED_STORE
@@ -82,7 +85,7 @@ actor SimulatedStorePurchaseHandler: SimulatedStorePurchaseHandlerType {
     }
 
     private func createStoreTransaction(product: TestStoreProduct) async -> StoreTransaction {
-        let purchaseDate = Date()
+        let purchaseDate = self.dateProvider.now()
         let purchaseToken = "test_\(purchaseDate.millisecondsSince1970)_\(UUID().uuidString)"
         let storefront = await Storefront.currentStorefront
         let simulatedStoreTransaction = SimulatedStoreTransaction(productIdentifier: product.productIdentifier,

--- a/Tests/UnitTests/SimulatedStore/SimulatedStorePurchaseHandlerTests.swift
+++ b/Tests/UnitTests/SimulatedStore/SimulatedStorePurchaseHandlerTests.swift
@@ -185,7 +185,7 @@ class SimulatedStorePurchaseHandlerTests: TestCase {
                                                            productType: .autoRenewableSubscription,
                                                            localizedDescription: "Description")
 
-    private static let mockDate = Date(millisecondsSince1970: 1756796794912)
+    private static let mockDate = Date(millisecondsSince1970: 1756796794912) // Sep 02 2025 07:06:34.912 UTC
 }
 
 #endif // SIMULATED_STORE

--- a/Tests/UnitTests/SimulatedStore/SimulatedStorePurchaseHandlerTests.swift
+++ b/Tests/UnitTests/SimulatedStore/SimulatedStorePurchaseHandlerTests.swift
@@ -20,14 +20,17 @@ import XCTest
 class SimulatedStorePurchaseHandlerTests: TestCase {
 
     private var mockSimulatedStorePurchaseUI: MockSimulatedStorePurchaseUI!
+    private var mockDateProvider: DateProvider!
 
     override func setUp() {
         super.setUp()
         self.mockSimulatedStorePurchaseUI = MockSimulatedStorePurchaseUI()
+        self.mockDateProvider = MockDateProvider(stubbedNow: Self.mockDate)
     }
 
     func testPurchaseProductCallsPurchaseUI() async {
-        let hander = SimulatedStorePurchaseHandler(purchaseUI: mockSimulatedStorePurchaseUI)
+        let hander = SimulatedStorePurchaseHandler(purchaseUI: mockSimulatedStorePurchaseUI,
+                                                   dateProvider: self.mockDateProvider)
 
         _ = await hander.purchase(product: Self.testStoreProduct)
 
@@ -42,7 +45,8 @@ class SimulatedStorePurchaseHandlerTests: TestCase {
             await self.fulfillment(of: [expectation])
             return .cancel
         }
-        let hander = SimulatedStorePurchaseHandler(purchaseUI: mockSimulatedStorePurchaseUI)
+        let hander = SimulatedStorePurchaseHandler(purchaseUI: mockSimulatedStorePurchaseUI,
+                                                   dateProvider: self.mockDateProvider)
 
         async let result0 = hander.purchase(product: Self.testStoreProduct)
 
@@ -80,7 +84,8 @@ class SimulatedStorePurchaseHandlerTests: TestCase {
 
     func testPurchaseProductWithSimulatedSuccess() async {
         mockSimulatedStorePurchaseUI.stubbedPurchaseResult.value = { return .simulateSuccess }
-        let hander = SimulatedStorePurchaseHandler(purchaseUI: mockSimulatedStorePurchaseUI)
+        let hander = SimulatedStorePurchaseHandler(purchaseUI: mockSimulatedStorePurchaseUI,
+                                                   dateProvider: self.mockDateProvider)
 
         let result = await hander.purchase(product: Self.testStoreProduct)
 
@@ -96,7 +101,8 @@ class SimulatedStorePurchaseHandlerTests: TestCase {
 
     func testPurchaseProductWithSimulatedFailure() async {
         mockSimulatedStorePurchaseUI.stubbedPurchaseResult.value = { return .simulateFailure }
-        let hander = SimulatedStorePurchaseHandler(purchaseUI: mockSimulatedStorePurchaseUI)
+        let hander = SimulatedStorePurchaseHandler(purchaseUI: mockSimulatedStorePurchaseUI,
+                                                   dateProvider: self.mockDateProvider)
 
         let result = await hander.purchase(product: Self.testStoreProduct)
 
@@ -112,7 +118,8 @@ class SimulatedStorePurchaseHandlerTests: TestCase {
 
     func testPurchaseProductWithSimulatedCancel() async {
         mockSimulatedStorePurchaseUI.stubbedPurchaseResult.value = { return .cancel }
-        let hander = SimulatedStorePurchaseHandler(purchaseUI: mockSimulatedStorePurchaseUI)
+        let hander = SimulatedStorePurchaseHandler(purchaseUI: mockSimulatedStorePurchaseUI,
+                                                   dateProvider: self.mockDateProvider)
 
         let result = await hander.purchase(product: Self.testStoreProduct)
 
@@ -128,7 +135,8 @@ class SimulatedStorePurchaseHandlerTests: TestCase {
 
     func testPurchaseProductWithUIError() async {
         mockSimulatedStorePurchaseUI.stubbedPurchaseResult.value = { return .error(ErrorUtils.unknownError()) }
-        let hander = SimulatedStorePurchaseHandler(purchaseUI: mockSimulatedStorePurchaseUI)
+        let hander = SimulatedStorePurchaseHandler(purchaseUI: mockSimulatedStorePurchaseUI,
+                                                   dateProvider: self.mockDateProvider)
 
         let result = await hander.purchase(product: Self.testStoreProduct)
 
@@ -142,12 +150,42 @@ class SimulatedStorePurchaseHandlerTests: TestCase {
         }
     }
 
+    func testStoreTransactionWhenPurchasingProduct() async throws {
+        mockSimulatedStorePurchaseUI.stubbedPurchaseResult.value = { return .simulateSuccess }
+        let hander = SimulatedStorePurchaseHandler(purchaseUI: mockSimulatedStorePurchaseUI,
+                                                   dateProvider: self.mockDateProvider)
+
+        let result = await hander.purchase(product: Self.testStoreProduct)
+
+        XCTAssertTrue(self.mockSimulatedStorePurchaseUI.invokedPresentPurchaseUI.value)
+        XCTAssertEqual(self.mockSimulatedStorePurchaseUI.invokedPresentPurchaseUICount.value, 1)
+
+        if case .success(let transaction) = result {
+            expect(transaction.productIdentifier).to(equal(Self.testStoreProduct.productIdentifier))
+            expect(transaction.purchaseDate) == Self.mockDate
+
+            // Expect a specific token format for the jwsRepresentation property
+            let token = try XCTUnwrap(transaction.jwsRepresentation)
+            expect(token.hasPrefix("test_1756796794912_")).to(beTrue())
+            var uuidSuffix = token
+            uuidSuffix.removeFirst("test_1756796794912_".count)
+            XCTAssertNotNil(UUID(uuidString: uuidSuffix))
+
+            // Expect the same token for the transaction identifier
+            expect(transaction.transactionIdentifier) == token
+        } else {
+            XCTFail("Expected .success result, got \(result)")
+        }
+    }
+
     private static let testStoreProduct = TestStoreProduct(localizedTitle: "Title",
                                                            price: 1.99,
                                                            localizedPriceString: "$1.99",
                                                            productIdentifier: "product",
                                                            productType: .autoRenewableSubscription,
                                                            localizedDescription: "Description")
+
+    private static let mockDate = Date(millisecondsSince1970: 1756796794912)
 }
 
 #endif // SIMULATED_STORE


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Description
When making a purchase in the Test Store (Simulated Store), the `fetch_token` for the POST receipt request now contains the string `test_$PURCHASETIME_$UUID`.