### PR TITLE
Fix API tests

### DIFF
--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAdTrackerAPI.h
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAdTrackerAPI.h
@@ -7,6 +7,8 @@
 
 #import <Foundation/Foundation.h>
 
+#ifdef ENABLE_AD_EVENTS_TRACKING
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RCAdTrackerAPI : NSObject
@@ -16,3 +18,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAdTrackerAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAdTrackerAPI.m
@@ -7,6 +7,8 @@
 
 #import "RCAdTrackerAPI.h"
 
+#ifdef ENABLE_AD_EVENTS_TRACKING
+
 @import RevenueCat;
 
 @implementation RCAdTrackerAPI
@@ -115,3 +117,5 @@
 }
 
 @end
+
+#endif

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/main.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/main.m
@@ -35,7 +35,10 @@
 
 int main(int argc, const char * argv[]) {
     @autoreleasepool {
+
+        #ifdef ENABLE_AD_EVENTS_TRACKING
         [RCAdTrackerAPI checkAPI];
+        #endif
 
         [RCAttributionAPI checkAPI];
         [RCAttributionNetworkAPI checkEnums];


### PR DESCRIPTION
#5685 added some ObjC API tests for the RC AdTracker APIs.

This PR disables these API tests by putting them behind `#ifdef ENABLE_AD_EVENTS_TRACKING`