### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,7 @@
 /Tests/RevenueCatUITests/ @RevenueCat/customer-center
 
 # Paywalls
-/RevenueCatUI/Templates/ @RevenueCat/monetization
+/RevenueCatUI/Templates/ @RevenueCat/paywalls
+/RevenueCatUI/Views/ @RevenueCat/paywalls
+/RevenueCatUI/PaywallView.swift @RevenueCat/paywalls
+/RevenueCatUI/View+PresentPaywall* @RevenueCat/paywalls


### PR DESCRIPTION
The monetization team is no longer… and this was missing some important stuff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since it only changes GitHub ownership routing; the main impact is who is auto-requested for reviews on paywall-related files.
> 
> **Overview**
> **CODEOWNERS updated for Paywalls.** Replaces the paywalls owner from `@RevenueCat/monetization` to `@RevenueCat/paywalls`.
> 
> Expands paywall ownership coverage beyond `RevenueCatUI/Templates/` to also include `RevenueCatUI/Views/`, `RevenueCatUI/PaywallView.swift`, and `RevenueCatUI/View+PresentPaywall*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48ec23f30749cbf527a68ade13c133ff766f91fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->