### PR TITLE
Enable Test Store

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -569,10 +569,7 @@ extension PurchaseInformation {
         case .amazon: return .storeAmazon
         case .unknownStore: return .storeUnknownStore
         case .paddle, .stripe, .rcBilling, .external: return .storeWeb
-
-        #if SIMULATED_STORE
         case .testStore: return .simulatedStore
-        #endif
         }
     }
 }

--- a/Sources/CodableExtensions/Store+Extensions.swift
+++ b/Sources/CodableExtensions/Store+Extensions.swift
@@ -66,9 +66,7 @@ private extension Store {
         case .rcBilling: return "rc_billing"
         case .external: return "external"
         case .paddle: return "paddle"
-        #if SIMULATED_STORE
         case .testStore: return "test"
-        #endif
         }
     }
 

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -420,7 +420,6 @@ extension Configuration {
     private static let simulatedStoreKeyPrefix = "test_"
 
     private static func validate(apiKey: String) -> APIKeyValidationResult {
-        #if SIMULATED_STORE
         if apiKey.hasPrefix(simulatedStoreKeyPrefix) {
             // Simulated Store key format: "test_CtDdmbdWBySmqJeeQUTyrNxETUVkajsJ"
 
@@ -435,7 +434,6 @@ extension Configuration {
                        " app on the RevenueCat dashboard and use its corresponding Apple API key before releasing.")
             #endif
         }
-        #endif // SIMULATED_STORE
 
         if applePlatformKeyPrefixes.contains(where: { prefix in apiKey.hasPrefix(prefix) }) {
             // Apple key format: "apple_CtDdmbdWBySmqJeeQUTyrNxETUVkajsJ"

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -49,12 +49,8 @@ import Foundation
     /// For entitlements granted via Paddle.
     @objc(RCPaddle) case paddle = 9
 
-    #if SIMULATED_STORE
-
     /// For entitlements granted via the Test Store.
     @objc(RCTestStore) case testStore = 10
-
-    #endif
 
 }
 

--- a/Sources/Purchasing/ProductsManagerFactory.swift
+++ b/Sources/Purchasing/ProductsManagerFactory.swift
@@ -22,18 +22,16 @@ enum ProductsManagerFactory {
                               backend: Backend,
                               deviceCache: DeviceCache,
                               requestTimeout: TimeInterval) -> ProductsManagerType {
-            #if SIMULATED_STORE
             if apiKeyValidationResult == .simulatedStore {
                 return SimulatedStoreProductsManager(backend: backend,
                                                      deviceCache: deviceCache,
                                                      requestTimeout: requestTimeout)
+            } else {
+                return ProductsManager(productsRequestFactory: ProductsRequestFactory(),
+                                       diagnosticsTracker: diagnosticsTracker,
+                                       systemInfo: systemInfo,
+                                       requestTimeout: requestTimeout)
             }
-            #endif // SIMULATED_STORE
-
-            return ProductsManager(productsRequestFactory: ProductsRequestFactory(),
-                                   diagnosticsTracker: diagnosticsTracker,
-                                   systemInfo: systemInfo,
-                                   requestTimeout: requestTimeout)
     }
 
 }

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -304,8 +304,6 @@ final class PurchasesOrchestrator {
     }
 
     func restorePurchases(completion: (@Sendable (Result<CustomerInfo, PurchasesError>) -> Void)?) {
-        #if SIMULATED_STORE
-
         if self.systemInfo.isSimulatedStoreAPIKey {
             Logger.debug(Strings.purchase.restore_purchases_simulated_store)
             self.customerInfoManager.customerInfo(appUserID: self.appUserID, fetchPolicy: .default) { result in
@@ -314,7 +312,6 @@ final class PurchasesOrchestrator {
             return
         }
 
-        #endif // SIMULATED_STORE
         self.syncPurchases(receiptRefreshPolicy: .always,
                            isRestore: true,
                            initiationSource: .restore,
@@ -322,8 +319,6 @@ final class PurchasesOrchestrator {
     }
 
     func syncPurchases(completion: (@Sendable (Result<CustomerInfo, PurchasesError>) -> Void)? = nil) {
-        #if SIMULATED_STORE
-
         if self.systemInfo.isSimulatedStoreAPIKey {
             Logger.debug(Strings.purchase.sync_purchases_simulated_store)
             self.customerInfoManager.customerInfo(appUserID: self.appUserID, fetchPolicy: .default) { result in
@@ -332,7 +327,6 @@ final class PurchasesOrchestrator {
             return
         }
 
-        #endif // SIMULATED_STORE
         self.syncPurchases(receiptRefreshPolicy: .never,
                            isRestore: allowSharingAppStoreAccount,
                            initiationSource: .restore,
@@ -1969,18 +1963,13 @@ private extension PurchasesOrchestrator {
     func handlePurchase(testStoreProduct: TestStoreProduct,
                         metadata: [String: String]?,
                         completion: @escaping PurchaseCompletedBlock) {
-        #if SIMULATED_STORE
         if self.systemInfo.isSimulatedStoreAPIKey {
             self.purchase(simulatedStoreProduct: testStoreProduct, metadata: metadata, completion: completion)
         } else {
             self.handleTestProductNotAvailableForPurchase(completion)
         }
-        #else
-        self.handleTestProductNotAvailableForPurchase(completion)
-        #endif // SIMULATED_STORE
     }
 
-    #if SIMULATED_STORE
     private func purchase(simulatedStoreProduct: SimulatedStoreProduct,
                           metadata: [String: String]?,
                           completion: @escaping PurchaseCompletedBlock) {
@@ -2004,7 +1993,6 @@ private extension PurchasesOrchestrator {
             }
         }
     }
-    #endif // SIMULATED_STORE
 
     private func handleTestProductNotAvailableForPurchase(_ completion: @escaping PurchaseCompletedBlock) {
         self.operationDispatcher.dispatchOnMainActor {

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -258,13 +258,12 @@ private extension TransactionPoster {
 
     func fetchEncodedReceipt(transaction: StoreTransactionType,
                              completion: @escaping (Result<EncodedAppleReceipt, BackendError>) -> Void) {
-        #if SIMULATED_STORE
         if systemInfo.isSimulatedStoreAPIKey {
             let purchaseToken = transaction.jwsRepresentation ?? ""
             completion(.success(.jws(purchaseToken)))
             return
         }
-        #endif
+
         if systemInfo.storeKitVersion.isStoreKit2EnabledAndAvailable,
            let jwsRepresentation = transaction.jwsRepresentation {
             if transaction.environment == .xcode, #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {

--- a/Sources/Purchasing/SimulatedStore/SimulatedStoreProductsManager.swift
+++ b/Sources/Purchasing/SimulatedStore/SimulatedStoreProductsManager.swift
@@ -13,8 +13,6 @@
 
 import Foundation
 
-#if SIMULATED_STORE
-
 /// Implementation of `ProductsManagerType` for the Simulated Store.
 final class SimulatedStoreProductsManager: ProductsManagerType {
 
@@ -67,5 +65,3 @@ final class SimulatedStoreProductsManager: ProductsManagerType {
     // See `CachingProductsManager`.
     func clearCache() { }
 }
-
-#endif // SIMULATED_STORE

--- a/Sources/Purchasing/SimulatedStore/SimulatedStorePurchaseHandler.swift
+++ b/Sources/Purchasing/SimulatedStore/SimulatedStorePurchaseHandler.swift
@@ -16,12 +16,9 @@ enum TestPurchaseResult {
 
 protocol SimulatedStorePurchaseHandlerType: AnyObject, Sendable {
 
-    #if SIMULATED_STORE
-
     @MainActor
     func purchase(product: TestStoreProduct) async -> TestPurchaseResult
 
-    #endif // SIMULATED_STORE
 }
 
 /// The object that handles purchases in the Simulated Store.
@@ -47,8 +44,6 @@ actor SimulatedStorePurchaseHandler: SimulatedStorePurchaseHandlerType {
         self.purchaseUI = purchaseUI
         self.dateProvider = dateProvider
     }
-
-    #if SIMULATED_STORE
 
     func purchase(product: TestStoreProduct) async -> TestPurchaseResult {
         guard !self.purchaseInProgress else {
@@ -101,7 +96,6 @@ actor SimulatedStorePurchaseHandler: SimulatedStorePurchaseHandlerType {
             withMessage: Strings.purchase.error_message_for_simulating_purchase_failure.description)
     }
 
-    #endif // SIMULATED_STORE
 }
 
 // MARK: - Purchase Alert Presentation

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCEntitlementInfoAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCEntitlementInfoAPI.m
@@ -49,9 +49,7 @@
         case RCUnknownStore:
         case RCPaddle:
         case RCExternal:
-#ifdef SIMULATED_STORE
         case RCTestStore:
-#endif
             NSLog(@"%ld", (long)rs);
             break;
     }

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/EntitlementInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/EntitlementInfoAPI.swift
@@ -53,12 +53,9 @@ func checkEntitlementInfoEnums() {
          .rcBilling,
          .unknownStore,
          .external,
-         .paddle:
+         .paddle,
+         .testStore:
         print(store!)
-    #if SIMULATED_STORE
-    case .testStore:
-        print(store!)
-    #endif
     @unknown default:
         fatalError()
     }

--- a/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
@@ -1094,11 +1094,7 @@ final class PurchaseInformationTests: TestCase {
         expect(subscriptionInfo.isLifetime).to(beFalse())
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
-        #if SIMULATED_STORE
         expect(subscriptionInfo.store) == .testStore
-        #else
-        expect(subscriptionInfo.store) == .unknownStore
-        #endif
     }
 
     // MARK: - Tests for improved title and price determination logic

--- a/Tests/UnitTests/Mocks/MockTestStorePurchaseHandler.swift
+++ b/Tests/UnitTests/Mocks/MockTestStorePurchaseHandler.swift
@@ -16,8 +16,6 @@ import Foundation
 
 actor MockSimulatedStorePurchaseHandler: SimulatedStorePurchaseHandlerType {
 
-    #if SIMULATED_STORE
-
     let stubbedPurchaseResult: Atomic<TestPurchaseResult> = .init(.cancel)
     let invokedPurchase: Atomic<Bool> = .init(false)
     let invokedPurchaseProduct: Atomic<TestStoreProduct?> = .init(nil)
@@ -29,5 +27,4 @@ actor MockSimulatedStorePurchaseHandler: SimulatedStorePurchaseHandlerType {
         return self.stubbedPurchaseResult.value
     }
 
-    #endif // SIMULATED_STORE
 }

--- a/Tests/UnitTests/Purchasing/ConfigurationTests.swift
+++ b/Tests/UnitTests/Purchasing/ConfigurationTests.swift
@@ -35,11 +35,9 @@ class ConfigurationTests: TestCase {
         expect(Configuration.validateAndLog(apiKey: "swRTCezdEzjnJSxdexDNJfcfiFrMXwqZ")) == .legacy
     }
 
-    #if SIMULATED_STORE
     func testValidateAPIKeyWithTestStoreKey() {
         expect(Configuration.validateAndLog(apiKey: "test_eg2t9g3098bgqqn")) == .simulatedStore
     }
-    #endif
 
     func testNoObserverModeWithStoreKit1() {
         let configuration = Configuration.Builder(withAPIKey: "test")

--- a/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
@@ -350,8 +350,6 @@ class TransactionPosterTests: TestCase {
         ) == true
     }
 
-    #if SIMULATED_STORE
-
     func testPostReceiptForPurchaseInSimulatedStore() throws {
         self.setUp(observerMode: false, storeKitVersion: .storeKit2, apiKeyValidationResult: .simulatedStore)
         let purchaseDate = Date()
@@ -386,8 +384,6 @@ class TransactionPosterTests: TestCase {
 
         expect(self.receiptFetcher.receiptDataCalled) == false
     }
-
-    #endif // SIMULATED_STORE
 
 }
 

--- a/Tests/UnitTests/Purchasing/SimulatedStoreUnitTests/SimulatedStoreProductsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/SimulatedStoreUnitTests/SimulatedStoreProductsManagerTests.swift
@@ -15,8 +15,6 @@ import Nimble
 @testable import RevenueCat
 import XCTest
 
-#if SIMULATED_STORE
-
 class SimulatedStoreProductsManagerTests: TestCase {
 
     static var requestTimeout: TimeInterval = 60
@@ -125,5 +123,3 @@ class SimulatedStoreProductsManagerTests: TestCase {
                                              requestTimeout: Self.requestTimeout)
     }
 }
-
-#endif // SIMULATED_STORE

--- a/Tests/UnitTests/SimulatedStore/PurchasesOrchestratorSimulatedStoreTests.swift
+++ b/Tests/UnitTests/SimulatedStore/PurchasesOrchestratorSimulatedStoreTests.swift
@@ -164,8 +164,6 @@ class PurchasesOrchestratorSimulatedStoreTests: TestCase {
         return testProduct.toStoreProduct()
     }
 
-#if SIMULATED_STORE
-
     // MARK: - PurchasesOrchestrator + API Key type
 
     func testPurchaseWithSimulatedStoreProductAndTestAPIKeyCallsSimulatedStorePurchaseHandler() async {
@@ -463,9 +461,6 @@ class PurchasesOrchestratorSimulatedStoreTests: TestCase {
         XCTAssertTrue(self.customerInfoManager.invokedCustomerInfo)
     }
 
-#endif
-
-#if !SIMULATED_STORE
     func testPurchaseWithTestStoreProductAndTestAPIKeyWhenTestStoreFlagDisabledReturnsError() async {
         let orchestrator = self.createOrchestrator()
         let testProduct = self.createTestStoreProduct()
@@ -482,7 +477,6 @@ class PurchasesOrchestratorSimulatedStoreTests: TestCase {
         }
 
     }
-#endif
 
     private func createOrchestrator() -> PurchasesOrchestrator {
         let orchestrator = PurchasesOrchestrator(

--- a/Tests/UnitTests/SimulatedStore/SimulatedStorePurchaseHandlerTests.swift
+++ b/Tests/UnitTests/SimulatedStore/SimulatedStorePurchaseHandlerTests.swift
@@ -15,8 +15,6 @@ import Nimble
 @_spi(Internal) @testable import RevenueCat
 import XCTest
 
-#if SIMULATED_STORE
-
 class SimulatedStorePurchaseHandlerTests: TestCase {
 
     private var mockSimulatedStorePurchaseUI: MockSimulatedStorePurchaseUI!
@@ -187,5 +185,3 @@ class SimulatedStorePurchaseHandlerTests: TestCase {
 
     private static let mockDate = Date(millisecondsSince1970: 1756796794912) // Sep 02 2025 07:06:34.912 UTC
 }
-
-#endif // SIMULATED_STORE


### PR DESCRIPTION
This PR removes the `SIMULATED_STORE` compiler flag to enable the Test Store functionality in the SDK