### PR TITLE
fix emerge tools snapshots

### DIFF
--- a/RevenueCatUI/Helpers/EmergeRenderingMode.swift
+++ b/RevenueCatUI/Helpers/EmergeRenderingMode.swift
@@ -4,16 +4,24 @@ import SwiftUI
 #if DEBUG
 // Extracted from Emerge SnapshotPreferences since importing that library
 // requires iOS 15 as deployment target
-enum EmergeRenderingMode: Int {
-    /// Renders using `CALayer.render(in:)`.
-    case coreAnimation
 
-    /// Renders using `UIView.drawHierarchy(in:afterScreenUpdates:true)`.
-    case uiView
+// swiftlint:disable missing_docs
+public enum EmergeRenderingMode: Int {
+  /// Renders using `CALayer.render(in:)`.
+  case coreAnimation
 
-    /// Renders the entire window instead of the previewed view.
-    /// This uses UIWindow.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
-    case window
+  /// Renders using `UIView.drawHierarchy(in:afterScreenUpdates:true)`.
+  @available(macOS, unavailable)
+  case uiView
+
+  /// Renders using `NSView.bitmapImageRepForCachingDisplay`.
+  @available(iOS, unavailable)
+  case nsView
+
+  /// Renders the entire window instead of the previewed view.
+  /// This uses `UIWindow.drawHierarchy(in: window.bounds, afterScreenUpdates: true)` on iOS
+  /// This uses `CGWindowListCreateImage` on macOS.
+  case window
 }
 
 // Classes in this file get compiled to an app that use any of the custom preview preferences.
@@ -22,25 +30,44 @@ enum EmergeRenderingMode: Int {
 @objc(EmergeModifierState)
 class EmergeModifierState: NSObject {
 
-    @objc
-    static let shared = EmergeModifierState()
+  @objc
+  static let shared = EmergeModifierState()
 
-    func reset() {
-        renderingMode = nil
-    }
+  func reset() {
+    expansionPreference = nil
+    renderingMode = nil
+    precision = nil
+    accessibilityEnabled = nil
+  }
 
-    var renderingMode: EmergeRenderingMode.RawValue?
+  var expansionPreference: Bool?
+  var renderingMode: EmergeRenderingMode.RawValue?
+  var precision: Float?
+  var accessibilityEnabled: Bool?
+  var appStoreSnapshot: Bool?
 }
 
 @objc(EmergeModifierFinder)
 class EmergeModifierFinder: NSObject {
-    let finder: (any View) -> (any View) = { view in
-        EmergeModifierState.shared.reset()
-        return view
-            .onPreferenceChange(RenderingModePreferenceKey.self, perform: { value in
-                EmergeModifierState.shared.renderingMode = value
-            })
-    }
+  let finder: (any View) -> (any View) = { view in
+    EmergeModifierState.shared.reset()
+    return view
+      .onPreferenceChange(ExpansionPreferenceKey.self, perform: { value in
+        EmergeModifierState.shared.expansionPreference = value
+      })
+      .onPreferenceChange(RenderingModePreferenceKey.self, perform: { value in
+        EmergeModifierState.shared.renderingMode = value
+      })
+      .onPreferenceChange(PrecisionPreferenceKey.self, perform: { value in
+        EmergeModifierState.shared.precision = value
+      })
+      .onPreferenceChange(AccessibilityPreferenceKey.self, perform: { value in
+        EmergeModifierState.shared.accessibilityEnabled = value
+      })
+      .onPreferenceChange(AppStoreSnapshotPreferenceKey.self, perform: { value in
+        EmergeModifierState.shared.appStoreSnapshot = value
+      })
+  }
 }
 
 struct RenderingModePreferenceKey: PreferenceKey {
@@ -85,4 +112,157 @@ extension View {
         preference(key: RenderingModePreferenceKey.self, value: renderingMode?.rawValue)
     }
 }
+
+struct ExpansionPreferenceKey: PreferenceKey {
+  static func reduce(value: inout Bool?, nextValue: () -> Bool?) {
+    if value == nil {
+      value = nextValue()
+    }
+  }
+
+  static var defaultValue: Bool?
+}
+
+extension View {
+    /// Applies an expansion effect to the view's snapshot.
+    ///
+    /// Use this method to control the emerge expansion effect on a view. When enabled,
+    /// the view's first scrollview will be expanded to show all content in the snapshot.
+    ///
+    /// - Parameter enabled: A Boolean value that determines whether the emerge expansion
+    ///   effect is applied. If `nil`, the effect will default to `true`.
+    ///
+    /// - Returns: A view with the expansion preference applied.
+    ///
+    /// # Example
+    /// ```swift
+    /// struct ContentView: View {
+    ///     var body: some View {
+    ///         Text("Hello, World!")
+    ///             .emergeExpansion(false)
+    ///     }
+    /// }
+    /// ```
+    public func emergeExpansion(_ enabled: Bool?) -> some View {
+        preference(key: ExpansionPreferenceKey.self, value: enabled)
+    }
+}
+
+struct PrecisionPreferenceKey: PreferenceKey {
+  static func reduce(value: inout Float?, nextValue: () -> Float?) {
+    value = nextValue()
+  }
+
+  static var defaultValue: Float?
+}
+
+extension View {
+    /// Sets the precision level for the snapshot on the view.
+    ///
+    /// Use this method to control the precision of the snapshot, which will be used for
+    /// the comparison logic. With precision level 1.0, the images fully match. With precision
+    /// level 0, the snapshot will never be flagged for having differences.
+    ///
+    /// - Parameter precision: A Float value representing the desired precision level for
+    ///   emerge snapshot operations. If `nil`, the value will default to 1.0.
+    ///
+    /// - Returns: A view with the snapshot precision preference applied.
+    ///
+    /// # Example
+    /// ```swift
+    /// struct ContentView: View {
+    ///     var body: some View {
+    ///         Image("sample")
+    ///             .emergeSnapshotPrecision(0.8)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Note: The actual impact of the precision value may vary depending on the
+    ///   specific implementation of the emerge snapshot feature.
+    public func emergeSnapshotPrecision(_ precision: Float?) -> some View {
+        preference(key: PrecisionPreferenceKey.self, value: precision)
+    }
+}
+
+struct AccessibilityPreferenceKey: PreferenceKey {
+  static func reduce(value: inout Bool?, nextValue: () -> Bool?) {
+    if value == nil {
+      value = nextValue()
+    }
+  }
+
+  static var defaultValue: Bool?
+}
+
+extension View {
+    /// Applies accessibility support to the view's snapshot.
+    ///
+    /// Use this method to control whether the snapshot should render with accessibility elements
+    /// highlighted as well as a corresponding legend for them.
+    ///
+    /// - Note: This method is only available on iOS. It is unavailable on macOS, watchOS, visionOS, and tvOS.
+    ///
+    /// - Parameter enabled: A Boolean value that determines whether the emerge accessibility
+    ///   features are applied. If `nil`, the effect will default to `false`.
+    ///
+    /// - Returns: A view with the accessibility preference applied.
+    ///
+    /// # Example
+    /// ```swift
+    /// struct ContentView: View {
+    ///     var body: some View {
+    ///         Text("Accessible Content")
+    ///             .emergeAccessibility(true)
+    ///     }
+    /// }
+    /// ```
+    @available(macOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(visionOS, unavailable)
+    @available(tvOS, unavailable)
+    public func emergeAccessibility(_ enabled: Bool?) -> some View {
+        preference(key: AccessibilityPreferenceKey.self, value: enabled)
+    }
+}
+
+struct AppStoreSnapshotPreferenceKey: PreferenceKey {
+  static func reduce(value: inout Bool?, nextValue: () -> Bool?) {
+    if value == nil {
+      value = nextValue()
+    }
+  }
+
+  static var defaultValue: Bool?
+}
+
+extension View {
+    /// Marks a snapshot for use with our App Store screenshot editing tool. This should ideally be used with a
+    /// full-size preview matching one of our supported devices.
+    ///
+    /// - Note: This method is only available on iOS. It is unavailable on macOS, watchOS, visionOS, and tvOS.
+    ///
+    /// - Parameter enabled: A Boolean value that determines whether the snapshot is for an App Store screenshot.
+    ///   If `nil`, the effect will default to `false`.
+    ///
+    /// - Returns: A view with the app store snapshot preference applied.
+    ///
+    /// # Example
+    /// ```swift
+    /// struct ContentView: View {
+    ///     var body: some View {
+    ///         Text("My App Store listing!")
+    ///             .emergeAppStoreSnapshot(true)
+    ///     }
+    /// }
+    /// ```
+    @available(macOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(visionOS, unavailable)
+    @available(tvOS, unavailable)
+    public func emergeAppStoreSnapshot(_ enabled: Bool?) -> some View {
+        preference(key: AppStoreSnapshotPreferenceKey.self, value: enabled)
+    }
+}
+
 #endif


### PR DESCRIPTION
### Motivation
Some snaps are failing https://github.com/RevenueCat/purchases-ios/pull/5529/checks?check_run_id=49854867429

### Description
Follow-up of https://github.com/RevenueCat/purchases-ios/pull/4922/files#diff-0b9b1f966a8e839ee369d66d98e7688b22bd05ff2026abbb3d2ceeca997ccccd.

These types have changed (a new enum case) and this solution stopped working. I've updated the code based on the latest emerge release.