### PR TITLE
Show latest expired if no active subscriptions

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -17,8 +17,6 @@ import Combine
 import Foundation
 @_spi(Internal) import RevenueCat
 
-// swiftlint:disable file_length
-
 #if os(iOS)
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -257,15 +255,6 @@ private extension CustomerCenterViewModel {
 
     func loadPurchases(customerInfo: CustomerInfo, configuration: CustomerCenterConfigData) async throws {
         self.customerInfo = customerInfo
-
-        let hasActiveProducts =  !customerInfo.activeSubscriptions.isEmpty || !customerInfo.nonSubscriptions.isEmpty
-
-        if !hasActiveProducts {
-            self.subscriptionsSection = []
-            self.nonSubscriptionsSection = []
-            self.state = .success
-            return
-        }
 
         await loadSubscriptionsSection(customerInfo: customerInfo, configuration: configuration)
         await loadNonSubscriptionsSection(customerInfo: customerInfo, configuration: configuration)

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -257,7 +257,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
     func testHasAnyPurchasesIsTrueWithOnlyVirtualCurrencies() async throws {
         let mockPurchases = MockCustomerCenterPurchases(
-            customerInfo: CustomerCenterViewModelTests.customerInfoWithExpiredSubscriptions,
+            customerInfo: CustomerCenterViewModelTests.customerInfoWithoutSubscriptions,
             customerCenterConfigData: CustomerCenterConfigData.mock(displayVirtualCurrencies: true)
         )
         mockPurchases.virtualCurrenciesResult = .success(VirtualCurrenciesFixtures.fourVirtualCurrencies)
@@ -269,8 +269,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadScreen()
 
-        expect(viewModel.subscriptionsSection.count) == 1
-        expect(viewModel.subscriptionsSection.first?.isExpired).to(beTrue())
+        expect(viewModel.subscriptionsSection).to(beEmpty())
         expect(viewModel.nonSubscriptionsSection).to(beEmpty())
         expect(viewModel.virtualCurrencies).toNot(beNil())
         expect(viewModel.hasAnyPurchases).to(beTrue())
@@ -278,7 +277,7 @@ final class CustomerCenterViewModelTests: TestCase {
 
     func testHasAnyPurchasesIsFalseWithVirtualCurrenciesHavingZeroBalance() async throws {
         let mockPurchases = MockCustomerCenterPurchases(
-            customerInfo: CustomerCenterViewModelTests.customerInfoWithExpiredSubscriptions,
+            customerInfo: CustomerCenterViewModelTests.customerInfoWithoutSubscriptions,
             customerCenterConfigData: CustomerCenterConfigData.mock(displayVirtualCurrencies: true)
         )
         mockPurchases.virtualCurrenciesResult = .success(VirtualCurrenciesFixtures.virtualCurrenciesWithZeroBalance)
@@ -290,11 +289,10 @@ final class CustomerCenterViewModelTests: TestCase {
 
         await viewModel.loadScreen()
 
-        expect(viewModel.subscriptionsSection.count) == 1
-        expect(viewModel.subscriptionsSection.first?.isExpired).to(beTrue())
+        expect(viewModel.subscriptionsSection).to(beEmpty())
         expect(viewModel.nonSubscriptionsSection).to(beEmpty())
         expect(viewModel.virtualCurrencies).toNot(beNil())
-        expect(viewModel.hasAnyPurchases).to(beTrue())
+        expect(viewModel.hasAnyPurchases).to(beFalse())
     }
 
     func testShouldShowActiveSubscription_whenUserHasOneActiveSubscriptionOneEntitlement() async throws {
@@ -1426,6 +1424,12 @@ private extension CustomerCenterViewModelTests {
             }
         }
         """
+        )
+    }()
+
+    static let customerInfoWithoutSubscriptions: CustomerInfo = {
+        return CustomerInfoFixtures.customerInfo(
+            subscriptions: [], entitlements: [], nonSubscriptions: []
         )
     }()
 

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -865,7 +865,7 @@ final class CustomerCenterViewModelTests: TestCase {
     }
 
     func testLoadScreenNoActiveSubscription() async throws {
-        let customerInfo = CustomerInfoFixtures.customerInfo(subscriptions: [], entitlements: [], nonSubscriptions: [])
+        let customerInfo = CustomerCenterViewModelTests.customerInfoWithoutSubscriptions
         let mockPurchases = MockCustomerCenterPurchases(customerInfo: customerInfo)
         let viewModel = CustomerCenterViewModel(actionWrapper: CustomerCenterActionWrapper(),
                                                 purchasesProvider: mockPurchases)
@@ -1231,7 +1231,7 @@ final class CustomerCenterViewModelTests: TestCase {
     func testShouldShowListWithVirtualCurrencies() async throws {
         // Test with only 1 virtual currency -> should be false
         var mockPurchases = MockCustomerCenterPurchases(
-            customerInfo: CustomerInfoFixtures.customerInfo(subscriptions: [], entitlements: [], nonSubscriptions: []),
+            customerInfo: CustomerCenterViewModelTests.customerInfoWithoutSubscriptions,
             customerCenterConfigData: CustomerCenterConfigData.mock(displayVirtualCurrencies: true)
         )
         mockPurchases.virtualCurrenciesResult = .success(VirtualCurrenciesFixtures.oneVirtualCurrency)


### PR DESCRIPTION
### Motivation
We've noticed that we were not showing the latest expired subscription if there are no subscriptions available.

### Description
- Remove early exit
- Show latest expired if no subs available
- Update tests
