### PR TITLE
Add PR label guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,21 @@ For snapshot testing, sample applications, pre-commit hooks, and release process
 - `CI.xcconfig` - CI-specific configuration
 - `api/*.swiftinterface` - Public API surface tracking
 
+### Pull Request Labels
+
+When creating a pull request, **always add one of these labels** to categorize the change. These labels determine automatic version bumps and changelog generation:
+
+| Label | When to Use |
+|-------|-------------|
+| `pr:feat` | New user-facing features or enhancements |
+| `pr:fix` | Bug fixes |
+| `pr:other` | Internal changes, refactors, CI, docs, or anything that shouldn't trigger a release |
+
+**Additional scope labels** (add alongside the primary label above):
+- `pr:RevenueCatUI` — Changes specific to the RevenueCatUI module (paywalls, customer center)
+- `feat:Paywalls_V2` — Changes related to Paywalls V2 (requires `pr:RevenueCatUI` as well)
+- `feat:Customer Center` — Changes related to Customer Center (requires `pr:RevenueCatUI` as well)
+
 ## When the Task is Ambiguous
 
 1. Search for similar existing implementation in this repo first


### PR DESCRIPTION
## Summary
- Adds a "Pull Request Labels" section to AGENTS.md
- Documents when to use `pr:feat`, `pr:fix`, and `pr:other` labels
- Documents scope labels like `pr:RevenueCatUI`, `feat:Paywalls_V2`, and `feat:Customer Center`

## Test plan
- [ ] Review the added documentation for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)