### PR TITLE
Fix Nimble test failure reporting in Tuist workspace

### DIFF
--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -6,7 +6,16 @@
 
     let packageSettings = PackageSettings(
         productTypes: [
+            // Nimble and its dependencies must be dynamic frameworks
+            // to fix "Attempted to report a test failure to XCTest while no test case was running"
+            // See: https://github.com/Quick/Nimble/issues/1101
             "Nimble": .framework,
+            "NimbleObjectiveC": .framework,
+            "CwlPreconditionTesting": .framework,
+            "CwlPosixPreconditionTesting": .framework,
+            "CwlCatchException": .framework,
+            "CwlMachBadInstructionHandler": .framework,
+            // Other frameworks
             "SnapshotTesting": .framework, // default is .staticFramework,
             "RevenueCat": .framework,
             "RevenueCatUI": .framework,


### PR DESCRIPTION
### Description
Fixes the "Attempted to report a test failure to XCTest while no test case was running" error that occurs when Nimble assertions fail in the Tuist-generated workspace.

### Problem

When running tests in the Tuist workspace, Nimble assertions that fail would produce:

```
Attempted to report a test failure to XCTest while no test case was running. The failure was:
"expected to be nil, got <file:///...>"
```

This is a known issue with Nimble when linked statically in Swift concurrency environments. See: https://github.com/Quick/Nimble/issues/1101

### Solution

Configure Nimble and all its dependencies as dynamic frameworks in `Tuist/Package.swift`:

- `Nimble`
- `NimbleObjectiveC`
- `CwlPreconditionTesting`
- `CwlPosixPreconditionTesting`
- `CwlCatchException`
- `CwlMachBadInstructionHandler`

Dynamic linking preserves the XCTest context needed for Nimble's failure reporting mechanism.

### Testing

- Verified that intentionally failing Nimble assertions now report correctly
- All existing tests continue to pass