### PR TITLE
Silence deprecation warnings in XCFramework

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1173,7 +1173,6 @@ platform :ios do
     swift_headers.each do |header_path|
       UI.message("Processing header: #{header_path}")
       
-      # Read the current header content
       content = File.read(header_path)
       
       # Check if pragma directives are already present
@@ -1187,10 +1186,7 @@ platform :ios do
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
           PRAGMA
           
-          # Insert the pragma directives
           content.insert(insertion_index, pragma_directives)
-          
-          # Write back to file
           File.write(header_path, content)
           UI.success("Added deprecation warning suppression to #{File.basename(header_path)}")
         else


### PR DESCRIPTION
This PR solves #5290 

### Motivation
The generated header RevenueCat-Swift.h in the SDK's XCFramework contains interfaces that depend on StoreKit APIs that are deprecated. As a result, projects that integrate the SDK using the XCFramework would receive multiple deprecation warnings in the issue navigator
<img width="700" height="831" alt="image" src="https://github.com/user-attachments/assets/4074998a-9934-4d07-b23c-e7d330081400" />

In particular, projects with the `SWIFT_TREAT_WARNINGS_AS_ERRORS` flag set to Yes would fail to build for this reason (see #5290)

### Description
This PR removes the deprecation warning by inserting an appropriate directive in all the generated RevenueCat-Swift.h files of the XCFramework before signing it
```
#pragma clang diagnostic ignored "-Wdeprecated-declarations"
```