### PR TITLE
Add code review guidelines to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,14 @@ When creating a pull request, **always add one of these labels** to categorize t
 - `feat:Paywalls_V2` — Changes related to Paywalls V2 (requires `pr:RevenueCatUI` as well)
 - `feat:Customer Center` — Changes related to Customer Center (requires `pr:RevenueCatUI` as well)
 
+## Code Review Guidelines
+
+When reviewing a pull request:
+
+1. **Check for linked specs** — If the PR description contains a link to `https://github.com/RevenueCat/sdk-specs`, fetch and read the spec before reviewing the code. The spec defines the expected behavior and requirements.
+2. **Verify the implementation matches the spec** — Ensure the code implements what the spec describes, including edge cases and error handling.
+3. **Check cross-platform consistency** — If the spec applies to multiple platforms, verify the implementation follows patterns from other SDKs (especially purchases-android).
+
 ## When the Task is Ambiguous
 
 1. Search for similar existing implementation in this repo first


### PR DESCRIPTION
## Summary
- Add code review guidelines to `AGENTS.md` instructing Claude to read specs from https://github.com/RevenueCat/sdk-specs when linked in PR descriptions before doing code reviews

## Test plan
- [ ] Open a PR that links to a spec in sdk-specs and verify Claude reads the spec before reviewing

🤖 Generated with [Claude Code](https://claude.com/claude-code)