### PR TITLE
Fix `EXC_BAD_ACCESS` when opening promotional offers in Customer Center

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -98,7 +98,7 @@ struct PromotionalOfferView: View {
             }
         }
         .navigationBarBackButtonHidden(true)
-        applyIfLet(appearance.tintColor(colorScheme: colorScheme), apply: { $0.tint($1)})
+        .applyIfLet(appearance.tintColor(colorScheme: colorScheme), apply: { $0.tint($1)})
         .onAppear {
             self.viewModel.onPromotionalOfferPurchaseFlowComplete = self.dismissPromotionalOfferView
         }


### PR DESCRIPTION
This was causing an `EXC_BAD_ACCESS` when opening a promotional offer view