### PR TITLE
Fix footer background image influencing footer height when using Fill / Fit mode

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -93,6 +93,12 @@ fileprivate extension View {
                     }
                     .edgesIgnoringSafeArea(.all)
                 }
+                // Enforces image clipping to the exact bounds of the view where .clipped does not.
+                // This prevents the background image from influencing the parent view's size,
+                // which was causing the footer to enlarge when using "fill" fit mode with tall images.
+                .mask(self.overlay(content: {
+                    Color.black
+                }))
                 .edgesIgnoringSafeArea(.all)
             }
         case let .video(viewModel, colorOverlay):


### PR DESCRIPTION
### Motivation
We've got a report that background images on footers were driving the size of the footer, instead of the content.

### Description
| Before | Header |
|--------|--------|
| <img width="553" height="1040" alt="before" src="https://github.com/user-attachments/assets/49f1b62b-8e2d-4a6c-a9fb-6c24daea16a9" /> |  <img width="553" height="1040" alt="after" src="https://github.com/user-attachments/assets/45fcbcd4-9bda-4dec-8db5-a4ee7950709c" /> |


