### PR TITLE
clean up a couple more places that were using the old corner radius

### DIFF
--- a/RevenueCatUI/CustomerCenter/ButtonStyles.swift
+++ b/RevenueCatUI/CustomerCenter/ButtonStyles.swift
@@ -64,7 +64,7 @@ struct CustomerCenterButtonStyle: ButtonStyle {
             .padding(.horizontal)
             .padding(.vertical, 12)
             .background(configuration.isPressed ? pressedColor : normalColor)
-            .cornerRadius(10)
+            .cornerRadius(CustomerCenterStylingUtilities.cornerRadius)
     }
 }
 

--- a/RevenueCatUI/CustomerCenter/Views/FallbackNoSubscriptionsView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/FallbackNoSubscriptionsView.swift
@@ -120,7 +120,7 @@ struct FallbackNoSubscriptionsView: View {
                 .background(Color(colorScheme == .light
                                   ? UIColor.systemBackground
                                   : UIColor.secondarySystemBackground))
-                .cornerRadius(10)
+                .cornerRadius(CustomerCenterStylingUtilities.cornerRadius)
                 .padding(.horizontal)
         }
         .tint(colorScheme == .dark ? .white : .black)


### PR DESCRIPTION
Noticed a couple more places where we were using the old corner radius. 

Eyeballing it, those seem like the only places left where we had `cornerRadius(10)`

| Before | After |
| :-: | :-: |
| <img width="495" height="903" alt="Screenshot 2025-09-11 at 5 22 20 PM" src="https://github.com/user-attachments/assets/f79e78b1-14d1-47cc-b2d4-4749e7c3bf37" /> | <img width="449" height="890" alt="Screenshot 2025-09-11 at 5 22 37 PM" src="https://github.com/user-attachments/assets/bfbc04dc-a0bf-4376-bd72-8dde26c97887" /> |
| <img width="523" height="905" alt="Screenshot 2025-09-11 at 5 18 59 PM" src="https://github.com/user-attachments/assets/f1bb7c01-a6b8-497e-abc9-36d995791404" />  |  <img width="461" height="914" alt="Screenshot 2025-09-11 at 5 19 14 PM" src="https://github.com/user-attachments/assets/b3f8b60c-9062-42b8-a7a5-0d6fee1b835d" /> |
