### PR TITLE
fix: Refresh purchase information after manage subscriptions sheet dismissal

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -187,20 +187,6 @@ import Foundation
 
     #endif
 
-    func publisher(for purchase: PurchaseInformation?) -> AnyPublisher<PurchaseInformation, Never>? {
-        guard let productIdentifier = purchase?.productIdentifier else {
-            return nil
-        }
-
-        return $subscriptionsSection.combineLatest($nonSubscriptionsSection)
-            .throttle(for: .seconds(0.3), scheduler: DispatchQueue.main, latest: true)
-            .compactMap {
-                $0.first(where: { $0.productIdentifier == productIdentifier })
-                ?? $1.first(where: { $0.productIdentifier == productIdentifier })
-            }
-            .eraseToAnyPublisher()
-    }
-
     func loadScreen(shouldSync: Bool = false) async {
         do {
             let customerInfo = shouldSync ?


### PR DESCRIPTION


<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
