### PR TITLE
Removed Slack actions from CircleCI config for release jobs that don't add much value and were not working before

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1264,7 +1264,6 @@ jobs:
           command: bundle exec fastlane build_and_publish_docs
           environment:
             DOCS_IOS_VERSION: "17.4"
-      - slack-notify-on-fail
 
   make-release:
     executor:
@@ -1278,7 +1277,6 @@ jobs:
           name: Deploy new version
           command: bundle exec fastlane release
           no_output_timeout: 30m
-      - slack-notify-on-fail
 
   push-revenuecat-pod:
     executor:
@@ -1291,7 +1289,6 @@ jobs:
           name: Deploy new version
           command: bundle exec fastlane push_revenuecat_pod
           no_output_timeout: 30m
-      - slack-notify-on-fail
 
   push-revenuecatui-pod:
     executor:
@@ -1304,7 +1301,6 @@ jobs:
           name: Deploy new version
           command: bundle exec fastlane push_revenuecatui_pod
           no_output_timeout: 30m
-      - slack-notify-on-fail
 
   prepare-next-version:
     executor:
@@ -1317,7 +1313,6 @@ jobs:
       - run:
           name: Prepare next version
           command: bundle exec fastlane prepare_next_version
-      - slack-notify-on-fail
 
   installation-tests-cocoapods:
     executor:
@@ -1663,20 +1658,14 @@ workflows:
     jobs:
       - make-release:
           <<: *release-tags
-          context:
-            - slack-secrets
       - push-revenuecat-pod:
           requires:
             - make-release
           <<: *release-tags
-          context:
-            - slack-secrets
       - push-revenuecatui-pod:
           requires:
             - push-revenuecat-pod
           <<: *release-tags
-          context:
-            - slack-secrets
       - deploy-to-spm:
           requires:
             - make-release
@@ -1685,8 +1674,6 @@ workflows:
           requires:
             - make-release
           <<: *release-tags
-          context:
-            - slack-secrets
       - deploy-purchase-tester:
           dry_run: false
           requires:
@@ -1700,8 +1687,6 @@ workflows:
     jobs:
       - prepare-next-version:
           <<: *only-main-branch
-          context:
-            - slack-secrets
 
   danger:
     jobs:


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
Some jobs that used the Slack notification orb did not specify the Slack secrets context, resulting in an error when sending the Slack message.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
Added the context to remaining jobs using the Slack orb.

I've decided not to add them to the `generate-snapshot` and `generate_revenuecatui_snapshots` jobs since they are triggered during development so that wouldn't add much value to the rest of the team. Please let me know in case you have different thoughts on this :)