### PR TITLE
Improve Danger xcodeproj sync warning message

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -73,18 +73,19 @@ def check_swift_files_in_project
 
   return if missing_files.empty? && lingering_references.empty?
 
-  message = "Please keep RevenueCat.xcodeproj in sync with Tuist-generated changes.\n"
+  message = "**`RevenueCat.xcodeproj` is out of sync.**\n"
   unless missing_files.empty?
-    message += "\nThe following Swift files were added but don't appear to be included in RevenueCat.xcodeproj:\n"
-    missing_files.each { |file| message += "• #{file}\n" }
+    message += "\nThe following Swift files were added but are missing from `RevenueCat.xcodeproj`:\n"
+    missing_files.each { |file| message += "• `#{file}`\n" }
   end
 
   unless lingering_references.empty?
-    message += "\nThe following Swift files were deleted but still appear referenced in RevenueCat.xcodeproj:\n"
-    lingering_references.each { |file| message += "• #{file}\n" }
+    message += "\nThe following Swift files were deleted but still referenced in `RevenueCat.xcodeproj`:\n"
+    lingering_references.each { |file| message += "• `#{file}`\n" }
   end
 
-  message += "\nIf you've changed files using the tuist project, make sure those changes are added to RevenueCat.xcodeproj, or double-check if they should be excluded."
+  message += "\nTo fix: open `RevenueCat.xcodeproj` in Xcode, add/remove the files above in the appropriate target. "
+  message += "Check where similar files in the same directory are assigned if you're unsure which target to use."
   warn(message)
 end
 


### PR DESCRIPTION
## Summary
- Makes the Danger warning for `RevenueCat.xcodeproj` out-of-sync clearer and more actionable
- Adds bold header, code formatting for paths, and explicit fix instructions

## Test plan
- [ ] Verify Danger message renders correctly on a PR with missing/stale xcodeproj references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Danger warning copy/formatting and adds clearer remediation instructions; no build or runtime behavior changes beyond CI messaging.
> 
> **Overview**
> Updates the Danger check that detects Swift file additions/deletions not reflected in `RevenueCat.xcodeproj` to emit a clearer, more actionable warning.
> 
> The message now includes a bold header, formats file paths as code, and replaces the generic guidance with explicit steps to open `RevenueCat.xcodeproj` and add/remove the listed files in the correct targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 773a8c09ea6cb32b822fec1d0c5815f562760aca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->