### PR TITLE
Add displayName to SubscriptionInfo

### DIFF
--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -241,7 +241,8 @@ public typealias ProductIdentifier = String
                 storeTransactionId: subscriptionData.storeTransactionId,
                 requestDate: response.requestDate,
                 price: subscriptionData.price.map { ProductPaidPrice(currency: $0.currency, amount: $0.amount) },
-                managementURL: subscriptionData.managementUrl
+                managementURL: subscriptionData.managementUrl,
+                displayName: subscriptionData.displayName
             ))
         })
     }

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -72,6 +72,9 @@ import Foundation
     /// Whether the subscription will renew at the next billing period.
     @objc public let willRenew: Bool
 
+    /// The display name of the subscription as configured in the RevenueCat dashboard.
+    @objc public let displayName: String?
+
     /// Paid price for the subscription
     @objc public let price: ProductPaidPrice?
 
@@ -93,7 +96,8 @@ import Foundation
          storeTransactionId: String?,
          requestDate: Date,
          price: ProductPaidPrice?,
-         managementURL: URL?) {
+         managementURL: URL?,
+         displayName: String?) {
         self.productIdentifier = productIdentifier
         self.purchaseDate = purchaseDate
         self.originalPurchaseDate = originalPurchaseDate
@@ -115,6 +119,7 @@ import Foundation
                                                                      periodType: periodType)
         self.price = price
         self.managementURL = managementURL
+        self.displayName = displayName
 
         super.init()
     }
@@ -136,7 +141,8 @@ import Foundation
             storeTransactionId: \(String(describing: storeTransactionId)),
             isActive: \(isActive),
             willRenew: \(willRenew),
-            managementURL: \(String(describing: managementURL))
+            managementURL: \(String(describing: managementURL)),
+            displayName: \(String(describing: displayName))
         }
         """
     }

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/SubscriptionInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/SubscriptionInfoAPI.swift
@@ -32,4 +32,5 @@ func checkSubscriptionInfoAPI() {
     let txId: String? = subscription.storeTransactionId
     let isActive: Bool = subscription.isActive
     let willRenew: Bool = subscription.willRenew
+    let displayName = subscription.displayName
 }


### PR DESCRIPTION
### Motivation
We've got a request to add `displayName` to `SubscriptionInfo`. It's exposed in [Android](https://github.com/RevenueCat/purchases-android/blob/85394eb53e51a1719f80e149e06a6d79a27db065/purchases/src/main/kotlin/com/revenuecat/purchases/SubscriptionInfo.kt#L88), but it's missing in iOS

### Description
- Add `displayName`
- Update `APITests`
