### PR TITLE
Use New iOS 26 Corner Radius in VC List Section

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrenciesScrollViewWithOSBackgroundSection.swift
+++ b/RevenueCatUI/CustomerCenter/Views/Virtual Currencies/VirtualCurrenciesScrollViewWithOSBackgroundSection.swift
@@ -140,10 +140,12 @@ struct VirtualCurrenciesScrollViewWithOSBackgroundSection: View {
                             .padding(.vertical, 12)
                         }
                     }
+                    #if compiler(>=5.9)
                     .background(Color(colorScheme == .light
                                       ? UIColor.systemBackground
-                                      : UIColor.secondarySystemBackground))
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                                      : UIColor.secondarySystemBackground),
+                                in: .rect(cornerRadius: CustomerCenterStylingUtilities.cornerRadius))
+                    #endif
                     .padding(.horizontal)
                 }
             }


### PR DESCRIPTION
### Description
- Updates the virtual currencies list section to use the new corner radiuses when run on iOS 26
- Updates the view modifier used to render the background to match what other places in the Customer Center are doing now (using `.background(_,in:)` instead of `.background()` + `.clipShape()`

#### Before
<img width="300" height="2622" alt="before" src="https://github.com/user-attachments/assets/8913f1cb-7a1a-457a-8614-3e3d8a94a02d" />

#### After
<img width="300" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-11 at 08 59 56" src="https://github.com/user-attachments/assets/4092c2de-d8e0-4332-aaa2-8ff5c21e5d56" />
