### PR TITLE
Add configurable search term for PaywallsTester Sandbox Paywalls tab

### DIFF
--- a/Local.xcconfig.SAMPLE
+++ b/Local.xcconfig.SAMPLE
@@ -39,6 +39,10 @@
 
 // Because two slashes are interpreted as a comment in this file, the scheme and host need to be set separately
 
+// Set a default search term for the Sandbox Paywalls tab in PaywallsTester (without quotes!):
+// If set, the app will automatically open to the Sandbox Paywalls tab with this search term pre-filled.
+// SANDBOX_PAYWALL_SEARCH = your-search-term
+
 // The following configuration options can be used when running the E2E tests through the Tuist generated Maestro project
 // REVENUECAT_FORCE_SERVER_ERROR_STRATEGY = primary_backend_down / never
 // REVENUECAT_API_HOST = custom-api-host.revenuecat.com

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Constants.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Constants.swift
@@ -35,4 +35,12 @@ enum Constants {
         }
         return "\(scheme)//\(host)"
     }()
+
+    /*
+     To set a default search term for the Sandbox Paywalls tab, add it in your local.xcconfig file like this:
+     SANDBOX_PAYWALL_SEARCH = your-search-term
+     */
+    static let sandboxPaywallSearch: String = {
+        Bundle.main.object(forInfoDictionaryKey: "SANDBOX_PAYWALL_SEARCH") as? String ?? ""
+    }()
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Info.plist
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Info.plist
@@ -48,6 +48,8 @@
 	<string>$(REVENUECAT_PROXY_URL_HOST)</string>
 	<key>REVENUECAT_PROXY_URL_SCHEME</key>
 	<string>$(REVENUECAT_PROXY_URL_SCHEME)</string>
+	<key>SANDBOX_PAYWALL_SEARCH</key>
+	<string>$(SANDBOX_PAYWALL_SEARCH)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
@@ -11,13 +11,29 @@ import SwiftUI
 
 struct AppContentView: View {
 
+    private enum Tab {
+        case examples
+        case myApps
+        case sandboxPaywalls
+    }
+
     @ObservedObject
     private var configuration = Configuration.shared
 
-
+    @State
+    private var selectedTab: Tab = {
+        if Purchases.isConfigured && !Constants.sandboxPaywallSearch.isEmpty {
+            return .sandboxPaywalls
+        }
+        #if os(macOS)
+        return .myApps
+        #else
+        return .examples
+        #endif
+    }()
 
     var body: some View {
-        TabView {
+        TabView(selection: $selectedTab) {
 
             #if !os(macOS)
             SamplePaywallsList()
@@ -26,17 +42,20 @@ struct AppContentView: View {
                         .renderingMode(.template)
                     Text("Examples")
                 }
+                .tag(Tab.examples)
             #endif
             AppList()
                 .tabItem {
                     Label("My Apps", systemImage: "network")
                 }
+                .tag(Tab.myApps)
 
             if Purchases.isConfigured {
                 APIKeyDashboardList()
                     .tabItem {
                         Label("Sandbox Paywalls", systemImage: "testtube.2")
                     }
+                    .tag(Tab.sandboxPaywalls)
             }
 
             #if !DEBUG

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -54,7 +54,7 @@ struct APIKeyDashboardList: View {
     private var isShowingVariablesEditor = false
 
     @State
-    private var searchText = ""
+    private var searchText = Constants.sandboxPaywallSearch
 
     var body: some View {
         ZStack {


### PR DESCRIPTION
## Summary
- Adds `SANDBOX_PAYWALL_SEARCH` configuration option in `Local.xcconfig`
- When set, pre-fills the search field in the Sandbox Paywalls tab
- Automatically opens to the Sandbox Paywalls tab on launch if a search term is configured

https://github.com/user-attachments/assets/5b61b803-f59d-4678-bd7e-9486b289a716

## Usage
Add to your `Local.xcconfig`:
```
SANDBOX_PAYWALL_SEARCH = your-search-term
```

Multi-word search terms are supported.

## Test plan
- [ ] Set `SANDBOX_PAYWALL_SEARCH` in Local.xcconfig
- [ ] Build and run PaywallsTester
- [ ] Verify app opens to Sandbox Paywalls tab with search term pre-filled
- [ ] Verify empty/unset value defaults to Examples tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)