### PR TITLE
Fix purchase error alert not displaying when using custom purchase logic

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -72,11 +72,8 @@ struct ButtonComponentView: View {
                 )
             }
             .withTransition(viewModel.component.transition)
-            .applyIf(self.shouldBeDisabled, apply: { view in
-                view
-                    .disabled(true)
-                    .opacity(0.35)
-            })
+            .disabled(self.shouldBeDisabled)
+            .opacity(self.shouldBeDisabled ? 0.35 : 1.0)
             #if canImport(SafariServices) && canImport(UIKit)
             .sheet(isPresented: .isNotNil(self.$inAppBrowserURL)) {
                 SafariView(url: self.inAppBrowserURL!)

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -75,10 +75,8 @@ struct PurchaseButtonComponentView: View {
                 showActivityIndicatorOverContent: self.showActivityIndicatorOverContent
             )
         }
-        .applyIf(self.shouldBeDisabled) {
-            $0.disabled(true)
-                .opacity(0.35)
-        }
+        .disabled(self.shouldBeDisabled)
+        .opacity(self.shouldBeDisabled ? 0.35 : 1.0)
         #if canImport(SafariServices) && canImport(UIKit)
         .sheet(isPresented: .isNotNil(self.$inAppBrowserURL)) {
             SafariView(url: self.inAppBrowserURL!)


### PR DESCRIPTION
## Summary
- Replace `applyIf(shouldBeDisabled)` with direct `.disabled()` and `.opacity()` modifiers on `PurchaseButtonComponentView` and `ButtonComponentView`
- The `applyIf` helper uses `if/else` branching in `@ViewBuilder`, creating different SwiftUI view identities. When `shouldBeDisabled` flips after a delayed purchase error (e.g. custom purchase logic with `performPurchase`), SwiftUI destroys and recreates `AsyncButton`, resetting its `@State var error` before `.alert()` can render
- Using direct modifiers preserves view identity across state changes, ensuring the error alert displays correctly

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/dff89e69-4351-4c04-b8a2-926d1e8bc94e" /> | <video src="https://github.com/user-attachments/assets/4722cada-0ce8-4d92-9f63-b4e9fd9a0d7a" /> |

## Test plan
- [x] Tested with native PaywallsTester app configured with `purchasesAreCompletedBy: .myApp` and a delayed `performPurchase` returning an error — alert now displays
- [x] Tested with React Native example app using custom purchase logic — alert now displays
- [x] Verified no regression: alert still works without custom purchase logic
- [x] Verified no regression: disabled state and opacity still apply correctly during purchase