### PR TITLE
Set paywall as non-scrolling if shorter than screen

### DIFF
--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -150,6 +150,7 @@ extension View {
                     ScrollView(axis.scrollViewAxis) {
                         self
                     }
+                    .scrollBounceBehaviorBasedOnSize()
                 }
             } else {
                 self
@@ -257,6 +258,7 @@ private struct ScrollableIfNecessaryModifier: ViewModifier {
                 )
         }
         .scrollable(self.axis.scrollViewAxis, if: self.overflowing)
+        .scrollBounceBehaviorBasedOnSize()
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -168,10 +168,12 @@ fileprivate extension View {
                 ScrollView(.horizontal) {
                     self
                 }
+                .scrollBounceBehaviorBasedOnSize()
             case .vertical:
                 ScrollView(.vertical) {
                     self
                 }
+                .scrollBounceBehaviorBasedOnSize()
             case .zlayer:
                 self
             }


### PR DESCRIPTION
Fixes the following issue where the view is scrollable when it doesn't need to:


https://github.com/user-attachments/assets/fedb30e7-ae48-40cd-ae92-c8d279492a1f



This is a more lean approach to #5825 only focusing on making the scrollview non-scrollable if not needed. That PR grew a lot and uncovered other issues. The approach in this PR doesn't change the way the views are rendered, they will all still be aligned to start vertically, but it makes sure the view is not scrollable if too short.

| Before | After |
|--------|--------|
| https://github.com/user-attachments/assets/c39f61d6-6a9f-4b78-b06c-4b7e5d3938b4 | https://github.com/user-attachments/assets/b5b8f856-aad2-4460-8b84-61d866277639 | 






