### PR TITLE
Fix slack_backend_integration_test_results Fastlane action crashing during integration / e2e tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 9f78bb91a9718218344660bc48da40c62ce9fd9c
+  revision: 083ced9d65172fb8a545c998291547eb30b72bd3
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri


### PR DESCRIPTION
Fixes Fastlane crashing when running integration / e2e tests due to a bug in the `slack_backend_integration_test_results` action.

[Related PR](https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/106)