### PR TITLE
Fix some more flaky tests

### DIFF
--- a/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
@@ -139,7 +139,7 @@ class BasePaywallViewEventsTests: TestCase {
 
         await self.waitForCloseEvent()
 
-        expect(self.events).to(haveCount(4))
+        await expect(self.events).toEventually(haveCount(4))
         expect(self.events.map(\.eventType)) == [.impression, .close, .impression, .close]
         expect(Set(self.events.map(\.data.sessionIdentifier))).to(haveCount(2))
     }


### PR DESCRIPTION
### Motivation
Tests in `OtherIntegrationTests.swift` were sometimes failing (e.g. [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/30246/workflows/1719e25f-3716-4ab2-9db5-00aee17cb2ed/jobs/376605)) with the error
> There is an issue with your configuration. Check the underlying error for more details. There's a problem with your configuration. None of the products registered in the RevenueCat dashboard could be fetched from App Store Connect (or the StoreKit Configuration file if one is being used).

I was able to consistently reproduce it in my machine with Xcode 26 (having installed the latest release of Xcode 26 recently probably helped to repro it).

### Description
I realized that `OtherIntegrationTests` were not configuring the `SKTestSession` with the StoreKit config file using the [`init(configurationFileNamed:)`](https://developer.apple.com/documentation/storekittest/sktestsession/init(configurationfilenamed:)) initializer. These tests were only relying on the StoreKit configuration file being set in the "BackendIntegrationTests" Xcode scheme.
<img width="603" height="307" alt="image" src="https://github.com/user-attachments/assets/eff63e12-9629-4656-88f7-d74ea54d7fd1" />

However, other integration tests like `StoreKit1IntegrationTests` and `StoreKit2IntegrationTests` are indeed initializing the `SKTestSession`
https://github.com/RevenueCat/purchases-ios/blob/ce89da5e00145eace57a4f5377f0d3c37365230e/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift#L36-L38

https://github.com/RevenueCat/purchases-ios/blob/ce89da5e00145eace57a4f5377f0d3c37365230e/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift#L58-L62

This PR adds the same configuration step to `OtherIntegrationTests`, with the hope that this will reduce the flakiness due to the error "None of the products registered in the RevenueCat dashboard could be fetched from App Store Connect (or the StoreKit Configuration file if one is being used)."