### PR TITLE
[WIP]: build purchase tester with iOS 18.0

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1286,6 +1286,7 @@ platform :ios do
       scheme: "PurchaseTester",
       destination: "generic/platform=ios",
       xcodebuild_formatter: '',
+      sdk: "iOS 18.0",
       export_method: 'app-store',
       export_options: {
         manageAppVersionAndBuildNumber: true,


### PR DESCRIPTION
### Description
The Purchase Tester app's deployment CI job is [failing](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/30080/workflows/23fed345-fbd2-4f51-9dee-f856ffc1a80a/jobs/373367) since App Store Connect is no longer accepting app builds built with iOS SDK versions <18.0. The CI job is failing with this error:

```
[15:04:59]: Error uploading ipa file: 
 [Application Loader Error Output]: ERROR: [ContentDelivery.Uploader] Validation failed (409) SDK version issue. This app was built with the iOS 17.4 SDK. All iOS and iPadOS apps must be built with the iOS 18 SDK or later, included in Xcode 16 or later, in order to be uploaded to App Store Connect or submitted for distribution. (ID: ad007ae2-9fab-4139-8e1b-4b1dfdcdf0e5)
[Application Loader Error Output]: Error uploading '/var/folders/qq/0tw4jpld7yn51m46bph9jbz40000gn/T/ff7e9821-ad78-47ab-b1ad-03e93105c936.ipa'.
[Application Loader Error Output]: Validation failed SDK version issue. This app was built with the iOS 17.4 SDK. All iOS and iPadOS apps must be built with the iOS 18 SDK or later, included in Xcode 16 or later, in order to be uploaded to App Store Connect or submitted for distribution. (ID: ad007ae2-9fab-4139-8e1b-4b1dfdcdf0e5) (409)
[Application Loader Error Output]: The call to the altool completed with a non-zero exit status: 1. This indicates a failure.
```

This PR updates the `deploy-purchase-tester` CI job to build the Purchase Tester app with the iOS 18.0 SDK.