### PR TITLE
Fix compilation of RevenueCatUI in Xcode 14

### DIFF
--- a/RevenueCatUI/CustomerCenter/ButtonStyles.swift
+++ b/RevenueCatUI/CustomerCenter/ButtonStyles.swift
@@ -169,6 +169,7 @@ struct DismissCircleButtonToolbarModifier: ViewModifier {
     var navigationOptions
 
     func body(content: Content) -> some View {
+        #if compiler(>=5.9)
         if navigationOptions.shouldShowCloseButton {
             content
                 .toolbar {
@@ -179,7 +180,9 @@ struct DismissCircleButtonToolbarModifier: ViewModifier {
         } else {
             content
         }
-
+        #else
+        content
+        #endif
     }
 }
 

--- a/RevenueCatUI/CustomerCenter/Views/ActiveSubscriptionButtonsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ActiveSubscriptionButtonsView.swift
@@ -61,10 +61,12 @@ struct ActiveSubscriptionButtonsView: View {
             }
         }
         .applyIf(tintColor != nil, apply: { $0.tint(tintColor) })
+        #if compiler(>=5.9)
         .background(Color(colorScheme == .light
                           ? UIColor.systemBackground
                           : UIColor.secondarySystemBackground),
                     in: .rect(cornerRadius: CustomerCenterStylingUtilities.cornerRadius))
+        #endif
     }
 
     private var tintColor: Color? {

--- a/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsCardView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/NoSubscriptionsCardView.swift
@@ -96,10 +96,12 @@ struct NoSubscriptionsCardView: View {
             }
         }
         .padding(16)
+        #if compiler(>=5.9)
         .background(Color(colorScheme == .light
                           ? UIColor.systemBackground
                           : UIColor.secondarySystemBackground),
                     in: .rect(cornerRadius: CustomerCenterStylingUtilities.cornerRadius))
+        #endif
         .animation(.easeInOut(duration: 0.3), value: viewModel.isLoadingOffering)
         .sheet(isPresented: $viewModel.showOffering, content: {
             PaywallView(

--- a/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PurchaseCardView.swift
@@ -161,10 +161,12 @@ struct PurchaseInformationCardView: View {
                 .padding()
             }
         }
+        #if compiler(>=5.9)
         .background(Color(colorScheme == .light
                           ? UIColor.secondarySystemFill
                           : UIColor.tertiarySystemBackground),
                     in: .rect(cornerRadius: CustomerCenterStylingUtilities.cornerRadius))
+        #endif
     }
 }
 
@@ -228,11 +230,13 @@ extension PurchaseInformationCardView {
                     .bold()
                     .padding(.vertical, 3)
                     .padding(.horizontal, 6)
+                    #if compiler(>=5.9)
                     .background(backgroundColor ?? Color(
                         colorScheme == .light
                         ? UIColor.systemBackground
                         : UIColor.secondarySystemBackground
                     ), in: .capsule)
+                    #endif
                     .overlay(
                         Capsule()
                             .stroke(borderColor, lineWidth: 1)
@@ -244,11 +248,13 @@ extension PurchaseInformationCardView {
                     .bold()
                     .padding(.vertical, 2)
                     .padding(.horizontal, 4)
+                    #if compiler(>=5.9)
                     .background(backgroundColor ?? Color(
                         colorScheme == .light
                         ? UIColor.systemBackground
                         : UIColor.secondarySystemBackground
                     ), in: .rect(cornerRadius: 4))
+                    #endif
                     .overlay(
                         RoundedRectangle(cornerRadius: 4)
                             .stroke(borderColor, lineWidth: 1)

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -394,9 +394,7 @@ struct RelevantPurchasesListView_Previews: PreviewProvider {
         .environment(\.localization, CustomerCenterConfigData.default.localization)
         .environment(\.appearance, CustomerCenterConfigData.default.appearance)
     }
-
 }
-
 #endif
 
 #endif

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -221,10 +221,12 @@ struct RelevantPurchasesListView: View {
                     Image(systemName: "chevron.forward")
                 }
                 .padding()
+                #if compiler(>=5.9)
                 .background(Color(colorScheme == .light
                                   ? UIColor.systemBackground
                                   : UIColor.secondarySystemBackground),
                             in: .rect(cornerRadius: CustomerCenterStylingUtilities.cornerRadius))
+                #endif
             }
         } else {
             Button {

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -237,10 +237,12 @@ struct RelevantPurchasesListView: View {
                 }
                 .padding(.horizontal)
                 .padding(.vertical, 12)
+                #if compiler(>=5.9)
                 .background(Color(colorScheme == .light
                                   ? UIColor.systemBackground
                                   : UIColor.secondarySystemBackground),
                             in: .rect(cornerRadius: CustomerCenterStylingUtilities.cornerRadius))
+                #endif
             }
         }
     }

--- a/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
@@ -156,6 +156,7 @@ struct AccountDetailsSection: View {
 
     @ViewBuilder
     var userIdView: some View {
+        #if compiler(>=5.9)
         if #available(iOS 17.0, *) {
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
@@ -196,6 +197,7 @@ struct AccountDetailsSection: View {
                 }
             }
         }
+        #endif
     }
     private static var dateFormatter: DateFormatter {
         let formatter = DateFormatter()

--- a/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/ScrollViewSection.swift
@@ -83,10 +83,12 @@ private struct CardStyleModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .padding()
+            #if compiler(>=5.9)
             .background(Color(colorScheme == .light
                               ? UIColor.systemBackground
                               : UIColor.secondarySystemBackground),
                         in: .rect(cornerRadius: CustomerCenterStylingUtilities.cornerRadius))
+            #endif
             .padding(.horizontal)
     }
 }


### PR DESCRIPTION
After the changes in #5519, there are some compilation errors in RevenueCatUI when using Xcode 14.

This PR fixes compilation of RevenueCatUI in Xcode 14.

## Notes
This PR adds some `#if compiler(>=5.9)` checks, disabling code not available in Xcode 14. It only affects code in RevenueCatUI and functionally this should be seamless (as Xcode 14 is not supported for App Store distribution anymore).