### PR TITLE
Fixed compilation of generated XCFramework because of synthesized Codable conformance in extension

### DIFF
--- a/Sources/Ads/Events/AdEvent.swift
+++ b/Sources/Ads/Events/AdEvent.swift
@@ -495,7 +495,7 @@ extension AdRevenue {
 // MARK: - Internal Event Enum
 
 /// Internal event enum for type-safe routing through the events system.
-internal enum AdEvent: Codable {
+internal enum AdEvent: Equatable, Codable, Sendable {
 
     // swiftlint:disable type_name
 


### PR DESCRIPTION
I noticed that between release [5.51.1](https://github.com/RevenueCat/purchases-ios/releases/tag/5.51.1) and [5.52.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.52.0) the XCFramework broke and currently doesn't compile on my machine.

It appears to be related to the synthesized Codable conformance in the Ad model types, which were previously behind a feature flag which was removed in https://github.com/RevenueCat/purchases-ios/pull/5943

I'm not 100% sure why this is only a problem when using the XCFramework to be honest, since compiling from source works as expected. This requires some more investigation and some CI checks in order to prevent the XCFramework from breaking again in the future. I'm working on this in a separate PR. For now this just fixes the issue.

<img width="739" height="363" alt="Screenshot 2025-12-29 at 12 15 03" src="https://github.com/user-attachments/assets/cd8fd8fe-c879-4c57-92ea-1362da53bd13" />
