### PR TITLE
Added a public initializer to the CustomerInfo class

### DIFF
--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -271,6 +271,46 @@ extension PeriodType: DefaultValueProvider {
         self.rawData = entitlement.rawData
     }
 
+    /// Initializes an ``EntitlementInfo`` instance.
+    /// Useful for Unit testing purposes, since the other (internal) initializers require a backend response
+    public init(
+        identifier: String,
+        isActive: Bool,
+        willRenew: Bool,
+        periodType: PeriodType,
+        latestPurchaseDate: Date? = nil,
+        originalPurchaseDate: Date? = nil,
+        expirationDate: Date? = nil,
+        store: Store,
+        productIdentifier: String,
+        productPlanIdentifier: String? = nil,
+        isSandbox: Bool,
+        unsubscribeDetectedAt: Date? = nil,
+        billingIssueDetectedAt: Date? = nil,
+        ownershipType: PurchaseOwnershipType,
+        verification: VerificationResult = .notRequested
+    ) {
+        self.contents = .init(
+            identifier: identifier,
+            isActive: isActive,
+            willRenew: willRenew,
+            periodType: periodType,
+            latestPurchaseDate: latestPurchaseDate,
+            originalPurchaseDate: originalPurchaseDate,
+            expirationDate: expirationDate,
+            store: store,
+            productIdentifier: productIdentifier,
+            productPlanIdentifier: productPlanIdentifier,
+            isSandbox: isSandbox,
+            unsubscribeDetectedAt: unsubscribeDetectedAt,
+            billingIssueDetectedAt: billingIssueDetectedAt,
+            ownershipType: ownershipType,
+            verification: verification
+        )
+        self.rawData = [:]
+        self.sandboxEnvironmentDetector = BundleSandboxEnvironmentDetector.default
+    }
+
     // MARK: -
 
     private let contents: Contents
@@ -336,9 +376,7 @@ extension EntitlementInfo: Identifiable {
 }
 
 private extension EntitlementInfo {
-
     struct Contents: Equatable, Hashable {
-
         let identifier: String
         let isActive: Bool
         let willRenew: Bool
@@ -354,9 +392,7 @@ private extension EntitlementInfo {
         let billingIssueDetectedAt: Date?
         let ownershipType: PurchaseOwnershipType
         let verification: VerificationResult
-
     }
-
 }
 
 extension EntitlementInfo.Contents: Sendable {}

--- a/Sources/Purchasing/EntitlementInfos.swift
+++ b/Sources/Purchasing/EntitlementInfos.swift
@@ -58,9 +58,11 @@ import Foundation
 
     // MARK: -
 
-    init(
-        entitlements: [String: EntitlementInfo],
-        verification: VerificationResult
+    /// Initializes an ``EntitlementInfos`` instance.
+    /// Useful for Unit testing purposes, since the other (internal) initializers require a backend response
+    public init(
+        entitlements: [String: EntitlementInfo] = [:],
+        verification: VerificationResult = .notRequested
     ) {
         self.all = entitlements
         self._verification = verification

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/CustomerInfoAPI.swift
@@ -66,3 +66,25 @@ func checkDeprecatedAPI() {
     let _: Set<String> = customerInfo.nonConsumablePurchases
     let _: [StoreTransaction] = customerInfo.nonSubscriptionTransactions
 }
+
+func checkCanCreateCustomerInfo() {
+    var entitlementInfos: EntitlementInfos!
+    _ = CustomerInfo(
+        entitlements: entitlementInfos,
+        requestDate: Date(),
+        firstSeen: Date(),
+        originalAppUserId: ""
+    )
+    
+    _ = CustomerInfo(
+        entitlements: entitlementInfos,
+        expirationDatesByProductId: ["": Date()],
+        purchaseDatesByProductId: ["": Date()],
+        allPurchasedProductIds: Set([""]),
+        requestDate: Date(),
+        firstSeen: Date(),
+        originalAppUserId: "",
+        originalPurchaseDate: Date(),
+        managementURL: URL(string: "Test")!
+    )
+}

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/EntitlementInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/EntitlementInfoAPI.swift
@@ -70,3 +70,34 @@ func checkEntitlementInfoEnums() {
         fatalError()
     }
 }
+
+func checkCanCreateEntitlementInfo() {
+    _ = EntitlementInfo(
+        identifier: "entitlement_id",
+        isActive: true,
+        willRenew: true,
+        periodType: .intro,
+        store: .appStore,
+        productIdentifier: "com.revenuecat.test",
+        isSandbox: false,
+        ownershipType: .purchased
+    )
+
+    _ = EntitlementInfo(
+        identifier: "entitlement_id",
+        isActive: true,
+        willRenew: true,
+        periodType: .trial,
+        latestPurchaseDate: Date(),
+        originalPurchaseDate: Date(),
+        expirationDate: Date(),
+        store: .appStore,
+        productIdentifier: "com.revenuecat.test",
+        productPlanIdentifier: "plan_id",
+        isSandbox: true,
+        unsubscribeDetectedAt: Date(),
+        billingIssueDetectedAt: Date(),
+        ownershipType: .purchased,
+        verification: .verified
+    )
+}

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/EntitlementInfosAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/EntitlementInfosAPI.swift
@@ -25,3 +25,21 @@ func checkEntitlementInfosAPI() {
 
     print(eis!, all, active, activeInAnyEnvironment, activeInCurrentEnvironment, enti!)
 }
+
+func checkCanCreateEntitlementInfos() {
+    _ = EntitlementInfos()
+    
+    _ = EntitlementInfos(
+        entitlements: ["": EntitlementInfo(
+            identifier: "",
+            isActive: true,
+            willRenew: true,
+            periodType: .intro,
+            store: .appStore,
+            productIdentifier: "com.revenuecat.test",
+            isSandbox: false,
+            ownershipType: .purchased
+        )],
+        verification: .verified
+    )
+}


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Useful for unit testing. For example, testing an implementation of several methods of `PaywallViewControllerDelegate`  requires passing a `CustomerInfo` object, but it currently cannot be constructed outside of the SDK. 

### Description
This PR adds a public initializer to `CustomerInfo` as well as its dependencies `EntitlementInfo` and `EntitlementInfo`. I tried implementing them by exposing as little internal types and aligning it with [Android](https://github.com/RevenueCat/purchases-android/blob/main/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfo.kt#L73) as much as possible
