### PR TITLE
Updated CircleCI resource class m1 to m4pro.medium due to coming deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1015,7 +1015,7 @@ jobs:
       name: macos-executor-for-macos-12_6
       # Pre-iOS 15 requires macOS 12 which requires Xcode 14.2
       # See https://circleci.com/docs/using-macos/#supported-xcode-versions
-      xcode_version: "14.2.0"
+      xcode_version: "14.3.1"
 
     steps:
       - checkout
@@ -1051,7 +1051,7 @@ jobs:
   run-test-ios-13:
     executor:
       name: macos-executor-for-macos-12_6
-      xcode_version: "14.2.0"
+      xcode_version: "14.3.1"
 
     steps:
       - checkout


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
CircleCI is [deprecating](https://circleci.com/changelog/deprecation-of-mac-m1-and-m2-resource-classes/?utm_medium=email&_hsenc=p2ANqtz--Zxz4WZD8EyG0q9pC4F_parWrraXCeAJ1CWZnyBw_DN5aXq8XWkSWQDpB0efdKCvjDN-KPjqQ1Oyau7flrrYldUI_JihKxr965PWaNxWBNW4EhGFA&_hsmi=386595751&utm_content=386595751&utm_source=hs_email) the `macos.m1.medium.gen` resource class in favor of the M4 resource classes.

### Description
I've updated our CircleCI config to use the `m4pro.medium` resource class instead
