### PR TITLE
Make an API `public`

### DIFF
--- a/Sources/Identity/ProductPaidPrice.swift
+++ b/Sources/Identity/ProductPaidPrice.swift
@@ -40,7 +40,7 @@ import Foundation
     ///   - currency: Currency paid
     ///   - amount: Amount paid
     ///   - formatted: Formatted price string with currency symbol
-    init(currency: String, amount: Double, formatted: String) {
+    public init(currency: String, amount: Double, formatted: String) {
         self.currency = currency
         self.amount = amount
         self.formatted = formatted


### PR DESCRIPTION
API tests were failing because tests expected certain initializer of `ProductPaidPrice` to be `public`, but it wasn't.

This PR makes that initializer public.