### PR TITLE
Allow downloads of paywall assets in parallel when warming up cache

### DIFF
--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 
+// swiftlint:disable file_length
 protocol PaywallCacheWarmingType: Sendable {
 
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)


### PR DESCRIPTION
In #5847 we changed the warm-up of paywalls custom fonts to be downloaded serially, instead of in parallel. And paywall images have always downloaded serially.

However, after some internal discussion, we've decided to
* Roll back to having custom fonts be downloaded in parallel (i.e. the state before #5847).
* Change image downloads to also happen in parallel.

The purpose here is to make the overall loading time as small as possible, so that paywalls assets are available as soon as possible.

Note that the simplification made in #5847 about removing the nested task groups still holds true. 