### PR TITLE
Fix scheduled pipelines triggering unintended workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2297,8 +2297,6 @@ workflows:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - not:
-            equal: ["release-train", << pipeline.schedule.name >>]
-        - not:
             equal: [bump, << pipeline.parameters.action >>]
     jobs:
       - prepare-next-version:
@@ -2341,7 +2339,7 @@ workflows:
     when:
       and:
         - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - equal: ["maestro_e2e_tests", << pipeline.schedule.name >>]
+        - equal: ["daily-maestro-e2e-tests", << pipeline.schedule.name >>]
     jobs:
       - run-all-maestro-e2e-tests:
           context:
@@ -2402,7 +2400,7 @@ workflows:
     when:
       and:
         - not:
-            equal: ["release-train", << pipeline.schedule.name >>]
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - not:
             equal: [bump, << pipeline.parameters.action >>]
         - not:


### PR DESCRIPTION
### Checklist
- [x] N/A — CI config only, no unit tests needed
- [x] N/A — no cross-platform follow-up needed

### Motivation

Scheduled pipelines (`daily-maestro-e2e-tests`, `load_shedder_integration_tests`, `cocoapods_token_keepalive`) were also triggering the `release-or-main` workflow on `main`, running dozens of extra jobs unnecessarily. Additionally, `daily-maestro-e2e-tests` had a schedule name mismatch and was never actually matching its workflow.

### Description

- **`release-or-main`**: replaced the narrow `not: equal: ["release-train", << pipeline.schedule.name >>]` check with `not: equal: [scheduled_pipeline, << pipeline.trigger_source >>]`, which excludes *all* scheduled pipelines. Each schedule already has its own dedicated workflow.
- **`daily-maestro-e2e-tests`**: fixed schedule name from `maestro_e2e_tests` to `daily-maestro-e2e-tests` to match the actual CircleCI schedule.
- **`snapshot-bump`**: removed redundant `release-train` schedule name exclusion, already covered by the existing `scheduled_pipeline` trigger source check.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, CI-only changes, but it may change which workflows run for scheduled pipelines and `main`/release branches if the trigger conditions are misconfigured.
> 
> **Overview**
> Prevents scheduled pipelines from triggering the `release-or-main` workflow by switching the guard to `not: equal: [scheduled_pipeline, << pipeline.trigger_source >>]`.
> 
> Fixes the `daily-maestro-e2e-tests` schedule name to `daily-maestro-e2e-tests` so the workflow actually matches, and removes a redundant `release-train` schedule exclusion from `snapshot-bump`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c50abf066f47c018992b9afb6992c591479db2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->