### PR TITLE
Replace enable-auto-merge-release-pr with merge-release-pr orb job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 orbs:
   macos: circleci/macos@2.5.1
   slack: circleci/slack@5.0.0
-  revenuecat: revenuecat/sdks-common-config@3.14.0
+  revenuecat: revenuecat/sdks-common-config@3.15.0
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 
@@ -2295,7 +2295,7 @@ workflows:
           requires:
             - make-release
           <<: *release-tags
-      - revenuecat/enable-auto-merge-release-pr:
+      - revenuecat/merge-release-pr:
           repo_name: purchases-ios
           requires:
             - make-release


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

The new `merge-release-pr` orb job (added in [sdks-circleci-orb#40](https://github.com/RevenueCat/sdks-circleci-orb/pull/40)) merges release PRs directly via the REST API instead of enabling auto-merge and waiting for GitHub to merge. This is more reliable and immediate.

### Description

- Bumps `revenuecat/sdks-common-config` orb from `3.14.0` to `3.15.0`
- Replaces `revenuecat/enable-auto-merge-release-pr` with `revenuecat/merge-release-pr` in the release workflow
- The new job uses the default `SQUASH` merge method


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that affects the release pipeline’s final PR merge step; main risk is unexpected behavior from the updated orb job/permissions during release tagging.
> 
> **Overview**
> Updates CircleCI’s `revenuecat/sdks-common-config` orb from `3.14.0` to `3.15.0`.
> 
> In the `deploy-tag` release workflow, replaces `revenuecat/enable-auto-merge-release-pr` with `revenuecat/merge-release-pr` so release PRs are merged immediately via the orb job after `make-release`, `deploy-rct-tester`, and `bump-sdk-in-rc-mobile-app` complete.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c361eaf4c48602ec2661d050ade3c75dd6051b00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->