### PR TITLE
Make managementURL public in SubscriptionInfo

### DIFF
--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -79,7 +79,7 @@ import Foundation
     @objc public let price: ProductPaidPrice?
 
     /// Management purchase URL
-    @_spi(Internal) public let managementURL: URL?
+    @objc public let managementURL: URL?
 
     init(productIdentifier: String,
          purchaseDate: Date,

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCSubscriptionInfoAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCSubscriptionInfoAPI.m
@@ -29,6 +29,8 @@
     NSString *storeTransactionId __unused = subscription.storeTransactionId;
     BOOL isActive __unused = subscription.isActive;
     BOOL willRenew __unused = subscription.willRenew;
+    NSString *displayName __unused = subscription.displayName;
+    NSURL *managementURL __unused = subscription.managementURL;
 }
 
 @end

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/SubscriptionInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/SubscriptionInfoAPI.swift
@@ -33,4 +33,5 @@ func checkSubscriptionInfoAPI() {
     let isActive: Bool = subscription.isActive
     let willRenew: Bool = subscription.willRenew
     let displayName: String? = subscription.displayName
+    let managementURL: URL? = subscription.managementURL
 }


### PR DESCRIPTION
### Motivation
We've been asked to make this one public, and figured that there's no reason to not have it public

### Description
- Make it public
- Update API tests
