### PR TITLE
Fix icon not updating on selection of package

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Icon/IconComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Icon/IconComponentView.swift
@@ -61,7 +61,6 @@ struct IconComponentView: View {
                 ) { (image, size) in
                     self.renderImage(image, size, with: style)
                 }
-                .id(style.url)
                 .padding(style.padding.extend(by: style.iconBackgroundBorder?.width ?? 0))
                 .shape(border: style.iconBackgroundBorder,
                        shape: style.iconBackgroundShape,

--- a/RevenueCatUI/Views/RemoteImage.swift
+++ b/RevenueCatUI/Views/RemoteImage.swift
@@ -113,10 +113,10 @@ private struct ColorSchemeRemoteImage<Content: View>: View {
 
     // Preferred method of loading images
 
-    @StateObject
+    @ObservedObject
     private var highResFileLoader: FileImageLoader
 
-    @StateObject
+    @ObservedObject
     private var lowResFileLoader: FileImageLoader
 
     // Legacy method of loading images
@@ -190,11 +190,8 @@ private struct ColorSchemeRemoteImage<Content: View>: View {
             for: colorScheme
         )
 
-        let highResLoader = FileImageLoader(fileRepository: .shared, url: highResURL)
-        let lowResLoader = FileImageLoader(fileRepository: .shared, url: lowResURL)
-
-        self._highResFileLoader = .init(wrappedValue: highResLoader)
-        self._lowResFileLoader = .init(wrappedValue: lowResLoader)
+        self.highResFileLoader = FileImageLoader(fileRepository: .shared, url: highResURL)
+        self.lowResFileLoader = FileImageLoader(fileRepository: .shared, url: lowResURL)
     }
 
     private static func selectURL(


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

resolves #5844 

We have an issue updating the icon after package selection.


### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->


It broke in 5.47.1 for some people, It has to do with the changes in #5775, but I cannot reproduce it. My best hunch is that the StateObjects that are inside of the RemoteImageView are surviving the URL update because the identity of the view did not change. This would cause the retention of the URL and the bug that we see.


>[!NOTE]
> Joan and one of the bug reporters both tested and confirmed this resolves the bug

|Before|After|
|:----:|:----:|
|![before](https://github.com/user-attachments/assets/c1607edc-5de4-406a-b11b-995a7c719395)|![After](https://github.com/user-attachments/assets/dfe6c7f1-105c-4bf4-baa9-559c107d6f81)|

