### PR TITLE
Remove CI step to install unused dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,6 @@ commands:
           steps:
             - install-brew-dependency:
                 dependency_name: "swiftlint"
-      - run: brew tap robotsandpencils/made
       - save_cache:
           key: homebrew-cache-{{ checksum "Brewfile.lock.json" }}-{{ arch }}
           paths:


### PR DESCRIPTION
### Motivation
Most CI jobs suddenly started failing (e.g. [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/32070))

### Description
The failures were happening when running 
```
brew tap robotsandpencils/made
```
That brew clones the repo `https://github.com/robotsandpencils/homebrew-made`, but it seems that repo has been either removed or made private. The made tap was originally used to provide the `xcodes` CLI tool, but `xcodes` doesn't need it anymore.

Successful CI run with the fix [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/32071)