### PR TITLE
Excluding xcarchive and separate dSYMs folder from XCFramework in order to reduce download size

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1410,21 +1410,20 @@ platform :ios do
 
     # sh runs from the Fastfile's location, but other commands run from the project root.
     output_directory_for_sh = "../#{output_directory}"
+    xcframework_path = "#{output_directory_for_sh}/#{product_name}.xcframework"
 
     # Post-process headers to suppress StoreKit 1 deprecation warnings
     suppress_deprecation_warnings_in_headers(
-      xcframework_path: "#{output_directory_for_sh}/#{product_name}.xcframework"
+      xcframework_path: xcframework_path
     )
 
     # Sign XCFramework for Xcode 15
     sign_xcframework(
-      file: "#{output_directory_for_sh}/#{product_name}.xcframework"
+      file: xcframework_path
     )
 
     xcframeworks_zip_path_for_sh = "../#{product_name}.xcframework.zip"
-    sh("ditto", "-c", "-k", "--sequesterRsrc", "--keepParent",
-      output_directory_for_sh,
-      xcframeworks_zip_path_for_sh)
+    sh("ditto", "-c", "-k", "--sequesterRsrc", xcframework_path, xcframeworks_zip_path_for_sh)
 
   end
 


### PR DESCRIPTION
### Motivation
It appears that the `RevenueCat(UI).xcframework.zip` files include the xcarchive files as well as a separate dSYMs folder, even though the dSYMs are already included in the XCFramework file for each architecture slice. 

By excluding these files the size of the zip file of the last release was able to be reduced by over 65%. 

### Description
As far as I know there is no need for us to have the dSYMs in this particular spot in the zip file, since they're already in the architecture specific folder where Xcode expects them. I also don't think we're using the original xcarchive files from the zip file anywhere.

<img width="228" height="162" alt="Original directory structure" src="https://github.com/user-attachments/assets/ac441d7c-059c-4954-ae59-4daf99c9ee26" />

<img width="248" height="131" alt="New directory structure" src="https://github.com/user-attachments/assets/a29fd7e6-f5f9-41c7-9e54-d1aff852cc6f" />
