### PR TITLE
[CI] Set xcbeautify version for Xcode 15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -618,6 +618,7 @@ jobs:
       - checkout
       - install-dependencies:
           install_xcbeautify: false
+          install_mint: true
           install_swiftlint: false
       - install-xcbeautify-for-xcode14
       - update-spm-installation-commit


### PR DESCRIPTION
Some CI jobs started to fail because version 3 of xcbeautify started being installed, which seems to require Xcode 16.3 (see error [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/31053/workflows/b5fd3601-18d8-46ef-9ebf-51ff226c41ef/jobs/394054))

> xcbeautify: A full installation of Xcode.app 16.3 is required to compile this software. Installing just the Command Line Tools is not sufficient.

This PR sets the version of xcbeautify to 2.30.1 for CI workflows that use Xcode 15.