### PR TITLE
Feat/test fix butotnstyles

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -260,8 +260,13 @@ private extension CustomerCenterView {
 
 }
 
+@available(iOS 15.0, *)
 private extension CustomerCenterView {
-    // Provide a navigation options instance that always includes a close handler.
+    /// Provide a navigation options instance that always includes a close handler.
+    ///
+    /// - Note: Using `@Environment(.dismiss)` directly inside child views (e.g., toolbar buttons) can fail to dismiss
+    /// the view when presented. To ensure reliable behavior on iOS 15, we capture `dismiss` at the
+    /// container level (CustomerCenterView) and propagate it via `navigationOptions.onCloseHandler`.
     var navigationOptionsWithDismiss: CustomerCenterNavigationOptions {
         if self.navigationOptions.onCloseHandler != nil {
             return self.navigationOptions

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -41,6 +41,10 @@ public struct CustomerCenterView: View {
     @Environment(\.colorScheme)
     private var colorScheme
 
+    // Propagate dismiss from the container to child views (iOS 15 fix)
+    @Environment(\.dismiss)
+    private var dismiss
+
     private let mode: CustomerCenterPresentationMode
 
     private let navigationOptions: CustomerCenterNavigationOptions
@@ -153,7 +157,7 @@ private extension CustomerCenterView {
                         .environment(\.appearance, configuration.appearance)
                         .environment(\.localization, configuration.localization)
                         .environment(\.customerCenterPresentationMode, self.mode)
-                        .environment(\.navigationOptions, self.navigationOptions)
+                        .environment(\.navigationOptions, self.navigationOptionsWithDismiss)
                         .environment(\.supportInformation, configuration.support)
                 } else {
                     TintedProgressView()
@@ -254,6 +258,22 @@ private extension CustomerCenterView {
                                   displayMode: self.mode)
     }
 
+}
+
+private extension CustomerCenterView {
+    // Provide a navigation options instance that always includes a close handler.
+    var navigationOptionsWithDismiss: CustomerCenterNavigationOptions {
+        if self.navigationOptions.onCloseHandler != nil {
+            return self.navigationOptions
+        } else {
+            return CustomerCenterNavigationOptions(
+                usesNavigationStack: self.navigationOptions.usesNavigationStack,
+                usesExistingNavigation: self.navigationOptions.usesExistingNavigation,
+                shouldShowCloseButton: self.navigationOptions.shouldShowCloseButton,
+                onCloseHandler: { self.dismiss() }
+            )
+        }
+    }
 }
 
 #if DEBUG


### PR DESCRIPTION
### Motivation
This PR addresses https://github.com/RevenueCat/react-native-purchases/issues/1381

It was pointed out that the dismiss is not working for iOS 15. After debugging, I noticed the issue is related to using `Environment dismiss` the way we are using it.

I've tested this on iOS15, iOS16, iOS17 and iOS18

### Description
- DismissCircleButton now requires a non-optional onDismiss: () -> Void and does not read @Environment(.dismiss).
- CustomerCenterView still captures @Environment(.dismiss) and injects it into navigationOptions.onCloseHandler, guaranteeing a working handler for all Customer Center views.