### PR TITLE
Add force_rerun_tests pipeline parameter to bypass test-run cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -470,8 +470,9 @@ commands:
 
             if [ -f "$CACHE_DIR/SUCCESS" ]; then
               echo "===== SKIPPED ====="
-              echo "Test already passed for this commit."
+              echo "This test already passed for this commit in a previous run of this job:"
               cat "$CACHE_DIR/SUCCESS"
+              echo "To force all tests to re-run, trigger the pipeline with force_rerun_tests=true."
               echo "SKIPPED" > "$STATUS_FILE"
               exit 0
             fi
@@ -587,8 +588,9 @@ commands:
 
             if [ -f "$CACHE_DIR/SUCCESS" ]; then
               echo "===== SKIPPED ====="
-              echo "Test already passed for this commit."
+              echo "This test already passed for this commit in a previous run of this job:"
               cat "$CACHE_DIR/SUCCESS"
+              echo "To force all tests to re-run, trigger the pipeline with force_rerun_tests=true."
               echo "SKIPPED" > "$STATUS_FILE"
               exit 0
             fi


### PR DESCRIPTION
### Checklist
- [x] N/A — CI-only changes, no SDK code modified

### Motivation
When a CI job is retried, the test-run caching layer (from #6333) skips tests that already passed for the same commit. This is desirable in most cases, but sometimes you need all tests to actually run — for example when investigating CI job times, benchmarking, or reproducing a flaky test.

### Description
Adds a `force_rerun_tests` pipeline parameter (default: `false`). When set to `true`:
- The cache-hit check is skipped — tests always run
- SUCCESS markers are not written — so caches are not polluted
- The iOS 14 runtime download is never skipped

The parameter is exposed as the `FORCE_RERUN_TESTS` environment variable via both executor definitions.

**Stacked on:** #6333

Made with [Cursor](https://cursor.com)