### PR TITLE
Fix markdown bold text in paywalls

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -115,7 +115,7 @@ private struct NonLocalizedMarkdownText: View {
         }
 
         return attrString
-        
+
         #else
         return nil
         #endif

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -239,6 +239,52 @@ struct TextComponentView_Previews: PreviewProvider {
         .previewLayout(.sizeThatFits)
         .previewDisplayName("Markdown")
 
+        // Markdown - Extra light
+        TextComponentView(
+            // swiftlint:disable:next force_try
+            viewModel: try! .init(
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        // swiftlint:disable:next line_length
+                        "id_1": .string("Hello, world\n**bold**\n_italic_ \n`code`\n[RevenueCat](https://revenuecat.com)")
+                    ]
+                ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                component: .init(
+                    text: "id_1",
+                    fontWeight: .extraLight,
+                    color: .init(light: .hex("#000000"))
+                )
+            )
+        )
+        .previewRequiredPaywallsV2Properties()
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Markdown - Extra light")
+
+        // Markdown - Black
+        TextComponentView(
+            // swiftlint:disable:next force_try
+            viewModel: try! .init(
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        // swiftlint:disable:next line_length
+                        "id_1": .string("Hello, world\n**bold**\n_italic_ \n`code`\n[RevenueCat](https://revenuecat.com)")
+                    ]
+                ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                component: .init(
+                    text: "id_1",
+                    fontWeight: .black,
+                    color: .init(light: .hex("#000000"))
+                )
+            )
+        )
+        .previewRequiredPaywallsV2Properties()
+        .previewLayout(.sizeThatFits)
+        .previewDisplayName("Markdown - Black")
+
         // Markdown - Invalid
         TextComponentView(
             // swiftlint:disable:next force_try


### PR DESCRIPTION
### Motivation

Markdown bold text in paywalls was only being applied when the text had a regular font weight. For example, setting the font weight of a text to Extra light would not apply markdown bold. This is a bug

### Description

This PR fixes the behavior for markdown bold text in paywalls so that it works as intended:
* If the font weight of the text is <= Bold, markdown bold should be Bold
* If the font weight of the text is > Bold, markdown bold should be the same as the whole text (no difference)

Related fix on Android: https://github.com/RevenueCat/purchases-android/pull/2421

Also added a Preview (also for snapshot tests) using bold markdown in a text with extra light font weight:
| Before  | After |
| -------- | ------- |
| <img width="109" height="120" alt="image" src="https://github.com/user-attachments/assets/5ad537e7-5edd-4d02-afc5-4dfed3e4d10b" />  | <img width="108" height="121" alt="image" src="https://github.com/user-attachments/assets/444e07b3-b82f-450d-a4a0-8d0baa7d6e1f" />    |


