### PR TITLE
Fix flaky test

### DIFF
--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1268,7 +1268,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
     func testFullHTTPRequestTimeoutFlow() async {
 
         enum MainBackendTimeoutRequestPath: HTTPRequestPath {
-            static let serverHostURL = URL(string: "http://this-is-a-main-host.com")!
+            static let serverHostURL = URL(string: "http://10.255.255.255")! // Unroutable IP to force a timeout
 
             case first
             case second
@@ -1286,7 +1286,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
             }
 
             var fallbackUrls: [URL] {
-                [URL(string: "https://this-is-a-fallback.com/\(relativePath)-fallback")!]
+                [URL(string: "https://this-is-a-fallback.com\(relativePath)-fallback")!]
             }
         }
 
@@ -1307,20 +1307,16 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
             HTTPRequestTimeoutManager.Timeout.mainBackendRequestSupportingFallback.rawValue
         )
 
-        stub(condition: isHost(MainBackendTimeoutRequestPath.serverHostURL.host!)) { _ in
-            return .timeoutResponse()
-        }
-
         // Stub request to the fallback URL
         var fallbackCalled = false
         stub(condition: isAbsoluteURLString(firstRequest.path.fallbackUrls.first!.absoluteString)) { request in
+            fallbackCalled = true
+
             // The fallback request should use the default timeout
             XCTAssertEqual(
                 request.timeoutInterval,
                 self.defaultRequestTimeout
             )
-
-            fallbackCalled = true
 
             return .emptySuccessResponse()
         }
@@ -1328,18 +1324,18 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         // Stub second request
         var secondRequestCalled = false
         stub(condition: isPath(secondRequest.path)) { request in
+            secondRequestCalled = true
+
             // The fallback request should use the default timeout
             XCTAssertEqual(
                 request.timeoutInterval,
                 HTTPRequestTimeoutManager.Timeout.reduced.rawValue
             )
 
-            secondRequestCalled = true
-
             return .emptySuccessResponse()
         }
 
-        await waitUntil { completion in
+        await waitUntil(timeout: .seconds(Int(defaultRequestTimeout) + 1)) { completion in
             self.client.perform(firstRequest) { (_: DataResponse) in
                 // A new request that supports fallback to the main backend
                 // should use the default timeout since previously a timeout was received


### PR DESCRIPTION
Attempts a fix for the recent test `testFullHTTPRequestTimeoutFlow` that is randomly failing (e.g. [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/32046/workflows/3a02a096-d4e2-409e-b16f-101a4bac9b6a/jobs/417944/tests)).

This PR only migrates the test to async/await, which could itself fix its flakiness. As discussed [here](https://github.com/RevenueCat/purchases-ios/pull/5887#discussion_r2569623211), if this is not enough, we can apply the changes in https://github.com/RevenueCat/purchases-ios/pull/5887/commits/c109ddfa13e01690114624b3c79af6cae4429ec4 in the future to make the test more deterministic