### PR TITLE
Fix objc_loadWeakRetained crash in PaywallViewController swipe-to-dismiss

### DIFF
--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -315,12 +315,6 @@ public class PaywallViewController: UIViewController {
 
     public override func viewDidDisappear(_ animated: Bool) {
         if self.isBeingDismissed && !self.isDismissingForExitOffer {
-            // For programmatic dismissals, clean up the stored delegate here since
-            // presentationControllerDidDismiss won't be called.
-            // For interactive (swipe) dismissals, cleanup happens in presentationControllerDidDismiss
-            // after forwarding is complete.
-            self.originalPresentationControllerDelegate = nil
-
             self.delegate?.paywallViewControllerWasDismissed?(self)
             self.purchaseHandler.resetForNewSession()
         }


### PR DESCRIPTION
## Summary

- Fixes a crash (`objc_loadWeakRetained`) in `PaywallViewController.presentationControllerShouldDismiss(_:)` triggered when the user swipes to dismiss a paywall sheet and the original presentation controller delegate has been deallocated.
- Changes `originalPresentationControllerDelegate` from a `weak` to a strong reference. This is safe because UIKit already retains the presenting view controller for the duration of the presentation.
- Nils out the stored reference in `presentationControllerDidDismiss` (the last callback in the interactive dismissal chain) after forwarding is complete.

### Crashlytics reference
- https://revenuecat.zendesk.com/agent/tickets/72893
- Crash in `objc_loadWeakRetained` → `@objc PaywallViewController.presentationControllerShouldDismiss(_:)`

## Test plan

- [ ] Present a `PaywallViewController` with an exit offer configured, swipe to dismiss — verify exit offer appears
- [ ] Present a `PaywallViewController` without an exit offer, swipe to dismiss — verify it dismisses normally
- [ ] Present a paywall, navigate away from the presenting VC (e.g., tab switch), then swipe to dismiss — verify no crash
- [ ] Verify the original presentation controller delegate receives callbacks after the paywall is dismissed