### PR TITLE
Bring back failure notifications to Slack for maestro-e2e-test-job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ aliases:
       name: run-maestro-e2e-tests-<< matrix.backend_environment >>
       context:
         - e2e-tests
-        - slack-secrets-ios
+        - slack-secrets
       matrix:
         parameters:
           backend_environment: ["production", "load_shedder_us_east_1", "load_shedder_us_east_2", "fallback"]


### PR DESCRIPTION
Follow-up to https://github.com/RevenueCat/purchases-ios/pull/5800

I changed the context for `maestro-e2e-test-job` when I shouldn't have. This fixes it.