### PR TITLE
Add .number() and .bool() to CustomVariableValue API tester

### DIFF
--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewControllerAPI.swift
@@ -107,6 +107,8 @@ func paywallViewControllerAPI(_ delegate: Delegate,
 func customVariableValueAPI() {
     // CustomVariableValue type and static constructors
     let _: CustomVariableValue = .string("test")
+    let _: CustomVariableValue = .number(42)
+    let _: CustomVariableValue = .bool(true)
 
     // Accessing underlying value
     let stringValue: CustomVariableValue = .string("hello")


### PR DESCRIPTION
## Summary
- Adds `.number()` and `.bool()` static constructors to the `CustomVariableValue` API tester, since they were promoted from `internal` to `public` in #6285.

## Test plan
- [x] API tester compiles with the new public methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates an API tester to compile against newly-public `CustomVariableValue` constructors, with no runtime logic or production code changes.
> 
> **Overview**
> Updates the Swift UI API tester to exercise the newly public `CustomVariableValue` constructors by adding `.number(42)` and `.bool(true)` usages in `customVariableValueAPI()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9095fcdf7a4e9e3a91b25dff7987a615833d1818. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->