### PR TITLE
Replace `RCPurchasesErrorCodeDomain` with `ErrorCode.errorDomain` in tests

### DIFF
--- a/Tests/BackendIntegrationTests/SubscriberAttributesManagerIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SubscriberAttributesManagerIntegrationTests.swift
@@ -99,7 +99,7 @@ class SubscriberAttributesManagerIntegrationTests: BaseStoreKitIntegrationTests 
 
         self.verifySyncedAttribute(self.userID, [reserved(.email): invalidEmail])
 
-        expect(error.domain) == RCPurchasesErrorCodeDomain
+        expect(error.domain) == ErrorCode.errorDomain
         expect(error.code) == ErrorCode.invalidSubscriberAttributesError.rawValue
         expect(error.subscriberAttributesErrors) == [
             "$email": "Email address is not a valid email."

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
@@ -144,7 +144,7 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
 
     func testSK1EligibilityIsFetchedFromBackendIfErrorCalculatingEligibilityAndStoreKitDoesNotHaveIt() throws {
         self.mockProductsManager.stubbedProductsCompletionResult = .success([])
-        let stubbedError = NSError(domain: RCPurchasesErrorCodeDomain,
+        let stubbedError = NSError(domain: ErrorCode.errorDomain,
                                    code: ErrorCode.invalidAppUserIdError.rawValue,
                                    userInfo: [:])
         mockIntroEligibilityCalculator.stubbedCheckTrialOrIntroDiscountEligibilityResult = .failure(stubbedError)
@@ -167,7 +167,7 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
     }
 
     func testSK1EligibilityIsNotFetchedFromBackendIfEligibilityAlreadyExists() throws {
-        let stubbedError = NSError(domain: RCPurchasesErrorCodeDomain,
+        let stubbedError = NSError(domain: ErrorCode.errorDomain,
                                    code: ErrorCode.invalidAppUserIdError.rawValue,
                                    userInfo: [:])
         mockIntroEligibilityCalculator.stubbedCheckTrialOrIntroDiscountEligibilityResult = .failure(stubbedError)

--- a/Tests/UnitTests/FoundationExtensions/NSError+RCExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/NSError+RCExtensionsTests.swift
@@ -13,7 +13,7 @@ class NSErrorRCExtensionsTests: TestCase {
     func testSubscriberAttributesErrorsNilIfNoAttributesErrors() {
         let errorCode = ErrorCode.purchaseNotAllowedError.rawValue
         let error = NSError(
-            domain: RCPurchasesErrorCodeDomain,
+            domain: ErrorCode.errorDomain,
             code: errorCode,
             userInfo: [:]
         )
@@ -25,7 +25,7 @@ class NSErrorRCExtensionsTests: TestCase {
         let attributeErrors = ["$phoneNumber": "phone number is in invalid format",
                                "$email": "email is too long"]
         let error = NSError(
-            domain: RCPurchasesErrorCodeDomain,
+            domain: ErrorCode.errorDomain,
             code: errorCode,
             userInfo: [ErrorDetails.attributeErrorsKey: attributeErrors]
         )

--- a/Tests/UnitTests/Networking/BaseErrorTests.swift
+++ b/Tests/UnitTests/Networking/BaseErrorTests.swift
@@ -34,7 +34,7 @@ class BaseErrorTests: TestCase {
         expect(
             file: file, line: line,
             nsError.domain
-        ) == RCPurchasesErrorCodeDomain
+        ) == ErrorCode.errorDomain
         expect(
             file: file, line: line,
             nsError.code

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -438,7 +438,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
 
         expect(receivedUserCancelled).toEventually(beFalse())
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.domain).toEventually(equal(RCPurchasesErrorCodeDomain))
+        expect(receivedError?.domain).toEventually(equal(ErrorCode.errorDomain))
         expect(receivedError?.code).toEventually(equal(ErrorCode.productAlreadyPurchasedError.rawValue))
         expect(receivedUnderlyingError?.domain).toEventually(equal(unknownError.domain))
         expect(receivedUnderlyingError?.code).toEventually(equal(unknownError.code))
@@ -531,7 +531,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(receivedError).toEventuallyNot(beNil())
         expect(self.backend.postReceiptDataCalled).toEventually(beFalse())
 
-        expect(receivedError?.domain) == RCPurchasesErrorCodeDomain
+        expect(receivedError?.domain) == ErrorCode.errorDomain
         expect(receivedError?.code) == ErrorCode.missingReceiptFileError.rawValue
     }
 
@@ -611,7 +611,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(self.backend.postReceiptDataCalled) == false
         expect(self.storeKit1Wrapper.finishCalled) == false
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.domain).toEventually(equal(RCPurchasesErrorCodeDomain))
+        expect(receivedError?.domain).toEventually(equal(ErrorCode.errorDomain))
         expect(receivedError?.code).toEventually(equal(ErrorCode.paymentPendingError.rawValue))
     }
 
@@ -784,7 +784,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
 
         expect(receivedError).toEventuallyNot(beNil())
         expect(receivedInfo).to(beNil())
-        expect(receivedError?.domain) == RCPurchasesErrorCodeDomain
+        expect(receivedError?.domain) == ErrorCode.errorDomain
         expect(receivedError?.code) == ErrorCode.operationAlreadyInProgressForProductError.rawValue
         expect(self.storeKit1Wrapper.addPaymentCallCount) == 1
         expect(receivedUserCancelled) == false


### PR DESCRIPTION
### Motivation
Sometimes we get compilation errors in the tests targets like these:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/2a67f3f8-1589-4290-8b5f-8aaa7199934f" />

The reason is that the `RCPurchasesErrorCodeDomain` symbol is not explicitly declared in the SDK. It's the Objective-C bridge of `ErrorCode.errorDomain` and is declared in the auto-generated `RevenueCat-Swift.h` file:
```swift
static NSString * _Nonnull const RCPurchasesErrorCodeDomain = @"RevenueCat.ErrorCode";
```
But this `RevenueCat-Swift.h` file doesn't always necessarily exist.

In particular, I got this error when adding the RevenueCat dependency to Unit Tests as a Swift Package using Tuist when working on #5888.

### Description
This PR replaces the uses of `RCPurchasesErrorCodeDomain` in tests with its Swift equivalent: `ErrorCode.errorDomain`, which is always defined.