### PR TITLE
Inject `SandboxEnvironmentDetector` for integration test

### DIFF
--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -22,19 +22,22 @@ import Foundation
         let forceSignatureFailures: Bool
         let disableHeaderSignatureVerification: Bool
         let testReceiptIdentifier: String?
+        let testSandboxEnvironmentDetector: SandboxEnvironmentDetectorType?
 
         init(
             enableReceiptFetchRetry: Bool = false,
             forceServerErrorStrategy: ForceServerErrorStrategy? = nil,
             forceSignatureFailures: Bool = false,
             disableHeaderSignatureVerification: Bool = false,
-            testReceiptIdentifier: String? = nil
+            testReceiptIdentifier: String? = nil,
+            testSandboxEnvironmentDetector: SandboxEnvironmentDetectorType? = nil
         ) {
             self.enableReceiptFetchRetry = enableReceiptFetchRetry
             self.forceServerErrorStrategy = forceServerErrorStrategy
             self.forceSignatureFailures = forceSignatureFailures
             self.disableHeaderSignatureVerification = disableHeaderSignatureVerification
             self.testReceiptIdentifier = testReceiptIdentifier
+            self.testSandboxEnvironmentDetector = testSandboxEnvironmentDetector
         }
         #else
         init(
@@ -155,6 +158,9 @@ internal protocol InternalDangerousSettingsType: Sendable {
     /// Allows defining the receipt identifier for `PostReceiptDataOperation`.
     /// This allows the backend to disambiguate between receipts created across separate test invocations.
     var testReceiptIdentifier: String? { get }
+
+    /// Allows injecting a custom `SandboxEnvironmentDetector` for integration tests only.
+    var testSandboxEnvironmentDetector: SandboxEnvironmentDetectorType? { get }
 
     #endif
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -358,7 +358,17 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
         let transactionFetcher = StoreKit2TransactionFetcher(diagnosticsTracker: diagnosticsTracker)
 
-        let sandboxEnvironmentDetector = SandboxEnvironmentDetector(transactionFetcher: transactionFetcher)
+        var injectedSandboxEnvironmentDetector: SandboxEnvironmentDetectorType?
+
+        #if DEBUG
+        if ProcessInfo.isRunningIntegrationTests {
+            injectedSandboxEnvironmentDetector = dangerousSettings?.internalSettings.testSandboxEnvironmentDetector
+        }
+        #endif
+
+        let sandboxEnvironmentDetector = injectedSandboxEnvironmentDetector
+        ?? SandboxEnvironmentDetector(transactionFetcher: transactionFetcher)
+
         SandboxEnvironmentDetector.default = sandboxEnvironmentDetector
 
         let systemInfo = SystemInfo(

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -49,9 +49,14 @@ class BaseBackendIntegrationTests: TestCase {
 
     var forceServerErrorStrategy: ForceServerErrorStrategy?
 
-    static var isSandbox: Bool = true {
-        didSet {
-            SandboxEnvironmentDetector.default = MockSandboxEnvironmentDetector(isSandbox: Self.isSandbox)
+    private let mockSandboxEnvironmentDetector = MockSandboxEnvironmentDetector(isSandbox: true)
+
+    var isSandbox: Bool {
+        get {
+            return self.mockSandboxEnvironmentDetector.isSandbox
+        }
+        set {
+            self.mockSandboxEnvironmentDetector.isSandbox = newValue
         }
     }
 
@@ -101,8 +106,6 @@ class BaseBackendIntegrationTests: TestCase {
               self.proxyURL != "REVENUECAT_PROXY_URL" else {
             throw ErrorUtils.configurationError(message: "Must set configuration in `Constants.swift`")
         }
-
-        Self.isSandbox = true
 
         self.mainThreadMonitor = .init()
         self.mainThreadMonitor.run()
@@ -274,6 +277,10 @@ extension BaseBackendIntegrationTests: InternalDangerousSettingsType {
 
     final func allServersUp() {
         self.forceServerErrorStrategy = nil
+    }
+
+    var testSandboxEnvironmentDetector: SandboxEnvironmentDetectorType? {
+        return self.mockSandboxEnvironmentDetector
     }
 
 }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -967,7 +967,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         try await self.purchaseMonthlyProduct()
 
         // 2. Relaunch in "production" mode
-        Self.isSandbox = false
+        self.isSandbox = false
         await self.resetSingleton()
 
         // 3. Verify no subscriptions are active

--- a/Tests/UnitTests/Mocks/MockSandboxEnvironmentDetector.swift
+++ b/Tests/UnitTests/Mocks/MockSandboxEnvironmentDetector.swift
@@ -20,9 +20,14 @@
 final class MockSandboxEnvironmentDetector: SandboxEnvironmentDetectorType {
 
     init(isSandbox: Bool = true) {
-        self.isSandbox = isSandbox
+        self._isSandbox = .init(isSandbox)
     }
 
-    let isSandbox: Bool
+    private let _isSandbox: Atomic<Bool>
+
+    var isSandbox: Bool {
+        get { self._isSandbox.value }
+        set { self._isSandbox.value = newValue }
+    }
 
 }


### PR DESCRIPTION
## Description

Fixes the `testSandboxXcodePurchasesDoNotGrantProductionEntitlements()` StoreKit integration test after the changes in #6154.

### Problem

After #6154 introduced `AppTransaction.environment` for sandbox detection, the integration test was failing because:
- The `SandboxEnvironmentDetector` is now initialized with cached environment detection at SDK startup
- Setting `SandboxEnvironmentDetector.default` after SDK initialization (as the test was doing) no longer affects the already-initialized SDK instance

### Solution

This PR introduces dependency injection for `SandboxEnvironmentDetector` in integration tests:

- Added `testSandboxEnvironmentDetector` to `DangerousSettings.Internal` to allow injecting a mock detector
- Modified `Purchases.swift` to use the injected mock detector during integration tests (when `ProcessInfo.isRunningIntegrationTests`)
- The `testSandboxXcodePurchasesDoNotGrantProductionEntitlements() test now simply modifies the mock detector's `isSandbox` property