### PR TITLE
Add SDK installation dropdown to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -55,6 +55,20 @@ body:
       required: true
 
   - type: dropdown
+    id: sdk-integration-method
+    attributes:
+      label: SDK integration method
+      description: How is the RevenueCat SDK integrated into your project?
+      options:
+        - Swift Package Manager
+        - CocoaPods
+        - Carthage
+        - XCFramework
+        - Other (please specify)
+    validations:
+      required: true
+
+  - type: dropdown
     id: storekit-version
     attributes:
       label: StoreKit version


### PR DESCRIPTION
### Motivation
Some bugs reported in GitHub issues are only reproducible when using a specific installation method of the SDK.

### Description
This PR adds a new dropdown to have the reporter select the method their project uses to integrate the SDK. The choices are:
- Swift Package Manager
- CocoaPods
- Carthage
- XCFramework
- Other (please specify)