### PR TITLE
Fix PaywallsTester tap to use presentPaywall for exit offer support

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -263,6 +263,7 @@ struct APIKeyDashboardList: View {
         #endif
                 .presentPaywallIfNeededModifier(offering: $offeringToPresent)
                 .presentPaywall(offering: $presentPaywallOffering, onDismiss: { })
+                .customPaywallVariables(self.customVariables)
                 .onChange(of: offeringToPresent) { offering in
                     if offering != nil {
                         self.isLoadingPaywall = false


### PR DESCRIPTION
## Summary
Regular tap on a paywall in the list used a plain `.sheet()` with `PaywallPresenter`, which bypasses exit offer logic. Long press → "Present Paywall" used `.presentPaywall()` modifier which supports exit offers.

Changed the regular tap to also use `.presentPaywall()` so exit offers work consistently.

Also added `.customPaywallVariables()` to the `.presentPaywall()` modifier chain so custom variables configured via the variables editor are passed through to V2 paywall components. The old `.sheet()` path had this inside the sheet content closure, but the new path needs it in the environment above the modifier.

## Changes
- Use `presentPaywallOffering` instead of `presentedPaywall` for the regular tap action in `APIKeyDashboardList`
- Apply `.customPaywallVariables()` to the `.presentPaywall()` path

## Testing
Tested locally in PaywallsTester: regular tap on a paywall now triggers exit offers on dismiss, matching the behavior of long press → "Present Paywall".

Closes PW-1129