### PR TITLE
Fix strong retain cycle on `Purchases` instance

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2307,9 +2307,9 @@ private extension Purchases {
         self.offeringsManager.updateOfferingsCache(
             appUserID: self.appUserID,
             isAppBackgrounded: isAppBackgrounded
-        ) { [cache = self.paywallCache] offeringsResultData in
+        ) { [weak self] offeringsResultData in
             if #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *),
-               let cache = cache, let offerings = offeringsResultData.value?.offerings {
+               let self = self, let cache = self.paywallCache, let offerings = offeringsResultData.value?.offerings {
                 self.operationDispatcher.dispatchOnWorkerThread {
                     await withTaskGroup(of: Void.self) { group in
                         group.addTask {


### PR DESCRIPTION
### Motivation
We got a crash report happening in the callback of `Purchases.updateOfferingsCache` (https://github.com/RevenueCat/purchases-ios/issues/5812). While the report is about a `EXC_BAD_ACCESS`, seemingly due to accessing a deallocated object, this made me realize that there is a retain cycle in the implementation of `Purchases.updateOfferingsCache`, where `self` was being strongly captured in the closure.

### Description
This PR uses `[weak self]` to capture a weak reference to `self` in the closure.

### Note
I don't think this PR fixes that crash, but I need to investigate deeper in order to find its cause.