### PR TITLE
Install Swiftlint via Mise

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 orbs:
   macos: circleci/macos@2.5.1
   slack: circleci/slack@5.0.0
-  revenuecat: revenuecat/sdks-common-config@3.9.0
+  revenuecat: revenuecat/sdks-common-config@3.10.0
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 
@@ -152,7 +152,6 @@ commands:
     steps:
       - install-dependencies:
           install_xcbeautify: false
-          install_swiftlint: false
           install_xcodes: true
       - run:
           name: Install simulator
@@ -217,9 +216,6 @@ commands:
       install_mint_0_17_5:
         type: boolean
         default: false
-      install_swiftlint:
-        type: boolean
-        default: true
       install_xcodes:
         type: boolean
         default: false
@@ -232,7 +228,6 @@ commands:
             echo "xcbeautify:<< parameters.install_xcbeautify >>" > .homebrew-deps
             echo "mint:<< parameters.install_mint >>" >> .homebrew-deps
             echo "mint_0_17_5:<< parameters.install_mint_0_17_5 >>" >> .homebrew-deps
-            echo "swiftlint:<< parameters.install_swiftlint >>" >> .homebrew-deps
             echo "xcodes:<< parameters.install_xcodes >>" >> .homebrew-deps
       - restore_cache:
           keys:
@@ -252,11 +247,6 @@ commands:
           steps:
             - install-mint-0_17_5
       - when:
-          condition: << parameters.install_swiftlint >>
-          steps:
-            - install-brew-dependency:
-                dependency_name: "swiftlint"
-      - when:
           condition: << parameters.install_xcodes >>
           steps:
             - install-brew-dependency:
@@ -264,7 +254,6 @@ commands:
       - save_cache:
           key: homebrew-cache-{{ checksum ".homebrew-deps" }}-{{ arch }}
           paths:
-            - /usr/local/Cellar/swiftlint/
             - /usr/local/Cellar/xcbeautify/
             - /usr/local/Cellar/xcodes/
             - /Users/$USER/Library/Caches/Homebrew/
@@ -628,7 +617,6 @@ jobs:
       # which uses xcpretty
       - install-dependencies:
           install_xcbeautify: false
-          install_swiftlint: false
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Tests
@@ -661,7 +649,6 @@ jobs:
       # which uses xcpretty
       - install-dependencies:
           install_xcbeautify: false
-          install_swiftlint: false
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Release Build
@@ -698,7 +685,6 @@ jobs:
       # which uses xcpretty
       - install-dependencies:
           install_xcbeautify: false
-          install_swiftlint: false
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Release Build
@@ -734,7 +720,6 @@ jobs:
       # which uses xcpretty
       - install-dependencies:
           install_xcbeautify: false
-          install_swiftlint: false
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Release Build
@@ -770,7 +755,6 @@ jobs:
       # which uses xcpretty
       - install-dependencies:
           install_xcbeautify: false
-          install_swiftlint: false
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Release Build
@@ -804,7 +788,6 @@ jobs:
       # which uses xcpretty
       - install-dependencies:
           install_xcbeautify: false
-          install_swiftlint: false
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Tests
@@ -854,8 +837,7 @@ jobs:
       xcode_version: "26.0.1"
     steps:
       - checkout
-      - install-dependencies:
-          install_swiftlint: false
+      - install-dependencies
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
@@ -882,8 +864,7 @@ jobs:
 
     steps:
       - checkout
-      - install-dependencies:
-          install_swiftlint: false
+      - install-dependencies
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
@@ -913,7 +894,6 @@ jobs:
       - install-dependencies:
           install_xcbeautify: false
           install_mint: true
-          install_swiftlint: false
       - install-xcbeautify-for-xcode15
       - run:
           name: Run tests
@@ -944,7 +924,6 @@ jobs:
       - install-dependencies:
           install_xcbeautify: false
           install_mint: true
-          install_swiftlint: false
       - install-xcbeautify-for-xcode15
       - update-spm-installation-commit
       - run:
@@ -980,7 +959,6 @@ jobs:
       - install-dependencies:
           install_xcbeautify: false
           install_mint: true
-          install_swiftlint: false
       - install-xcbeautify-for-xcode15
       - update-spm-installation-commit
       - install-runtime:
@@ -1066,7 +1044,6 @@ jobs:
           install_xcbeautify: false
           # Mint 0.17.5 is required here as newer versions of Mint don't support macOS 12.
           install_mint_0_17_5: true
-          install_swiftlint: false
       - install-xcbeautify-for-xcode14
       - update-spm-installation-commit
       - install-runtime:
@@ -1101,7 +1078,6 @@ jobs:
       - install-dependencies:
           install_xcbeautify: false
           install_mint: true
-          install_swiftlint: false
       - macos/install-rosetta
       - install-xcbeautify-for-xcode14
       - update-spm-installation-commit
@@ -1209,8 +1185,7 @@ jobs:
           platform: "iOS"
           device: "iPhone 16 Pro"
       - checkout
-      - install-dependencies:
-          install_swiftlint: false
+      - install-dependencies
       - revenuecat/install-maestro
       - tuist-generate-workspace:
           query: "Maestro"
@@ -1449,14 +1424,18 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - install-dependencies
+      - install-dependencies:
+          install_xcbeautify: false
+      - revenuecat/install-swiftlint
       - run:
           command: mkdir -p fastlane/test_output/swiftlint
       - run:
           name: Run fastlane swiftlint lane
           command: |
+            export PATH="$HOME/.local/share/mise/shims:$PATH"
             bundle exec fastlane run swiftlint raise_if_swiftlint_error:true strict:true \
             reporter:junit output_file:fastlane/test_output/swiftlint/junit.xml
+          no_output_timeout: 5m
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -1615,8 +1594,7 @@ jobs:
 
     steps:
       - checkout
-      - install-dependencies:
-          install_swiftlint: false
+      - install-dependencies
       - run:
           name: Fetch paywall-preview-resources
           command: bundle exec fastlane ios fetch_paywall_preview_resources

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 tuist = "4.48.2"
+swiftlint = "0.62.2"
 
 [hooks]
 postinstall = "mise run install"


### PR DESCRIPTION
### Motivation
Test SwiftLint via mise

### Description
Instead of updating it through homebrew, we're now using mise to install SwiftLint (and have a fixed version). 

We need to do this in any repo that installs SwiftLint 💅 
