### PR TITLE
Add Customer Center to RCT Tester app

### DIFF
--- a/Tests/TestingApps/RCTTester/RCTTester/Sources/Views/MainView.swift
+++ b/Tests/TestingApps/RCTTester/RCTTester/Sources/Views/MainView.swift
@@ -42,7 +42,13 @@ struct MainView: View {
             #if os(iOS)
             Section("Customer Center") {
                 NavigationLink {
-                    CustomerCenterView()
+                    CustomerCenterView(
+                        navigationOptions: CustomerCenterNavigationOptions(
+                            usesNavigationStack: false,
+                            usesExistingNavigation: true,
+                            shouldShowCloseButton: false
+                        )
+                    )
                 } label: {
                     Label("Open Customer Center", systemImage: "person.crop.circle")
                 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests — N/A, test app change only
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids — N/A

### Motivation

The RCT Tester app currently has no way to open the SDK's Customer Center. This adds it so we can manually test Customer Center flows from the tester app.

### Description

Adds a new "Customer Center" section to the RCT Tester main screen with a `NavigationLink` that opens `CustomerCenterView`. Guarded with `#if os(iOS)` since Customer Center is iOS-only.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-app-only UI change that adds an iOS-gated navigation link; no production purchase logic or data handling changes.
> 
> **Overview**
> Adds a new **iOS-only** "Customer Center" section to `MainView` in the RCTTester app, including a `NavigationLink` that presents `RevenueCatUI`'s `CustomerCenterView` with custom `CustomerCenterNavigationOptions`.
> 
> Also imports `RevenueCatUI` in `MainView` to support the new screen.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de6a6ac899e1cc7114936b0c5e87a920cb0af33f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->