### PR TITLE
Update CircleCI orb sdks-common-config to 3.12.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 orbs:
   macos: circleci/macos@2.5.1
   slack: circleci/slack@5.0.0
-  revenuecat: revenuecat/sdks-common-config@dev:045d2d8cd7ac24d4591c662de97e133c1eff795a
+  revenuecat: revenuecat/sdks-common-config@3.12.0
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 


### PR DESCRIPTION
## Summary
- Update `sdks-common-config` CircleCI orb from dev version to released `3.12.0`

In https://github.com/RevenueCat/purchases-ios/pull/6195 we pointed to the development version of the orb, which has now been released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the CircleCI orb version reference, with potential impact limited to CI behavior if the orb’s released configuration differs from the previously pinned dev commit.
> 
> **Overview**
> Updates CircleCI to use the released `revenuecat/sdks-common-config@3.12.0` orb instead of a pinned dev commit, aligning CI with the official orb release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10f88b2d364bf9df4b7c45de7ebc710927bbe24b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->