### PR TITLE
Fixed daily integration-tests-all run missing the Circle CI context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1717,7 +1717,9 @@ workflows:
           major: "4"
           context:
             - slack-secrets
-      - integration-tests-all
+      - integration-tests-all:
+          context:
+            - slack-secrets
 
   daily-maestro-e2e-tests:
     when:


### PR DESCRIPTION
The daily job run of `integration-tests-all` was missing the correct Circle CI context. 

I've verified all other jobs that call the same Fastlane lane and they all seem to be using the correct context now.