### PR TITLE
Update changelog with missing changes in v5.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,8 +283,27 @@
 ### 🐞 Bugfixes
 * Remove submodules temporarily to fix SPM (#5246) via Toni Rico (@tonidero)
 
+## RevenueCatUI SDK
+### Paywallv2
+#### 🐞 Bugfixes
+* Fixed overflowing images (#5162) via Josh Holtz (@joshdholtz)
+### Customer Center
+#### ✨ New Features
+* Introduce NoSubscriptions card view for empty states (#5178) via Facundo Menzella (@facumenzella)
+* Use groupID to present manageSubscriptions sheet (#5182) via Facundo Menzella (@facumenzella)
+
 ### 🔄 Other Changes
 * Add accessibility identifier to PurchaseCardView (#5176) via Facundo Menzella (@facumenzella)
+* Remove dependency of Purchases.shared from UIConfigProvider (#5242) via Josh Holtz (@joshdholtz)
+* Update offerings cache in UI preview mode (#5241) via Antonio Pallares (@ajpallares)
+* Introduce PaywallFontManagerType to handle custom fonts in the paywall editor (#5208) via Facundo Menzella (@facumenzella)
+* Warm up caches in parallel (#5240) via Antonio Pallares (@ajpallares)
+* SampleCat: A new iOS Sample app that guides users through any configuration issues (#5200) via Pol Piella Abadia (@polpielladev)
+* [Paywalls] Render top level tabs component stack properties (#5210) via Mark Villacampa (@MarkVillacampa)
+* [Paywalls] Use tab id instead of tab index to select tab (#5209) via Mark Villacampa (@MarkVillacampa)
+* Paywall screenshots for cross platform validation (#5205) via Josh Holtz (@joshdholtz)
+* Fix broken URLs in 4 -> 5 Migration Guides (#5229) via Will Taylor (@fire-at-will)
+* Adds `showStoreMessagesAutomatically` parameter to CEC mode (#5230) via JayShortway (@JayShortway)
 
 ## 5.26.0
 ## RevenueCat SDK


### PR DESCRIPTION
[The PR for v5.27.0](https://github.com/RevenueCat/purchases-ios/pull/5243) was never merged and v5.27.0 was never released. Therefore, all the changes in v5.27.0 were first released in v5.27.1.

This PR updates the changelog to include all the changes released in v5.27.1