### PR TITLE
Fix CI caching for xcbeautify and xcodes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ commands:
             echo "xcodes:<< parameters.install_xcodes >>" >> .homebrew-deps
       - restore_cache:
           keys:
-            - homebrew-cache-{{ checksum ".homebrew-deps" }}-{{ arch }}
+            - v2-homebrew-cache-{{ checksum ".homebrew-deps" }}-{{ arch }}
       - when:
           condition: << parameters.install_xcbeautify >>
           steps:
@@ -220,10 +220,10 @@ commands:
             - install-brew-dependency:
                 dependency_name: "xcodes"
       - save_cache:
-          key: homebrew-cache-{{ checksum ".homebrew-deps" }}-{{ arch }}
+          key: v2-homebrew-cache-{{ checksum ".homebrew-deps" }}-{{ arch }}
           paths:
-            - /usr/local/Cellar/xcbeautify/
-            - /usr/local/Cellar/xcodes/
+            - /opt/homebrew/Cellar/xcbeautify/
+            - /opt/homebrew/Cellar/xcodes/
             - /Users/$USER/Library/Caches/Homebrew/
 
   install-brew-dependency:
@@ -248,16 +248,40 @@ commands:
   install-xcbeautify-for-xcode14:
     description: "Installs xcbeautify 1.6.0 using Mint"
     steps:
+      - restore_cache:
+          keys:
+            - mint-xcbeautify-1.6.0-{{ arch }}
       - run:
           name: Install xcbeautify using Mint
-          command: mint install cpisciotta/xcbeautify@1.6.0
+          command: |
+            if which xcbeautify > /dev/null 2>&1; then
+                echo "xcbeautify already installed, skipping."
+                exit 0
+            fi
+            mint install cpisciotta/xcbeautify@1.6.0
+      - save_cache:
+          key: mint-xcbeautify-1.6.0-{{ arch }}
+          paths:
+            - ~/.mint
 
   install-xcbeautify-for-xcode15:
     description: "Installs xcbeautify 2.30.1 using Mint"
     steps:
+      - restore_cache:
+          keys:
+            - mint-xcbeautify-2.30.1-{{ arch }}
       - run:
           name: Install xcbeautify 2.30.1 using Mint
-          command: mint install cpisciotta/xcbeautify@2.30.1
+          command: |
+            if which xcbeautify > /dev/null 2>&1; then
+                echo "xcbeautify already installed, skipping."
+                exit 0
+            fi
+            mint install cpisciotta/xcbeautify@2.30.1
+      - save_cache:
+          key: mint-xcbeautify-2.30.1-{{ arch }}
+          paths:
+            - ~/.mint
 
   install-rubydocker-dependencies:
     steps:


### PR DESCRIPTION
### Motivation

xcbeautify (and xcodes) were never actually restored from the CircleCI cache on ARM runners. The Homebrew cache paths pointed to `/usr/local/Cellar/` (Intel prefix), but all CI executors now use `m4pro.medium` (ARM), where Homebrew installs to `/opt/homebrew/Cellar/`. Additionally, Mint-installed xcbeautify versions (used by older Xcode jobs) had no caching at all.

### Description

- Fixed Homebrew cache paths from `/usr/local/Cellar/` to `/opt/homebrew/Cellar/` for xcbeautify and xcodes.
- Bumped the cache key to `v2-homebrew-cache-...` to invalidate stale caches (CircleCI caches are immutable).
- Added `restore_cache`/`save_cache` around the Mint-based xcbeautify installs (`install-xcbeautify-for-xcode14` and `install-xcbeautify-for-xcode15`) so they skip recompilation when cached.

Made with [Cursor](https://cursor.com)