### PR TITLE
Allow the use of Test Store in release builds using the uiPreview dangerous setting for the RC Mobile app

### DIFF
--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -65,12 +65,6 @@ import Foundation
     @_spi(Internal) public let uiPreviewMode: Bool
 
     /**
-     * if `true`, the SDK will allow initialization with a Test Store
-     * api key in release builds.
-     */
-    @_spi(Internal) public let allowTestStoreApiKeyInReleaseBuilds: Bool
-
-    /**
      * A property meant for apps that do their own entitlements computation, separated from RevenueCat.
      * It:
      *   - disables automatic CustomerInfo cache updates
@@ -116,25 +110,22 @@ import Foundation
     /**
      * Used to initialize the SDK in UI preview mode.
      *
-     * - Parameter uiPreviewMode: if `true`, the SDK will return a set of mock products instead of the
-     * - Parameter allowTestStoreApiKeyInReleaseBuilds: if `true` the SDK will allow the use of a test store API key in release builds.
-     * products obtained from StoreKit. This is useful for testing or preview purposes.
+     * - Parameter uiPreviewMode: if `true`, the SDK will return a set of mock products instead
+     * of the products obtained from StoreKit. This is useful for testing or preview purposes.
      */
-    @_spi(Internal) public convenience init(uiPreviewMode: Bool, allowTestStoreApiKeyInReleaseBuilds: Bool) {
-        self.init(autoSyncPurchases: false, internalSettings: Internal.default, uiPreviewMode: uiPreviewMode, allowTestStoreApiKeyInReleaseBuilds: allowTestStoreApiKeyInReleaseBuilds)
+    @_spi(Internal) public convenience init(uiPreviewMode: Bool) {
+        self.init(autoSyncPurchases: false, internalSettings: Internal.default, uiPreviewMode: uiPreviewMode)
     }
 
     /// Designated initializer
     internal init(autoSyncPurchases: Bool,
                   customEntitlementComputation: Bool = false,
                   internalSettings: InternalDangerousSettingsType,
-                  uiPreviewMode: Bool = false,
-                  allowTestStoreApiKeyInReleaseBuilds: Bool = false) {
+                  uiPreviewMode: Bool = false) {
         self.autoSyncPurchases = autoSyncPurchases
         self.internalSettings = internalSettings
         self.customEntitlementComputation = customEntitlementComputation
         self.uiPreviewMode = uiPreviewMode
-        self.allowTestStoreApiKeyInReleaseBuilds = allowTestStoreApiKeyInReleaseBuilds
     }
 
 }

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -470,7 +470,7 @@ extension Configuration.APIKeyValidationResult {
 
     func checkForSimulatedStoreAPIKeyInRelease(systemInfo: SystemInfo) {
         #if !DEBUG
-        guard self == .simulatedStore, !systemInfo.dangerousSettings.allowTestStoreApiKeyInReleaseBuilds else {
+        guard self == .simulatedStore, !systemInfo.dangerousSettings.uiPreviewMode else {
             return
         }
 


### PR DESCRIPTION

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
We don't allow the use of the Test Store (api key) in release builds, because of the risk of developers accidentally shipping a version of their app that user's cant make purchases in. 

When using the SDK in our own RC Mobile app however, the app crashes when a project only has a Test Store API key configured, even though the preview functionality works as expected (and could actually benefit from using the Test Store).

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
I've added a check for the `uiPreviewMode` dangerous setting, and if enabled the SDK bypasses the Test Store API key validation.