### PR TITLE
Add a custom close for deeper navs in customer center

### DIFF
--- a/RevenueCatUI/CustomerCenter/ButtonStyles.swift
+++ b/RevenueCatUI/CustomerCenter/ButtonStyles.swift
@@ -162,10 +162,16 @@ struct DismissCircleButtonToolbarModifier: ViewModifier {
     @Environment(\.navigationOptions)
     var navigationOptions
 
+    private var customDismiss: (() -> Void)?
+
+    init(customDismiss: (() -> Void)?) {
+        self.customDismiss = customDismiss
+    }
+
     func body(content: Content) -> some View {
         #if compiler(>=5.9)
         if navigationOptions.shouldShowCloseButton {
-            let onClose = navigationOptions.onCloseHandler ?? { dismiss() }
+            let onClose = customDismiss ?? navigationOptions.onCloseHandler ?? { dismiss() }
             content
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
@@ -188,7 +194,12 @@ struct DismissCircleButtonToolbarModifier: ViewModifier {
 extension View {
     /// Adds a toolbar with a dismiss button if `navigationOptions.shouldShowCloseButton` is true.
     func dismissCircleButtonToolbarIfNeeded() -> some View {
-        modifier(DismissCircleButtonToolbarModifier())
+        modifier(DismissCircleButtonToolbarModifier(customDismiss: nil))
+    }
+
+    /// Adds a toolbar with a dismiss button if `navigationOptions.shouldShowCloseButton` is true.
+    func dismissCircleButtonToolbarIfNeeded(customDismiss: @escaping (() -> Void)) -> some View {
+        modifier(DismissCircleButtonToolbarModifier(customDismiss: customDismiss))
     }
 }
 

--- a/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/AppUpdateWarningView.swift
@@ -80,7 +80,6 @@ struct AppUpdateWarningView: View {
                 })
                 .scrollableIfNecessary(.vertical)
             }
-            .dismissCircleButtonToolbarIfNeeded()
     }
 }
 

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -199,6 +199,7 @@ private extension CustomerCenterView {
                         }
                     }
                 )
+                .dismissCircleButtonToolbarIfNeeded()
             } else if viewModel.shouldShowList {
                 listView(screen)
             } else {

--- a/RevenueCatUI/CustomerCenter/Views/FallbackNoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FallbackNoSubscriptionsView.swift
@@ -88,7 +88,6 @@ struct FallbackNoSubscriptionsView: View {
                 restorePurchasesButton
             }
         }
-        .dismissCircleButtonToolbarIfNeeded()
         .compatibleNavigation(
             isPresented: $showAllInAppCurrenciesScreen,
             usesNavigationStack: navigationOptions.usesNavigationStack

--- a/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FeedbackSurveyView.swift
@@ -80,7 +80,9 @@ struct FeedbackSurveyView: View {
             List {
                 content
             }
-            .dismissCircleButtonToolbarIfNeeded()
+            .dismissCircleButtonToolbarIfNeeded(customDismiss: {
+                isPresented = false
+            })
             .compatibleNavigation(
                 item: $viewModel.promotionalOfferData,
                 usesNavigationStack: navigationOptions.usesNavigationStack


### PR DESCRIPTION
### Motivation
We've got a report in KMP that the deeper close button was not working correctly.  https://github.com/RevenueCat/purchases-ios/pull/5529 introduced that regression.

### Description
- Add a custom close passed in the context where used
- If passed, we ignore the rest.
- Remove the extra calls where it is redundant:
  1. Root view uses the default
  2. Feedback uses the custom close
