### PR TITLE
MON-1374: Handle Promotional offer text in paywalls

### DIFF
--- a/RevenueCatUI/Data/TestData.swift
+++ b/RevenueCatUI/Data/TestData.swift
@@ -213,6 +213,29 @@ enum TestData {
     )
 
     #if DEBUG
+
+    static let productWithPromoOfferPayUpFront = TestStoreProduct(
+        localizedTitle: "PRO monthly",
+        price: 3.99,
+        localizedPriceString: "$3.99",
+        productIdentifier: "com.revenuecat.promo.product_2",
+        productType: .autoRenewableSubscription,
+        localizedDescription: "PRO monthly",
+        subscriptionGroupIdentifier: "group",
+        subscriptionPeriod: .init(value: 1, unit: .month),
+        introductoryDiscount: nil,
+        discounts: [ .init(
+            identifier: "intro",
+            price: 1.99,
+            localizedPriceString: "$1.99",
+            paymentMode: .payUpFront,
+            subscriptionPeriod: .init(value: 1, unit: .week),
+            numberOfPeriods: 1,
+            type: .promotional
+        )],
+        locale: Self.locale
+    )
+
     static let productWithIntroOffer = TestStoreProduct(
         localizedTitle: "PRO monthly",
         price: 3.99,
@@ -280,6 +303,14 @@ enum TestData {
         identifier: "Unknown",
         packageType: .unknown,
         storeProduct: Self.annualProduct.toStoreProduct(),
+        offeringIdentifier: Self.offeringIdentifier,
+        webCheckoutUrl: nil
+    )
+
+    static let packageWithPromoOfferPayUpFront = Package(
+        identifier: PackageType.monthly.identifier,
+        packageType: .monthly,
+        storeProduct: productWithPromoOfferPayUpFront.toStoreProduct(),
         offeringIdentifier: Self.offeringIdentifier,
         webCheckoutUrl: nil
     )

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -51,7 +51,7 @@ struct TextComponentView: View {
             isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                 package: self.packageContext.package
             ),
-            promoOffer: self.paywallPromoOfferCache.get(for: self.packageContext.package),
+            promoOffer: self.paywallPromoOfferCache.get(for: self.packageContext.package)
         ) { style in
             if style.visible {
                 NonLocalizedMarkdownText(text: style.text, font: style.font, fontWeight: style.fontWeight)

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -51,9 +51,7 @@ struct TextComponentView: View {
             isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                 package: self.packageContext.package
             ),
-            isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(
-                for: self.packageContext.package
-            )
+            promoOffer: self.paywallPromoOfferCache.get(for: self.packageContext.package),
         ) { style in
             if style.visible {
                 NonLocalizedMarkdownText(text: style.text, font: style.font, fontWeight: style.fontWeight)

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -50,14 +50,14 @@ class TextComponentViewModel {
         condition: ScreenCondition,
         packageContext: PackageContext,
         isEligibleForIntroOffer: Bool,
-        isEligibleForPromoOffer: Bool,
+        promoOffer: PromotionalOffer?,
         @ViewBuilder apply: @escaping (TextComponentStyle) -> some View
     ) -> some View {
         let localizedPartial = LocalizedTextPartial.buildPartial(
             state: state,
             condition: condition,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
-            isEligibleForPromoOffer: isEligibleForPromoOffer,
+            isEligibleForPromoOffer: promoOffer != nil,
             with: self.presentedOverrides
         )
         let partial = localizedPartial?.partial
@@ -71,7 +71,8 @@ class TextComponentViewModel {
                 packageContext: packageContext,
                 variableConfig: uiConfigProvider.variableConfig,
                 locale: self.localizationProvider.locale,
-                localizations: self.uiConfigProvider.getLocalizations(for: self.localizationProvider.locale)
+                localizations: self.uiConfigProvider.getLocalizations(for: self.localizationProvider.locale),
+                promoOffer: promoOffer
             ),
             fontName: partial?.fontName ?? self.component.fontName,
             fontWeight: partial?.fontWeightResolved ?? self.component.fontWeightResolved,
@@ -87,17 +88,21 @@ class TextComponentViewModel {
         apply(style)
     }
 
-    private static func processText(_ text: String,
-                                    packageContext: PackageContext,
-                                    variableConfig: UIConfig.VariableConfig,
-                                    locale: Locale,
-                                    localizations: [String: String]) -> String {
+    private static func processText(
+        _ text: String,
+        packageContext: PackageContext,
+        variableConfig: UIConfig.VariableConfig,
+        locale: Locale,
+        localizations: [String: String],
+        promoOffer: PromotionalOffer? = nil
+    ) -> String {
         let processedWithV2 = Self.processTextV2(
             text,
             packageContext: packageContext,
             variableConfig: variableConfig,
             locale: locale,
-            localizations: localizations
+            localizations: localizations,
+            promoOffer: promoOffer
         )
         // Note: This is temporary while in closed beta and shortly after
         let processedWithV2AndV1 = Self.processTextV1(
@@ -109,11 +114,14 @@ class TextComponentViewModel {
         return processedWithV2AndV1
     }
 
-    private static func processTextV2(_ text: String,
-                                      packageContext: PackageContext,
-                                      variableConfig: UIConfig.VariableConfig,
-                                      locale: Locale,
-                                      localizations: [String: String]) -> String {
+    private static func processTextV2(
+        _ text: String,
+        packageContext: PackageContext,
+        variableConfig: UIConfig.VariableConfig,
+        locale: Locale,
+        localizations: [String: String],
+        promoOffer: PromotionalOffer? = nil
+    ) -> String {
         guard let package = packageContext.package else {
             return text
         }
@@ -134,7 +142,8 @@ class TextComponentViewModel {
             in: text,
             with: package,
             locale: locale,
-            localizations: localizations
+            localizations: localizations,
+            promoOffer: promoOffer
         )
     }
 

--- a/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
+++ b/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
@@ -44,7 +44,7 @@ struct VariableHandlerV2 {
         with package: Package,
         locale: Locale,
         localizations: [String: String],
-        promoOffer: PromotionalOffer?
+        promoOffer: PromotionalOffer? = nil
     ) -> String {
         let whisker = Whisker(template: text) { variableRaw, functionRaw in
             let variable = self.findVariable(variableRaw)

--- a/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
+++ b/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
@@ -43,7 +43,8 @@ struct VariableHandlerV2 {
         in text: String,
         with package: Package,
         locale: Locale,
-        localizations: [String: String]
+        localizations: [String: String],
+        promoOffer: PromotionalOffer?
     ) -> String {
         let whisker = Whisker(template: text) { variableRaw, functionRaw in
             let variable = self.findVariable(variableRaw)
@@ -54,7 +55,8 @@ struct VariableHandlerV2 {
                 locale: locale,
                 localizations: localizations,
                 discountRelativeToMostExpensivePerMonth: self.discountRelativeToMostExpensivePerMonth,
-                date: self.dateProvider()
+                date: self.dateProvider(),
+                promoOffer: promoOffer
             ) ?? ""
 
             return function?.process(processedVariable) ?? processedVariable
@@ -226,12 +228,15 @@ enum FunctionsV2: String {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension VariablesV2 {
 
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
-    func process(package: Package,
-                 locale: Locale,
-                 localizations: [String: String],
-                 discountRelativeToMostExpensivePerMonth: Double?,
-                 date: Date) -> String {
+    // swiftlint:disable:next cyclomatic_complexity function_body_length function_parameter_count
+    func process(
+        package: Package,
+        locale: Locale,
+        localizations: [String: String],
+        discountRelativeToMostExpensivePerMonth: Double?,
+        date: Date,
+        promoOffer: PromotionalOffer?
+    ) -> String {
         switch self {
         case .productCurrencyCode:
             return self.productCurrencyCode(package: package)
@@ -268,31 +273,63 @@ extension VariablesV2 {
         case .productPeriodWithUnit:
             return self.productPeriodWithUnit(package: package, localizations: localizations)
         case .productOfferPrice:
-            return self.productOfferPrice(package: package, localizations: localizations)
+            return self.productOfferPrice(
+                package: package,
+                localizations: localizations,
+                promoOffer: promoOffer
+            )
         case .productOfferPricePerDay:
-            return self.productOfferPricePerDay(package: package, localizations: localizations)
+            return self.productOfferPricePerDay(
+                package: package,
+                localizations: localizations,
+                promoOffer: promoOffer
+            )
         case .productOfferPricePerWeek:
-            return self.productOfferPricePerWeek(package: package, localizations: localizations)
+            return self.productOfferPricePerWeek(
+                package: package,
+                localizations: localizations,
+                promoOffer: promoOffer
+            )
         case .productOfferPricePerMonth:
-            return self.productOfferPricePerMonth(package: package, localizations: localizations)
+            return self.productOfferPricePerMonth(
+                package: package,
+                localizations: localizations,
+                promoOffer: promoOffer
+            )
         case .productOfferPricePerYear:
-            return self.productOfferPricePerYear(package: package, localizations: localizations)
+            return self.productOfferPricePerYear(
+                package: package,
+                localizations: localizations,
+                promoOffer: promoOffer
+            )
         case .productOfferPeriod:
-            return self.productOfferPeriod(package: package, localizations: localizations)
+            return self.productOfferPeriod(
+                package: package,
+                localizations: localizations,
+                promoOffer: promoOffer
+            )
         case .productOfferPeriodAbbreviated:
-            return self.productOfferPeriodAbbreviated(package: package, localizations: localizations)
+            return self.productOfferPeriodAbbreviated(
+                package: package,
+                localizations: localizations,
+                promoOffer: promoOffer
+            )
         case .productOfferPeriodInDays:
-            return self.productOfferPeriodInDays(package: package)
+            return self.productOfferPeriodInDays(package: package, promoOffer: promoOffer)
         case .productOfferPeriodInWeeks:
-            return self.productOfferPeriodInWeeks(package: package)
+            return self.productOfferPeriodInWeeks(package: package, promoOffer: promoOffer)
         case .productOfferPeriodInMonths:
-            return self.productOfferPeriodInMonths(package: package)
+            return self.productOfferPeriodInMonths(package: package, promoOffer: promoOffer)
         case .productOfferPeriodInYears:
-            return self.productOfferPeriodInYears(package: package)
+            return self.productOfferPeriodInYears(package: package, promoOffer: promoOffer)
         case .productOfferPeriodWithUnit:
-            return self.productOfferPeriodWithUnit(package: package, localizations: localizations)
+            return self.productOfferPeriodWithUnit(
+                package: package,
+                localizations: localizations,
+                promoOffer: promoOffer
+            )
         case .productOfferEndDate:
-            return self.productOfferEndDate(package: package, locale: locale, date: date)
+            return self.productOfferEndDate(package: package, locale: locale, date: date, promoOffer: promoOffer)
         case .productSecondaryOfferPrice:
             return self.productSecondaryOfferPrice(package: package)
         case .productSecondaryOfferPeriod:
@@ -464,8 +501,12 @@ extension VariablesV2 {
         return String(format: localizedFormat, period.value)
     }
 
-    func productOfferPrice(package: Package, localizations: [String: String]) -> String {
-        guard let discount = package.storeProduct.introductoryDiscount else {
+    func productOfferPrice(
+        package: Package,
+        localizations: [String: String],
+        promoOffer: PromotionalOffer?
+    ) -> String {
+        guard let discount = package.storeProduct.introductoryDiscount ?? promoOffer?.discount else {
             return ""
         }
 
@@ -476,8 +517,12 @@ extension VariablesV2 {
         return discount.localizedPriceString
     }
 
-    func productOfferPricePerDay(package: Package, localizations: [String: String]) -> String {
-        guard let discount = package.storeProduct.introductoryDiscount else {
+    func productOfferPricePerDay(
+        package: Package,
+        localizations: [String: String],
+        promoOffer: PromotionalOffer?
+    ) -> String {
+        guard let discount = package.storeProduct.introductoryDiscount ?? promoOffer?.discount else {
             return ""
         }
 
@@ -496,8 +541,12 @@ extension VariablesV2 {
         return formatter.string(from: price as NSDecimalNumber) ?? ""
     }
 
-    func productOfferPricePerWeek(package: Package, localizations: [String: String]) -> String {
-        guard let discount = package.storeProduct.introductoryDiscount else {
+    func productOfferPricePerWeek(
+        package: Package,
+        localizations: [String: String],
+        promoOffer: PromotionalOffer?
+    ) -> String {
+        guard let discount = package.storeProduct.introductoryDiscount ?? promoOffer?.discount else {
             return ""
         }
 
@@ -516,8 +565,12 @@ extension VariablesV2 {
         return formatter.string(from: price as NSDecimalNumber) ?? ""
     }
 
-    func productOfferPricePerMonth(package: Package, localizations: [String: String]) -> String {
-        guard let discount = package.storeProduct.introductoryDiscount else {
+    func productOfferPricePerMonth(
+        package: Package,
+        localizations: [String: String],
+        promoOffer: PromotionalOffer?
+    ) -> String {
+        guard let discount = package.storeProduct.introductoryDiscount ?? promoOffer?.discount else {
             return ""
         }
 
@@ -536,8 +589,12 @@ extension VariablesV2 {
         return formatter.string(from: price as NSDecimalNumber) ?? ""
     }
 
-    func productOfferPricePerYear(package: Package, localizations: [String: String]) -> String {
-        guard let discount = package.storeProduct.introductoryDiscount else {
+    func productOfferPricePerYear(
+        package: Package,
+        localizations: [String: String],
+        promoOffer: PromotionalOffer?
+    ) -> String {
+        guard let discount = package.storeProduct.introductoryDiscount ?? promoOffer?.discount else {
             return ""
         }
 
@@ -556,24 +613,34 @@ extension VariablesV2 {
         return formatter.string(from: price as NSDecimalNumber) ?? ""
     }
 
-    func productOfferPeriod(package: Package, localizations: [String: String]) -> String {
-        guard let period =  package.storeProduct.introductoryDiscount?.subscriptionPeriod else {
+    func productOfferPeriod(
+        package: Package,
+        localizations: [String: String],
+        promoOffer: PromotionalOffer?
+    ) -> String {
+        let initialOffer = package.storeProduct.introductoryDiscount?.subscriptionPeriod
+        guard let period = initialOffer ?? promoOffer?.discount.subscriptionPeriod else {
             return ""
         }
 
         return localizations[period.periodLocalizationKey] ?? ""
     }
 
-    func productOfferPeriodAbbreviated(package: Package, localizations: [String: String]) -> String {
-        guard let period =  package.storeProduct.introductoryDiscount?.subscriptionPeriod else {
+    func productOfferPeriodAbbreviated(
+        package: Package,
+        localizations: [String: String],
+        promoOffer: PromotionalOffer?
+    ) -> String {
+        let initialOffer = package.storeProduct.introductoryDiscount?.subscriptionPeriod
+        guard let period = initialOffer ?? promoOffer?.discount.subscriptionPeriod else {
             return ""
         }
 
         return localizations[period.periodAbbreviatedLocalizationKey] ?? ""
     }
 
-    func productOfferPeriodInDays(package: Package) -> String {
-        guard let discount = package.storeProduct.introductoryDiscount else {
+    func productOfferPeriodInDays(package: Package, promoOffer: PromotionalOffer?) -> String {
+        guard let discount = package.storeProduct.introductoryDiscount ?? promoOffer?.discount else {
             return ""
         }
 
@@ -584,8 +651,8 @@ extension VariablesV2 {
         return "\(discount.subscriptionPeriod.periodInUnit(unit: .day))"
     }
 
-    func productOfferPeriodInWeeks(package: Package) -> String {
-        guard let discount = package.storeProduct.introductoryDiscount else {
+    func productOfferPeriodInWeeks(package: Package, promoOffer: PromotionalOffer?) -> String {
+        guard let discount = package.storeProduct.introductoryDiscount ?? promoOffer?.discount else {
             return ""
         }
 
@@ -596,8 +663,8 @@ extension VariablesV2 {
         return "\(discount.subscriptionPeriod.periodInUnit(unit: .week))"
     }
 
-    func productOfferPeriodInMonths(package: Package) -> String {
-        guard let discount = package.storeProduct.introductoryDiscount else {
+    func productOfferPeriodInMonths(package: Package, promoOffer: PromotionalOffer?) -> String {
+        guard let discount = package.storeProduct.introductoryDiscount ?? promoOffer?.discount else {
             return ""
         }
 
@@ -608,8 +675,8 @@ extension VariablesV2 {
         return "\(discount.subscriptionPeriod.periodInUnit(unit: .month))"
     }
 
-    func productOfferPeriodInYears(package: Package) -> String {
-        guard let discount = package.storeProduct.introductoryDiscount else {
+    func productOfferPeriodInYears(package: Package, promoOffer: PromotionalOffer?) -> String {
+        guard let discount = package.storeProduct.introductoryDiscount ?? promoOffer?.discount else {
             return ""
         }
 
@@ -620,8 +687,13 @@ extension VariablesV2 {
         return "\(discount.subscriptionPeriod.periodInUnit(unit: .year))"
     }
 
-    func productOfferPeriodWithUnit(package: Package, localizations: [String: String]) -> String {
-        guard let period =  package.storeProduct.introductoryDiscount?.subscriptionPeriod else {
+    func productOfferPeriodWithUnit(
+        package: Package,
+        localizations: [String: String],
+        promoOffer: PromotionalOffer?
+    ) -> String {
+        let introOffer = package.storeProduct.introductoryDiscount?.subscriptionPeriod
+        guard let period = introOffer ?? promoOffer?.discount.subscriptionPeriod else {
             return ""
         }
 
@@ -632,8 +704,8 @@ extension VariablesV2 {
         return String(format: localizedFormat, period.value)
     }
 
-    func productOfferEndDate(package: Package, locale: Locale, date: Date) -> String {
-        guard let discount = package.storeProduct.introductoryDiscount else {
+    func productOfferEndDate(package: Package, locale: Locale, date: Date, promoOffer: PromotionalOffer?) -> String {
+        guard let discount = package.storeProduct.introductoryDiscount ?? promoOffer?.discount else {
             return ""
         }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
@@ -13,7 +13,7 @@
 // swiftlint:disable file_length type_body_length 
 
 import Nimble
-import RevenueCat
+@testable import RevenueCat
 @testable import RevenueCatUI
 import XCTest
 
@@ -386,6 +386,37 @@ class VariableHandlerV2Test: TestCase {
             with: TestData.packageWithIntroOfferPayUpFront,
             locale: locale,
             localizations: localizations["en_US"]!
+        )
+        expect(result).to(equal("$0.28"))
+    }
+
+    func testProductPayUpFrontPromoOfferPrice() {
+        let discount = TestData.packageWithPromoOfferPayUpFront.storeProduct.discounts.first!
+        let result = variableHandler.processVariables(
+            in: "{{ product.offer_price }}",
+            with: TestData.packageWithPromoOfferPayUpFront,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            promoOffer: .init(
+                discount: discount,
+                signedData: .init(identifier: "", keyIdentifier: "", nonce: .init(), signature: "", timestamp: 0)
+            )
+        )
+        expect(result).to(equal("$1.99"))
+    }
+
+    func testProductPayUpFrontPromoOfferPricePerDay() {
+        let discount = TestData.packageWithPromoOfferPayUpFront.storeProduct.discounts.first!
+
+        let result = variableHandler.processVariables(
+            in: "{{ product.offer_price_per_day }}",
+            with: TestData.packageWithPromoOfferPayUpFront,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            promoOffer: .init(
+                discount: discount,
+                signedData: .init(identifier: "", keyIdentifier: "", nonce: .init(), signature: "", timestamp: 0)
+            )
         )
         expect(result).to(equal("$0.28"))
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->


Paywalls with promotional offers are not properly displaying the text related to that promotional offer.

This passes in the cached promotional offer to the existing text field introductory offer parsing logic to resolve that issue.


### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
