### PR TITLE
Open promotional offers from CustomerCenter Detail screen

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -110,7 +110,7 @@ class BaseManageSubscriptionViewModel: ObservableObject {
                 }
 
         case let .promotionalOffer(promotionalOffer) where purchaseInformation?.store == .appStore:
-            if promotionalOffer.eligible, let productIdentifier = feedbackSurveyData?.productIdentifier {
+            if promotionalOffer.eligible, let productIdentifier = purchaseInformation?.productIdentifier {
                 self.loadingPath = path
                 let result = await loadPromotionalOfferUseCase.execute(
                     promoOfferDetails: promotionalOffer,
@@ -133,6 +133,10 @@ class BaseManageSubscriptionViewModel: ObservableObject {
         default:
             await self.onPathSelected(path: path)
         }
+    }
+
+    func onDismissPromotionalOffer() {
+        self.promotionalOfferData = nil
     }
 
     func onDismissInAppBrowser() {

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -175,6 +175,23 @@ struct SubscriptionDetailView: View {
             }, content: { inAppBrowserURL in
                 SafariView(url: inAppBrowserURL.url)
             })
+            .sheet(
+                item: $viewModel.promotionalOfferData
+            ) { promotionalOfferData in
+                PromotionalOfferView(
+                    promotionalOffer: promotionalOfferData.promotionalOffer,
+                    product: promotionalOfferData.product,
+                    promoOfferDetails: promotionalOfferData.promoOfferDetails,
+                    purchasesProvider: self.viewModel.purchasesProvider,
+                    actionWrapper: self.viewModel.actionWrapper,
+                    onDismissPromotionalOfferView: { _ in
+                        viewModel.onDismissPromotionalOffer()
+                    }
+                )
+                .interactiveDismissDisabled()
+                .environment(\.appearance, appearance)
+                .environment(\.localization, localization)
+            }
             .alert(isPresented: $showSimulatorAlert, content: {
                 return Alert(
                     title: Text("Can't open URL"),


### PR DESCRIPTION
### Motivation
We've noticed this has not been working after a [report](https://github.com/RevenueCat/purchases-ios/issues/5568).
Promotionals can be attached to any path, not only to feedback survey

### Description
- Open promo offers from detail screen

