### PR TITLE
[EXTERNAL] Support new SubscriptionStoreView APIs for iOS 18+

### DIFF
--- a/Sources/Support/PaywallExtensions.swift
+++ b/Sources/Support/PaywallExtensions.swift
@@ -110,6 +110,30 @@ extension SubscriptionStoreView where Content == AutomaticSubscriptionStoreMarke
 
 }
 
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, *)
+extension SubscriptionStoreView {
+
+    /// Creates a ``SubscriptionStoreView`` from an ``Offering``
+    /// with a custom content structure.
+    /// When the user purchases products through this paywall, the `RevenueCat` SDK will handle
+    /// the result automatically. All you need to do is to dismiss the paywall.
+    ///
+    /// - Warning: In order to use StoreKit paywalls you must configure the `RevenueCat` SDK
+    /// in SK2 mode using ``Configuration/Builder/with(storeKitVersion:)``.
+    public static func forOffering<C>(
+        _ offering: Offering,
+        @StoreContentBuilder content: () -> C
+    ) -> some View where Content == SubscriptionStoreContentView<C>, C: StoreContent {
+        return self
+            .init(
+                productIDs: offering.subscriptionProductIdentifiers,
+                content: content
+            )
+            .handlePurchases(offering)
+    }
+
+}
+
 // MARK: - Private
 
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Starting with iOS 18, StoreKit introduced new APIs for `SubscriptionStoreView` that allow more flexible content placement.

- https://developer.apple.com/documentation/storekit/subscriptionstoreview/init(productids:content:)
- https://developer.apple.com/videos/play/wwdc2024/10061/?time=266

However, the current RevenueCat integration requires creating `SubscriptionStoreView` using [dedicated static methods](https://github.com/RevenueCat/purchases-ios/blob/1b9c2bb7110781bca1492cc90947b221fda7c6ed/Sources/Support/PaywallExtensions.swift#L73-L111), which prevents developers from taking advantage of these new APIs.

### Description

This PR adds a new static method that enables the use of the updated `SubscriptionStoreView` APIs on iOS 18 and later. The method design follows the conventions of the existing methods to ensure consistency.