### PR TITLE
Fix failing Test Store unit test

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -2037,7 +2037,6 @@ extension PurchasesOrchestrator {
         _ initiationSource: ProductRequestData.InitiationSource,
         _ metadata: [String: String]?
     ) async throws -> CustomerInfo {
-        let storefront = await Storefront.currentStorefront
         let offeringContext = self.getAndRemovePresentedOfferingContext(for: transaction)
         let paywall = self.getAndRemovePresentedPaywall()
         let unsyncedAttributes = self.unsyncedAttributes
@@ -2049,7 +2048,7 @@ extension PurchasesOrchestrator {
             unsyncedAttributes: unsyncedAttributes,
             metadata: metadata,
             aadAttributionToken: adServicesToken,
-            storefront: storefront,
+            storefront: transaction.storefront,
             source: .init(isRestore: self.allowSharingAppStoreAccount,
                           initiationSource: initiationSource)
         )


### PR DESCRIPTION
A test was failing (e.g. https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/30434/workflows/31afc45c-7e88-4f12-963c-05cdb11e6e94/jobs/380961) due to an error in the implementation of the creation of `PurchasedTransactionData` for Test Store purchases. Instead of using the storefront of the `Transaction`, the implementation was fetching `StoreKit`'s `currentStorefront`. As a result, the mocked `Storefront` from the unit tests was not actually being returned, making the test fail.