### PR TITLE
Revert changes from #5877

### DIFF
--- a/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker+TestData.swift
+++ b/RevenueCatUI/Data/IntroEligibility/TrialOrIntroEligibilityChecker+TestData.swift
@@ -18,8 +18,7 @@ import RevenueCat
 extension TrialOrIntroEligibilityChecker {
 
     /// Creates a mock `TrialOrIntroEligibilityChecker` with a constant result.
-    @_spi(Internal)
-    public static func producing(eligibility: @autoclosure @escaping () -> IntroEligibilityStatus) -> Self {
+    static func producing(eligibility: @autoclosure @escaping () -> IntroEligibilityStatus) -> Self {
         return .init { packages in
             return Dictionary(
                 uniqueKeysWithValues: Set(packages)
@@ -35,7 +34,6 @@ extension TrialOrIntroEligibilityChecker {
     }
 #if DEBUG
     /// Creates a copy of this `TrialOrIntroEligibilityChecker` with a delay.
-    @_spi(Internal)
     func with(delay seconds: TimeInterval) -> Self {
         return .init { [checker = self.checker] in
             await Task.sleep(seconds: seconds)

--- a/Sources/Paywalls/Components/Common/ComponentOverrides.swift
+++ b/Sources/Paywalls/Components/Common/ComponentOverrides.swift
@@ -158,7 +158,7 @@ public extension PaywallComponent {
             case screenSize = "screen_size"
             case selectedPackage = "selected_package"
             case introOffer = "intro_offer"
-            case anyIntroOffer = "intro_offer_available"
+            case anyIntroOffer = "introductory_offer_available"
             case promoOffer = "promo_offer"
             case anyPromoOffer = "promo_offer_available"
             case selected


### PR DESCRIPTION
### Motivation
Follow-up of https://github.com/RevenueCat/purchases-ios/pull/5877

I missed that there are no strict checks to merge for chained PRs. Sorry @vegaro 

