### PR TITLE
Fix CircleCI builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1158,7 +1158,7 @@ platform :ios do
     old_kind_line = "kind = branch;"
     new_kind_line = "kind = revision;"
 
-    commit_hash = sh("git", "rev-parse", "HEAD").strip
+    commit_hash = last_git_commit[:commit_hash]
     old_branch_line = "branch = main;"
     new_revision_line = "revision = #{commit_hash};"
 


### PR DESCRIPTION
Some CircleCI jobs started to fail (see [first occurrence](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/31179)) with the logs

> dyld[6872]: missing symbol called
> Received "abort trap" signal

It seems it was due to the gem cache containing some incompatible binaries.

So far, the gem cache would only depend on:
* The Gemfile.lock
* The CI machine's `arch` (in practice, `arch1-darwin-arm64` for all jobs in this repo)
* The version of ruby (hardcoded to `3.2.0` in the cache key)

This meant that all CI jobs in all macOS machines would use the same cache key (i.e. would share the same cache).

This PR makes it so that the cache key also depends on the (minor) version of macOS. Meaning that a CI job for macOS 26.0 will have a different cache key than one for macOS 26.1.


### Note 1
These failures have started happening the exact same day as [CircleCI enabled blobless checkouts by default](https://circleci.com/changelog/default-method-used-to-checkout-code-from-your-repository-is-changing-on-nov/). I don't know how the CI failures could be related to it but seems like too much of a coincidence

### Note 2
Could reproduce the failures again in https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/31194 using a new temporary cache shared for all CI jobs. It seems to depend on which macOS version generates the cache. So it makes sense to have a cache for each version of macOS