### PR TITLE
Updated reference snapshot for load shedder offerings response

### DIFF
--- a/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferingsFromLoadShedder.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferingsFromLoadShedder.1.json
@@ -1517,9 +1517,6 @@
           "tos_url" : "https://revenuecat.com/tos"
         },
         "default_locale" : "en_US",
-        "exit_offers" : {
-
-        },
         "localized_strings" : {
           "en_US" : {
             "call_to_action" : "Continue",


### PR DESCRIPTION
The `exit_offers` object was removed for V1 paywall responses in the offerings endpoint.