### PR TITLE
Added zero_decimal_place_countries in backend integration tests offerings snapshot reference

### DIFF
--- a/Tests/BackendIntegrationTests/__Snapshots__/FallbackURLBackendIntegrationTests/testCanGetOfferingsFromFallbackURL.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/FallbackURLBackendIntegrationTests/testCanGetOfferingsFromFallbackURL.1.json
@@ -1466,7 +1466,17 @@
 
         },
         "revision" : 2,
-        "template_name" : "components"
+        "template_name" : "components",
+        "zero_decimal_place_countries" : {
+          "apple" : [
+            "TWN",
+            "KAZ",
+            "MEX",
+            "PHL",
+            "THA",
+            "IND"
+          ]
+        }
       }
     },
     {

--- a/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferingsFromLoadShedder.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferingsFromLoadShedder.1.json
@@ -1457,7 +1457,17 @@
 
         },
         "revision" : 2,
-        "template_name" : "components"
+        "template_name" : "components",
+        "zero_decimal_place_countries" : {
+          "apple" : [
+            "TWN",
+            "KAZ",
+            "MEX",
+            "PHL",
+            "THA",
+            "IND"
+          ]
+        }
       }
     },
     {

--- a/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
@@ -1466,7 +1466,17 @@
 
         },
         "revision" : 2,
-        "template_name" : "components"
+        "template_name" : "components",
+        "zero_decimal_place_countries" : {
+          "apple" : [
+            "TWN",
+            "KAZ",
+            "MEX",
+            "PHL",
+            "THA",
+            "IND"
+          ]
+        }
       }
     },
     {


### PR DESCRIPTION
Backend integration tests broke because of this newly added field. This PR adds them to the regular backend integration tests, load shedder and fallback ones.