### PR TITLE
Fix potential infinite recursion in MagicWeather

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Magic Weather SwiftUI.xcodeproj/project.pbxproj
+++ b/Examples/MagicWeatherSwiftUI/Magic Weather SwiftUI.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		A73C6F032E29944D00DBC86A /* PurchasesDelegateHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73C6EEA2E29944D00DBC86A /* PurchasesDelegateHandler.swift */; };
 		A73C6F042E29944D00DBC86A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73C6EEF2E29944D00DBC86A /* ContentView.swift */; };
 		A73C6F052E29944D00DBC86A /* WeatherViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73C6EED2E29944D00DBC86A /* WeatherViewModel.swift */; };
+		CCF831142F29F96000829663 /* PresentableNSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF831132F29F95500829663 /* PresentableNSError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -52,6 +53,7 @@
 		A73C6EF22E29944D00DBC86A /* WeatherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherView.swift; sourceTree = "<group>"; };
 		A73C6EF52E29944D00DBC86A /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		A73C6EF62E29944D00DBC86A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		CCF831132F29F95500829663 /* PresentableNSError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentableNSError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,6 +113,7 @@
 		A73C6EE82E29944D00DBC86A /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				CCF831132F29F95500829663 /* PresentableNSError.swift */,
 				A73C6EE62E29944D00DBC86A /* Extensions.swift */,
 				A73C6EE72E29944D00DBC86A /* SampleData.swift */,
 			);
@@ -251,6 +254,7 @@
 				A73C6EFF2E29944D00DBC86A /* UserView.swift in Sources */,
 				A73C6F002E29944D00DBC86A /* WeatherView.swift in Sources */,
 				A73C6F012E29944D00DBC86A /* SampleData.swift in Sources */,
+				CCF831142F29F96000829663 /* PresentableNSError.swift in Sources */,
 				A73C6F022E29944D00DBC86A /* PaywallView.swift in Sources */,
 				A73C6F032E29944D00DBC86A /* PurchasesDelegateHandler.swift in Sources */,
 				A73C6F042E29944D00DBC86A /* ContentView.swift in Sources */,

--- a/Examples/MagicWeatherSwiftUI/MagicWeatherSwiftUI/Sources/Helpers/PresentableNSError.swift
+++ b/Examples/MagicWeatherSwiftUI/MagicWeatherSwiftUI/Sources/Helpers/PresentableNSError.swift
@@ -1,0 +1,32 @@
+//
+//  PresentableNSError.swift
+//  Magic Weather SwiftUI
+//
+//  Created by Mustapha Tarek Ben Lechhab on 2026-01-28.
+//
+
+import Foundation
+
+struct PresentableNSError: LocalizedError {
+    let nsError: NSError
+
+    init(_ error: Error) {
+        self.nsError = error as NSError
+    }
+
+    var errorDescription: String? {
+        nsError.localizedDescription
+    }
+    
+    var failureReason: String? {
+        nsError.localizedFailureReason ?? (nsError.userInfo[NSLocalizedFailureReasonErrorKey] as? String)
+    }
+    
+    var recoverySuggestion: String? {
+        nsError.localizedRecoverySuggestion ?? (nsError.userInfo[NSLocalizedRecoverySuggestionErrorKey] as? String)
+    }
+    
+    var helpAnchor: String? {
+        nsError.helpAnchor ?? (nsError.userInfo[NSHelpAnchorErrorKey] as? String)
+    }
+}

--- a/Examples/MagicWeatherSwiftUI/MagicWeatherSwiftUI/Sources/Views/PaywallView.swift
+++ b/Examples/MagicWeatherSwiftUI/MagicWeatherSwiftUI/Sources/Views/PaywallView.swift
@@ -40,7 +40,7 @@ private struct PaywallContent: View {
 
     /// - State for displaying an overlay view
     @State private var isPurchasing: Bool = false
-    @State private var error: NSError?
+    @State private var error: PresentableNSError?
     @State private var displayError: Bool = false
 
     var body: some View {
@@ -67,7 +67,7 @@ private struct PaywallContent: View {
                                     }
                                 } catch {
                                     self.isPurchasing = false
-                                    self.error = error as NSError
+                                    self.error = PresentableNSError(error)
                                     self.displayError = true
                                 }
                             }
@@ -148,14 +148,6 @@ private struct PackageCellView: View {
                 .bold()
         }
         .contentShape(Rectangle()) // Make the whole cell tappable
-    }
-
-}
-
-extension NSError: LocalizedError {
-
-    public var errorDescription: String? {
-        return self.localizedDescription
     }
 
 }


### PR DESCRIPTION
### Motivation

We [received a report](https://community.revenuecat.com/sdks-51/investigating-a-crash-with-nserror-from-sample-project-7364) that the MagicWeather sample app can sometimes crash due to an infinite recursion in the following extension:

```swift
extension NSError: LocalizedError {

    public var errorDescription: String? {
        return self.localizedDescription
    }

}
```

After researching it, it turns out that it can sometimes end up in an infinite recursion indeed.

### Description

This PR introduces the following fix:

- Add a new `PresentableNSError` where the bridging is clearer and leaves not room for ambiguity
- Update call sites
