### PR TITLE
Add CI action for recording new baseline swiftinterface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ parameters:
   generate_revenuecatui_snapshots:
     default: false
     type: boolean
+  generate_swiftinterface:
+    default: false
+    type: boolean
   # params used by the trigger CircleCI Pipeline GitHub Action: https://github.com/marketplace/actions/trigger-circleci-pipeline
   GHA_Event:
     type: string
@@ -102,6 +105,7 @@ aliases:
         ignore: /.*/
       branches:
         only: main
+  swiftinterface-xcode-version: &swiftinterface-xcode-version "26.2"
 commands:
   slack-notify-on-fail:
     steps:
@@ -1841,7 +1845,7 @@ jobs:
   check-api-changes:
     executor:
       name: macos-executor
-      xcode_version: "16.3.0"
+      xcode_version: *swiftinterface-xcode-version
     steps:
       - checkout
       - install-dependencies
@@ -1883,6 +1887,24 @@ jobs:
           destination: revenuecat-api-visionos.swiftinterface
       - slack-notify-on-fail
 
+  generate-swiftinterface:
+    executor:
+      name: macos-executor
+      xcode_version: *swiftinterface-xcode-version
+    steps:
+      - checkout
+      - install-dependencies
+      - revenuecat/setup-git-credentials
+      - run:
+          name: Generate swiftinterface files
+          command: |
+            bundle exec fastlane ios generate_swiftinterface
+      - run:
+          name: Update baseline swiftinterface files
+          command: |
+            bundle exec fastlane ios create_swiftinterface_pr
+      - slack-notify-on-fail
+
   deploy-to-spm:
     docker:
       - image: cimg/base:stable
@@ -1915,6 +1937,13 @@ jobs:
           command: bundle exec fastlane trigger_bump_sdk_in_rc_mobile_app
 
 workflows:
+
+  generate-swiftinterface:
+    when: << pipeline.parameters.generate_swiftinterface >>
+    jobs:
+      - generate-swiftinterface:
+          context:
+            - slack-secrets-ios
 
   generate-snapshot:
     when: << pipeline.parameters.generate_snapshots >>
@@ -1951,6 +1980,7 @@ workflows:
             equal: [bump, << pipeline.parameters.action >>]
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
+        - not: << pipeline.parameters.generate_swiftinterface >>
     jobs:
       - lint
       - check-api-changes:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1230,6 +1230,13 @@ platform :ios do
     )
   end
 
+  desc "Trigger CircleCI job to generate and update baseline swiftinterface files"
+  lane :trigger_generate_swiftinterface do
+    generate_snapshots(
+      pipeline: "generate_swiftinterface"
+    )
+  end
+
   private_lane :build_release do |options|
     platform = options[:platform]
     scheme = options[:scheme] || 'RevenueCat'
@@ -1277,6 +1284,51 @@ platform :ios do
       base_branch: ENV["CIRCLE_BRANCH"],
       files_to_add: "../*/__Snapshots__/*"
      )
+  end
+
+  desc "Creates a new PR after new swiftinterface baseline files were generated"
+  lane :create_swiftinterface_pr do
+    base_branch = ENV["CIRCLE_BRANCH"]
+    build_number = ENV["CIRCLE_BUILD_NUM"]
+    branch_name = "generated_swiftinterface/#{base_branch}-#{build_number}"
+
+    # Copy generated files to the api/ directory
+    ApiDiffHelper::PLATFORM_CHECKS.each do |platform|
+      src = "#{ApiDiffHelper::PR_SWIFTINTERFACE_DIR}/RevenueCat#{platform[:suffix]}.swiftinterface"
+      dst = "../api/revenuecat-api#{platform[:suffix]}.swiftinterface"
+
+      if File.exist?(src)
+        FileUtils.cp(src, dst)
+        UI.success("Updated #{dst}")
+      else
+        UI.error("Missing generated file: #{src}")
+      end
+    end
+
+    file_count = sh("git diff --numstat ../api/*.swiftinterface | wc -l").strip.to_i
+
+    if file_count == 0
+      UI.important("No swiftinterface changes to commit")
+    else
+      sh("git", "checkout", "-b", branch_name)
+      sh("git", "add", "../api/*.swiftinterface")
+      sh("git", "commit", "-m", "[skip ci] Update baseline swiftinterface files")
+      sh("git", "push", "origin", branch_name)
+
+      circle_user = ENV["CIRCLE_USERNAME"]
+      branch_link = "https://github.com/RevenueCat/purchases-ios/tree/#{base_branch}"
+      body = "Requested by @#{circle_user} for [#{base_branch}](#{branch_link})"
+
+      create_pull_request(
+        repo: "revenuecat/#{REPO_NAME}",
+        title: "Update baseline swiftinterface files for `#{base_branch}`",
+        body: body,
+        base: base_branch,
+        api_token: ENV["GITHUB_TOKEN"],
+        head: branch_name,
+        labels: ["pr:other"]
+      )
+    end
   end
 
   desc "Creates a new PR on purchases-ios-snapshots after new snapshot files were generated"


### PR DESCRIPTION
Adds a CircleCI action that can be triggered in ordere to record a new version of the baseline swiftinterface for the API diff check. This will open a PR with the newly recorded swiftinterface, see https://github.com/RevenueCat/purchases-ios/pull/6316 for an example.