### PR TITLE
Fix compilation error in VariableHandlerV2 offer price functions

### DIFF
--- a/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
+++ b/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
@@ -744,7 +744,7 @@ extension VariablesV2 {
         return formatDiscountPrice(
             discount.price,
             package: package,
-            showZeroDecimalPlacePrices: showZeroDecimalPlacePrices,
+            showZeroDecimalPlacePrices: offerContext.showZeroDecimalPlacePrices,
             fallback: discount.localizedPriceString
         )
     }
@@ -770,7 +770,7 @@ extension VariablesV2 {
         return formatDiscountPrice(
             discount.pricePerDay?.decimalValue,
             package: package,
-            showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+            showZeroDecimalPlacePrices: offerContext.showZeroDecimalPlacePrices
         )
     }
 
@@ -795,7 +795,7 @@ extension VariablesV2 {
         return formatDiscountPrice(
             discount.pricePerWeek?.decimalValue,
             package: package,
-            showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+            showZeroDecimalPlacePrices: offerContext.showZeroDecimalPlacePrices
         )
     }
 
@@ -820,7 +820,7 @@ extension VariablesV2 {
         return formatDiscountPrice(
             discount.pricePerMonth?.decimalValue,
             package: package,
-            showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+            showZeroDecimalPlacePrices: offerContext.showZeroDecimalPlacePrices
         )
     }
 
@@ -845,7 +845,7 @@ extension VariablesV2 {
         return formatDiscountPrice(
             discount.pricePerYear?.decimalValue,
             package: package,
-            showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+            showZeroDecimalPlacePrices: offerContext.showZeroDecimalPlacePrices
         )
     }
 


### PR DESCRIPTION
### Motivation

The `RevenueCatUI` scheme fails to compile because `showZeroDecimalPlacePrices` is referenced without the `offerContext.` prefix in 5 `formatDiscountPrice` calls inside `VariableHandlerV2.swift`.

### Description

The following functions in the `VariablesV2` extension were using a bare `showZeroDecimalPlacePrices` instead of `offerContext.showZeroDecimalPlacePrices`:

- `productOfferPrice`
- `productOfferPricePerDay`
- `productOfferPricePerWeek`
- `productOfferPricePerMonth`
- `productOfferPricePerYear`

Each function already had the correct usage in its guard-else fallback path (e.g., `offerContext.showZeroDecimalPlacePrices`), but the `formatDiscountPrice` calls after the guard were missing the prefix. This was likely introduced in #6260.