### PR TITLE
Remove extra check for showing new support ticket creation button

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -255,8 +255,7 @@ private extension SubscriptionDetailView {
                         .padding(.vertical, 16)
                 }
 
-                if viewModel.shouldShowCreateTicketButton(supportTickets: support?.supportTickets),
-                   viewModel.shouldShowContactSupport {
+                if viewModel.shouldShowCreateTicketButton(supportTickets: support?.supportTickets) {
                     createTicketButton
                         .padding(.vertical, 16)
                 } else if let url = support?.supportURL(


### PR DESCRIPTION
### Motivation
There was an extra check in place that was stopping the new contact support button from showing at the right time.

### Description
The check removed should only be used for the old contact support button and we should instead rely on the new check for the new button