### PR TITLE
Conditional visibility - fallback visibility for old SDKs

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
@@ -63,7 +63,7 @@ class CarouselComponentViewModel {
             anyPackageHasIntroOffer: packageContext.variableContext.hasAnyIntroOffer,
             anyPackageHasPromoOffer: anyPackageHasPromoOffer,
             selectedPackage: packageContext.package,
-            conditionalVisibilityFallback: component.conditionalVisibilityFallback,
+            evaluateUnknownConditionsAs: component.evaluateUnknownConditionsAs,
             with: self.presentedOverrides
         )
 

--- a/RevenueCatUI/Templates/V2/Components/Icon/IconComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Icon/IconComponentViewModel.swift
@@ -105,7 +105,7 @@ class IconComponentViewModel {
             anyPackageHasIntroOffer: packageContext.variableContext.hasAnyIntroOffer,
             anyPackageHasPromoOffer: anyPackageHasPromoOffer,
             selectedPackage: packageContext.package,
-            conditionalVisibilityFallback: component.conditionalVisibilityFallback,
+            evaluateUnknownConditionsAs: component.evaluateUnknownConditionsAs,
             with: self.presentedOverrides
         )
 

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
@@ -67,7 +67,7 @@ class ImageComponentViewModel {
             anyPackageHasIntroOffer: packageContext.variableContext.hasAnyIntroOffer,
             anyPackageHasPromoOffer: anyPackageHasPromoOffer,
             selectedPackage: packageContext.package,
-            conditionalVisibilityFallback: component.conditionalVisibilityFallback,
+            evaluateUnknownConditionsAs: component.evaluateUnknownConditionsAs,
             with: self.presentedOverrides
         )
         let partial = localizedPartial?.partial

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
@@ -74,7 +74,7 @@ class StackComponentViewModel {
             anyPackageHasIntroOffer: packageContext.variableContext.hasAnyIntroOffer,
             anyPackageHasPromoOffer: anyPackageHasPromoOffer,
             selectedPackage: packageContext.package,
-            conditionalVisibilityFallback: component.conditionalVisibilityFallback,
+            evaluateUnknownConditionsAs: component.evaluateUnknownConditionsAs,
             with: self.presentedOverrides
         )
 

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -63,7 +63,7 @@ class TextComponentViewModel {
             anyPackageHasIntroOffer: packageContext.variableContext.hasAnyIntroOffer,
             anyPackageHasPromoOffer: anyPackageHasPromoOffer,
             selectedPackage: packageContext.package,
-            conditionalVisibilityFallback: component.conditionalVisibilityFallback,
+            evaluateUnknownConditionsAs: component.evaluateUnknownConditionsAs,
             with: self.presentedOverrides
         )
         let partial = localizedPartial?.partial

--- a/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentView.swift
@@ -366,7 +366,7 @@ struct ContentView_Previews: PreviewProvider {
                     padding: .init(top: 5, bottom: 5, leading: 5, trailing: 5),
                     margin: .init(top: 5, bottom: 5, leading: 5, trailing: 5),
                     items: items,
-                    conditionalVisibilityFallback: nil,
+                    evaluateUnknownConditionsAs: nil,
                     overrides: nil
                 ), localizationProvider: LocalizationProvider(
                     locale: Locale.current,

--- a/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentViewModel.swift
@@ -62,7 +62,7 @@ class TimelineComponentViewModel {
             anyPackageHasIntroOffer: packageContext.variableContext.hasAnyIntroOffer,
             anyPackageHasPromoOffer: anyPackageHasPromoOffer,
             selectedPackage: packageContext.package,
-            conditionalVisibilityFallback: component.conditionalVisibilityFallback,
+            evaluateUnknownConditionsAs: component.evaluateUnknownConditionsAs,
             with: self.presentedOverrides
         )
 
@@ -124,7 +124,7 @@ class TimelineItemViewModel {
             anyPackageHasIntroOffer: packageContext.variableContext.hasAnyIntroOffer,
             anyPackageHasPromoOffer: anyPackageHasPromoOffer,
             selectedPackage: packageContext.package,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: self.presentedOverrides
         )
 

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoComponentViewModel.swift
@@ -62,7 +62,7 @@ class VideoComponentViewModel {
             anyPackageHasIntroOffer: packageContext.variableContext.hasAnyIntroOffer,
             anyPackageHasPromoOffer: anyPackageHasPromoOffer,
             selectedPackage: packageContext.package,
-            conditionalVisibilityFallback: component.conditionalVisibilityFallback,
+            evaluateUnknownConditionsAs: component.evaluateUnknownConditionsAs,
             with: self.presentedOverrides
         )
         let partial = localizedPartial?.partial

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -61,7 +61,7 @@ extension PresentedPartial {
         anyPackageHasIntroOffer: Bool = false,
         anyPackageHasPromoOffer: Bool = false,
         selectedPackage: Package?,
-        conditionalVisibilityFallback: Bool?,
+        evaluateUnknownConditionsAs: Bool?,
         with presentedOverrides: PresentedOverrides<Self>?
     ) -> Self? {
         guard let presentedOverrides else {
@@ -78,7 +78,7 @@ extension PresentedPartial {
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             anyPackageHasIntroOffer: anyPackageHasIntroOffer,
             anyPackageHasPromoOffer: anyPackageHasPromoOffer,
-            conditionalVisibilityFallback: conditionalVisibilityFallback,
+            evaluateUnknownConditionsAs: evaluateUnknownConditionsAs,
             selectedPackage: selectedPackage
         ) {
             presentedPartial = Self.combine(presentedPartial, with: presentedOverride.properties)
@@ -96,7 +96,7 @@ extension PresentedPartial {
         isEligibleForPromoOffer: Bool,
         anyPackageHasIntroOffer: Bool,
         anyPackageHasPromoOffer: Bool,
-        conditionalVisibilityFallback: Bool?,
+        evaluateUnknownConditionsAs: Bool?,
         selectedPackage: Package?
     ) -> Bool {
         // Early return when any condition evaluates to false
@@ -180,7 +180,7 @@ extension PresentedPartial {
                 }
             case .unsupported:
                 // if a fallback is specified, use it, otherwise ignore the unsupported condition entirely
-                return conditionalVisibilityFallback ?? true
+                return evaluateUnknownConditionsAs ?? true
             @unknown default:
                 return false
             }

--- a/Sources/Paywalls/Components/PaywallCarouselComponent.swift
+++ b/Sources/Paywalls/Components/PaywallCarouselComponent.swift
@@ -134,7 +134,7 @@ public extension PaywallComponent {
         public let pageControl: PageControl?
 
         public let overrides: ComponentOverrides<PartialCarouselComponent>?
-        public let conditionalVisibilityFallback: Bool?
+        public let evaluateUnknownConditionsAs: Bool?
 
         public init(
             visible: Bool? = nil,
@@ -154,7 +154,7 @@ public extension PaywallComponent {
             autoAdvance: PaywallComponent.CarouselComponent.AutoAdvanceSlides? = nil,
             pageControl: PageControl? = nil,
             overrides: ComponentOverrides<PartialCarouselComponent>? = nil,
-            conditionalVisibilityFallback: Bool? = nil
+            evaluateUnknownConditionsAs: Bool? = nil
         ) {
             self.type = .carousel
 
@@ -175,7 +175,7 @@ public extension PaywallComponent {
             self.autoAdvance = autoAdvance
             self.pageControl = pageControl
             self.overrides = overrides
-            self.conditionalVisibilityFallback = conditionalVisibilityFallback
+            self.evaluateUnknownConditionsAs = evaluateUnknownConditionsAs
         }
 
         public static func == (lhs: CarouselComponent, rhs: CarouselComponent) -> Bool {
@@ -197,7 +197,7 @@ public extension PaywallComponent {
                 lhs.autoAdvance == rhs.autoAdvance &&
                 lhs.pageControl == rhs.pageControl &&
                 lhs.overrides == rhs.overrides &&
-                lhs.conditionalVisibilityFallback == rhs.conditionalVisibilityFallback
+                lhs.evaluateUnknownConditionsAs == rhs.evaluateUnknownConditionsAs
         }
 
         // MARK: - Hashable
@@ -220,7 +220,7 @@ public extension PaywallComponent {
             hasher.combine(autoAdvance)
             hasher.combine(pageControl)
             hasher.combine(overrides)
-            hasher.combine(conditionalVisibilityFallback)
+            hasher.combine(evaluateUnknownConditionsAs)
         }
 
     }

--- a/Sources/Paywalls/Components/PaywallIconComponent.swift
+++ b/Sources/Paywalls/Components/PaywallIconComponent.swift
@@ -88,7 +88,7 @@ public extension PaywallComponent {
         public let iconBackground: IconBackground?
 
         public let overrides: ComponentOverrides<PartialIconComponent>?
-        public let conditionalVisibilityFallback: Bool?
+        public let evaluateUnknownConditionsAs: Bool?
 
         public init(
             visible: Bool? = nil,
@@ -101,7 +101,7 @@ public extension PaywallComponent {
             color: ColorScheme,
             iconBackground: IconBackground?,
             overrides: ComponentOverrides<PartialIconComponent>? = nil,
-            conditionalVisibilityFallback: Bool? = nil
+            evaluateUnknownConditionsAs: Bool? = nil
         ) {
             self.type = .image
             self.visible = visible
@@ -114,7 +114,7 @@ public extension PaywallComponent {
             self.color = color
             self.iconBackground = iconBackground
             self.overrides = overrides
-            self.conditionalVisibilityFallback = conditionalVisibilityFallback
+            self.evaluateUnknownConditionsAs = evaluateUnknownConditionsAs
         }
 
         public func hash(into hasher: inout Hasher) {
@@ -129,7 +129,7 @@ public extension PaywallComponent {
             hasher.combine(color)
             hasher.combine(iconBackground)
             hasher.combine(overrides)
-            hasher.combine(conditionalVisibilityFallback)
+            hasher.combine(evaluateUnknownConditionsAs)
         }
 
         public static func == (lhs: IconComponent, rhs: IconComponent) -> Bool {
@@ -144,7 +144,7 @@ public extension PaywallComponent {
                    lhs.color == rhs.color &&
                    lhs.iconBackground == rhs.iconBackground &&
                    lhs.overrides == rhs.overrides &&
-                   lhs.conditionalVisibilityFallback == rhs.conditionalVisibilityFallback
+                   lhs.evaluateUnknownConditionsAs == rhs.evaluateUnknownConditionsAs
         }
     }
 

--- a/Sources/Paywalls/Components/PaywallImageComponent.swift
+++ b/Sources/Paywalls/Components/PaywallImageComponent.swift
@@ -26,7 +26,7 @@ public extension PaywallComponent {
         public let shadow: Shadow?
 
         public let overrides: ComponentOverrides<PartialImageComponent>?
-        public let conditionalVisibilityFallback: Bool?
+        public let evaluateUnknownConditionsAs: Bool?
 
         public init(
             visible: Bool? = nil,
@@ -41,7 +41,7 @@ public extension PaywallComponent {
             border: Border? = nil,
             shadow: Shadow? = nil,
             overrides: ComponentOverrides<PartialImageComponent>? = nil,
-            conditionalVisibilityFallback: Bool? = nil
+            evaluateUnknownConditionsAs: Bool? = nil
         ) {
             self.type = .image
             self.visible = visible
@@ -56,7 +56,7 @@ public extension PaywallComponent {
             self.border = border
             self.shadow = shadow
             self.overrides = overrides
-            self.conditionalVisibilityFallback = conditionalVisibilityFallback
+            self.evaluateUnknownConditionsAs = evaluateUnknownConditionsAs
         }
 
         public func hash(into hasher: inout Hasher) {
@@ -73,7 +73,7 @@ public extension PaywallComponent {
             hasher.combine(border)
             hasher.combine(shadow)
             hasher.combine(overrides)
-            hasher.combine(conditionalVisibilityFallback)
+            hasher.combine(evaluateUnknownConditionsAs)
         }
 
         public static func == (lhs: ImageComponent, rhs: ImageComponent) -> Bool {
@@ -90,7 +90,7 @@ public extension PaywallComponent {
                    lhs.border == rhs.border &&
                    lhs.shadow == rhs.shadow &&
                    lhs.overrides == rhs.overrides &&
-                   lhs.conditionalVisibilityFallback == rhs.conditionalVisibilityFallback
+                   lhs.evaluateUnknownConditionsAs == rhs.evaluateUnknownConditionsAs
         }
     }
 

--- a/Sources/Paywalls/Components/PaywallStackComponent.swift
+++ b/Sources/Paywalls/Components/PaywallStackComponent.swift
@@ -46,7 +46,7 @@ public extension PaywallComponent {
         public let overflow: Overflow?
 
         public let overrides: ComponentOverrides<PartialStackComponent>?
-        public let conditionalVisibilityFallback: Bool?
+        public let evaluateUnknownConditionsAs: Bool?
 
         public init(
             visible: Bool? = nil,
@@ -64,7 +64,7 @@ public extension PaywallComponent {
             badge: Badge? = nil,
             overflow: Overflow? = nil,
             overrides: ComponentOverrides<PartialStackComponent>? = nil,
-            conditionalVisibilityFallback: Bool? = nil
+            evaluateUnknownConditionsAs: Bool? = nil
         ) {
             self.visible = visible
             self.components = components
@@ -82,7 +82,7 @@ public extension PaywallComponent {
             self.badge = badge
             self.overflow = overflow
             self.overrides = overrides
-            self.conditionalVisibilityFallback = conditionalVisibilityFallback
+            self.evaluateUnknownConditionsAs = evaluateUnknownConditionsAs
         }
         public func hash(into hasher: inout Hasher) {
             hasher.combine(type)
@@ -101,7 +101,7 @@ public extension PaywallComponent {
             hasher.combine(badge)
             hasher.combine(overflow)
             hasher.combine(overrides)
-            hasher.combine(conditionalVisibilityFallback)
+            hasher.combine(evaluateUnknownConditionsAs)
         }
 
         public static func == (lhs: StackComponent, rhs: StackComponent) -> Bool {
@@ -121,7 +121,7 @@ public extension PaywallComponent {
                    lhs.badge == rhs.badge &&
                    lhs.overflow == rhs.overflow &&
                    lhs.overrides == rhs.overrides &&
-                   lhs.conditionalVisibilityFallback == rhs.conditionalVisibilityFallback
+                   lhs.evaluateUnknownConditionsAs == rhs.evaluateUnknownConditionsAs
         }
     }
 

--- a/Sources/Paywalls/Components/PaywallTextComponent.swift
+++ b/Sources/Paywalls/Components/PaywallTextComponent.swift
@@ -25,7 +25,7 @@ public extension PaywallComponent {
         public let padding: Padding
         public let margin: Padding
         public let fontWeightInt: Int?
-        public let conditionalVisibilityFallback: Bool?
+        public let evaluateUnknownConditionsAs: Bool?
 
         public let overrides: ComponentOverrides<PartialTextComponent>?
 
@@ -46,7 +46,7 @@ public extension PaywallComponent {
             fontSize: CGFloat = 16,
             horizontalAlignment: HorizontalAlignment = .center,
             overrides: ComponentOverrides<PartialTextComponent>? = nil,
-            conditionalVisibilityFallback: Bool? = nil,
+            evaluateUnknownConditionsAs: Bool? = nil,
             fontWeightInt: Int? = nil
         ) {
             self.type = .text
@@ -62,7 +62,7 @@ public extension PaywallComponent {
             self.fontSize = fontSize
             self.horizontalAlignment = horizontalAlignment
             self.overrides = overrides
-            self.conditionalVisibilityFallback = conditionalVisibilityFallback
+            self.evaluateUnknownConditionsAs = evaluateUnknownConditionsAs
             self.fontWeightInt = fontWeightInt
         }
 
@@ -80,7 +80,7 @@ public extension PaywallComponent {
             case padding
             case margin
             case overrides
-            case conditionalVisibilityFallback
+            case evaluateUnknownConditionsAs
             case fontWeightInt
         }
 
@@ -102,9 +102,9 @@ public extension PaywallComponent {
                 ComponentOverrides<PartialTextComponent>.self,
                 forKey: .overrides
             )
-            self.conditionalVisibilityFallback = try container.decodeIfPresent(
+            self.evaluateUnknownConditionsAs = try container.decodeIfPresent(
                 Bool.self,
-                forKey: .conditionalVisibilityFallback
+                forKey: .evaluateUnknownConditionsAs
             )
             self.fontWeightInt = try container.decodeIfPresent(Int.self, forKey: .fontWeightInt)
 
@@ -134,7 +134,8 @@ public extension PaywallComponent {
             try container.encode(padding, forKey: .padding)
             try container.encode(margin, forKey: .margin)
             try container.encodeIfPresent(overrides, forKey: .overrides)
-            try container.encodeIfPresent(conditionalVisibilityFallback, forKey: .conditionalVisibilityFallback)
+            try container
+                .encodeIfPresent(evaluateUnknownConditionsAs, forKey: .evaluateUnknownConditionsAs)
             try container.encodeIfPresent(fontWeightInt, forKey: .fontWeightInt)
             try container.encode(fontSize, forKey: .fontSize)
         }
@@ -153,7 +154,7 @@ public extension PaywallComponent {
             hasher.combine(padding)
             hasher.combine(margin)
             hasher.combine(overrides)
-            hasher.combine(conditionalVisibilityFallback)
+            hasher.combine(evaluateUnknownConditionsAs)
             hasher.combine(fontWeightInt)
         }
 
@@ -171,7 +172,7 @@ public extension PaywallComponent {
                    lhs.padding == rhs.padding &&
                    lhs.margin == rhs.margin &&
                    lhs.overrides == rhs.overrides &&
-                   lhs.conditionalVisibilityFallback == rhs.conditionalVisibilityFallback &&
+                   lhs.evaluateUnknownConditionsAs == rhs.evaluateUnknownConditionsAs &&
                    lhs.fontWeightInt == rhs.fontWeightInt
         }
     }

--- a/Sources/Paywalls/Components/PaywallTimelineComponent.swift
+++ b/Sources/Paywalls/Components/PaywallTimelineComponent.swift
@@ -28,7 +28,7 @@ public extension PaywallComponent {
         public let padding: Padding
         public let margin: Padding
         public let items: [Item]
-        public let conditionalVisibilityFallback: Bool?
+        public let evaluateUnknownConditionsAs: Bool?
         public let overrides: ComponentOverrides<PartialTimelineComponent>?
 
         public init(
@@ -41,7 +41,7 @@ public extension PaywallComponent {
             padding: Padding,
             margin: Padding,
             items: [Item],
-            conditionalVisibilityFallback: Bool?,
+            evaluateUnknownConditionsAs: Bool?,
             overrides: ComponentOverrides<PartialTimelineComponent>?
         ) {
             self.type = .timeline
@@ -54,7 +54,7 @@ public extension PaywallComponent {
             self.padding = padding
             self.margin = margin
             self.items = items
-            self.conditionalVisibilityFallback = conditionalVisibilityFallback
+            self.evaluateUnknownConditionsAs = evaluateUnknownConditionsAs
             self.overrides = overrides
         }
 
@@ -71,7 +71,7 @@ public extension PaywallComponent {
                    lhs.padding == rhs.padding &&
                    lhs.margin == rhs.margin &&
                    lhs.items == rhs.items &&
-                   lhs.conditionalVisibilityFallback == rhs.conditionalVisibilityFallback
+                   lhs.evaluateUnknownConditionsAs == rhs.evaluateUnknownConditionsAs
         }
 
         public func hash(into hasher: inout Hasher) {
@@ -84,7 +84,7 @@ public extension PaywallComponent {
             hasher.combine(padding)
             hasher.combine(margin)
             hasher.combine(items)
-            hasher.combine(conditionalVisibilityFallback)
+            hasher.combine(evaluateUnknownConditionsAs)
         }
 
         public final class Item: Codable, Sendable, Hashable, Equatable {

--- a/Sources/Paywalls/Components/PaywallVideoComponent.swift
+++ b/Sources/Paywalls/Components/PaywallVideoComponent.swift
@@ -35,7 +35,7 @@ extension PaywallComponent {
         public let margin: Padding?
         public let border: Border?
         public let shadow: Shadow?
-        public let conditionalVisibilityFallback: Bool?
+        public let evaluateUnknownConditionsAs: Bool?
 
         public let overrides: ComponentOverrides<PartialVideoComponent>?
 
@@ -55,7 +55,7 @@ extension PaywallComponent {
             margin: Padding? = nil,
             border: Border? = nil,
             shadow: Shadow? = nil,
-            conditionalVisibilityFallback: Bool? = nil,
+            evaluateUnknownConditionsAs: Bool? = nil,
             overrides: ComponentOverrides<PartialVideoComponent>? = nil
         ) {
             self.type = .video
@@ -74,7 +74,7 @@ extension PaywallComponent {
             self.margin = margin
             self.border = border
             self.shadow = shadow
-            self.conditionalVisibilityFallback = conditionalVisibilityFallback
+            self.evaluateUnknownConditionsAs = evaluateUnknownConditionsAs
             self.overrides = overrides
         }
 
@@ -94,7 +94,7 @@ extension PaywallComponent {
             hasher.combine(border)
             hasher.combine(shadow)
             hasher.combine(overrides)
-            hasher.combine(conditionalVisibilityFallback)
+            hasher.combine(evaluateUnknownConditionsAs)
             hasher.combine(source)
             hasher.combine(fallbackSource)
         }
@@ -115,7 +115,7 @@ extension PaywallComponent {
             lhs.border == rhs.border &&
             lhs.shadow == rhs.shadow &&
             lhs.overrides == rhs.overrides &&
-            lhs.conditionalVisibilityFallback == rhs.conditionalVisibilityFallback &&
+            lhs.evaluateUnknownConditionsAs == rhs.evaluateUnknownConditionsAs &&
             lhs.fallbackSource == rhs.fallbackSource &&
             lhs.source == rhs.source
         }

--- a/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
@@ -51,7 +51,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -79,7 +79,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: selectedPackage,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -111,7 +111,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: selectedPackage,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -146,7 +146,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: selectedPackage,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -179,7 +179,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -210,7 +210,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -237,7 +237,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -268,7 +268,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -295,7 +295,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForPromoOffer: false,
             anyPackageHasIntroOffer: anyPackageHasIntroOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -326,7 +326,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForPromoOffer: false,
             anyPackageHasIntroOffer: anyPackageHasIntroOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -353,7 +353,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -384,7 +384,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -411,7 +411,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForPromoOffer: false,
             anyPackageHasPromoOffer: anyPackageHasPromoOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -442,7 +442,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForPromoOffer: false,
             anyPackageHasPromoOffer: anyPackageHasPromoOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -470,7 +470,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: selectedPackage,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -501,7 +501,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -532,7 +532,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -566,7 +566,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: selectedPackage,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -601,7 +601,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: selectedPackage,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -634,7 +634,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: selectedPackage,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -665,7 +665,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: selectedPackage,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -696,7 +696,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: selectedPackage,
-            conditionalVisibilityFallback: false,
+            evaluateUnknownConditionsAs: false,
             with: presentedOverrides
         )
 
@@ -726,7 +726,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: selectedPackage,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -753,7 +753,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: nil,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 
@@ -786,7 +786,7 @@ class PresentedPartialsTest: TestCase {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackage: selectedPackage,
-            conditionalVisibilityFallback: nil,
+            evaluateUnknownConditionsAs: nil,
             with: presentedOverrides
         )
 

--- a/Tests/UnitTests/Paywalls/Components/JSON/VideoComponent.json
+++ b/Tests/UnitTests/Paywalls/Components/JSON/VideoComponent.json
@@ -19,6 +19,7 @@
   },
   "fit_mode": "fill",
   "id": "P0Tzh3p6d3",
+  "evaluate_unknown_conditions_as": true,
   "loop": true,
   "mask_shape": {
     "corners": {

--- a/Tests/UnitTests/Paywalls/Components/VideoComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/VideoComponentTests.swift
@@ -42,6 +42,7 @@ class VideoComponentTests: TestCase {
         XCTAssertNotNil(video.shadow)
         XCTAssertFalse(video.showControls)
         XCTAssertNotNil(video.size)
+        XCTAssertTrue(video.evaluateUnknownConditionsAs.unsafelyUnwrapped)
         XCTAssertEqual(video, video2)
 
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->


As we evolve the conditional visibility feature and add new conditions, our users will likely wind up in a spot where their paywalls don't render in an expected way. We need to provide an option to allow them to account for old SDKs and to control how their paywall renders if they use newer conditions that old SDKs are unaware of.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

Adds a property to the components that defines how the SDK should handle unsupported conditions
