### PR TITLE
[EXTERNAL] Fix xcframework zip when used as a binaryTarget in SPM

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1492,7 +1492,7 @@ platform :ios do
     # Use zip -r to preserve directory structure
     # Change to the xcframework's parent directory so the zip contains the xcframework folder
     Dir.chdir(File.dirname(xcframework_path)) do
-      sh("zip", "-r", "-q", xcframework_zip_path, File.basename(xcframework_path))
+      sh("zip", "-r", "-y", "-q", xcframework_zip_path, File.basename(xcframework_path))
     end
 
   end


### PR DESCRIPTION
When using the current zip xcframework as a binaryTarget in SPM, it fails code verification with the following error:
```
RevenueCat.xcframework: a sealed resource is missing or invalid
```

This broke in version 5.58.0 with commit
```
f8ea8e54211d0c2386d0f9ff7e03361ae1166673
```

That commit moved away from ditto and started using zip.

The problem is that ditto copies symlinks by default, while the zip command copies the folder contents for symlinks by default.

The fix is to use the -y flag for the zip command, which copies the symlinks instead of following them, restoring the previous ditto behavior.

To reproduce the problem with 5.58.0:
```
curl -L -o RevenueCat.xcframework.zip https://github.com/RevenueCat/purchases-ios/releases/download/5.58.0/RevenueCat.xcframework.zip
unzip RevenueCat.xcframework.zip
codesign --verify --verbose RevenueCat.xcframework
```

```
RevenueCat.xcframework: a sealed resource is missing or invalid
```

5.57.2 works as expected:
```
curl -L -o RevenueCat.xcframework.zip https://github.com/RevenueCat/purchases-ios/releases/download/5.57.2/RevenueCat.xcframework.zip
unzip RevenueCat.xcframework.zip -d RevenueCat.xcframework
codesign --verify --verbose RevenueCat.xcframework
```

```
RevenueCat.xcframework: valid on disk
RevenueCat.xcframework: satisfies its Designated Requirement
```

Verify the change in this commit:
```
bundle exec fastlane ios export_xcframeworks
codesign --timestamp -s - build/xcframeworks/RevenueCat/RevenueCat.xcframework
codesign --verify --verbose build/xcframeworks/RevenueCat/RevenueCat.xcframework
```

```
RevenueCat.xcframework: valid on disk
RevenueCat.xcframework: satisfies its Designated Requirement
```

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how release XCFramework zips are generated by preserving symlinks, which directly affects distributed artifacts consumed via SPM and could impact downstream installation if incorrect.
> 
> **Overview**
> Fixes XCFramework zip packaging for SPM `binaryTarget` consumption by updating the Fastlane `export_xcframeworks` flow to zip with `-y`, preserving symlinks instead of following them.
> 
> This restores codesign verification integrity for the unzipped `.xcframework` (avoiding “sealed resource is missing or invalid” failures) after the earlier switch from `ditto` to `zip`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d953de89297e40651d6c62ae1fb3683e94b28dba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->