### PR TITLE
Merge dashboard default custom variables into condition evaluation

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
@@ -57,7 +57,8 @@ class CarouselComponentViewModel {
     ) -> some View {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
         let partial = PresentedCarouselPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/Components/Icon/IconComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Icon/IconComponentViewModel.swift
@@ -99,7 +99,8 @@ class IconComponentViewModel {
     ) -> some View {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
         let partial = PresentedIconPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
@@ -59,7 +59,8 @@ class ImageComponentViewModel {
     ) -> ImageComponentStyle {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
 
         let localizedPartial = LocalizedImagePartial.buildPartial(

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
@@ -66,7 +66,8 @@ class StackComponentViewModel {
     ) -> StackComponentStyle {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
 
         let partial = PresentedStackPartial.buildPartial(

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -65,7 +65,8 @@ class TextComponentViewModel {
         let isEligibleForPromoOffer = promoOffer != nil
         let conditionContext = ConditionContext(
             selectedPackageId: packageContext.package?.identifier,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
         let localizedPartial = LocalizedTextPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentView.swift
@@ -84,7 +84,8 @@ struct TimelineComponentView: View {
                         for: self.packageContext.package
                     ),
                     selectedPackageId: self.packageContext.package?.identifier,
-                    customVariables: self.customVariables
+                    customVariables: self.customVariables,
+                    defaultCustomVariables: viewModel.uiConfigProvider.defaultCustomVariables
                 ) { itemStyle in
                     if itemStyle.visible {
                         timelineRow(itemStyle: itemStyle, style: style)
@@ -111,7 +112,8 @@ struct TimelineComponentView: View {
                             for: self.packageContext.package
                         ),
                         selectedPackageId: self.packageContext.package?.identifier,
-                        customVariables: self.customVariables
+                        customVariables: self.customVariables,
+                        defaultCustomVariables: viewModel.uiConfigProvider.defaultCustomVariables
                     ) { itemStyle in
                         if itemStyle.visible {
                             let next = viewModel.items.indices.contains(index + 1) ? viewModel.items[index + 1] : nil

--- a/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentViewModel.swift
@@ -56,7 +56,8 @@ class TimelineComponentViewModel {
     ) -> some View {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
         let partial = PresentedTimelinePartial.buildPartial(
             state: state,
@@ -115,11 +116,13 @@ class TimelineItemViewModel {
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
         customVariables: [String: CustomVariableValue],
+        defaultCustomVariables: [String: CustomVariableValue] = [:],
         @ViewBuilder apply: @escaping (TimelineItemStyle) -> some View
     ) -> some View {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: defaultCustomVariables
         )
         let partial = PresentedTimelineItemPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoComponentViewModel.swift
@@ -83,7 +83,8 @@ class VideoComponentViewModel {
     ) -> some View {
         let conditionContext = ConditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
         )
         let localizedPartial = LocalizedVideoPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -47,16 +47,21 @@ struct ConditionContext {
     /// The identifier of the currently selected package, or nil if none is selected.
     let selectedPackageId: String?
 
-    /// Custom variables provided by the developer for condition evaluation.
+    /// Custom variables for condition evaluation (merged from defaults + developer overrides).
     let customVariables: [String: CustomVariableValue]
 
     /// Creates a context with the given parameters.
+    /// - Parameters:
+    ///   - selectedPackageId: The currently selected package identifier.
+    ///   - customVariables: Developer-provided custom variables (take precedence over defaults).
+    ///   - defaultCustomVariables: Dashboard-defined default custom variables.
     init(
         selectedPackageId: String? = nil,
-        customVariables: [String: CustomVariableValue] = [:]
+        customVariables: [String: CustomVariableValue] = [:],
+        defaultCustomVariables: [String: CustomVariableValue] = [:]
     ) {
         self.selectedPackageId = selectedPackageId
-        self.customVariables = customVariables
+        self.customVariables = defaultCustomVariables.merging(customVariables) { _, new in new }
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
@@ -758,6 +758,174 @@ class PresentedPartialsTests: TestCase {
 
     // MARK: - Unsupported Condition Tests
 
+    // MARK: - Default Custom Variables Merge Tests
+
+    func testVariableCondition_UsesDefaultWhenDeveloperDoesNotProvide() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "plan", value: .string("free"))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: [:],
+            defaultCustomVariables: ["plan": .string("free")]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testVariableCondition_DeveloperOverridesDefault() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "plan", value: .string("premium"))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: ["plan": .string("premium")],
+            defaultCustomVariables: ["plan": .string("free")]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testVariableCondition_DeveloperOverridesDefault_DefaultDoesNotMatch() throws {
+        // Default is "free", developer overrides with "premium", condition checks for "free" → no match
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "plan", value: .string("free"))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: ["plan": .string("premium")],
+            defaultCustomVariables: ["plan": .string("free")]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).to(beNil())
+    }
+
+    func testVariableCondition_DefaultBoolUsedInCondition() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "is_vip", value: .bool(true))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: [:],
+            defaultCustomVariables: ["is_vip": .bool(true)]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testVariableCondition_DefaultNumberUsedInCondition() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "level", value: .int(5))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: [:],
+            defaultCustomVariables: ["level": .number(5)]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testVariableCondition_MergesMultipleDefaultsWithDeveloperVariables() throws {
+        // Default provides "plan" and "level", developer provides "plan" override
+        // Condition checks "level" from defaults → should match
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "level", value: .int(3))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: ["plan": .string("premium")],
+            defaultCustomVariables: ["plan": .string("free"), "level": .number(3)]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testVariableCondition_EmptyDefaultsDoNotAffectBehavior() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .variable(operator: .equals, variable: "plan", value: .string("premium"))
+        ]
+
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: ["plan": .string("premium")],
+            defaultCustomVariables: [:]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    // MARK: - Unsupported Condition Tests
+
     func testUnsupportedCondition_DoesNotMatch() throws {
         let conditions: [PaywallComponent.ExtendedCondition] = [.unsupported]
 


### PR DESCRIPTION
## Summary

- Merges dashboard-defined default custom variables with developer-provided overrides before condition evaluation, achieving parity with Android SDK (PR #3117)
- Developer-provided values take precedence on conflict

## Motivation

On iOS, the merge of default custom variables with developer overrides already happens for **text replacement** (in `VariableHandlerV2.processCustomVariable()`), but was **missing** for condition evaluation. This meant a condition like `plan = "free"` would fail on iOS if only the dashboard defines `plan`'s default value, while it would succeed on Android.

This caused a subtle cross-platform inconsistency: the same paywall could behave differently on iOS vs Android when conditions rely on dashboard-defined default variables.

## Approach

Merge at `ConditionContext` init — added a `defaultCustomVariables` parameter that gets merged with `customVariables` using `defaultCustomVariables.merging(customVariables) { _, new in new }`. This is a single merge point rather than updating 8+ scattered call sites with pre-merged dictionaries.

Each ViewModel call site now passes `uiConfigProvider.defaultCustomVariables` when constructing `ConditionContext`. For `TimelineItemViewModel` (which doesn't have `uiConfigProvider`), a `defaultCustomVariables` parameter was added to its `styles()` method and passed from the View.

## Test plan

- [x] `swift build` compiles successfully
- [x] All 44 `PresentedPartialsTests` pass (37 existing + 7 new)
- [x] SwiftLint passes with no violations
- [ ] Verify on device that conditions using dashboard defaults work correctly

New tests cover:
- Variable condition uses default when developer doesn't provide it
- Developer-provided variable overrides dashboard default
- Default doesn't match when developer overrides with different value
- Bool and number defaults used in conditions
- Multiple defaults merged with developer variables
- Empty defaults don't affect behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes override-condition evaluation across multiple Paywalls V2 components by merging dashboard default variables with developer-provided ones, which can alter which overrides apply at runtime. Risk is limited to paywall UI behavior but could change visibility/styling for users relying on variable conditions.
> 
> **Overview**
> Makes Paywalls V2 override condition evaluation honor dashboard-defined *default* custom variables by extending `ConditionContext` to merge `defaultCustomVariables` with developer-provided `customVariables` (developer values win).
> 
> Updates component view models (carousel, icon, image, stack, text, timeline/video) to pass `uiConfigProvider.defaultCustomVariables` into `ConditionContext`, including plumbing defaults through `TimelineItemViewModel.styles()` from `TimelineComponentView`.
> 
> Adds a focused test suite in `PresentedPartialsTests` covering default-vs-developer precedence and type cases for variable-based conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49cceaabf121e9d754902c48bbd3d4564ad933b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->