### PR TITLE
CircleCI: Update deprecated Xcode versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -683,7 +683,7 @@ jobs:
           command: bundle exec fastlane test_revenuecatui
           no_output_timeout: 15m
           environment:
-            DEVICE: iPhone 15 Pro,OS=17.2
+            DEVICE: iPhone 15 Pro,OS=17.5
       - create-snapshot-pr-if-needed:
           condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
           job: "create_snapshots_repo_pr"
@@ -821,7 +821,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 15 (17.2.0)
+            SCAN_DEVICE: iPhone 15 (17.5.0)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: RevenueCat


### PR DESCRIPTION
### Motivation
CircleCI is deprecating some Xcode versions in their machines (see https://circleci.com/changelog/deprecation-of-eol-xcode-versions/).

### Description
This PR adapts our CI executions to only use supported Xcode versions:
* Xcode 15.2.0 --> Xcode 15.4.0
* iOS 17.2 --> iOS 17.5 for iOS 17 tests