### PR TITLE
[DX-520] Do not log unknown errors from health report endpoint

### DIFF
--- a/Sources/Support/SDKHealthManager.swift
+++ b/Sources/Support/SDKHealthManager.swift
@@ -40,7 +40,10 @@ final class SDKHealthManager: Sendable {
         let report = await healthReport()
         switch report.status {
         case let .unhealthy(error):
-            Logger.error(HealthReportLogMessage.unhealthy(error: error, report: report))
+            switch error {
+            case .unknown: break
+            default: Logger.error(HealthReportLogMessage.unhealthy(error: error, report: report))
+            }
         case let .healthy(warnings):
             if warnings.isEmpty {
                 Logger.info(HealthReportLogMessage.healthy(report: report))

--- a/Tests/UnitTests/Misc/SDKHealthManagerTests.swift
+++ b/Tests/UnitTests/Misc/SDKHealthManagerTests.swift
@@ -56,7 +56,7 @@ class SDKHealthManagerTests: TestCase {
         expect(report.status).to(beUnhealthyWithUnknownError())
     }
 
-    func testHealthReportIsNotLoggedForUnhealthyErrors() async {
+    func testHealthReportIsNotLoggedForUnknownErrors() async {
         let manager = makeSUT(backendResponse: .failure(BackendError.networkError(
             .errorResponse(
                 .init(code: .unknownError, originalCode: 0),

--- a/Tests/UnitTests/Misc/SDKHealthManagerTests.swift
+++ b/Tests/UnitTests/Misc/SDKHealthManagerTests.swift
@@ -56,6 +56,19 @@ class SDKHealthManagerTests: TestCase {
         expect(report.status).to(beUnhealthyWithUnknownError())
     }
 
+    func testHealthReportIsNotLoggedForUnhealthyErrors() async {
+        let manager = makeSUT(backendResponse: .failure(BackendError.networkError(
+            .errorResponse(
+                .init(code: .unknownError, originalCode: 0),
+                .internalServerError
+            )
+        )))
+
+        await manager.logSDKHealthReportOutcome()
+
+        self.logger.verifyMessageWasNotLogged("SDK Configuration is not valid", level: .error)
+    }
+
     func testHealthReportReturnsUnhealthyForNonBackendError() async {
         let manager = makeSUT(backendResponse: .failure(BackendError.networkError(.errorResponse(
             .init(code: .unknownError, originalCode: 0),


### PR DESCRIPTION
We recently got some reports of 500 responses from the health_report endpoint from some of our users with a large number of products.

We currently show that as an unknown error, which causes confusion. To mitigate this, let's only really show the error if it is an actual valid response. 

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids
