### PR TITLE
Fix flaky tests

### DIFF
--- a/Tests/BackendIntegrationTests/VirtualCurrencyIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/VirtualCurrencyIntegrationTests.swift
@@ -37,8 +37,9 @@ class VirtualCurrencyStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         let virtualCurrenciesBeforePurchase = try await self.purchases.virtualCurrencies()
         assertAllVirtualCurrenciesHaveZeroBalances(virtualCurrenciesBeforePurchase)
 
-        try await self.purchaseConsumablePackage()
-        self.verifyAnyTransactionWasFinished()
+        let resultData = try await self.purchaseConsumablePackage()
+        let transaction = try XCTUnwrap(resultData.transaction)
+        self.verifySpecificTransactionWasFinished(transaction)
 
         try self.purchases.invalidateVirtualCurrenciesCache()
 
@@ -69,8 +70,9 @@ class VirtualCurrencyStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         let virtualCurrenciesBeforePurchase = try await self.purchases.virtualCurrencies()
         assertAllVirtualCurrenciesHaveZeroBalances(virtualCurrenciesBeforePurchase)
 
-        try await self.purchaseNonConsumablePackage()
-        self.verifyAnyTransactionWasFinished()
+        let resultData = try await self.purchaseNonConsumablePackage()
+        let transaction = try XCTUnwrap(resultData.transaction)
+        self.verifySpecificTransactionWasFinished(transaction)
 
         try self.purchases.invalidateVirtualCurrenciesCache()
 


### PR DESCRIPTION
#### Fixed tests

The assertions for some tests were made more specific by checking that the expected transaction is finished. This means that logs for other transactions being finished won't affect the test result.

* VirtualCurrencyStoreKit1IntegrationTests.testGrantsVCForAutoRenewingSubscriptionWithVCGrant()
  * Recent failure [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/32459/workflows/fbd33893-82b3-4738-b4a7-278f397ddf3a/jobs/427542/tests)

Did the same improvement for `VirtualCurrencyStoreKit1IntegrationTests`'s `testGrantsVCForConsumableWithVCGrant` and `testGrantsVCForNonConsumableWithVCGrant` tests