### PR TITLE
Fix missing Customer Center actions on SK1 purchases

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -550,7 +550,22 @@ extension PurchaseInformation {
     }
 
     var isAppStoreRenewableSubscription: Bool {
-        return productType == .autoRenewableSubscription && store == .appStore
+        guard store == .appStore else { return false }
+
+        if productType == .autoRenewableSubscription {
+            return true
+        }
+
+        if productType == .nonRenewableSubscription {
+            return false
+        }
+
+        // For SK1 products, productType always reports .nonConsumable regardless of actual type,
+        // so we cannot rely on it to distinguish auto-renewable subscriptions from other products.
+        // We fall back to isSubscription (from the backend), which correctly identifies subscriptions.
+        // This ensures SK1 auto-renewable subscriptions show proper management options like
+        // "Cancel subscription" and "Change plans" in the Customer Center.
+        return isSubscription
     }
 
     var storeLocalizationKey: CCLocalizedString {


### PR DESCRIPTION
Followup on #5811 

Subscription customer center options were missing for SK1 purchases since they were not categorized as subscription

| Before | After |
|--------|--------|
| <img width="332" height="720" alt="image" src="https://github.com/user-attachments/assets/0cd49af0-c853-4e64-a596-c4861e7e2808" /> | <img width="332" height="720" alt="image" src="https://github.com/user-attachments/assets/d3956bde-f2b2-4c95-bc99-311bd7872af9" /> | 

