### PR TITLE
Fix jwsRepresentation visibility for Obj-C consumers

### DIFF
--- a/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -42,7 +42,10 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc public var transactionIdentifier: String { self.transaction.transactionIdentifier }
     @objc public var quantity: Int { self.transaction.quantity }
     @objc public var storefront: Storefront? { self.transaction.storefront }
-    @objc internal var jwsRepresentation: String? { self.transaction.jwsRepresentation }
+    /// The JWS representation of this transaction. Only available in Objective-C.
+    /// - Note: In Swift, use StoreKit 2's `Transaction.jwsRepresentation` directly.
+    @available(swift, obsoleted: 1.0, message: "Use StoreKit 2's Transaction.jwsRepresentation directly")
+    @objc public var jwsRepresentation: String? { self.transaction.jwsRepresentation }
     internal var environment: StoreEnvironment? { self.transaction.environment }
     internal var reason: TransactionReason? { self.transaction.reason }
 


### PR DESCRIPTION
## Context

This issue was discovered while testing #5888 (Tuist SPM dependency mode changes).

PR #4526 added an Obj-C API test for `jwsRepresentation` on `StoreTransaction`, intending it to be "available exclusively in Objective-C". However, the property was marked as `@objc internal`, which:

- **With XcodeProj mode**: Worked accidentally due to looser module boundaries
- **With SPM mode**: Fails because SPM enforces strict module visibility

## Problem

```swift
// Current (broken for SPM)
@objc internal var jwsRepresentation: String? { ... }
```

The `internal` visibility means the Obj-C header doesn't export it, so external Obj-C consumers can't access it.

## Solution

Use `@available(swift, obsoleted: 1.0)` to make it public for Obj-C but hidden from Swift:

```swift
@available(swift, obsoleted: 1.0, message: "Use StoreKit 2's Transaction.jwsRepresentation directly")
@objc public var jwsRepresentation: String? { ... }
```

This ensures:
- ✅ Obj-C consumers can access `jwsRepresentation`
- ✅ Swift consumers don't see it (they should use SK2's API directly)
- ✅ Works with both XcodeProj and SPM dependency modes

## Related

- #4526 — Original PR that added the Obj-C API test
- #5888 — Tuist PR that exposed this issue

🤖 Generated with [Claude Code](https://claude.ai/code)