### PR TITLE
Tuist: rename generated Xcode workspace to RevenueCat-Tuist.xcworkspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,7 @@ Local.xcconfig
 **/Derived/
 
 # Tuist workspaces
-RevenueCat-Workspace.xcworkspace/
+RevenueCat-Tuist.xcworkspace/
 Projects/**/*.xcodeproj
 Examples/**/*.xcodeproj
 

--- a/Workspace.swift
+++ b/Workspace.swift
@@ -32,7 +32,7 @@ if FileManager.default.fileExists(atPath: "Local.xcconfig") {
 }
 
 let workspace = Workspace(
-    name: "RevenueCat-Workspace",
+    name: "RevenueCat-Tuist",
     projects: projects,
     additionalFiles: additionalFiles
 )


### PR DESCRIPTION
### Motivation
Currently, the tuist-generated Xcode workspace is named `RevenueCat-Workspace.xcworkspace`. This can lead to confusion with the existing `RevenueCat.xcworkspace`, making it not clear which one is which.

### Description
This PR renames the tuist-generated Xcode workspace to `RevenueCat-Tuist.xcworkspace` to make it clearer.