### PR TITLE
Fix simulated failed purchase in Test Store

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1992,9 +1992,7 @@ private extension PurchasesOrchestrator {
                                                                                     fetchPolicy: .cachedOrFetched)
                 await completion(nil, customerInfo, ErrorUtils.purchaseCancelledError().asPublicError, true)
             case .failure(let purchasesError):
-                let customerInfo = try? await self.customerInfoManager.customerInfo(appUserID: self.appUserID,
-                                                                                    fetchPolicy: .cachedOrFetched)
-                await completion(nil, customerInfo, purchasesError.asPublicError, false)
+                await completion(nil, nil, purchasesError.asPublicError, false)
             case .success(let transaction):
                 do {
                     let customerInfo = try await self.handlePurchasedTransaction(transaction, .purchase, metadata)

--- a/Tests/UnitTests/SimulatedStore/PurchasesOrchestratorSimulatedStoreTests.swift
+++ b/Tests/UnitTests/SimulatedStore/PurchasesOrchestratorSimulatedStoreTests.swift
@@ -329,9 +329,9 @@ class PurchasesOrchestratorSimulatedStoreTests: TestCase {
         }
 
         XCTAssertNil(transaction)
+        XCTAssertNil(customerInfo)
         XCTAssertFalse(userCancelled)
         XCTAssertEqual(error?.asErrorCode, ErrorCode.ineligibleError)
-        XCTAssertEqual(customerInfo, Self.mockCustomerInfo)
     }
 
     func testSuccessfulPurchaseOfTestStoreProductPostsReceipt() async throws {


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
The `PurchasesOrchestrator` was returning the `CustomerInfo` in the case of simulated failure of a purchase in the Test Store. This was causing the simulated failure case not throw an error in the SDK's `purchase` method. 
This was inconsistent with the behavior of the SDK for failures for the real App Store.

### Description
The `PurchasesOrchestrator` now returns a `nil` `CustomerInfo` in the simulated failure of a purchase in the Test Store. This means that an error is thrown from the `purchase` methods in the SDK.