### PR TITLE
Fixed passing major version as integer to send Slack alert action which accepts a string instead

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1270,7 +1270,7 @@ platform :ios do
       slack_backend_integration_test_results(
         environment: "load_shedder_us_east_1", 
         success: success, 
-        version: major,
+        version: major.to_s,
         message_binary_solo_on_failure: false
       )
       ping_heartbeat_monitor(url: ENV["HEARTBEAT_MONITOR_URL_LOAD_SHEDDER_V#{major}_INTEGRATION_TESTS"])

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -37,14 +37,6 @@ Removes the Examples directory before building with Carthage to prevent unnecess
 
 
 
-### send_slack_loadshedder_integration_test_in_major
-
-```sh
-[bundle exec] fastlane send_slack_loadshedder_integration_test_in_major
-```
-
-
-
 ----
 
 


### PR DESCRIPTION
```
[00:33:44]: You passed invalid parameters to 'slack_backend_integration_test_results'.
[00:33:44]: Check out the error below and available options by running `fastlane action slack_backend_integration_test_results`

[00:33:44]: Called from Fastfile at line 1322
[00:33:44]: ```
[00:33:44]:     1320:         raise exception
[00:33:44]:     1321:       ensure
[00:33:44]:  => 1322:         slack_backend_integration_test_results(
[00:33:44]:     1323:           environment: "load_shedder_us_east_1", 
[00:33:44]:     1324:           success: success, 
[00:33:44]: ```
[00:33:44]: 'version' value must be a String! Found Integer instead.
```