### PR TITLE
Fixes path used for event storage on macOS

### DIFF
--- a/Sources/Ads/Events/AdEventStore.swift
+++ b/Sources/Ads/Events/AdEventStore.swift
@@ -119,6 +119,13 @@ extension AdEventStore {
     }
 
     private static func revenueCatFolder(in container: URL) -> URL {
+        #if os(macOS)
+        // Prefix with bundleID if the path is not scoped to an app container to avoid conflicts.
+        if !container.path.contains("/Library/Containers/"),
+           let bundleID = Bundle.main.bundleIdentifier {
+            return container.appendingPathComponent("\(bundleID).revenuecat")
+        }
+        #endif
         return container.appendingPathComponent("revenuecat")
     }
 

--- a/Sources/Events/FeatureEvents/FeatureEventStore.swift
+++ b/Sources/Events/FeatureEvents/FeatureEventStore.swift
@@ -122,6 +122,13 @@ extension FeatureEventStore {
     }
 
     private static func revenueCatFolder(in container: URL) -> URL {
+        #if os(macOS)
+        // Prefix with bundleID if the path is not scoped to an app container to avoid conflicts.
+        if !container.path.contains("/Library/Containers/"),
+           let bundleID = Bundle.main.bundleIdentifier {
+            return container.appendingPathComponent("\(bundleID).revenuecat")
+        }
+        #endif
         return container.appendingPathComponent("revenuecat")
     }
 


### PR DESCRIPTION
## Description
There are some scenarios on macOS in which the Application Support directory is shared between apps. We're using the `revenuecat` subfolder for feature events, which means we can have conflicts with other apps using RC on the same machine.

This only happens for non-sandboxed apps so this is unlikely to be an actual problem as non-sandboxed apps cannot be published on the Mac App Store.

This is a very quick fix without any cleanup at the old path. We can do that in a follow-up PR. 