### PR TITLE
Migrate to slack-secrets context again after fixing conflict between orb and Fastlane Slack action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,8 @@ commands:
     steps:
       # Map custom variable names to the Slack orb variables, since the default variable names are already used by the Fastlane Slack integration
       # we will probably remove these at some point when we move all jobs to use the Fastlane Slack integration
+      # Note: It's safe to modify SLACK_ACCESS_TOKEN and SLACK_DEFAULT_CHANNEL here because this command is always
+      # called as the last step in jobs, so it won't interfere with Fastlane commands that run before it
       - run:
           name: Set Slack environment variables
           when: always


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
It turns out the CircleCI orb still used the `SLACK_ACCESS_TOKEN` and `SLACK_DEFAULT_CHANNEL` values from the `slack-secrets-ios` context after we switched to the `slack-secrets` context. This was resolved by rolling back to the previous context in https://github.com/RevenueCat/purchases-ios/pull/5800

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
With this change I've migrated the old values to the new context, but under a different name. In the `slack-notify-on-fail` job I'm injecting these variables to the orb. 

At some point we'll probably want to consolidate this and have all jobs rely on Fastlane to handle the Slack notifications. But there are quite a few so this seemed like the simpler solution for now.