### PR TITLE
Experiment: run iOS 26 tests on GitHub Actions

### DIFF
--- a/.github/workflows/run-test-ios-26.yml
+++ b/.github/workflows/run-test-ios-26.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   run-test-ios-26:
-    runs-on: macos-26
+    runs-on: macos-26-xlarge
     timeout-minutes: 60
     env:
       CIRCLECI_TESTS_GENERATE_SNAPSHOTS: ${{ github.event_name == 'workflow_dispatch' && inputs.generate_snapshots && 'true' || 'false' }}


### PR DESCRIPTION
### Motivation

Experiment to evaluate running the iOS 26 test suite on GitHub Actions.

### Summary

- Adds a new GitHub Actions workflow that runs the iOS 26 SPM release build and unit tests on `macos-26`.
- Triggered on pushes to `main`, pull requests, and manual dispatch (with optional snapshot generation).
- Uploads test results and compressed xcresult bundles as artifacts.


Made with [Cursor](https://cursor.com)