### PR TITLE
MON-1296 Fix gradient rendering issue in iOS 26

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -94,6 +94,12 @@ struct ImageComponentView: View {
                     }
                     .applyImageWidth(size: style.size)
                     .applyImageHeight(size: style.size, aspectRatio: self.aspectRatio(style: style))
+                    .applyIfLet(style.colorOverlay, apply: { view, colorOverlay in
+                        view.overlay(
+                            Color.clear
+                                .backgroundStyle(.color(colorOverlay))
+                        )
+                    })
                     .clipped()
                     .padding(style.padding.extend(by: style.border?.width ?? 0))
                     .shape(border: style.border,
@@ -155,14 +161,6 @@ struct ImageComponentView: View {
             .frame(maxWidth: maxWidth)
             // WIP: Fix this later when accessibility info is available
             .accessibilityHidden(true)
-            .applyIfLet(style.colorOverlay, apply: { view, colorOverlay in
-                view.overlay(
-                    Color.clear
-                        .applyImageWidth(size: style.size)
-                        .applyImageHeight(size: style.size, aspectRatio: self.aspectRatio(style: style))
-                        .backgroundStyle(.color(colorOverlay))
-                )
-            })
     }
 
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

Resolves #5464

The iOS 26 rendering of this component did not redraw the way that is did in previous versions, but it's actually expected behavior. With images that have aspect ratios and content modes and all that, resizing them behaves differently. If the overlay is supposed to be on the final rendered image and follow the same rules as the resizing, we should apply the overlay after the resizing.


> [!NOTE]
> I made 2 commits to show the 2 options I had. I chose this option because it's not redundant.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
