### PR TITLE
Fix displaying badge only in selected override and prevent fallback paywall for missing localizations

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -38,7 +38,10 @@ class TextComponentViewModel {
         self.localizationProvider = localizationProvider
         self.uiConfigProvider = uiConfigProvider
         self.component = component
-        self.text = try localizationProvider.localizedStrings.string(key: component.text)
+        self.text = (try? localizationProvider.localizedStrings.string(key: component.text)) ?? {
+            Logger.warning("Missing localization for text_lid '\(component.text)', using empty string.")
+            return ""
+        }()
 
         self.presentedOverrides = try self.component.overrides?.toPresentedOverrides {
             try LocalizedTextPartial.create(from: $0, using: localizationProvider.localizedStrings)

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -503,7 +503,9 @@ struct ViewModelFactory {
             )
         }
 
-        let badgeViewModels = try component.badge?.stack.components.map { component in
+        let badgeSource = component.badge
+            ?? component.overrides?.lazy.compactMap(\.properties.badge).first
+        let badgeViewModels = try badgeSource?.stack.components.map { component in
             try self.toViewModel(
                 component: component,
                 packageValidator: packageValidator,


### PR DESCRIPTION
When a badge is added only in an override state (e.g., "selected") via the paywall builder, two issues occur on iOS:
  
  1. Badge doesn't render in the override state: `badgeViewModels` are created from the base badge's
     components. When the badge only exists in an override (base badge is `nil`), `badgeViewModels` is
     empty, so the badge renders with no content.
  2. The frontend creates a `text_lid` for the badge's text component but doesn't
     localize it. The override's own `text_lid` is correctly localized, but the base one is orphaned.
      It exists in the component JSON but has no entry in `components_localizations`. In Android this caused the paywall to always render in the fallback state, in iOS the fallback state was
     avoided this because it never created view models for the override badge. With fix 1, iOS now
     hits this orphan key and renders the fallback paywall. So the combination of fix 1 and 2 makes sure the badge renders fine only when the component is selected.

  A frontend fix will be deployed to prevent orphan `text_lids` for new paywalls, but existing broken
  paywalls are already in the wild, that's why we need the SDK to be more resilient and don't show the fallback paywall in this weird state (when all the localizations are missing for a `text_lid`)

## Changes

- `ViewModelFactory.swift`: When the base badge is nil, fall back to the first override's badge
  components to create badgeViewModels. The badge itself still only renders when the override
  condition is active (e.g., selected), since StackComponentViewModel.styles() uses partial?.badge ?? 
  self.component.badge which remains nil in the default state.
- `TextComponentViewModel.swift`: Handle orphan `text_lids` gracefully. If the base `text_lid` lookup
  throws, catch the error, log a warning, and use an empty string instead of propagating the failure.
  The empty string is never visible because the badge only renders when the override condition is
  active, at which point the override's correctly-localized `text_lid` is used.