### PR TITLE
[v4] Remove brew tap of unused repository in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,6 @@ commands:
           steps:
             - install-brew-dependency:
                 dependency_name: "swiftlint"
-      - run: brew tap robotsandpencils/made
       - save_cache:
           key: homebrew-cache-{{ checksum "Brewfile.lock.json" }}-{{ arch }}
           paths:


### PR DESCRIPTION
V4 back-port of https://github.com/RevenueCat/purchases-ios/pull/5890 to get CI working again.