### PR TITLE
Merge dashboard default custom variables into condition evaluation

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
@@ -57,7 +57,8 @@ class CarouselComponentViewModel {
     ) -> some View {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
         let partial = PresentedCarouselPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/Components/Icon/IconComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Icon/IconComponentViewModel.swift
@@ -99,7 +99,8 @@ class IconComponentViewModel {
     ) -> some View {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
         let partial = PresentedIconPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
@@ -59,7 +59,8 @@ class ImageComponentViewModel {
     ) -> ImageComponentStyle {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
 
         let localizedPartial = LocalizedImagePartial.buildPartial(

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
@@ -66,7 +66,8 @@ class StackComponentViewModel {
     ) -> StackComponentStyle {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
 
         let partial = PresentedStackPartial.buildPartial(

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -65,7 +65,8 @@ class TextComponentViewModel {
         let isEligibleForPromoOffer = promoOffer != nil
         let conditionContext = ConditionContext(
             selectedPackageId: packageContext.package?.identifier,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
         let localizedPartial = LocalizedTextPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentView.swift
@@ -84,7 +84,8 @@ struct TimelineComponentView: View {
                         for: self.packageContext.package
                     ),
                     selectedPackageId: self.packageContext.package?.identifier,
-                    customVariables: self.customVariables
+                    customVariables: self.customVariables,
+                    defaultCustomVariables: viewModel.uiConfigProvider.defaultCustomVariables
                 ) { itemStyle in
                     if itemStyle.visible {
                         timelineRow(itemStyle: itemStyle, style: style)
@@ -111,7 +112,8 @@ struct TimelineComponentView: View {
                             for: self.packageContext.package
                         ),
                         selectedPackageId: self.packageContext.package?.identifier,
-                        customVariables: self.customVariables
+                        customVariables: self.customVariables,
+                        defaultCustomVariables: viewModel.uiConfigProvider.defaultCustomVariables
                     ) { itemStyle in
                         if itemStyle.visible {
                             let next = viewModel.items.indices.contains(index + 1) ? viewModel.items[index + 1] : nil

--- a/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentViewModel.swift
@@ -56,7 +56,8 @@ class TimelineComponentViewModel {
     ) -> some View {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
         let partial = PresentedTimelinePartial.buildPartial(
             state: state,
@@ -115,11 +116,13 @@ class TimelineItemViewModel {
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
         customVariables: [String: CustomVariableValue],
+        defaultCustomVariables: [String: CustomVariableValue] = [:],
         @ViewBuilder apply: @escaping (TimelineItemStyle) -> some View
     ) -> some View {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: defaultCustomVariables
         )
         let partial = PresentedTimelineItemPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoComponentViewModel.swift
@@ -83,7 +83,8 @@ class VideoComponentViewModel {
     ) -> some View {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
         let localizedPartial = LocalizedVideoPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -47,16 +47,21 @@ struct ConditionContext {
     /// The identifier of the currently selected package, or nil if none is selected.
     let selectedPackageId: String?
 
-    /// Custom variables provided by the developer for condition evaluation.
+    /// Custom variables for condition evaluation (merged from defaults + developer overrides).
     let customVariables: [String: CustomVariableValue]
 
     /// Creates a context with the given parameters.
+    /// - Parameters:
+    ///   - selectedPackageId: The currently selected package identifier.
+    ///   - customVariables: Developer-provided custom variables (take precedence over defaults).
+    ///   - defaultCustomVariables: Dashboard-defined default custom variables.
     init(
         selectedPackageId: String? = nil,
-        customVariables: [String: CustomVariableValue] = [:]
+        customVariables: [String: CustomVariableValue] = [:],
+        defaultCustomVariables: [String: CustomVariableValue] = [:]
     ) {
         self.selectedPackageId = selectedPackageId
-        self.customVariables = customVariables
+        self.customVariables = defaultCustomVariables.merging(customVariables) { _, new in new }
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
@@ -741,6 +741,174 @@ class PresentedPartialsTests: TestCase {
 
     // MARK: - Unsupported Condition Tests
 
+    // MARK: - Default Custom Variables Merge Tests
+
+    func testVariableCondition_UsesDefaultWhenDeveloperDoesNotProvide() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "plan", value: .string("free"))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: [:],
+            defaultCustomVariables: ["plan": .string("free")]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testVariableCondition_DeveloperOverridesDefault() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "plan", value: .string("premium"))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: ["plan": .string("premium")],
+            defaultCustomVariables: ["plan": .string("free")]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testVariableCondition_DeveloperOverridesDefault_DefaultDoesNotMatch() throws {
+        // Default is "free", developer overrides with "premium", condition checks for "free" → no match
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "plan", value: .string("free"))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: ["plan": .string("premium")],
+            defaultCustomVariables: ["plan": .string("free")]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).to(beNil())
+    }
+
+    func testVariableCondition_DefaultBoolUsedInCondition() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "is_vip", value: .bool(true))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: [:],
+            defaultCustomVariables: ["is_vip": .bool(true)]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testVariableCondition_DefaultNumberUsedInCondition() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "level", value: .int(5))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: [:],
+            defaultCustomVariables: ["level": .number(5)]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testVariableCondition_MergesMultipleDefaultsWithDeveloperVariables() throws {
+        // Default provides "plan" and "level", developer provides "plan" override
+        // Condition checks "level" from defaults → should match
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "level", value: .int(3))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: ["plan": .string("premium")],
+            defaultCustomVariables: ["plan": .string("free"), "level": .number(3)]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testVariableCondition_EmptyDefaultsDoNotAffectBehavior() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "plan", value: .string("premium"))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: ["plan": .string("premium")],
+            defaultCustomVariables: [:]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    // MARK: - Unsupported Condition Tests
+
     func testUnsupportedCondition_DoesNotMatch() throws {
         let conditions: [PaywallComponent.ExtendedCondition] = [.unsupported]
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomVariablesEditorView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomVariablesEditorView.swift
@@ -15,6 +15,12 @@ import SwiftUI
 
 struct CustomVariablesEditorView: View {
 
+    enum VariableType: String, CaseIterable {
+        case string = "String"
+        case number = "Number"
+        case bool = "Bool"
+    }
+
     @Binding var variables: [String: CustomVariableValue]
     @Environment(\.dismiss) private var dismiss
 
@@ -23,7 +29,10 @@ struct CustomVariablesEditorView: View {
 
     @State private var isAddingVariable = false
     @State private var newVariableName = ""
-    @State private var newVariableValue = ""
+    @State private var newVariableStringValue = ""
+    @State private var newVariableNumberValue = ""
+    @State private var newVariableBoolValue = false
+    @State private var newVariableType: VariableType = .string
 
     struct VariableItem: Identifiable {
         let id = UUID()
@@ -109,7 +118,24 @@ struct CustomVariablesEditorView: View {
                 #endif
                 .autocorrectionDisabled()
 
-            TextField("Value", text: $newVariableValue)
+            Picker("Type", selection: $newVariableType) {
+                ForEach(VariableType.allCases, id: \.self) { type in
+                    Text(type.rawValue).tag(type)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            switch newVariableType {
+            case .string:
+                TextField("Value", text: $newVariableStringValue)
+            case .number:
+                TextField("Value", text: $newVariableNumberValue)
+                    #if os(iOS) || os(visionOS)
+                    .keyboardType(.decimalPad)
+                    #endif
+            case .bool:
+                Toggle("Value", isOn: $newVariableBoolValue)
+            }
 
             HStack {
                 Button("Cancel", role: .destructive) {
@@ -123,11 +149,22 @@ struct CustomVariablesEditorView: View {
                     addVariable()
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(newVariableName.isEmpty)
+                .disabled(newVariableName.isEmpty || !isNewValueValid)
             }
             .padding(.vertical, 4)
         } header: {
             Text("New Variable")
+        }
+    }
+
+    private var isNewValueValid: Bool {
+        switch newVariableType {
+        case .string:
+            return true
+        case .number:
+            return Double(newVariableNumberValue) != nil
+        case .bool:
+            return true
         }
     }
 
@@ -142,13 +179,41 @@ struct CustomVariablesEditorView: View {
                     .foregroundColor(.secondary)
             }
             Spacer()
+            Text(typeLabel(for: value))
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(
+                    Capsule()
+                        .fill(Color.secondary.opacity(0.15))
+                )
         }
+    }
+
+    private func typeLabel(for value: CustomVariableValue) -> String {
+        #if DEBUG
+        if value.isString { return "String" }
+        if value.isNumber { return "Number" }
+        if value.isBool { return "Bool" }
+        #endif
+        return ""
     }
 
     private func addVariable() {
         guard !newVariableName.isEmpty else { return }
 
-        let newItem = VariableItem(key: newVariableName, value: .string(newVariableValue))
+        let value: CustomVariableValue
+        switch newVariableType {
+        case .string:
+            value = .string(newVariableStringValue)
+        case .number:
+            value = .number(Double(newVariableNumberValue) ?? 0)
+        case .bool:
+            value = .bool(newVariableBoolValue)
+        }
+
+        let newItem = VariableItem(key: newVariableName, value: value)
         variablesList.append(newItem)
         variablesList.sort { $0.key < $1.key }
 
@@ -161,7 +226,10 @@ struct CustomVariablesEditorView: View {
             isAddingVariable = false
         }
         newVariableName = ""
-        newVariableValue = ""
+        newVariableStringValue = ""
+        newVariableNumberValue = ""
+        newVariableBoolValue = false
+        newVariableType = .string
     }
 
     private func deleteVariables(at offsets: IndexSet) {
@@ -174,7 +242,7 @@ struct CustomVariablesEditorView: View {
 #Preview {
     CustomVariablesEditorView(variables: .constant([
         "player_name": .string("John"),
-        "level": .string("42"),
-        "is_premium": .string("true")
+        "level": .number(42),
+        "is_premium": .bool(true)
     ]))
 }


### PR DESCRIPTION
## Summary

- Merges dashboard-defined default custom variables with developer-provided overrides before condition evaluation, achieving parity with Android SDK (PR #3117)
- Developer-provided values take precedence on conflict

## Motivation

On iOS, the merge of default custom variables with developer overrides already happens for **text replacement** (in `VariableHandlerV2.processCustomVariable()`), but was **missing** for condition evaluation. This meant a condition like `plan = "free"` would fail on iOS if only the dashboard defines `plan`'s default value, while it would succeed on Android.

This caused a subtle cross-platform inconsistency: the same paywall could behave differently on iOS vs Android when conditions rely on dashboard-defined default variables.

## Approach

Merge at `ConditionContext` init — added a `defaultCustomVariables` parameter that gets merged with `customVariables` using `defaultCustomVariables.merging(customVariables) { _, new in new }`. This is a single merge point rather than updating 8+ scattered call sites with pre-merged dictionaries.

Each ViewModel call site now passes `uiConfigProvider.defaultCustomVariables` when constructing `ConditionContext`. For `TimelineItemViewModel` (which doesn't have `uiConfigProvider`), a `defaultCustomVariables` parameter was added to its `styles()` method and passed from the View.

## Test plan

- [x] `swift build` compiles successfully
- [x] All 44 `PresentedPartialsTests` pass (37 existing + 7 new)
- [x] SwiftLint passes with no violations
- [ ] Verify on device that conditions using dashboard defaults work correctly

New tests cover:
- Variable condition uses default when developer doesn't provide it
- Developer-provided variable overrides dashboard default
- Default doesn't match when developer overrides with different value
- Bool and number defaults used in conditions
- Multiple defaults merged with developer variables
- Empty defaults don't affect behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes in paywall override condition evaluation because default dashboard variables are now considered, which could alter which overrides apply at runtime. Scope is contained to Paywalls V2 view models and is covered by targeted unit tests.
> 
> **Overview**
> Paywalls V2 override conditions now evaluate against *merged* custom variables (dashboard defaults + developer-provided values), with developer values taking precedence, by extending `ConditionContext` to accept `defaultCustomVariables` and performing the merge centrally.
> 
> All component view models that build a `ConditionContext` now pass `uiConfigProvider.defaultCustomVariables` (including a new `defaultCustomVariables` parameter plumbed through `TimelineItemViewModel.styles()`), and new unit tests validate default-vs-developer precedence across types. The PaywallsTester `CustomVariablesEditorView` UI was updated to create/edit typed variables (string/number/bool) to better exercise variable conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5eb0ca259938282d6e78d926442e375ed13f96fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->