### PR TITLE
Update Tuist Package.resolved after swift-snapshot-testing bump

### DIFF
--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "307cbbbed5d781834365009af8023abbc6ef88a08803b78642391c6cfb4b3ab3",
+  "originHash" : "87fe8f3a1799f58c25f9dd030ce2cb8465656be2f14e4d3cae4c1185d6b51b05",
   "pins" : [
     {
       "identity" : "cwlcatchexception",
@@ -56,11 +56,39 @@
       }
     },
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "2a2a938798236b8fa0bc57c453ee9de9f9ec3ab0",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "26ed3a2b4a2df47917ca9b790a57f91285b923fb"
+        "revision" : "bf8d8c27f0f0c6d5e77bff0db76ab68f2050d15d",
+        "version" : "1.18.9"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],


### PR DESCRIPTION
### Motivation

#6335 updated `Tuist/Package.swift` to use `exact: "1.18.9"` for `swift-snapshot-testing`, but the `Tuist/Package.resolved` file was not regenerated in that PR. Without this update, `tuist install` / `tuist generate` would re-resolve on every run.

### Description

Ran `tuist install` to regenerate `Tuist/Package.resolved`. The resolved file now pins:
- `swift-snapshot-testing` at `1.18.9`
- New transitive dependencies: `swift-custom-dump` (1.4.1), `swift-syntax` (602.0.0), `xctest-dynamic-overlay` (1.9.0)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only change that updates pinned dependency revisions and adds transitive pins; risk is limited to build/test resolution differences.
> 
> **Overview**
> Regenerates `Tuist/Package.resolved` to match the `swift-snapshot-testing` pin at `1.18.9`, updating its resolved revision and `originHash` so `tuist install/generate` no longer re-resolves each run.
> 
> The lockfile now also pins new transitive dependencies (`swift-custom-dump` `1.4.1`, `swift-syntax` `602.0.0`, `xctest-dynamic-overlay` `1.9.0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc89535d33c515f2e129024799ed9dc6410a9dc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->