### PR TITLE
Fix xcode 14 build

### DIFF
--- a/Sources/Misc/Concurrency/SynchronizedUserDefaults.swift
+++ b/Sources/Misc/Concurrency/SynchronizedUserDefaults.swift
@@ -34,7 +34,7 @@ import Foundation
 /// - SeeAlso: https://github.com/RevenueCat/purchases-ios/issues/5729
 internal final class SynchronizedUserDefaults {
 
-    private nonisolated(unsafe) let userDefaults: UserDefaults
+    private let userDefaults: UserDefaults
 
     init(userDefaults: UserDefaults) {
         self.userDefaults = userDefaults
@@ -58,7 +58,9 @@ internal final class SynchronizedUserDefaults {
 
 }
 
-extension SynchronizedUserDefaults: Sendable {}
+// `UserDefaults` is thread-safe per Apple docs and this class only holds an immutable reference,
+// so `@unchecked Sendable` is safe here. `nonisolated(unsafe)` requires Swift 5.10+.
+extension SynchronizedUserDefaults: @unchecked Sendable {}
 
 /// A `UserDefaults` wrapper that uses a lock to synchronize access.
 ///


### PR DESCRIPTION
I broke building on xcode 14 in https://github.com/RevenueCat/purchases-ios/pull/5959 because of the use of `nonisolated`