### PR TITLE
Revert to fastlane v2.229.1 from 2.230.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # dependencies
-gem 'fastlane', '2.230.0'
+gem 'fastlane', '2.229.1'
 gem 'cocoapods', '1.16.2'
 gem 'cocoapods-trunk', '1.6.0'
 gem 'danger', '9.5.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       async (>= 1.25)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1197.0)
+    aws-partitions (1.1196.0)
     aws-sdk-core (3.240.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -199,7 +199,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.0)
-    fastlane (2.230.0)
+    fastlane (2.229.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       abbrev (~> 0.1.2)
       addressable (>= 2.8, < 3.0.0)
@@ -228,7 +228,6 @@ GEM
       http-cookie (~> 1.0.5)
       json (< 3.0.0)
       jwt (>= 2.1.0, < 3)
-      logger (>= 1.6, < 2.0)
       mini_magick (>= 4.9.4, < 5.0.0)
       multipart-post (>= 2.0.0, < 3.0.0)
       mutex_m (~> 0.3.0)
@@ -314,7 +313,7 @@ GEM
     io-event (1.11.2)
     io-stream (0.10.0)
     jmespath (1.6.2)
-    json (2.18.0)
+    json (2.16.0)
     jwt (2.10.2)
       base64
     kramdown (2.5.1)
@@ -332,7 +331,7 @@ GEM
     mini_portile2 (2.8.9)
     minitest (5.25.5)
     molinillo (0.8.0)
-    multi_json (1.18.0)
+    multi_json (1.17.0)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
     nanaimo (0.4.0)
@@ -353,7 +352,7 @@ GEM
     open3 (0.2.1)
     open4 (1.3.4)
     oppen (0.9.8)
-    optparse (0.8.1)
+    optparse (0.8.0)
     os (1.1.4)
     pastel (0.8.0)
       tty-color (~> 0.5)
@@ -464,7 +463,7 @@ DEPENDENCIES
   cocoapods-trunk (= 1.6.0)
   danger (= 9.5.3)
   emerge
-  fastlane (= 2.230.0)
+  fastlane (= 2.229.1)
   fastlane-plugin-create_xcframework!
   fastlane-plugin-emerge
   fastlane-plugin-revenuecat_internal!


### PR DESCRIPTION
This reverts PR #5950.

I believe there's a new regression in fastlane 2.230.0 where the Mac Catalyst pkg is being validated as an IPA due to the changes in https://github.com/fastlane/fastlane/pull/22145