### PR TITLE
FIX: Overlay sometimes blocking taps

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
@@ -150,6 +150,7 @@ struct VideoComponentView: View {
                     .applyIfLet(style.colorOverlay, apply: { view, colorOverlay in
                         view.overlay(
                             Color.clear.backgroundStyle(.color(colorOverlay))
+                                .allowsHitTesting(false)
                         )
                     })
                     .padding(style.padding.extend(by: style.border?.width ?? 0))

--- a/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/Shape.swift
@@ -148,6 +148,7 @@ struct ShapeModifier: ViewModifier {
                         view.clipShape(shape).overlay {
                             border.color.toView(colorScheme: colorScheme)
                                 .mask(shape.strokeBorder(Color.black, lineWidth: border.width))
+                                .allowsHitTesting(false)
                         }
                     }
             }
@@ -185,6 +186,7 @@ private struct ConcaveMaskModifier: ViewModifier {
                 view.overlay {
                     border.color.toView(colorScheme: colorScheme)
                         .mask(shape.strokeBorder(Color.black, lineWidth: border.width))
+                        .allowsHitTesting(false)
                 }
             }
     }
@@ -261,6 +263,7 @@ private struct ConvexMaskModifier: ViewModifier {
                 view.overlay {
                     border.color.toView(colorScheme: colorScheme)
                         .mask(shape.strokeBorder(Color.black, lineWidth: border.width))
+                        .allowsHitTesting(false)
                 }
             }
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Sometimes overlays blocked user interaction

### Description

Stops that from happening by disabling hit testing 