### PR TITLE
Fix compilation error with XCFramework in Xcode 26

### DIFF
--- a/Sources/Misc/Obsoletions.swift
+++ b/Sources/Misc/Obsoletions.swift
@@ -61,7 +61,7 @@ public extension Purchases {
     @available(watchOS, introduced: 6.2, unavailable, renamed: "restorePurchases()")
     @available(macOS, introduced: 10.15, unavailable, renamed: "restorePurchases()")
     @available(macCatalyst, introduced: 13.0, unavailable, renamed: "restorePurchases()")
-    func restoreTransactions() async throws -> CustomerInfo {
+    func restoreTransactions() throws -> CustomerInfo {
         fatalError()
     }
 
@@ -102,7 +102,7 @@ public extension Purchases {
     @available(watchOS, introduced: 6.2, unavailable, renamed: "customerInfo()")
     @available(macOS, introduced: 10.15, unavailable, renamed: "customerInfo()")
     @available(macCatalyst, introduced: 13.0, unavailable, renamed: "customerInfo()")
-    func purchaserInfo() async throws -> CustomerInfo {
+    func purchaserInfo() throws -> CustomerInfo {
         fatalError()
     }
 
@@ -191,7 +191,7 @@ public extension Purchases {
     @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(package:)")
     @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(package:)")
     @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(package:)")
-    func purchasePackage(_ package: Package) async throws -> PurchaseResultData {
+    func purchasePackage(_ package: Package) throws -> PurchaseResultData {
         fatalError()
     }
 
@@ -234,7 +234,7 @@ public extension Purchases {
     @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(package:promotionalOffer:)")
     @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(package:promotionalOffer:)")
     func purchasePackage(_ package: Package,
-                         discount: SKPaymentDiscount) async throws -> PurchaseResultData {
+                         discount: SKPaymentDiscount) throws -> PurchaseResultData {
         fatalError()
     }
 
@@ -276,7 +276,7 @@ public extension Purchases {
     @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(product:)")
     @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(product:)")
     @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(product:)")
-    func purchaseProduct(_ product: SKProduct) async throws {
+    func purchaseProduct(_ product: SKProduct) throws {
         fatalError()
     }
 
@@ -321,7 +321,7 @@ public extension Purchases {
     @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(product:promotionalOffer:)")
     @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(product:promotionalOffer:)")
     @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(product:promotionalOffer:)")
-    func purchaseProduct(_ product: SKProduct, discount: SKPaymentDiscount) async throws {
+    func purchaseProduct(_ product: SKProduct, discount: SKPaymentDiscount) throws {
         fatalError()
     }
 
@@ -330,7 +330,7 @@ public extension Purchases {
     @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(package:promotionalOffer:)")
     @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(package:promotionalOffer:)")
     @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(package:promotionalOffer:)")
-    func purchase(package: Package, discount: StoreProductDiscount) async throws -> PurchaseResultData {
+    func purchase(package: Package, discount: StoreProductDiscount) throws -> PurchaseResultData {
         fatalError()
     }
 
@@ -348,7 +348,7 @@ public extension Purchases {
     @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(package:promotionalOffer:)")
     @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(package:promotionalOffer:)")
     @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(package:promotionalOffer:)")
-    func purchase(product: StoreProduct, discount: StoreProductDiscount) async throws -> PurchaseResultData {
+    func purchase(product: StoreProduct, discount: StoreProductDiscount) throws -> PurchaseResultData {
         fatalError()
     }
 
@@ -466,7 +466,7 @@ public extension Purchases {
     @available(macCatalyst, introduced: 13.0, unavailable,
                message: "Check eligibility for a discount using getPromotionalOffer:")
     func paymentDiscount(for discount: SKProductDiscount,
-                         product: SKProduct) async throws -> SKPaymentDiscount {
+                         product: SKProduct) throws -> SKPaymentDiscount {
         fatalError()
     }
 


### PR DESCRIPTION
This PR fixes #5585, where archiving an app that integrates the SDK via XCFramework results in compiler errors.

The fixes are very similar to those done in https://github.com/RevenueCat/purchases-ios/pull/5542:

> Solution
The async raising the errors are all part of obsoleted APIs. These APIs should never be used as their implementation just do fatalError().
The solution has been to remove the async from the methods' signatures. This is a soft breaking change in the sense that callers of these methods will get a warning saying the await is not necessary. In addition, as developers shouldn't be using these APIs anyway, this should be the least disruptive solution.

