### PR TITLE
Fix `backend-integration-tests-custom-entitlements` on CI

### DIFF
--- a/BackendIntegrationTests/BackendIntegrationTests-CustomEntitlements.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-CustomEntitlements.xctestplan
@@ -2,7 +2,7 @@
   "configurations" : [
     {
       "id" : "62C79EF4-8071-439C-B693-34F1E57211FC",
-      "name" : "Configuration 1",
+      "name" : "Default",
       "options" : {
         "testTimeoutsEnabled" : true
       }


### PR DESCRIPTION
After #5958, I forgot to update the configuration name in the `backend-integration-tests-custom-entitlements` Test Plan to also be called "Default" (the same as I changed in other Test Plans). This was causing the `backend-integration-tests-custom-entitlements` job to fail.

This PR fixes it