### PR TITLE
Add missing APITests for Exit Offers

### DIFF
--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewControllerAPI.swift
@@ -133,6 +133,9 @@ final class Delegate: PaywallViewControllerDelegate {
     func paywallViewControllerDidStartPurchase(_ controller: PaywallViewController) {}
 
     func paywallViewController(_ controller: PaywallViewController,
+                               didStartPurchaseWith package: Package) {}
+
+    func paywallViewController(_ controller: PaywallViewController,
                                didFinishPurchasingWith customerInfo: CustomerInfo) {}
 
     func paywallViewController(_ controller: PaywallViewController,
@@ -156,6 +159,9 @@ final class Delegate: PaywallViewControllerDelegate {
 
     func paywallViewController(_ controller: PaywallViewController,
                                didChangeSizeTo size: CGSize) {}
+
+    func paywallViewController(_ controller: PaywallViewController,
+                               willPresentExitOfferController exitOfferController: PaywallViewController) {}
 
 }
 

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/PaywallAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/PaywallAPI.swift
@@ -204,9 +204,10 @@ func checkPaywallEvent(_ event: PaywallEvent) {
     case let .close(creationData, data):
         checkPaywallEventCreationData(creationData)
         checkPaywallEventData(data)
-    case let .exitOffer(creationData, data, _):
+    case let .exitOffer(creationData, data, exitOfferData):
         checkPaywallEventCreationData(creationData)
         checkPaywallEventData(data)
+        checkExitOfferData(exitOfferData)
     case let .purchaseInitiated(creationData, data):
         checkPaywallEventCreationData(creationData)
         checkPaywallEventData(data)
@@ -216,7 +217,9 @@ func checkPaywallEvent(_ event: PaywallEvent) {
     @unknown default: break
     }
 
+    let _: PaywallEvent.CreationData = event.creationData
     let _: PaywallEvent.Data = event.data
+    let _: PaywallEvent.ExitOfferData? = event.exitOfferData
 }
 
 func checkPaywallEventCreationData(_ creationData: PaywallEvent.CreationData) {
@@ -269,4 +272,36 @@ func checkPaywallComponentsData(_ data: PaywallComponentsData) {
     let _: Int = data.revision
     let _: [String] = data.zeroDecimalPlaceCountries
     let _: String = data.defaultLocale
+}
+
+func checkExitOffer(_ exitOffer: ExitOffer) {
+    let offeringId: String = exitOffer.offeringId
+
+    let _: ExitOffer = ExitOffer(offeringId: offeringId)
+}
+
+func checkExitOffers(_ exitOffers: ExitOffers) {
+    let dismiss: ExitOffer? = exitOffers.dismiss
+
+    let _: ExitOffers = ExitOffers()
+    let _: ExitOffers = ExitOffers(dismiss: dismiss)
+}
+
+func checkExitOfferType(_ type: ExitOfferType) {
+    switch type {
+    case .dismiss:
+        break
+    @unknown default:
+        break
+    }
+}
+
+func checkExitOfferData(_ data: PaywallEvent.ExitOfferData) {
+    let exitOfferType: ExitOfferType = data.exitOfferType
+    let exitOfferingIdentifier: String = data.exitOfferingIdentifier
+
+    let _: PaywallEvent.ExitOfferData = PaywallEvent.ExitOfferData(
+        exitOfferType: exitOfferType,
+        exitOfferingIdentifier: exitOfferingIdentifier
+    )
 }


### PR DESCRIPTION
### Motivation
I've noticed we're missing these for Exit Offers.
