### PR TITLE
Fix tabs conditional overrides losing extended conditions

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -13,7 +13,7 @@
 // swiftlint:disable file_length
 
 import Foundation
-import RevenueCat
+@_spi(Internal) import RevenueCat
 import SwiftUI
 
 #if !os(tvOS) // For Paywalls V2
@@ -300,7 +300,7 @@ struct ViewModelFactory {
                 overflow: nil,
                 overrides: component.overrides.map { overrides in
                     overrides.map { override in
-                        return .init(conditions: override.conditions, properties: .init(
+                        return .init(extendedConditions: override.extendedConditions, properties: .init(
                             visible: override.properties.visible,
                             dimension: nil,
                             size: override.properties.size,

--- a/Tests/RevenueCatUITests/PaywallsV2/ViewModelFactoryBadgeTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/ViewModelFactoryBadgeTests.swift
@@ -12,7 +12,7 @@
 //  Created by Facundo Menzella on 2/16/26.
 
 import Nimble
-import RevenueCat
+@_spi(Internal) import RevenueCat
 @testable import RevenueCatUI
 import XCTest
 
@@ -200,6 +200,53 @@ class ViewModelFactoryBadgeTests: TestCase {
 
         // Then: badgeViewModels should be populated
         expect(viewModel.badgeViewModels).toNot(beEmpty())
+    }
+
+    @MainActor
+    func testTabsOverrideWithSelectedPackageCondition_DoesNotThrowUnsupportedCondition() throws {
+        let tabs = PaywallComponent.TabsComponent(
+            control: .init(
+                type: .buttons,
+                stack: .init(
+                    components: [
+                        .tabControlButton(.init(
+                            tabId: "tab_1",
+                            stack: .init(components: [])
+                        ))
+                    ]
+                )
+            ),
+            tabs: [
+                .init(
+                    id: "tab_1",
+                    stack: .init(components: [])
+                )
+            ],
+            overrides: [
+                .init(
+                    extendedConditions: [
+                        .selectedPackage(operator: .in, packages: ["annual"])
+                    ],
+                    properties: .init(visible: false)
+                )
+            ]
+        )
+
+        let factory = ViewModelFactory()
+        let packageValidator = PackageValidator()
+
+        expect {
+            _ = try factory.toViewModel(
+                component: .tabs(tabs),
+                packageValidator: packageValidator,
+                firstItemIgnoresSafeAreaInfo: nil,
+                purchaseButtonCollector: nil,
+                offering: Self.mockOffering,
+                localizationProvider: .init(locale: .current, localizedStrings: [:]),
+                uiConfigProvider: try Self.createUIConfigProvider(),
+                colorScheme: .light
+            )
+        }.toNot(throwError(PaywallError.unsupportedCondition))
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
- preserve `extendedConditions` when converting `TabsComponent` overrides through the synthetic stack in `ViewModelFactory`
- avoid downgrading recognized V0 conditions (`variable`, `selected_package`) to `.unsupported`
- add regression coverage to ensure tabs overrides with recognized extended conditions do not throw `PaywallError.unsupportedCondition`

## Verification
- `swift test --filter ViewModelFactoryBadgeTests`

## Context
Compared with Android base PR https://github.com/RevenueCat/purchases-android/pull/3117:
- Android keeps condition types through override evaluation and tests recognized vs unsupported handling.
- This patch aligns iOS tabs behavior with that pattern.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts how `TabsComponent` overrides are converted for evaluation; mistakes could change paywall visibility/override behavior or trigger unintended fallback via `PaywallError.unsupportedCondition`. Scope is small and covered by a new regression test.
> 
> **Overview**
> Fixes `TabsComponent` override conversion in `ViewModelFactory` to **preserve `extendedConditions`** when building the synthetic stack used for tabs, instead of downgrading them into legacy `conditions`.
> 
> Adds a regression test ensuring a tabs override using the recognized `selectedPackage` extended condition does **not** throw `PaywallError.unsupportedCondition`, and updates imports to use `@_spi(Internal) import RevenueCat` where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 575637fbdbfaeb71c5adc4c49cd9e3c92b5dd10f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->