### PR TITLE
[EXTERNAL] Fix xcframework zip when used as a binaryTarget in SPM (#6461) via @tehsven

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1492,7 +1492,7 @@ platform :ios do
     # Use zip -r to preserve directory structure
     # Change to the xcframework's parent directory so the zip contains the xcframework folder
     Dir.chdir(File.dirname(xcframework_path)) do
-      sh("zip", "-r", "-q", xcframework_zip_path, File.basename(xcframework_path))
+      sh("zip", "-r", "-y", "-q", xcframework_zip_path, File.basename(xcframework_path))
     end
 
   end


### PR DESCRIPTION
When using the current zip xcframework as a binaryTarget in SPM, it fails code verification with the following error:
```
RevenueCat.xcframework: a sealed resource is missing or invalid
```

This broke in version 5.58.0 with commit
```
f8ea8e54211d0c2386d0f9ff7e03361ae1166673
```

That commit moved away from ditto and started using zip.

The problem is that ditto copies symlinks by default, while the zip command copies the folder contents for symlinks by default.

The fix is to use the -y flag for the zip command, which copies the symlinks instead of following them, restoring the previous ditto behavior.

To reproduce the problem with 5.58.0:
```
curl -L -o RevenueCat.xcframework.zip https://github.com/RevenueCat/purchases-ios/releases/download/5.58.0/RevenueCat.xcframework.zip
unzip RevenueCat.xcframework.zip
codesign --verify --verbose RevenueCat.xcframework
```

```
RevenueCat.xcframework: a sealed resource is missing or invalid
```

5.57.2 works as expected:
```
curl -L -o RevenueCat.xcframework.zip https://github.com/RevenueCat/purchases-ios/releases/download/5.57.2/RevenueCat.xcframework.zip
unzip RevenueCat.xcframework.zip -d RevenueCat.xcframework
codesign --verify --verbose RevenueCat.xcframework
```

```
RevenueCat.xcframework: valid on disk
RevenueCat.xcframework: satisfies its Designated Requirement
```

Verify the change in this commit:
```
bundle exec fastlane ios export_xcframeworks
codesign --timestamp -s - build/xcframeworks/RevenueCat/RevenueCat.xcframework
codesign --verify --verbose build/xcframeworks/RevenueCat/RevenueCat.xcframework
```

```
RevenueCat.xcframework: valid on disk
RevenueCat.xcframework: satisfies its Designated Requirement
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release artifact packaging step for signed XCFrameworks; while small, it can affect downstream installation/codesign verification for distributed binaries.
> 
> **Overview**
> Fixes XCFramework ZIP packaging by adding `-y` to the `zip` invocation in `fastlane/Fastfile`, ensuring symlinks inside the `.xcframework` are preserved rather than followed.
> 
> This restores expected structure for SPM `binaryTarget` consumers and prevents codesign verification failures caused by missing/invalid sealed resources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit becc95d45c1af06cca17e3ef646d682ebf441374. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->