### PR TITLE
Fix image shadow issue

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -101,8 +101,10 @@ struct ImageComponentView: View {
                     .padding(style.padding.extend(by: style.border?.width ?? 0))
                     .shape(border: style.border,
                            shape: style.shape)
-                    .shadow(shadow: style.shadow,
-                            shape: style.shape?.toInsettableShape(size: size))
+                    .applyIfLet(style.shadow, apply: { view, shadow in
+                        // We need to use the normal shadow modifier and not our custom one for png images
+                        view.shadow(color: shadow.color, radius: shadow.radius, x: shadow.x, y: shadow.y)
+                    })
                     .padding(style.margin)
                 }
                 .onSizeChange({ size = $0 })


### PR DESCRIPTION
We have an image shadow issue on transparent images. The custom shadow modifier will shade the bounding box, including the transparent pixels. The SwiftUI modifier will only shade the non-transparent pixels.