### PR TITLE
Reduce flakiness of an Offline StoreKit integration test

### DIFF
--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -333,6 +333,10 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchasingMultipleProductsWhileServerIsDownHandlesAllTransactionsWhenForegroundingApp() async throws {
+        // To prevent the subscription renewal from happening during the test. Otherwise,
+        // it could sometimes interfere with the consumable purchase verification, causing flakiness.
+        self.setLongestTestSessionTimeRate(self.testSession)
+
         self.logger.clearMessages()
 
         // 1. Purchase while server is down


### PR DESCRIPTION
### Description

Fix flaky test `OfflineStoreKit1IntegrationTests.testPurchasingMultipleProductsWhileServerIsDownHandlesAllTransactionsWhenForegroundingApp()` by preventing StoreKit subscription auto-renewal during execution.

Sets the longest StoreKit test session time rate at the start of the test to avoid subscription renewals occurring mid-test, which could interfere with consumable purchase verification and cause flakiness.