### PR TITLE
Add RevenueCatUI to Obj-c APITests

### DIFF
--- a/Projects/APITesters/Project.swift
+++ b/Projects/APITesters/Project.swift
@@ -45,7 +45,8 @@ let project = Project(
                 ]
             ),
             dependencies: [
-                .revenueCat
+                .revenueCat,
+                .revenueCatUI
             ],
             metadata: .metadata(tags: ["APITester"])
         ),


### PR DESCRIPTION
### Motivation
Seems like [this PR](https://github.com/RevenueCat/purchases-ios/pull/6080) broke API tests (failure [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/33822/workflows/4e42a13e-1160-440d-974a-977584c13db2/jobs/457469))

