### PR TITLE
VideoComponent Cache Prewarming: only cache warm low res videos by default

### DIFF
--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -32,8 +32,8 @@ extension PaywallComponentsData {
         return imageUrls
     }
 
-    var allVideoURLs: [URL] {
-        return self.componentsConfig.base.allVideoURLs
+    var allLowResVideoUrls: [URL] {
+        return self.componentsConfig.base.allLowResVideoUrls
     }
 
 }
@@ -49,7 +49,7 @@ extension PaywallComponentsData.PaywallComponentsConfig {
         return rootStackImageURLs + stickFooterImageURLs
     }
 
-    var allVideoURLs: [URL] {
+    var allLowResVideoUrls: [URL] {
         let rootStackVideoURLs = self.collectAllVideoURLs(in: self.stack)
         let stickFooterVideoURLs = self.stickyFooter.flatMap { self.collectAllVideoURLs(in: $0.stack) } ?? []
 
@@ -208,7 +208,7 @@ extension PaywallComponentsData.PaywallComponentsConfig {
                     self.collectAllVideoURLs(in: stack)
                 })
             case .video(let video):
-                urls += video.videoUrls
+                urls += video.lowResVideoUrls
             }
         }
 
@@ -299,11 +299,9 @@ private extension PaywallComponent.VideoComponent {
         fallbackSource?.imageUrls ?? []
     }
 
-    var videoUrls: [URL] {
+    var lowResVideoUrls: [URL] {
         [
-            source.light.url,
             source.light.urlLowRes,
-            source.dark?.url,
             source.dark?.urlLowRes
         ].compactMap { $0 }
     }

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -114,7 +114,7 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
         guard !self.hasLoadedVideos else { return }
         self.hasLoadedVideos = true
 
-        let videoURLs = offerings.allVideosInPaywalls
+        let videoURLs = offerings.allLowResVideosInPaywalls
         guard !videoURLs.isEmpty else { return }
 
         Logger.verbose(Strings.paywalls.warming_up_videos(videoURLs: videoURLs))
@@ -254,14 +254,14 @@ private extension Offerings {
         )
     }
 
-    var allVideosInPaywalls: Set<URL> {
+    var allLowResVideosInPaywalls: Set<URL> {
         return .init(
             self
                 .all
                 .values
                 .lazy
                 .compactMap(\.paywallComponents)
-                .flatMap(\.data.allVideoURLs)
+                .flatMap(\.data.allLowResVideoUrls)
         )
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

To prevent unreasonable burden on our infrastructure, download the low res for everything instead of both high and low res

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
