### PR TITLE
Update Tuist swift-snapshot-testing dependency to match Package.swift

### DIFF
--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/pointfreeco/swift-snapshot-testing",
-            revision: "26ed3a2b4a2df47917ca9b790a57f91285b923fb"
+            exact: "1.18.9"
         ),
         .package(
             url: "https://github.com/RevenueCat/purchases-ios",


### PR DESCRIPTION
### Motivation

PR #6303 updated the `swift-snapshot-testing` dependency in `Package.swift` from a revision pin to `exact: "1.18.9"`, but `Tuist/Package.swift` was not updated and still references the old revision.

### Description

Updates `Tuist/Package.swift` to use `exact: "1.18.9"` for `swift-snapshot-testing`, matching what `Package.swift` now specifies after #6303.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency pin change in a build configuration file; low functional risk beyond potential build/test differences if the revision previously diverged from `1.18.9`.
> 
> **Overview**
> Updates `Tuist/Package.swift` to pin `pointfreeco/swift-snapshot-testing` using `exact: "1.18.9"` instead of a specific git revision, aligning this dependency spec with the root `Package.swift`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b87f6aa474b24ca87605ae8f66eac8205be6beb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->