### PR TITLE
Updating Customer Center UI to be ready for iOS 26

### DIFF
--- a/RevenueCatUI/CustomerCenter/ButtonStyles.swift
+++ b/RevenueCatUI/CustomerCenter/ButtonStyles.swift
@@ -32,15 +32,27 @@ struct ProminentButtonStyle: PrimitiveButtonStyle {
         let background = Color.from(colorInformation: appearance.buttonBackgroundColor, for: colorScheme)
         let textColor = Color.from(colorInformation: appearance.buttonTextColor, for: colorScheme)
 
-        Button(action: { configuration.trigger() }, label: {
-            configuration.label.frame(maxWidth: .infinity)
-        })
-        .font(.body.weight(.medium))
-        .buttonStyle(.borderedProminent)
-        .controlSize(.large)
-        .buttonBorderShape(.roundedRectangle(radius: 16))
-        .applyIf(background != nil, apply: { $0.tint(background) })
-        .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
+        if #available(iOS 26.0, *) {
+            Button(action: { configuration.trigger() }, label: {
+                configuration.label.frame(maxWidth: .infinity)
+            })
+            .font(.body.weight(.medium))
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .applyIf(background != nil, apply: { $0.tint(background) })
+            .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
+        } else {
+            Button(action: { configuration.trigger() }, label: {
+                configuration.label.frame(maxWidth: .infinity)
+            })
+            .font(.body.weight(.medium))
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .buttonBorderShape(.roundedRectangle(radius: 16))
+            .applyIf(background != nil, apply: { $0.tint(background) })
+            .applyIf(textColor != nil, apply: { $0.foregroundColor(textColor) })
+        }
+        
     }
 }
 
@@ -93,26 +105,39 @@ struct DismissCircleButton: View {
     var customDismiss: (() -> Void)?
 
     var body: some View {
-        Button {
-            if let customDismiss {
-                customDismiss()
-            } else {
-                self.dismiss()
+        
+        if #available(iOS 26.0, *) {
+            Button(role: .close) {
+                if let customDismiss {
+                    customDismiss()
+                } else {
+                    self.dismiss()
+                }
             }
-        } label: {
-            Circle()
-                .fill(Color(uiColor: .secondarySystemFill))
-                .frame(width: 28, height: 28)
-                .overlay(
-                    Image(systemName: "xmark")
-                        .font(.system(size: 14, weight: .bold))
-                        .foregroundStyle(.secondary)
-                        .imageScale(.medium)
-                )
-            }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("circled_close_button")
-        .accessibilityLabel(Text(localization[.dismiss]))
+            .accessibilityIdentifier("circled_close_button")
+            .accessibilityLabel(Text(localization[.dismiss]))
+        } else {
+            Button {
+                if let customDismiss {
+                    customDismiss()
+                } else {
+                    self.dismiss()
+                }
+            } label: {
+                Circle()
+                    .fill(Color(uiColor: .secondarySystemFill))
+                    .frame(width: 28, height: 28)
+                    .overlay(
+                        Image(systemName: "xmark")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundStyle(.secondary)
+                            .imageScale(.medium)
+                    )
+                }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("circled_close_button")
+            .accessibilityLabel(Text(localization[.dismiss]))
+        }
     }
 
 }
@@ -130,7 +155,7 @@ struct DismissCircleButtonToolbarModifier: ViewModifier {
         if navigationOptions.shouldShowCloseButton {
             content
                 .toolbar {
-                    ToolbarItem(placement: .navigationBarTrailing) {
+                    ToolbarItem(placement: .topBarTrailing) {
                         DismissCircleButton(customDismiss: navigationOptions.onCloseHandler)
                     }
                 }

--- a/RevenueCatUI/CustomerCenter/Views/ActiveSubscriptionButtonsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ActiveSubscriptionButtonsView.swift
@@ -33,6 +33,17 @@ struct ActiveSubscriptionButtonsView: View {
     var viewModel: BaseManageSubscriptionViewModel
 
     var body: some View {
+        if #available(iOS 26.0, *) {
+            content
+                .background(Color(colorScheme == .light ? UIColor.systemBackground : UIColor.secondarySystemBackground), in: .rect(cornerRadius: 26))
+        } else {
+            content
+                .background(Color(colorScheme == .light ? UIColor.systemBackground : UIColor.secondarySystemBackground), in: .rect(cornerRadius: 10))
+        }
+        
+    }
+    
+    private var content: some View {
         VStack(alignment: .leading, spacing: 0) {
             ForEach(self.viewModel.relevantPathsForPurchase, id: \.id) { path in
                 AsyncButton(action: {
@@ -43,9 +54,14 @@ struct ActiveSubscriptionButtonsView: View {
                     if self.viewModel.loadingPath?.id == path.id {
                         TintedProgressView()
                     } else {
-                        CompatibilityLabeledContent(path.title)
-                            .padding(.horizontal)
-                            .padding(.vertical, 12)
+                        if #available(iOS 26.0, *) {
+                            CompatibilityLabeledContent(path.title)
+                                .padding()
+                        } else {
+                            CompatibilityLabeledContent(path.title)
+                                .padding(.horizontal)
+                                .padding(.vertical, 12)
+                        }
                     }
                 })
                 .disabled(self.viewModel.loadingPath != nil)
@@ -57,10 +73,6 @@ struct ActiveSubscriptionButtonsView: View {
             }
         }
         .applyIf(tintColor != nil, apply: { $0.tint(tintColor) })
-        .background(Color(colorScheme == .light
-                          ? UIColor.systemBackground
-                          : UIColor.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 10))
     }
 
     private var tintColor: Color? {

--- a/RevenueCatUI/CustomerCenter/Views/FallbackNoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FallbackNoSubscriptionsView.swift
@@ -73,9 +73,8 @@ struct FallbackNoSubscriptionsView: View {
                     localization: localization,
                     purchasesProvider: purchasesProvider
                 )
-                    .cornerRadius(10)
-                    .padding(.horizontal)
-                    .padding(.bottom, 32)
+                .padding(.horizontal)
+                .padding(.bottom, 32)
 
                 if let virtualCurrencies, !virtualCurrencies.all.isEmpty {
                     VirtualCurrenciesScrollViewWithOSBackgroundSection(

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsCardView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsCardView.swift
@@ -64,6 +64,16 @@ struct NoSubscriptionsCardView: View {
     }
 
     var body: some View {
+        if #available(iOS 26.0, *) {
+            content
+                .cornerRadius(26)
+        } else {
+            content
+                .cornerRadius(10)
+        }
+    }
+
+    private var content: some View {
         VStack(alignment: .center, spacing: 8) {
             Text(title)
                 .font(.headline)
@@ -172,7 +182,6 @@ struct NoSubscriptionsCardView_Previews: PreviewProvider {
                     localization: CustomerCenterConfigData.default.localization,
                     purchasesProvider: MockCustomerCenterPurchases()
                 )
-                .cornerRadius(10)
                 .padding([.leading, .trailing])
             }
             .preferredColorScheme(colorScheme)

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
@@ -95,6 +95,16 @@ struct PurchaseInformationCardView: View {
     }
 
     var body: some View {
+        if #available(iOS 26.0, *) {
+            content
+                .cornerRadius(26)
+        } else {
+            content
+                .cornerRadius(10)
+        }
+    }
+    
+    private var content: some View {
         VStack(alignment: .leading, spacing: 0) {
             CompatibilityLabeledContent {
                 VStack(alignment: .leading, spacing: 0) {
@@ -221,24 +231,39 @@ extension PurchaseInformationCardView {
         var accessibilityIdentifier: String = "PurchaseInformationCardView.Badge"
 
         var body: some View {
-            Text(title)
-                .font(.caption2)
-                .bold()
-                .padding(.vertical, 2)
-                .padding(.horizontal, 4)
-                .background(
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(backgroundColor ?? Color(
-                            colorScheme == .light
-                            ? UIColor.systemBackground
-                            : UIColor.secondarySystemBackground
-                        ))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 4)
-                        .stroke(borderColor, lineWidth: 1)
-                )
-                .accessibilityIdentifier([accessibilityIdentifier, id].joined(separator: "_"))
+            if #available(iOS 26.0, *) {
+                Text(title)
+                    .font(.caption2)
+                    .bold()
+                    .padding(.vertical, 3)
+                    .padding(.horizontal, 6)
+                    .background(backgroundColor ?? Color(
+                        colorScheme == .light
+                        ? UIColor.systemBackground
+                        : UIColor.secondarySystemBackground
+                    ), in: .capsule)
+                    .overlay(
+                        Capsule()
+                            .stroke(borderColor, lineWidth: 1)
+                    )
+                    .accessibilityIdentifier([accessibilityIdentifier, id].joined(separator: "_"))
+            } else {
+                Text(title)
+                    .font(.caption2)
+                    .bold()
+                    .padding(.vertical, 2)
+                    .padding(.horizontal, 4)
+                    .background(backgroundColor ?? Color(
+                        colorScheme == .light
+                        ? UIColor.systemBackground
+                        : UIColor.secondarySystemBackground
+                    ), in: .rect(cornerRadius: 4))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(borderColor, lineWidth: 1)
+                    )
+                    .accessibilityIdentifier([accessibilityIdentifier, id].joined(separator: "_"))
+            }
         }
 
         static func cancelled(_ localizations: CustomerCenterConfigData.Localization) -> Badge {
@@ -342,7 +367,6 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     localization: CustomerCenterConfigData.default.localization,
                     accessibilityIdentifier: "accessibilityIdentifier"
                 )
-                .cornerRadius(10)
                 .padding([.leading, .trailing])
 
                 PurchaseInformationCardView(
@@ -353,7 +377,6 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     localization: CustomerCenterConfigData.default.localization,
                     accessibilityIdentifier: "accessibilityIdentifier"
                 )
-                .cornerRadius(10)
                 .padding([.leading, .trailing])
 
                 PurchaseInformationCardView(
@@ -365,7 +388,6 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     localization: CustomerCenterConfigData.default.localization,
                     accessibilityIdentifier: "accessibilityIdentifier"
                 )
-                .cornerRadius(10)
                 .padding([.leading, .trailing])
 
                 PurchaseInformationCardView(
@@ -373,7 +395,6 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     localization: CustomerCenterConfigData.default.localization,
                     accessibilityIdentifier: "accessibilityIdentifier"
                 )
-                .cornerRadius(10)
                 .padding([.leading, .trailing])
 
                 PurchaseInformationCardView(
@@ -381,7 +402,6 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     localization: CustomerCenterConfigData.default.localization,
                     accessibilityIdentifier: "accessibilityIdentifier"
                 )
-                .cornerRadius(10)
                 .padding([.leading, .trailing])
 
                 PurchaseInformationCardView(
@@ -393,7 +413,6 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     localization: CustomerCenterConfigData.default.localization,
                     accessibilityIdentifier: "accessibilityIdentifier"
                 )
-                .cornerRadius(10)
                 .padding([.leading, .trailing])
 
                 PurchaseInformationCardView(
@@ -405,7 +424,6 @@ struct PurchaseInformationCardView_Previews: PreviewProvider {
                     additionalInfo: "An error occurred while processing the refund request. Please try again.",
                     subtitle: "Renews 24 May for $19.99"
                 )
-                .cornerRadius(10)
                 .padding([.leading, .trailing])
             }
             .preferredColorScheme(colorScheme)

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -135,7 +135,6 @@ struct RelevantPurchasesListView: View {
             LazyVStack(spacing: 0) {
                 if !customerInfoViewModel.hasAnyPurchases {
                     emptyView
-                        .cornerRadius(10)
                         .padding(.horizontal)
                         .padding(.bottom, 32)
                 } else {

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -180,6 +180,8 @@ struct RelevantPurchasesListView: View {
 
                 if viewModel.shouldShowSeeAllPurchases {
                     seeAllSubscriptionsButton
+                        .tint(colorScheme == .dark ? .white : .black)
+                        .padding(.horizontal)
                         .padding(.bottom, 32)
                 } else {
                     Spacer().frame(height: 16)
@@ -209,22 +211,35 @@ struct RelevantPurchasesListView: View {
             .prefix(RelevantPurchasesListViewModel.maxNonSubscriptionsToShow))
     }
 
+    @ViewBuilder
     private var seeAllSubscriptionsButton: some View {
-        Button {
-            viewModel.showAllPurchases = true
-        } label: {
-            CompatibilityLabeledContent(localization[.seeAllPurchases]) {
-                Image(systemName: "chevron.forward")
+        if #available(iOS 26.0, *) {
+            Button {
+                viewModel.showAllPurchases = true
+            } label: {
+                CompatibilityLabeledContent(localization[.seeAllPurchases]) {
+                    Image(systemName: "chevron.forward")
+                }
+                .padding()
+                .background(Color(colorScheme == .light ? UIColor.systemBackground : UIColor.secondarySystemBackground))
+                .cornerRadius(26)
             }
-            .padding(.horizontal)
-            .padding(.vertical, 12)
-            .background(Color(colorScheme == .light
-                              ? UIColor.systemBackground
-                              : UIColor.secondarySystemBackground))
-            .cornerRadius(10)
-            .padding(.horizontal)
+        } else {
+            Button {
+                viewModel.showAllPurchases = true
+            } label: {
+                CompatibilityLabeledContent(localization[.seeAllPurchases]) {
+                    Image(systemName: "chevron.forward")
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 12)
+                .background(Color(colorScheme == .light
+                                  ? UIColor.systemBackground
+                                  : UIColor.secondarySystemBackground))
+                .cornerRadius(10)
+            }
         }
-        .tint(colorScheme == .dark ? .white : .black)
+       
     }
 
     private var dateFormatter: DateFormatter {

--- a/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
@@ -62,7 +62,6 @@ struct PurchasesInformationSection: View {
                         localization: localization,
                         accessibilityIdentifier: "purchase_card_\(offset)"
                     )
-                    .cornerRadius(10)
                     .padding(.horizontal)
                 }
                 .padding(.bottom, 16)

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -201,7 +201,6 @@ struct SubscriptionDetailView: View {
                         localization: localization,
                         purchasesProvider: viewModel.purchasesProvider
                     )
-                    .cornerRadius(10)
                     .padding(.horizontal)
                     .padding(.vertical, 32)
                 } else {
@@ -213,7 +212,6 @@ struct SubscriptionDetailView: View {
                             refundStatus: viewModel.refundRequestStatus,
                             showChevron: false
                         )
-                        .cornerRadius(10)
                         .padding(.horizontal)
                         .padding(.vertical, 32)
                     }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
As the release of iOS 26 approaches (with the iPhone event announced for [Sept 9](https://www.apple.com/apple-events)), the current CustomerCenter design may start to feel outdated once the app is updated. To ensure we align with the new style from day one, this PR introduces the necessary updates.

### Description
- This update introduces changes that apply starting from iOS 26.0:
- Cells are now styled with increased roundness on iOS 26 to better align with the native look and feel.
- The dismiss button now uses the new `Button(role: .close)` API.
- Labels (e.g., _Active_) are presented inside capsules to reflect the updated rounded design language.
- The prominent button now uses a default shape

#### Additional improvements (affecting other iOS versions as well):

- The [correct system icon](https://developer.apple.com/design/human-interface-guidelines/icons) is now used for Copy in the UserID cell.
- The UX and design of the UserID cell have been refined: a dedicated button now allows users to copy the ID with a single tap _(available from iOS 17+)_.
- The user ID is now selectable, making it easier to copy manually.

**NOTE: I do not think this branch should be merged / released yet as availability checking for iOS 26 is only available in Xcode 26 and up.**


https://github.com/user-attachments/assets/2c98f9a4-690c-429a-a491-f00682700157
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-09-03 at 12 36 40" src="https://github.com/user-attac
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-09-03 at 13 52 03" src="https://github.com/user-attachments/assets/0297ea71-3ca8-4423-ad60-3187f5e5e7a5" />
hments/assets/70ef6a70-3f77-465b-8991-bd0432cc6d28" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-09-03 at 13 58 33" src="https://github.com/user-attachments/assets/b3768067-86d4-4247-b223-55ec9d5f3bf3" />

