### PR TITLE
Update sdks-common-config orb to 3.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 orbs:
   macos: circleci/macos@2.5.1
   slack: circleci/slack@5.0.0
-  revenuecat: revenuecat/sdks-common-config@3.12.0
+  revenuecat: revenuecat/sdks-common-config@3.13.0
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 


### PR DESCRIPTION
Updates the revenuecat/sdks-common-config CircleCI orb to version 3.13.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but could alter CI job behavior if the updated orb changes executors/commands under the hood.
> 
> **Overview**
> Updates the CircleCI config to use `revenuecat/sdks-common-config@3.13.0` (from `3.12.0`), pulling in the latest shared CI orb behavior for this pipeline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 356cda64e3b9fd8512ded77355ddcdbf3afc48a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->