### PR TITLE
Remove Paywall Image Display Log

### DIFF
--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -34,7 +34,6 @@ enum Strings {
 
     case image_starting_request(URL)
     case image_result(Result<(), ImageLoader.Error>)
-    case image_displayed_using(String)
 
     case restoring_purchases
     case restored_purchases
@@ -134,9 +133,6 @@ extension Strings: CustomStringConvertible {
             case let .failure(error):
                 return "Failed loading image: \(error)"
             }
-
-        case let .image_displayed_using(method):
-            return "Successfully display image using: \(method)"
 
         case .restoring_purchases:
             return "Restoring purchases"

--- a/RevenueCatUI/Views/RemoteImage.swift
+++ b/RevenueCatUI/Views/RemoteImage.swift
@@ -323,8 +323,6 @@ private struct ColorSchemeRemoteImage<Content: View>: View {
                     )
                 }
             }
-
-            Logger.debug(Strings.image_displayed_using(self.imageLoadedFrom?.rawValue ?? "unknown"))
         }
     }
 


### PR DESCRIPTION
### Description
Currently, a message is logged each time an image is displayed in a paywall. This can be a bit noisy when a paywall contains multiple images. Here's an example of a paywall that generates a good number of these logs each time the paywall is displayed:

<img width="1724" height="1902" alt="Image 10-14-25 at 9 00 AM" src="https://github.com/user-attachments/assets/98714d9e-3dd9-4091-b72a-54bd1c75278d" />

This PR addresses this by removing the image display log.