### PR TITLE
Fix presented offering context lost in Customer Center purchases

### DIFF
--- a/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
+++ b/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
@@ -63,6 +63,8 @@ import SwiftUI
         promotionalOffer: PromotionalOffer?
     ) async throws -> PurchaseResultData
 
+    func purchase(package: Package) async throws -> PurchaseResultData
+
     func track(customerCenterEvent: any CustomerCenterEventType)
 
     func loadCustomerCenter() async throws -> CustomerCenterConfigData

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterPurchases.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterPurchases.swift
@@ -70,6 +70,10 @@ final class CustomerCenterPurchases: CustomerCenterPurchasesType {
         }
     }
 
+    func purchase(package: Package) async throws -> PurchaseResultData {
+        return try await Purchases.shared.purchase(package: package)
+    }
+
     func track(customerCenterEvent: any CustomerCenterEventType) {
         Purchases.shared.track(customerCenterEvent: customerCenterEvent)
     }

--- a/RevenueCatUI/CustomerCenter/Mocks/MockCustomerCenterPurchases.swift
+++ b/RevenueCatUI/CustomerCenter/Mocks/MockCustomerCenterPurchases.swift
@@ -96,6 +96,13 @@ final class MockCustomerCenterPurchases: @unchecked Sendable, CustomerCenterPurc
         return try purchaseResult.get()
     }
 
+    var purchasePackageCallCount = 0
+    var purchasePackageResult: Result<PurchaseResultData, Error>?
+    func purchase(package: Package) async throws -> PurchaseResultData {
+        purchasePackageCallCount += 1
+        return try (purchasePackageResult ?? purchaseResult).get()
+    }
+
     var trackCallCount = 0
     var trackError: Error?
     var trackedEvents: [CustomerCenterEventType] = []

--- a/RevenueCatUI/CustomerCenter/ViewModels/NoSubscriptionsCardViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/NoSubscriptionsCardViewModel.swift
@@ -75,8 +75,7 @@ final class NoSubscriptionsCardViewModel: ObservableObject {
     @Sendable @MainActor
     func performPurchase(packageToPurchase: Package) async -> (userCancelled: Bool, error: Error?) {
         do {
-            let result = try await purchasesProvider.purchase(product: packageToPurchase.storeProduct,
-                                                              promotionalOffer: nil)
+            let result = try await purchasesProvider.purchase(package: packageToPurchase)
             return (result.userCancelled, nil)
         } catch {
             return (false, error)


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

`NoSubscriptionsCardViewModel.performPurchase` was calling `purchase(product:promotionalOffer:)` with `packageToPurchase.storeProduct`, which strips the offering context from the purchase. This means the backend loses visibility into which offering presented the product to the customer.

### Description

- Added a `purchase(package:)` method to `CustomerCenterPurchasesType` so purchases can be made with the full `Package`, preserving the presented offering context.
- Updated `CustomerCenterPurchases` to delegate to `Purchases.shared.purchase(package:)`.
- Updated `MockCustomerCenterPurchases` with matching mock support.
- Changed `NoSubscriptionsCardViewModel.performPurchase` to use the new `purchase(package:)` method instead of `purchase(product:promotionalOffer:)`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Customer Center purchase entrypoint from `StoreProduct`-based purchases to `Package`-based purchases, which can affect purchase metadata/context sent to the backend and requires all `CustomerCenterPurchasesType` conformers to implement the new API.
> 
> **Overview**
> Fixes Customer Center purchases losing presented-offering context by introducing `purchase(package:)` on `CustomerCenterPurchasesType` and wiring it through `CustomerCenterPurchases` to `Purchases.shared.purchase(package:)`.
> 
> Updates `NoSubscriptionsCardViewModel.performPurchase` to buy via `Package` (instead of `package.storeProduct`) and extends `MockCustomerCenterPurchases` with counters/results for the new package purchase path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cf4d3ba8b4ba1c2cbd8e20675b17b31311695c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->