### PR TITLE
Update CI to use Xcode 26.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -727,7 +727,7 @@ jobs:
           command: bundle exec fastlane test_revenuecatui
           no_output_timeout: 15m
           environment:
-            DEVICE: iPhone 17,OS=26.3
+            DEVICE: iPhone 17,OS=26.2
       - create-snapshot-pr-if-needed:
           condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
           job: "create_snapshots_repo_pr"
@@ -805,7 +805,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 17 (26.3)
+            SCAN_DEVICE: iPhone 17 (26.2)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: RevenueCat


### PR DESCRIPTION
### Motivation
Update CI jobs to use the latest Xcode 26.3 beta instead of 26.2.

### Description
Updates all three CircleCI jobs that reference Xcode 26 (`run-revenuecat-ui-ios-26`, `run-test-ios-26`, `run-all-maestro-e2e-tests`) from Xcode 26.2 to 26.3. Simulator OS versions remain at 26.2, since the [CircleCI Xcode 26.3 image](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v16191/manifest.txt) ships with iOS 26.2 simulators.