### PR TITLE
Execute `release-train` only when making a release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1699,7 +1699,7 @@ workflows:
         - not:
             equal: ["release-train", << pipeline.schedule.name >>]
         - not:
-            equal: ["bump", << pipeline.schedule.name >>]
+            equal: [bump, << pipeline.parameters.action >>]
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
     jobs:
@@ -1779,7 +1779,7 @@ workflows:
         - not:
             equal: ["release-train", << pipeline.schedule.name >>]
         - not:
-            equal: ["bump", << pipeline.schedule.name >>]
+            equal: [bump, << pipeline.parameters.action >>]
     jobs:
       - prepare-next-version:
           <<: *only-main-branch
@@ -1877,7 +1877,7 @@ workflows:
         - not:
             equal: ["release-train", << pipeline.schedule.name >>]
         - not:
-            equal: ["bump", << pipeline.schedule.name >>]
+            equal: [bump, << pipeline.parameters.action >>]
         - or:
           - matches:
               pattern: "^(release/.*|main)$"


### PR DESCRIPTION
On CI, when manually running the `bump` or when the scheduled `bump` happens, we only need `release-train` to run. Tests (`all-tests` and `build-test`) have already been executed for the same commit, so it's not useful to run them all again in the same commit, even more so as the `release-train` workflow does not wait for/require them to pass before running.

This PR simplifies it so that bumping only runs `release-train`. All tests will have been executed already on that commit in `main` and will be run before making the release on the `Release` branch