### PR TITLE
Enable auto-merge on release PR after deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2010,18 +2010,6 @@ jobs:
           name: All tests succeeded
           command: echo "All tests succeeded"
 
-  enable-auto-merge-release-pr:
-    docker:
-      - image: cimg/ruby:3.2.0
-    working_directory: ~/purchases-ios
-    shell: /bin/bash --login -o pipefail
-    steps:
-      - checkout
-      - install-rubydocker-dependencies
-      - run:
-          name: Enable auto-merge on release PR
-          command: bundle exec fastlane run enable_auto_merge_for_pr repo_name:purchases-ios branch:release/$(cat .version | tr -d '\n')
-
   all-tasks-passed:
     docker:
       - image: cimg/base:stable
@@ -2302,7 +2290,8 @@ workflows:
           requires:
             - make-release
           <<: *release-tags
-      - enable-auto-merge-release-pr:
+      - revenuecat/enable-auto-merge-release-pr:
+          repo_name: purchases-ios
           requires:
             - make-release
             - deploy-rct-tester


### PR DESCRIPTION
### Checklist
- [x] No unit tests needed (CI config changes only)
- [ ] N/A for purchases-android or hybrids

### Motivation

After a release is tagged and all deploys finish, the release PR into `main` still requires manual merging. This automates it by enabling GitHub auto-merge on the release PR once all deploy jobs succeed.

### Description

- Adds `all-tests-succeeded` intermediate gate (split from `all-tasks-passed`) to separate the test gate from the release gate.
- Reorders `deploy-tag` workflow so `make-release` runs after all deploy jobs (they only need the git tag, not the GitHub release).
- Adds `revenuecat/enable-auto-merge-release-pr` (from the shared orb) as the final job in `deploy-tag`, requiring all other jobs. It uses the `enable_auto_merge_for_pr` plugin action to enable GitHub auto-merge on the release PR.
- `all-tasks-passed` on release branches now gates on `tag-release-branch`, keeping it pending until the release is approved and tagged. Once auto-merge is enabled and this check passes, the PR merges automatically.
- `approve-release` now requires `all-tests-succeeded` instead of `all-tasks-passed`.

> **Depends on:**
> - [fastlane-plugin-revenuecat_internal#115](https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/115) — the `enable_auto_merge_for_pr` action and `find_open_pr_number` helper must be merged and released before this PR can work.
> - [sdks-circleci-orb#32](https://github.com/RevenueCat/sdks-circleci-orb/pull/32) — the `enable-auto-merge-release-pr` orb job (already merged and published as v3.12.0).