### PR TITLE
Make custom variable number/bool setters public for UIKit

### DIFF
--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -83,7 +83,7 @@ public class PaywallViewController: UIViewController {
     /// - Parameters:
     ///   - value: The numeric value to set.
     ///   - key: The variable key (without the `custom.` prefix).
-    @objc func setCustomVariableNumber(_ value: Double, forKey key: String) {
+    @objc public func setCustomVariableNumber(_ value: Double, forKey key: String) {
         CustomVariableKeyValidator.validate(key)
         self.customVariables[key] = .number(value)
     }
@@ -92,7 +92,7 @@ public class PaywallViewController: UIViewController {
     /// - Parameters:
     ///   - value: The boolean value to set.
     ///   - key: The variable key (without the `custom.` prefix).
-    @objc func setCustomVariableBool(_ value: Bool, forKey key: String) {
+    @objc public func setCustomVariableBool(_ value: Bool, forKey key: String) {
         CustomVariableKeyValidator.validate(key)
         self.customVariables[key] = .bool(value)
     }


### PR DESCRIPTION
## Summary
- Adds `public` access modifier to `setCustomVariableNumber(_:forKey:)` and `setCustomVariableBool(_:forKey:)` on `PaywallViewController`
- These were `internal` by default, but `purchases-hybrid-common` needs to call them from `PurchasesHybridCommonUI` to support number and boolean custom paywall variables ([PR #1551](https://github.com/RevenueCat/purchases-hybrid-common/pull/1551))

## Test plan
- [ ] Verify iOS builds pass in purchases-hybrid-common CI after updating the dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk API surface change: only widens visibility of two existing `PaywallViewController` methods without altering paywall behavior or data handling.
> 
> **Overview**
> Exposes `PaywallViewController` Objective-C APIs `setCustomVariableNumber(_:forKey:)` and `setCustomVariableBool(_:forKey:)` by changing them to `public`, enabling external/hybrid SDK callers to set numeric and boolean custom paywall variables (matching the existing public string setter).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5abe9c33365c8a25e0789c5bdaa62a8c8a123e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->