### PR TITLE
Expose healthRequest on PurchasesSwiftType

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2046,15 +2046,21 @@ extension Purchases {
     }
 }
 
-extension Purchases: InternalPurchasesType {
+// MARK: - Health
 
-    internal func healthRequest(signatureVerification: Bool) async throws {
+extension Purchases {
+
+    public func healthRequest(signatureVerification: Bool) async throws {
         do {
             try await self.backend.healthRequest(signatureVerification: signatureVerification)
         } catch {
             throw NewErrorUtils.purchasesError(withUntypedError: error)
         }
     }
+
+}
+
+extension Purchases: InternalPurchasesType {
 
     #if DEBUG
     internal func healthReport() async -> PurchasesDiagnostics.SDKHealthReport {

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -1298,16 +1298,17 @@ public protocol PurchasesSwiftType: AnyObject {
          */
         func virtualCurrencies() async throws -> VirtualCurrencies
     #endif
+
+    /// Performs an unauthenticated request to the API to verify connectivity.
+    /// - Parameter signatureVerification: Whether to verify the response signature.
+    /// - Throws: ``PublicError`` if request failed.
+    func healthRequest(signatureVerification: Bool) async throws
 }
 
 // MARK: -
 
 /// Interface for ``Purchases``'s internal-only methods.
 internal protocol InternalPurchasesType: AnyObject {
-
-    /// Performs an unauthenticated request to the API to verify connectivity.
-    /// - Throws: `PublicError` if request failed.
-    func healthRequest(signatureVerification: Bool) async throws
 
     #if DEBUG
         /// Requests an in-depth report of the SDK's configuration from the server.


### PR DESCRIPTION
## Summary
- Move `healthRequest` from `InternalPurchasesType` to `PurchasesSwiftType` protocol, making it public
- Update implementation in `Purchases.swift` from `internal` to `public`
- Enables hybrid SDKs to call `healthRequest` through `PurchasesHybridCommon`

## Test plan
- [ ] Verify existing `healthRequest` unit tests still pass
- [ ] Verify hybrid common layer can compile against updated SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)