### PR TITLE
Avoid public enums

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -97,6 +97,7 @@ def check_for_public_enums
     .select { |file| File.exist?(file) }
 
   public_enum_pattern = /^\+\s*public\s+enum\s+/
+  spi_public_enum_pattern = /@_spi\([^)]*\)\s*public\s+enum/
 
   files_with_public_enums = []
 
@@ -105,7 +106,7 @@ def check_for_public_enums
     next unless diff
 
     diff.patch.each_line do |line|
-      if line.match?(public_enum_pattern)
+      if line.match?(public_enum_pattern) && !line.match?(spi_public_enum_pattern)
         files_with_public_enums << file
         break
       end


### PR DESCRIPTION
### Motivation
@vegaro reminded me about https://github.com/RevenueCat/purchases-ios/pull/6080#discussion_r2730851708

### Description
Warn automatically if a public enum is added

<img width="883" height="256" alt="Screenshot 2026-01-27 at 11 43 36" src="https://github.com/user-attachments/assets/92ff0c58-f4af-49b9-9846-6aee03699d0d" />
