### PR TITLE
Fix reduced timeouts being used for HTTP requests when a proxy URL is configured

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -606,9 +606,8 @@ private extension HTTPClient {
         #endif
 
         finalURLRequest.timeoutInterval = requestTimeoutManager.timeout(
-            for: request.httpRequest.path,
             isFallback: request.isFallbackURLRequest,
-            hasProxyURL: SystemInfo.proxyURL != nil
+            fallbackAvailable: request.httpRequest.path.supportsFallbackURLs && SystemInfo.proxyURL == nil
         )
 
         // swiftlint:disable:next redundant_void_return

--- a/Sources/Networking/HTTPClient/HTTPRequestTimeoutManager.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestTimeoutManager.swift
@@ -13,11 +13,10 @@ protocol HTTPRequestTimeoutManagerType {
     /// Determines the timeout to be used by the HTTP Request for the given path.
     ///
     /// - Parameters:
-    ///   - path: The HTTP request path for which to determine the timeout
     ///   - isFallback: Whether this is a fallback request
-    ///   - hasProxyURL: Whether a proxy URL is configured, which disables fallback URLs
+    ///   - fallbackAvailable: Whether fallback URLs are available for this request
     /// - Returns: The timeout interval in seconds
-    func timeout(for path: HTTPRequestPath, isFallback: Bool, hasProxyURL: Bool) -> TimeInterval
+    func timeout(isFallback: Bool, fallbackAvailable: Bool) -> TimeInterval
 
     /// Updates the internal state in response to the result received from the backend.
     ///
@@ -67,16 +66,14 @@ class HTTPRequestTimeoutManager: HTTPRequestTimeoutManagerType {
         self.dateProvider = dateProvider
     }
 
-    func timeout(for path: HTTPRequestPath, isFallback: Bool, hasProxyURL: Bool) -> TimeInterval {
+    func timeout(isFallback: Bool, fallbackAvailable: Bool) -> TimeInterval {
         if shouldResetTimeout {
             resetLastTimeoutRequestTime()
         }
 
         let timeout: TimeInterval
 
-        // A fallback request, a request that doesn't support a fallback, or a proxy is configured
-        // (proxy disables fallback URLs, so the aggressive short timeout should not be used)
-        if isFallback || !path.supportsFallbackURLs || hasProxyURL {
+        if isFallback || !fallbackAvailable {
             timeout = self.defaultTimeout
         }
         // Main backend request that supports fallback when a timeout was previously received from the main backend

--- a/Tests/UnitTests/Mocks/MockHTTPRequestTimeoutManager.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPRequestTimeoutManager.swift
@@ -14,8 +14,8 @@ class MockHTTPRequestTimeoutManager: HTTPRequestTimeoutManagerType {
     private let defaultTimeout: TimeInterval
     private(set) var recordedResults: [HTTPRequestTimeoutManager.RequestResult] = []
     private(set) var timeoutCallCount = 0
-    private(set) var lastTimeoutPath: HTTPRequestPath?
     private(set) var lastTimeoutIsFallback: Bool?
+    private(set) var lastTimeoutFallbackAvailable: Bool?
 
     init(defaultTimeout: TimeInterval) {
         self.defaultTimeout = defaultTimeout
@@ -24,10 +24,10 @@ class MockHTTPRequestTimeoutManager: HTTPRequestTimeoutManagerType {
 
     var timeoutToReturn: TimeInterval
 
-    func timeout(for path: HTTPRequestPath, isFallback: Bool, hasProxyURL: Bool) -> TimeInterval {
+    func timeout(isFallback: Bool, fallbackAvailable: Bool) -> TimeInterval {
         timeoutCallCount += 1
-        lastTimeoutPath = path
         lastTimeoutIsFallback = isFallback
+        lastTimeoutFallbackAvailable = fallbackAvailable
         return timeoutToReturn
     }
 
@@ -38,8 +38,8 @@ class MockHTTPRequestTimeoutManager: HTTPRequestTimeoutManagerType {
     func reset() {
         recordedResults.removeAll()
         timeoutCallCount = 0
-        lastTimeoutPath = nil
         lastTimeoutIsFallback = nil
+        lastTimeoutFallbackAvailable = nil
         timeoutToReturn = defaultTimeout
     }
 }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1123,9 +1123,8 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
 
         XCTAssertEqual(
             timeoutManager.timeout(
-                for: request.path,
                 isFallback: false,
-                hasProxyURL: false
+                fallbackAvailable: true
             ),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
@@ -1144,9 +1143,8 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
 
         XCTAssertEqual(
             timeoutManager.timeout(
-                for: request.path,
                 isFallback: false,
-                hasProxyURL: false
+                fallbackAvailable: true
             ),
             HTTPRequestTimeoutManager.Timeout.mainBackendRequestSupportingFallback.rawValue
         )
@@ -1197,12 +1195,11 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         }
 
         // Make sure it uses the default timeout because it doesn't support fallback requests
-        XCTAssertEqual(timeoutManager.timeout(for: request.path, isFallback: false, hasProxyURL: false), self.defaultRequestTimeout)
+        XCTAssertEqual(timeoutManager.timeout(isFallback: false, fallbackAvailable: false), self.defaultRequestTimeout)
 
         // Make sure it uses the default timeout for backend requests suppoting fallback
-        let requestSupportingFallback = HTTPRequest(method: .get, path: .getProductEntitlementMapping)
         XCTAssertEqual(
-            timeoutManager.timeout(for: requestSupportingFallback.path, isFallback: false, hasProxyURL: false),
+            timeoutManager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.mainBackendRequestSupportingFallback.rawValue
         )
     }
@@ -1229,7 +1226,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
 
         // Still reduced timeout because error was not a timeout
         XCTAssertEqual(
-            timeoutManager.timeout(for: request.path, isFallback: false, hasProxyURL: false),
+            timeoutManager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
     }
@@ -1262,7 +1259,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
 
         // Timeout should remain at mainBackendRequestSupportingFallback because .other doesn't change the timeout state
         XCTAssertEqual(
-            timeoutManager.timeout(for: request.path, isFallback: false, hasProxyURL: false),
+            timeoutManager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.mainBackendRequestSupportingFallback.rawValue
         )
     }
@@ -1305,7 +1302,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         // The initial request to the main backend should use the value for a request
         // to the main backend that supports fallback
         XCTAssertEqual(
-            self.timeoutManager.timeout(for: firstRequest.path, isFallback: false, hasProxyURL: false),
+            self.timeoutManager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.mainBackendRequestSupportingFallback.rawValue
         )
 
@@ -1346,7 +1343,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
                 // A new request that supports fallback to the main backend
                 // should use the default timeout since previously a timeout was received
                 XCTAssertEqual(
-                    self.timeoutManager.timeout(for: secondRequest.path, isFallback: false, hasProxyURL: false),
+                    self.timeoutManager.timeout(isFallback: false, fallbackAvailable: true),
                     HTTPRequestTimeoutManager.Timeout.reduced.rawValue
                 )
 

--- a/Tests/UnitTests/Networking/HTTPRequestTimeoutManager.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTimeoutManager.swift
@@ -28,7 +28,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
     /// when the request supports a fallback
     func testDefaultTimeoutForPathWithFallback() {
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.mainBackendRequestSupportingFallback.rawValue
         )
     }
@@ -36,7 +36,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
     /// Initially the default timeout should be returned for a request that is a fallback request
     func testDefaultTimeoutForPathWithFallbackForFallbackRequest() {
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: true, hasProxyURL: false),
+            manager.timeout(isFallback: true, fallbackAvailable: true),
             Self.defaultTimeout
         )
     }
@@ -44,7 +44,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
     /// For a path that does not support fallbacks the default timeout should be used initially
     func testDefaultTimeoutForPathWithoutFallback() {
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withoutFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: false),
             Self.defaultTimeout
         )
     }
@@ -53,7 +53,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
     /// timeout should be used initially
     func testDefaultTimeoutForPathWithoutFallbackForFallbackRequest() {
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withoutFallback, isFallback: true, hasProxyURL: false),
+            manager.timeout(isFallback: true, fallbackAvailable: false),
             Self.defaultTimeout
         )
     }
@@ -64,7 +64,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
         manager.recordRequestResult(.timeoutOnMainBackendForFallbackSupportedEndpoint)
 
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
     }
@@ -79,7 +79,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
         dateProvider.advance(by: 2)
 
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
 
@@ -87,7 +87,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
         dateProvider.advance(by: 11 * 60)
 
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.mainBackendRequestSupportingFallback.rawValue
         )
     }
@@ -97,14 +97,14 @@ class HTTPRequestTimeoutManagerTests: TestCase {
         // Record timeout first
         manager.recordRequestResult(.timeoutOnMainBackendForFallbackSupportedEndpoint)
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
 
         // Record success - should reset timeout state
         manager.recordRequestResult(.successOnMainBackend)
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.mainBackendRequestSupportingFallback.rawValue
         )
     }
@@ -114,14 +114,14 @@ class HTTPRequestTimeoutManagerTests: TestCase {
         // Record timeout first
         manager.recordRequestResult(.timeoutOnMainBackendForFallbackSupportedEndpoint)
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
 
         // Record .other - should not change state
         manager.recordRequestResult(.other)
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
     }
@@ -131,7 +131,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
         // Record timeout
         manager.recordRequestResult(.timeoutOnMainBackendForFallbackSupportedEndpoint)
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
 
@@ -140,7 +140,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
 
         // Timeout should still be reduced
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
     }
@@ -149,7 +149,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
     func testTimeoutDoesNotResetIfNoTimeoutHasOccurred() {
         // No timeout recorded
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.mainBackendRequestSupportingFallback.rawValue
         )
 
@@ -158,7 +158,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
 
         // Should still be default since no timeout occurred
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.mainBackendRequestSupportingFallback.rawValue
         )
     }
@@ -169,7 +169,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
         // First timeout
         manager.recordRequestResult(.timeoutOnMainBackendForFallbackSupportedEndpoint)
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
 
@@ -179,7 +179,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
         // Second timeout - should update timestamp
         manager.recordRequestResult(.timeoutOnMainBackendForFallbackSupportedEndpoint)
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
 
@@ -188,7 +188,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
 
         // Should still be reduced because last timeout was only 5 seconds ago
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
     }
@@ -199,7 +199,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
         // Record timeout
         manager.recordRequestResult(.timeoutOnMainBackendForFallbackSupportedEndpoint)
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
 
@@ -209,7 +209,7 @@ class HTTPRequestTimeoutManagerTests: TestCase {
         // Record success - should reset immediately regardless of time
         manager.recordRequestResult(.successOnMainBackend)
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.mainBackendRequestSupportingFallback.rawValue
         )
     }
@@ -222,15 +222,15 @@ class HTTPRequestTimeoutManagerTests: TestCase {
 
         // Multiple calls should all return reduced timeout
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: true),
             HTTPRequestTimeoutManager.Timeout.reduced.rawValue
         )
     }
@@ -243,14 +243,14 @@ class HTTPRequestTimeoutManagerTests: TestCase {
 
         // Fallback requests should always use default timeout
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: true, hasProxyURL: false),
+            manager.timeout(isFallback: true, fallbackAvailable: true),
             Self.defaultTimeout
         )
 
         // Even after success, fallback should still use default timeout
         manager.recordRequestResult(.successOnMainBackend)
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withFallback, isFallback: true, hasProxyURL: false),
+            manager.timeout(isFallback: true, fallbackAvailable: true),
             Self.defaultTimeout
         )
     }
@@ -260,52 +260,22 @@ class HTTPRequestTimeoutManagerTests: TestCase {
     func testEndpointsWithoutFallbackSupportAlwaysUseDefaultTimeout() {
         // Initially
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withoutFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: false),
             Self.defaultTimeout
         )
 
         // Even after recording timeout
         manager.recordRequestResult(.timeoutOnMainBackendForFallbackSupportedEndpoint)
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withoutFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: false),
             Self.defaultTimeout
         )
 
         // After success
         manager.recordRequestResult(.successOnMainBackend)
         XCTAssertEqual(
-            manager.timeout(for: Mockpath.withoutFallback, isFallback: false, hasProxyURL: false),
+            manager.timeout(isFallback: false, fallbackAvailable: false),
             Self.defaultTimeout
         )
-    }
-
-    enum Mockpath: HTTPRequestPath {
-        case withFallback
-        case withoutFallback
-
-        static var serverHostURL: URL { URL(string: "https://api.revenuecat.com")! }
-
-        var authenticated: Bool { true }
-
-        var shouldSendEtag: Bool { true }
-
-        var supportsSignatureVerification: Bool { false }
-
-        var needsNonceForSigning: Bool { false }
-
-        var name: String { "Test" }
-
-        var relativePath: String { "/v1/test" }
-
-        var fallbackUrls: [URL] {
-            switch self {
-            case .withFallback:
-                return [
-                    Self.serverHostURL.appendingPathComponent("/fallback")
-                ]
-            case .withoutFallback:
-                return []
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary

- When a proxy URL is configured, fallback URLs are disabled. However, the timeout manager still applied the aggressive 5s/2s timeouts meant for endpoints with fallback support.
- This caused proxy requests to time out with no fallback recovery path, making the proxy unusable for slow connections.
- Added `hasProxyURL` parameter to the timeout manager so it uses the default timeout when a proxy is active.

## Test plan

- [x] Added `testUsesDefaultTimeoutForFallbackSupportingEndpointWhenProxyURLIsSet` — verifies default timeout is used for fallback-supporting endpoints when proxy is set
- [x] Added `testDoesNotUseReducedTimeoutAfterTimeoutWhenProxyURLIsSet` — verifies reduced timeout is not applied after a prior timeout when proxy is set
- [x] All 155 existing HTTPClient/timeout tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core HTTP request timeout selection logic; incorrect conditions could change timeout behavior and affect request reliability, though the behavior change is scoped to when `SystemInfo.proxyURL` is set.
> 
> **Overview**
> Prevents the dynamic timeout manager from applying aggressive (5s/2s) timeouts when a proxy URL is configured and fallback URLs are therefore unavailable.
> 
> This updates the timeout manager API to take `fallbackAvailable` (instead of a `path`) and wires `HTTPClient` to pass `supportsFallbackURLs && SystemInfo.proxyURL == nil`, plus adds unit coverage ensuring proxy-based requests use the default timeout even after prior main-backend timeouts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddf792d4d1cd9932f136bf81ba4cb799f23454e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->