### PR TITLE
Fix compilation of RevenueCatUI in watchOS with Xcode 16

### DIFF
--- a/RevenueCatUI/Templates/Template5View.swift
+++ b/RevenueCatUI/Templates/Template5View.swift
@@ -414,7 +414,7 @@ struct Template5View_Previews: PreviewProvider {
 
 }
 
-@available(iOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)


### PR DESCRIPTION
CI is failing for the spm-revenuecat-ui-watchos workflow [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/32306/workflows/435af705-a961-49ae-880b-d4c47c48e3b1/jobs/424092).

This PR fixes it