### PR TITLE
FIX: Video Component speed and overlay issues

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
@@ -107,6 +107,7 @@ struct VideoComponentView: View {
                                     guard url != cachedURL else { return }
                                     await MainActor.run {
                                         self.stagedURL = url
+                                        // If we have a cached video, no need to display a fallback image
                                         self.imageSource = nil
                                     }
                                 } catch {
@@ -122,16 +123,23 @@ struct VideoComponentView: View {
                             withChecksum: viewData.checksum
                         ) {
                             self.cachedURL = cachedURL
+                            // If we have a cached video, no need to display a fallback image
                             self.imageSource = nil
                         } else if let lowResUrl = viewData.lowResUrl, lowResUrl != viewData.url {
-                            self.imageSource = viewModel.imageSource
                             let lowResCachedURL = fileRepository.getCachedFileURL(
                                 for: lowResUrl,
                                 withChecksum: viewData.lowResChecksum
                             )
                             self.cachedURL = lowResCachedURL ?? lowResUrl
+
+                            if lowResCachedURL == nil {
+                                // Display the fallback image while loading takes place
+                                self.imageSource = viewModel.imageSource
+                            }
+
                             resumeDownloadOfFullResolutionVideo()
                         } else {
+                            // Display the fallback image while loading takes place
                             self.imageSource = viewModel.imageSource
                             resumeDownloadOfFullResolutionVideo()
                         }


### PR DESCRIPTION
Loading felt slow, and the gradient wasn't quite right.

The image would not render when the low-res video was starting to load before the initial cache was populated. So we need to explicitly set and unset the image at the appropriate times. 

The gradient was applied before resizing, causing it not to match what we saw in the editor. This was a bug I fixed in September for the image component, but forgot to change it for the video component…

![Simulator Screen Recording - iPhone 16e - 2025-10-29 at 08 28 34](https://github.com/user-attachments/assets/6c4fd2ca-9aca-43c3-977d-54c969581b80)
<img width="419" height="237" alt="Screenshot 2025-10-29 at 8 44 12 AM" src="https://github.com/user-attachments/assets/e649a34d-cdf7-4a38-8b34-4ffcc80247ec" />
