### PR TITLE
Added remaining backend source assertions in backend integration tests

### DIFF
--- a/Tests/BackendIntegrationTests/FallbackURLBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/FallbackURLBackendIntegrationTests.swift
@@ -56,6 +56,7 @@ class FallbackURLSignedBackendStoreKit2IntegrationTests: BaseStoreKitIntegration
 
         expect(receivedOfferings.all).toNot(beEmpty())
         assertSnapshot(matching: receivedOfferings.response, as: .formattedJson)
+        expect(receivedOfferings.contents.originalSource) == .fallbackUrl
     }
 
     func testCanGetProductEntitlementMappingFromFallbackURL() async throws {

--- a/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
@@ -176,6 +176,8 @@ class BaseLoadShedderStoreKitIntegrationTests: BaseStoreKitIntegrationTests {
             Strings.network.request_handled_by_load_shedder(HTTPRequest.Path.postReceiptData),
             level: .debug
         )
+
+        expect(purchaseData.customerInfo.originalSource) == .loadShedder
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
Adds a few remaining backend source assertions in the integration tests. All load shedder and fallback url integration tests should now be covered
