### PR TITLE
Fix: Ensure the initial tab selects the package on first appearance

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
@@ -87,6 +87,8 @@ struct LoadedTabsComponentView: View {
     @State
     private var tierPackageContexts: [String: PackageContext]
 
+    @State var wasConfigured: Bool = false
+
     var activeTabViewModel: TabViewModel? {
         return self.viewModel.tabViewModels[self.tabControlContext.selectedTabId] ??
             self.viewModel.tabViewModels.values.first
@@ -133,6 +135,21 @@ struct LoadedTabsComponentView: View {
             )
             .environmentObject(self.tabControlContext)
             .environmentObject(tierPackageContext)
+            .onAppear {
+                if !wasConfigured {
+                    self.wasConfigured = true
+                    // In the event that the tabs components contain unique selected packages, we need to ensure that
+                    // the first selected tab's selected package is propagated up to the purchase button. This sends
+                    // that signal only for the initially rendered tab, then the onChange passed into the loadedTabView
+                    // handles subsequent changes
+                    if let package = tierPackageContext.package {
+                        self.packageContext.update(
+                            package: package,
+                            variableContext: tierPackageContext.variableContext
+                        )
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

Given a tabs component that contains packages, where one package is selected in each tab, the initially rendered tab's selected package should be the package that the purchase button recognizes and attempts to purchase

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

This will pass up the initially displayed tab's selected package if it is present so that the purchase button doesn't fall back and pick a different package on tap. 

|Before… Had to click around| After - Set by default|
|:---:|:---:|
|![bad](https://github.com/user-attachments/assets/2eb1b7e1-45a7-4d60-aade-f30d04100159)|![Good](https://github.com/user-attachments/assets/fdd38059-7a83-448c-90a3-9e46496a3b51)|

