### PR TITLE
Update Xcode versions to avoid CircleCI deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -520,7 +520,7 @@ jobs:
   spm-release-build-xcode-16:
     executor:
       name: macos-executor
-      xcode_version: "16.0.0"
+      xcode_version: "16.4"
 
     steps:
       - checkout
@@ -709,7 +709,7 @@ jobs:
   run-revenuecat-ui-ios-18:
     executor:
       name: macos-executor
-      xcode_version: "16.0"
+      xcode_version: "16.4"
 
     steps:
       - checkout
@@ -725,7 +725,7 @@ jobs:
           command: bundle exec fastlane test_revenuecatui
           no_output_timeout: 15m
           environment:
-            DEVICE: iPhone 16,OS=18.0
+            DEVICE: iPhone 16,OS=18.5
       - create-snapshot-pr-if-needed:
           condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
           job: "create_snapshots_repo_pr"
@@ -851,7 +851,7 @@ jobs:
   run-test-ios-18:
     executor:
       name: macos-executor
-      xcode_version: "16.0"
+      xcode_version: "16.4"
 
     steps:
       - checkout
@@ -862,7 +862,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 16 (18.0)
+            SCAN_DEVICE: iPhone 16 (18.5)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: RevenueCat


### PR DESCRIPTION
## Summary
- Update spm-release-build-xcode-16: Xcode 16.0.0 → 16.4
- Update run-revenuecat-ui-ios-18: Xcode 16.0 → 16.4, iOS 18.0 → 18.5
- Update run-test-ios-18: Xcode 16.0 → 16.4, iOS 18.0 → 18.5

## Details
These changes address the CircleCI deprecation of EoL Xcode versions (13.4.1, 15.1.0, 15.2.0, 15.3.0, 16.0.0, 16.1.0) announced at https://circleci.com/changelog/deprecation-of-eol-xcode-versions/

The updated versions stay within the same major version where possible and use iOS simulator versions that are available in the respective Xcode VM images according to https://circleci.com/docs/guides/test/testing-ios/#supported-xcode-versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)