### PR TITLE
Add compiler check for SubscriptionStoreContentView API

### DIFF
--- a/Sources/Support/PaywallExtensions.swift
+++ b/Sources/Support/PaywallExtensions.swift
@@ -110,6 +110,7 @@ extension SubscriptionStoreView where Content == AutomaticSubscriptionStoreMarke
 
 }
 
+#if compiler(>=6.0)
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, *)
 extension SubscriptionStoreView {
 
@@ -133,6 +134,7 @@ extension SubscriptionStoreView {
     }
 
 }
+#endif
 
 // MARK: - Private
 


### PR DESCRIPTION
## Summary
- Wraps the `SubscriptionStoreContentView` extension from #6320 in `#if compiler(>=6.0)` to fix build failures on older Xcode versions (15.x)
- `StoreContentBuilder`, `SubscriptionStoreContentView`, and `StoreContent` are iOS 18+ SDK types that don't exist in older SDKs. The `@available` annotation handles runtime checks but the compiler still needs the types to exist at compile time.

## Test plan
- [x] Verify iOS 15/16 CI jobs pass