### PR TITLE
Fix flaky snapshot test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1580,29 +1580,29 @@ workflows:
       - run-revenuecat-ui-ios-18
       - run-revenuecat-ui-ios-26
 
-  build-test:
-    when:
-      and:
-        - not:
-            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not: << pipeline.parameters.generate_snapshots >>
-        - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
-    jobs:
-      - lint
-      - validate-package-swift:
-          name: validate-package-swift-5.7
-          xcode_version: "14.0.1"
-          mac_os_executor_name: macos-executor-for-macos-12_6
-      - validate-package-swift:
-          name: validate-package-swift-5.8
-          xcode_version: "14.3.1"
-          mac_os_executor_name: macos-executor
-      - run-test-ios-18
-      - run-test-ios-26
-      - pod-lib-lint
-      - run-revenuecat-ui-ios-18
-      - run-revenuecat-ui-ios-26
-      - emerge_purchases_ui_snapshot_tests
+  # build-test:
+  #   when:
+  #     and:
+  #       - not:
+  #           equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+  #       - not: << pipeline.parameters.generate_snapshots >>
+  #       - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
+  #   jobs:
+  #     - lint
+  #     - validate-package-swift:
+  #         name: validate-package-swift-5.7
+  #         xcode_version: "14.0.1"
+  #         mac_os_executor_name: macos-executor-for-macos-12_6
+  #     - validate-package-swift:
+  #         name: validate-package-swift-5.8
+  #         xcode_version: "14.3.1"
+  #         mac_os_executor_name: macos-executor
+  #     - run-test-ios-18
+  #     - run-test-ios-26
+  #     - pod-lib-lint
+  #     - run-revenuecat-ui-ios-18
+  #     - run-revenuecat-ui-ios-26
+  #     - emerge_purchases_ui_snapshot_tests
   emerge_snapshot_tests:
     when:
       or:
@@ -1666,9 +1666,9 @@ workflows:
       - prepare-next-version:
           <<: *only-main-branch
 
-  danger:
-    jobs:
-      - danger
+  # danger:
+  #   jobs:
+  #     - danger
 
   weekly-run-workflow:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1580,29 +1580,29 @@ workflows:
       - run-revenuecat-ui-ios-18
       - run-revenuecat-ui-ios-26
 
-  # build-test:
-  #   when:
-  #     and:
-  #       - not:
-  #           equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-  #       - not: << pipeline.parameters.generate_snapshots >>
-  #       - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
-  #   jobs:
-  #     - lint
-  #     - validate-package-swift:
-  #         name: validate-package-swift-5.7
-  #         xcode_version: "14.0.1"
-  #         mac_os_executor_name: macos-executor-for-macos-12_6
-  #     - validate-package-swift:
-  #         name: validate-package-swift-5.8
-  #         xcode_version: "14.3.1"
-  #         mac_os_executor_name: macos-executor
-  #     - run-test-ios-18
-  #     - run-test-ios-26
-  #     - pod-lib-lint
-  #     - run-revenuecat-ui-ios-18
-  #     - run-revenuecat-ui-ios-26
-  #     - emerge_purchases_ui_snapshot_tests
+  build-test:
+    when:
+      and:
+        - not:
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - not: << pipeline.parameters.generate_snapshots >>
+        - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
+    jobs:
+      - lint
+      - validate-package-swift:
+          name: validate-package-swift-5.7
+          xcode_version: "14.0.1"
+          mac_os_executor_name: macos-executor-for-macos-12_6
+      - validate-package-swift:
+          name: validate-package-swift-5.8
+          xcode_version: "14.3.1"
+          mac_os_executor_name: macos-executor
+      - run-test-ios-18
+      - run-test-ios-26
+      - pod-lib-lint
+      - run-revenuecat-ui-ios-18
+      - run-revenuecat-ui-ios-26
+      - emerge_purchases_ui_snapshot_tests
   emerge_snapshot_tests:
     when:
       or:
@@ -1666,9 +1666,9 @@ workflows:
       - prepare-next-version:
           <<: *only-main-branch
 
-  # danger:
-  #   jobs:
-  #     - danger
+  danger:
+    jobs:
+      - danger
 
   weekly-run-workflow:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ parameters:
         run-manual-docs-deploy,
         update_paywall_templates,
         record_paywall_screenshots,
-        tuist
+        tuist,
+        emerge_snapshot_tests
       ]
     default: default
   generate_snapshots:
@@ -1602,6 +1603,13 @@ workflows:
       - run-revenuecat-ui-ios-18
       - run-revenuecat-ui-ios-26
       - emerge_purchases_ui_snapshot_tests
+  emerge_snapshot_tests:
+    when:
+      or:
+        - equal: [emerge_snapshot_tests, << pipeline.parameters.action >>]
+    jobs:
+      - emerge_purchases_ui_snapshot_tests
+
 
   create-tag:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,7 @@ parameters:
         run-manual-docs-deploy,
         update_paywall_templates,
         record_paywall_screenshots,
-        tuist,
-        emerge_snapshot_tests
+        tuist
       ]
     default: default
   generate_snapshots:
@@ -1603,13 +1602,6 @@ workflows:
       - run-revenuecat-ui-ios-18
       - run-revenuecat-ui-ios-26
       - emerge_purchases_ui_snapshot_tests
-  emerge_snapshot_tests:
-    when:
-      or:
-        - equal: [emerge_snapshot_tests, << pipeline.parameters.action >>]
-    jobs:
-      - emerge_purchases_ui_snapshot_tests
-
 
   create-tag:
     when:

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
@@ -399,7 +399,7 @@ struct BadgePreviews: View {
                 localizationProvider: .init(
                     locale: Locale.current,
                     localizedStrings: [
-                        "text_1": .string("Feature 1\nFeature 2\nFeature 3\nFeature 4"),
+                        "text_1": .string(""),
                         "text_2": .string("Special Discount\nSave 50%")
                     ]
                 )

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
@@ -312,9 +312,11 @@ struct EdgeToEdgeTopBottomModifier: ViewModifier {
             content
                 .background(
                     GeometryReader { geometry in
+                        let _ = print("geometry.size: \(geometry.size)")
                         Color.clear
                             .onAppear {
                                 stackSize = geometry.size
+                                debugTxts.append("stackSize: \(stackSize.width)x\(stackSize.height)")
                             }
                     }
                 )
@@ -328,7 +330,10 @@ struct EdgeToEdgeTopBottomModifier: ViewModifier {
                 .backgroundStyle(badge.backgroundStyle)
                 .shape(border: nil,
                        shape: effectiveShape(badge: badge,
-                                             pillStackRadius: min(stackSize.width, stackSize.height)/2))
+                                             pillStackRadius: 33))
+        }
+        .overlay {
+            Text(self.debugTxts.joined(separator: " - "))
         }
     }
 

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
@@ -295,6 +295,7 @@ private func radiusInfo(shape: ShapeModifier.Shape?, pillRadius: Double? = 0) ->
 struct EdgeToEdgeTopBottomModifier: ViewModifier {
 
     @State private var stackSize: CGSize = .zero
+    @State private var debugTxts: [String] = []
     var badge: BadgeModifier.BadgeInfo
 
     var badgeView: some View {

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
@@ -295,7 +295,6 @@ private func radiusInfo(shape: ShapeModifier.Shape?, pillRadius: Double? = 0) ->
 struct EdgeToEdgeTopBottomModifier: ViewModifier {
 
     @State private var stackSize: CGSize = .zero
-    @State private var debugTxts: [String] = []
     var badge: BadgeModifier.BadgeInfo
 
     var badgeView: some View {
@@ -311,10 +310,8 @@ struct EdgeToEdgeTopBottomModifier: ViewModifier {
                 badgeView
             }
             content
-                .onSizeChange{ size in
-                    let _ = print("stackSize: \(size.width)x\(size.height)")
+                .onSizeChange { size in
                     stackSize = size
-                    debugTxts.append("stackSize: \(stackSize.width)x\(stackSize.height)")
                 }
             if badge.alignment == .bottom {
                 badgeView
@@ -327,9 +324,6 @@ struct EdgeToEdgeTopBottomModifier: ViewModifier {
                 .shape(border: nil,
                        shape: effectiveShape(badge: badge,
                                              pillStackRadius: min(stackSize.width, stackSize.height)/2))
-        }
-        .overlay {
-            Text(self.debugTxts.joined(separator: " - "))
         }
     }
 

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
@@ -331,7 +331,7 @@ struct EdgeToEdgeTopBottomModifier: ViewModifier {
                 .backgroundStyle(badge.backgroundStyle)
                 .shape(border: nil,
                        shape: effectiveShape(badge: badge,
-                                             pillStackRadius: 33))
+                                             pillStackRadius: min(stackSize.width, stackSize.height)/2))
         }
         .overlay {
             Text(self.debugTxts.joined(separator: " - "))

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
@@ -399,7 +399,7 @@ struct BadgePreviews: View {
                 localizationProvider: .init(
                     locale: Locale.current,
                     localizedStrings: [
-                        "text_1": .string(""),
+                        "text_1": .string("Feature 1\nFeature 2\nFeature 3\nFeature 4"),
                         "text_2": .string("Special Discount\nSave 50%")
                     ]
                 )

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
@@ -311,16 +311,11 @@ struct EdgeToEdgeTopBottomModifier: ViewModifier {
                 badgeView
             }
             content
-                .background(
-                    GeometryReader { geometry in
-                        let _ = print("geometry.size: \(geometry.size)")
-                        Color.clear
-                            .onAppear {
-                                stackSize = geometry.size
-                                debugTxts.append("stackSize: \(stackSize.width)x\(stackSize.height)")
-                            }
-                    }
-                )
+                .onSizeChange{ size in
+                    let _ = print("stackSize: \(size.width)x\(size.height)")
+                    stackSize = size
+                    debugTxts.append("stackSize: \(stackSize.width)x\(stackSize.height)")
+                }
             if badge.alignment == .bottom {
                 badgeView
             }


### PR DESCRIPTION
This snapshot has been constantly changing back and forth

<img width="1402" height="548" alt="image" src="https://github.com/user-attachments/assets/726000e7-a72a-418a-9b34-2a48085b3e19" />


I found out that, sometimes, the `GeometryReader` in `BadgeModifier` was reporting a width of 60, whereas the actual preview would be wider.
https://github.com/RevenueCat/purchases-ios/blob/fc15bc67aebee66da0dc605e348b1bb8f717cb39/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift#L307-L333

As a result, an incorrect radius was being calculated in https://github.com/RevenueCat/purchases-ios/blob/fc15bc67aebee66da0dc605e348b1bb8f717cb39/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift#L331

The reason seems to be that `onAppear`, which is only called once, was sometimes being called before the preview had its final size set, resulting in a premature size being used from the `GeometryReader`.

With the use of `onSizeChange`, we make sure that the size gets updated not only once, but every time the `content`'s size changes.

I confirmed this with temporary snapshots that added some debugging text to the preview [here](https://www.emergetools.com/snapshot/e2dda24f-f665-4ff5-99fa-74f90fdfaf23), showing that only sometimes the width of the preview is 60 but then is updated to its final width.
<img width="977" height="212" alt="image" src="https://github.com/user-attachments/assets/411532d4-bf75-439d-9570-b57955299f56" />
and the fix seems to wor