### PR TITLE
[EXTERNAL] fix: dont show video in now playing (control center/lock screen)

### DIFF
--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -91,6 +91,9 @@ enum Strings {
     case customFontFailedToLoad(fontName: String)
     case googleFontsNotSupported
 
+    // Video
+    case video_failed_to_set_audio_session_category(Error)
+
     // Exit Offers
     case errorFetchingOfferings(Error)
     case exitOfferNotFound(String)
@@ -302,6 +305,9 @@ extension Strings: CustomStringConvertible {
             return "Custom font '\(fontName)' could not be loaded. Falling back to system font."
         case .googleFontsNotSupported:
             return "Google Fonts are not supported on this platform"
+
+        case .video_failed_to_set_audio_session_category(let error):
+            return "Failed to set audio session category: \(error)"
 
         case .errorFetchingOfferings(let error):
             return "Error fetching offerings: \(error)"

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
@@ -12,6 +12,7 @@
 //  Created by Jacob Zivan Rakidzich on 8/18/25.
 
 import AVKit
+import RevenueCat
 import SwiftUI
 
 #if canImport(UIKit) && !os(watchOS)
@@ -53,12 +54,6 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
         avPlayer.preventsDisplaySleepDuringVideoPlayback = false
         avPlayer.allowsExternalPlayback = false
 
-        try? AVAudioSession.sharedInstance().setCategory(
-            .ambient,
-            mode: .default,
-            options: [.mixWithOthers]
-        )
-
         self.player = avPlayer
 
         if shouldAutoPlay {
@@ -66,7 +61,26 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
         }
     }
 
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
     func makeUIViewController(context: Context) -> AVPlayerViewController {
+        let audioSession = AVAudioSession.sharedInstance()
+        context.coordinator.previousCategory = audioSession.category
+        context.coordinator.previousMode = audioSession.mode
+        context.coordinator.previousOptions = audioSession.categoryOptions
+
+        do {
+            try audioSession.setCategory(
+                .ambient,
+                mode: .default,
+                options: [.mixWithOthers]
+            )
+        } catch {
+            Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
+        }
+
         let controller = AVPlayerViewController()
         controller.player = player
         controller.view.backgroundColor = .clear
@@ -84,5 +98,29 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: AVPlayerViewController, context: Context) { }
+
+    class Coordinator {
+        var previousCategory: AVAudioSession.Category?
+        var previousMode: AVAudioSession.Mode?
+        var previousOptions: AVAudioSession.CategoryOptions?
+
+        deinit {
+            guard let category = previousCategory,
+                  let mode = previousMode,
+                  let options = previousOptions else {
+                return
+            }
+
+            do {
+                try AVAudioSession.sharedInstance().setCategory(
+                    category,
+                    mode: mode,
+                    options: options
+                )
+            } catch {
+                Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
+            }
+        }
+    }
 }
 #endif


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

Resolves #6006 

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

I have observed that media also could be viewed in Dynamic Island.

Set `preventsDisplaySleepDuringVideoPlayback`, `allowsExternalPlayback` to false, to make sure the media doesnt show up in now playing.

Used ambient category for AVAudioSession, making it so that it doesnt block other audio while video is playing. 

On AVPlayerViewController, set `allowsPictureInPicturePlayback` to false, to make sure this media cant be played elsewhere.

Old pr: #6009 