### PR TITLE
Add flag to show / hide user section in CustomerCenter

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigData+Mock.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterConfigData+Mock.swift
@@ -24,6 +24,7 @@ extension CustomerCenterConfigData {
         lastPublishedAppVersion: String? = "1.0.0",
         shouldWarnCustomerToUpdate: Bool = false,
         displayPurchaseHistoryLink: Bool = false,
+        displayUserDetailsSection: Bool = true,
         displayVirtualCurrencies: Bool = false,
         refundWindowDuration: CustomerCenterConfigData.HelpPath.RefundWindowDuration = .forever,
         shouldWarnCustomersAboutMultipleSubscriptions: Bool = false
@@ -130,6 +131,7 @@ extension CustomerCenterConfigData {
                 email: "test-support@revenuecat.com",
                 shouldWarnCustomerToUpdate: shouldWarnCustomerToUpdate,
                 displayPurchaseHistoryLink: displayPurchaseHistoryLink,
+                displayUserDetailsSection: displayUserDetailsSection,
                 displayVirtualCurrencies: displayVirtualCurrencies,
                 shouldWarnCustomersAboutMultipleSubscriptions: shouldWarnCustomersAboutMultipleSubscriptions
             ),

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -121,6 +121,10 @@ import Foundation
         configuration?.support.displayVirtualCurrencies == true
     }
 
+    var shouldShowUserDetailsSection: Bool {
+        configuration?.support.displayUserDetailsSection == true
+    }
+
     private let currentVersionFetcher: CurrentVersionFetcher
 
     internal var customerInfo: CustomerInfo?

--- a/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/RelevantPurchasesListView.swift
@@ -14,6 +14,7 @@
 @_spi(Internal) import RevenueCat
 import SwiftUI
 
+// swiftlint:disable file_length
 #if os(iOS)
 
 @available(iOS 15.0, *)
@@ -187,11 +188,13 @@ struct RelevantPurchasesListView: View {
                     Spacer().frame(height: 16)
                 }
 
-                AccountDetailsSection(
-                    originalPurchaseDate: customerInfoViewModel.originalPurchaseDate,
-                    originalAppUserId: customerInfoViewModel.originalAppUserId,
-                    localization: localization
-                )
+                if customerInfoViewModel.shouldShowUserDetailsSection {
+                    AccountDetailsSection(
+                        originalPurchaseDate: customerInfoViewModel.originalPurchaseDate,
+                        originalAppUserId: customerInfoViewModel.originalAppUserId,
+                        localization: localization
+                    )
+                }
             }
             .padding(.top, 16)
         }

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -256,7 +256,9 @@ private extension SubscriptionDetailView {
                         .padding(.vertical, 16)
                 }
 
-                accountDetailsView
+                if customerInfoViewModel.shouldShowUserDetailsSection {
+                    accountDetailsView
+                }
             }
             .opacity(viewModel.isRefreshing ? 0.5 : 1)
             .animation(.easeInOut(duration: 0.3), value: viewModel.isRefreshing)

--- a/Sources/CustomerCenter/CustomerCenterConfigData.swift
+++ b/Sources/CustomerCenter/CustomerCenterConfigData.swift
@@ -683,6 +683,7 @@ import Foundation
         @_spi(Internal) public let email: String
         @_spi(Internal) public let shouldWarnCustomerToUpdate: Bool
         @_spi(Internal) public let displayPurchaseHistoryLink: Bool
+        @_spi(Internal) public let displayUserDetailsSection: Bool
         @_spi(Internal) public let displayVirtualCurrencies: Bool
         @_spi(Internal) public let shouldWarnCustomersAboutMultipleSubscriptions: Bool
 
@@ -690,12 +691,14 @@ import Foundation
             email: String,
             shouldWarnCustomerToUpdate: Bool,
             displayPurchaseHistoryLink: Bool,
+            displayUserDetailsSection: Bool,
             displayVirtualCurrencies: Bool,
             shouldWarnCustomersAboutMultipleSubscriptions: Bool
         ) {
             self.email = email
             self.shouldWarnCustomerToUpdate = shouldWarnCustomerToUpdate
             self.displayPurchaseHistoryLink = displayPurchaseHistoryLink
+            self.displayUserDetailsSection = displayUserDetailsSection
             self.displayVirtualCurrencies = displayVirtualCurrencies
             self.shouldWarnCustomersAboutMultipleSubscriptions = shouldWarnCustomersAboutMultipleSubscriptions
         }
@@ -926,6 +929,7 @@ extension CustomerCenterConfigData.Support {
         self.email = response.email
         self.shouldWarnCustomerToUpdate = response.shouldWarnCustomerToUpdate ?? true
         self.displayPurchaseHistoryLink = response.displayPurchaseHistoryLink ?? false
+        self.displayUserDetailsSection = response.displayUserDetailsSection ?? true
         self.displayVirtualCurrencies = response.displayVirtualCurrencies ?? false
         self.shouldWarnCustomersAboutMultipleSubscriptions = response.shouldWarnCustomersAboutMultipleSubscriptions
             ?? false

--- a/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
+++ b/Sources/Networking/Responses/CustomerCenterConfigResponse.swift
@@ -151,6 +151,7 @@ struct CustomerCenterConfigResponse {
         let email: String
         let shouldWarnCustomerToUpdate: Bool?
         let displayPurchaseHistoryLink: Bool?
+        let displayUserDetailsSection: Bool?
         let displayVirtualCurrencies: Bool?
         let shouldWarnCustomersAboutMultipleSubscriptions: Bool?
     }

--- a/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ContactSupportUtilitiesTests.swift
@@ -26,6 +26,7 @@ class ContactSupportUtilitiesTest: TestCase {
         email: "support@example.com",
         shouldWarnCustomerToUpdate: false,
         displayPurchaseHistoryLink: false,
+        displayUserDetailsSection: false,
         displayVirtualCurrencies: false,
         shouldWarnCustomersAboutMultipleSubscriptions: false
     )

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -274,6 +274,52 @@ final class CustomerCenterViewModelTests: TestCase {
         expect(viewModel.shouldShowVirtualCurrencies).to(beFalse())
     }
 
+    func testShouldShowUserDetailsSectionIsFalseBeforeConfigIsLoaded() {
+        let mockPurchases = MockCustomerCenterPurchases(
+            customerInfo: CustomerInfoFixtures.customerInfoWithAppleSubscriptions,
+            customerCenterConfigData: CustomerCenterConfigData.mock(displayUserDetailsSection: true)
+        )
+
+        let viewModel = CustomerCenterViewModel(
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchasesProvider: mockPurchases
+        )
+
+        expect(viewModel.shouldShowUserDetailsSection).to(beFalse())
+    }
+
+    func testShouldShowUserDetailsSectionTrue() async {
+        let mockPurchases = MockCustomerCenterPurchases(
+            customerInfo: CustomerInfoFixtures.customerInfoWithAppleSubscriptions,
+            customerCenterConfigData: CustomerCenterConfigData.mock(displayUserDetailsSection: true)
+        )
+
+        let viewModel = CustomerCenterViewModel(
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchasesProvider: mockPurchases
+        )
+
+        await viewModel.loadScreen()
+
+        expect(viewModel.shouldShowUserDetailsSection).to(beTrue())
+    }
+
+    func testShouldShowUserDetailsSectionFalse() async {
+        let mockPurchases = MockCustomerCenterPurchases(
+            customerInfo: CustomerInfoFixtures.customerInfoWithAppleSubscriptions,
+            customerCenterConfigData: CustomerCenterConfigData.mock(displayUserDetailsSection: false)
+        )
+
+        let viewModel = CustomerCenterViewModel(
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchasesProvider: mockPurchases
+        )
+
+        await viewModel.loadScreen()
+
+        expect(viewModel.shouldShowUserDetailsSection).to(beFalse())
+    }
+
     func testHasAnyPurchasesIsTrueWithOnlyVirtualCurrencies() async throws {
         let mockPurchases = MockCustomerCenterPurchases(
             customerInfo: CustomerCenterViewModelTests.customerInfoWithoutSubscriptions,

--- a/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
+++ b/Tests/UnitTests/CustomerCenter/CustomerCenterConfigDataTests.swift
@@ -136,6 +136,7 @@ final class CustomerCenterConfigDataTests: TestCase {
                     email: "support@example.com",
                     shouldWarnCustomerToUpdate: false,
                     displayPurchaseHistoryLink: true,
+                    displayUserDetailsSection: true,
                     displayVirtualCurrencies: true,
                     shouldWarnCustomersAboutMultipleSubscriptions: false
                 ),
@@ -215,6 +216,7 @@ final class CustomerCenterConfigDataTests: TestCase {
         expect(configData.support.shouldWarnCustomerToUpdate) == false
         expect(configData.support.email) == "support@example.com"
         expect(configData.support.displayPurchaseHistoryLink) == true
+        expect(configData.support.displayUserDetailsSection) == true
     }
 
     /// The real json uses `snake_case`. This test should initialise the struct with default values
@@ -287,5 +289,6 @@ final class CustomerCenterConfigDataTests: TestCase {
         expect(configData.support.email) == "support@example.com"
         expect(configData.support.shouldWarnCustomerToUpdate) == true
         expect(configData.support.displayPurchaseHistoryLink) == false
+        expect(configData.support.displayUserDetailsSection) == true
     }
 }

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerCenterConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerCenterConfigTests.swift
@@ -240,6 +240,7 @@ final class BackendGetCustomerCenterConfigTests: BaseBackendTests {
         expect(support.email) == "support@revenuecat.com"
         expect(support.displayPurchaseHistoryLink) == true
         expect(support.shouldWarnCustomerToUpdate) == false
+        expect(support.displayUserDetailsSection) == true
         expect(support.displayVirtualCurrencies) == true
     }
 
@@ -413,6 +414,7 @@ private extension BackendGetCustomerCenterConfigTests {
                 "email": "support@revenuecat.com",
                 "should_warn_customer_to_update": false,
                 "display_purchase_history_link": true,
+                "display_user_details_section": true,
                 "display_virtual_currencies": true
             ] as [String: Any],
             "change_plans": [


### PR DESCRIPTION
### Motivation
We've been getting a few reports about how to hide this section, or other requesting to show all of it 😅 
Instead of overcomplicating things, we're adding a flag in the dashboard to remove the section entirely.

### Description
- Add flag to hide / show section
- Hide / show section based on flag
