### PR TITLE
Prewarm images in tabs control

### DIFF
--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -139,6 +139,10 @@ extension PaywallComponentsData.PaywallComponentsConfig {
                     urls += item.icon.imageUrls
                 }
             case .tabs(let tabs):
+                urls += self.collectAllImageURLs(
+                    in: tabs.control.stack,
+                    includeHighResInComponentHeirarchy: includeHighResInComponentHeirarchy
+                )
                 for tab in tabs.tabs {
                     urls += self.collectAllImageURLs(
                         in: tab.stack,


### PR DESCRIPTION
Images in the controls of the tabs were not being prewarmed, causing them to not display correctly

The cache warming logic was crawling `tabs.tabs` (the tab content) but missing `tabs.control.stack` (the control buttons).
