### PR TITLE
Update to use CI commands from CircleCI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,24 +391,6 @@ commands:
       - scan-and-archive:
           directory: << parameters.directory >>
 
-  setup-git-credentials:
-    steps:
-      - run:
-          name: Setup Git config
-          command: |
-            git config --global user.email $GIT_EMAIL
-            git config --global user.name $GIT_USERNAME
-
-  trust-github-key:
-    steps:
-      - run:
-          name: Trust GitHub key
-          command: |
-            for ip in $(dig @8.8.8.8 github.com +short); \
-            do ssh-keyscan github.com,$ip; \
-            ssh-keyscan $ip; \
-            done 2>/dev/null >> ~/.ssh/known_hosts
-
   update-spm-installation-commit:
     steps:
       - run:
@@ -563,7 +545,7 @@ commands:
       - when:
           condition: << parameters.condition >>
           steps:
-            - setup-git-credentials
+            - revenuecat/setup-git-credentials
             - run:
                 name: Run << parameters.job >>
                 command: bundle exec fastlane << parameters.job >> version:"<< parameters.version >>"
@@ -1400,7 +1382,7 @@ jobs:
       name: macos-executor
     steps:
       - checkout
-      - trust-github-key
+      - revenuecat/trust-github-key
       # Bundler
       - restore_cache:
           keys:
@@ -1439,7 +1421,7 @@ jobs:
       # https://github.com/RevenueCat/purchases-ios/pull/1997
       xcode_version: "14.3.1"
     steps:
-      - setup-git-credentials
+      - revenuecat/setup-git-credentials
       - checkout
       - install-bundle-dependencies
       - run:
@@ -1456,7 +1438,7 @@ jobs:
       # https://github.com/RevenueCat/purchases-ios/pull/1997
       xcode_version: "14.3.1"
     steps:
-      - setup-git-credentials
+      - revenuecat/setup-git-credentials
       - checkout
       - install-bundle-dependencies
       - run:
@@ -1470,7 +1452,7 @@ jobs:
       name: macos-executor
     steps:
       - checkout
-      - trust-github-key
+      - revenuecat/trust-github-key
       - install-dependencies
       - update-spm-installation-commit
       - run:
@@ -1484,7 +1466,7 @@ jobs:
     steps:
       - checkout
       - install-bundle-dependencies
-      - trust-github-key
+      - revenuecat/trust-github-key
       - run:
           name: Deploy new version
           command: bundle exec fastlane push_revenuecat_pod
@@ -1496,7 +1478,7 @@ jobs:
     steps:
       - checkout
       - install-bundle-dependencies
-      - trust-github-key
+      - revenuecat/trust-github-key
       - run:
           name: Deploy new version
           command: bundle exec fastlane push_revenuecatui_pod
@@ -1519,8 +1501,8 @@ jobs:
     steps:
       - checkout
       - install-dependencies
-      - setup-git-credentials
-      - trust-github-key
+      - revenuecat/setup-git-credentials
+      - revenuecat/trust-github-key
       - run:
           name: Prepare next version
           command: bundle exec fastlane prepare_next_version
@@ -1732,8 +1714,8 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - setup-git-credentials
-      - trust-github-key
+      - revenuecat/setup-git-credentials
+      - revenuecat/trust-github-key
       - install-rubydocker-dependencies
       - run:
           name: Check Release PR is approved
@@ -1750,8 +1732,8 @@ jobs:
       name: macos-executor
     steps:
       - checkout
-      - setup-git-credentials
-      - trust-github-key
+      - revenuecat/setup-git-credentials
+      - revenuecat/trust-github-key
       - install-dependencies
       - run:
           name: Create automatic PR
@@ -1772,8 +1754,8 @@ jobs:
       name: macos-executor
     steps:
       - checkout
-      - setup-git-credentials
-      - trust-github-key
+      - revenuecat/setup-git-credentials
+      - revenuecat/trust-github-key
       - install-dependencies
       - update-spm-installation-commit
       - run:
@@ -1792,8 +1774,8 @@ jobs:
         default: false
     steps:
       - checkout
-      - setup-git-credentials
-      - trust-github-key
+      - revenuecat/setup-git-credentials
+      - revenuecat/trust-github-key
       - install-dependencies
       - update-spm-installation-commit
       - run:
@@ -1811,8 +1793,8 @@ jobs:
         default: false
     steps:
       - checkout
-      - setup-git-credentials
-      - trust-github-key
+      - revenuecat/setup-git-credentials
+      - revenuecat/trust-github-key
       - install-dependencies
       - revenuecat/install-tuist
       - run:
@@ -1825,8 +1807,8 @@ jobs:
       name: macos-executor
     steps:
       - checkout
-      - setup-git-credentials
-      - trust-github-key
+      - revenuecat/setup-git-credentials
+      - revenuecat/trust-github-key
       - install-dependencies
       - update-spm-installation-commit
       - run:
@@ -1838,8 +1820,8 @@ jobs:
       name: macos-executor
     steps:
       - checkout
-      - setup-git-credentials
-      - trust-github-key
+      - revenuecat/setup-git-credentials
+      - revenuecat/trust-github-key
       - install-dependencies
 
       # LOCAL_SOURCE
@@ -1982,7 +1964,7 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - setup-git-credentials
+      - revenuecat/setup-git-credentials
       - run:
           name: Clone purchases-ios and push to purchases-ios-spm
           command: |
@@ -2001,7 +1983,7 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - setup-git-credentials
+      - revenuecat/setup-git-credentials
       - install-rubydocker-dependencies
       - run:
           name: Trigger RC App Pipeline


### PR DESCRIPTION
### Description
We made some changes in the orb to the github commands since the previous ones started failing. This changes the current jobs to use the new commands

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CircleCI pipeline steps used by docs builds, release/tagging, and deployment jobs; a misconfiguration could block CI or publishing even though no product code changes.
> 
> **Overview**
> Updates `.circleci/config.yml` to **replace locally-defined Git setup commands** with the `revenuecat/sdks-common-config` orb equivalents.
> 
> Removes the in-repo `setup-git-credentials` and `trust-github-key` command definitions and updates all affected jobs (snapshot PR creation, docs build/deploy, release checks/tagging, SPM/pod publishing, and other release automation) to call `revenuecat/setup-git-credentials` and `revenuecat/trust-github-key` instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 612ba8d643a133d1cc58efa32a2307f765cbf0f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->