### PR TITLE
Fix custom variables not propagating to exit offers

### DIFF
--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -461,6 +461,7 @@ extension View {
 private struct PresentingPaywallModifier: ViewModifier {
 
     @Environment(\.scenePhase) var scenePhase
+    @Environment(\.customPaywallVariables) private var customPaywallVariables
 
     private struct Data: Identifiable {
         var customerInfo: CustomerInfo
@@ -736,6 +737,7 @@ private struct PresentingPaywallModifier: ViewModifier {
                 purchaseHandler: self.purchaseHandler
             )
         )
+        .customPaywallVariables(self.customPaywallVariables)
         .onPurchaseStarted {
             self.purchaseStarted?($0)
         }
@@ -787,6 +789,8 @@ private struct PresentingPaywallModifier: ViewModifier {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(tvOS, unavailable)
 private struct PresentingPaywallBindingModifier: ViewModifier {
+
+    @Environment(\.customPaywallVariables) private var customPaywallVariables
 
     @Binding var offering: Offering?
 
@@ -932,6 +936,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
                 purchaseHandler: self.purchaseHandler
             )
         )
+        .customPaywallVariables(self.customPaywallVariables)
         .onPurchaseStarted {
             self.purchaseStarted?($0)
         }


### PR DESCRIPTION
## Summary
- Custom variables set via `.customPaywallVariables()` were not being passed to exit offer paywalls
- SwiftUI's `sheet`/`fullScreenCover` modifiers create new view hierarchies that don't inherit environment values from the parent
- Added `@Environment(\.customPaywallVariables)` to both paywall presentation modifiers and applied them to exit offer PaywallViews

## Test plan
- [ ] Set custom variables on a paywall view that has an exit offer configured
- [ ] Dismiss the main paywall without purchasing
- [ ] Verify the exit offer paywall displays the custom variables correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)