### PR TITLE
Add placement and targeting rule to paywall events

### DIFF
--- a/Sources/Paywalls/Events/Networking/EventsRequest+Paywall.swift
+++ b/Sources/Paywalls/Events/Networking/EventsRequest+Paywall.swift
@@ -69,6 +69,22 @@ extension FeatureEventsRequest.PaywallEvent {
         var targetingRevision: Int?
         var targetingRuleId: String?
 
+        /// Returns `nil` if all fields are `nil`.
+        init?(
+            placementIdentifier: String?,
+            targetingRevision: Int?,
+            targetingRuleId: String?
+        ) {
+            guard placementIdentifier != nil ||
+                    targetingRevision != nil ||
+                    targetingRuleId != nil else {
+                return nil
+            }
+            self.placementIdentifier = placementIdentifier
+            self.targetingRevision = targetingRevision
+            self.targetingRuleId = targetingRuleId
+        }
+
     }
 
     enum EventType: String {
@@ -106,19 +122,6 @@ extension FeatureEventsRequest.PaywallEvent {
         let exitOfferData = decodedPaywallEvent.exitOfferData
         let componentInteractionData = decodedPaywallEvent.componentInteractionData
 
-        let presentedContext: PresentedOfferingContextData?
-        if data.placementIdentifier != nil ||
-            data.targetingRevision != nil ||
-            data.targetingRuleId != nil {
-            presentedContext = PresentedOfferingContextData(
-                placementIdentifier: data.placementIdentifier,
-                targetingRevision: data.targetingRevision,
-                targetingRuleId: data.targetingRuleId
-            )
-        } else {
-            presentedContext = nil
-        }
-
         self.init(
             id: creationData.id.uuidString,
             version: Self.version,
@@ -133,7 +136,11 @@ extension FeatureEventsRequest.PaywallEvent {
             darkMode: data.darkMode,
             localeIdentifier: data.localeIdentifier,
             source: data.source,
-            presentedOfferingContext: presentedContext,
+            presentedOfferingContext: PresentedOfferingContextData(
+                placementIdentifier: data.placementIdentifier,
+                targetingRevision: data.targetingRevision,
+                targetingRuleId: data.targetingRuleId
+            ),
             exitOfferType: exitOfferData?.exitOfferType,
             exitOfferingID: exitOfferData?.exitOfferingIdentifier,
             packageId: data.packageId,

--- a/Sources/Paywalls/Events/Networking/EventsRequest+Paywall.swift
+++ b/Sources/Paywalls/Events/Networking/EventsRequest+Paywall.swift
@@ -30,6 +30,7 @@ extension FeatureEventsRequest {
         var darkMode: Bool
         var localeIdentifier: String
         var source: PaywallSource?
+        var presentedOfferingContext: PresentedOfferingContextData?
         var exitOfferType: ExitOfferType?
         var exitOfferingID: String?
         var packageId: String?
@@ -55,6 +56,14 @@ extension FeatureEventsRequest {
         var resultingPackageIdentifier: String?
         var currentProductIdentifier: String?
         var resultingProductIdentifier: String?
+
+        struct PresentedOfferingContextData: Encodable {
+
+            var placementIdentifier: String?
+            var targetingRevision: Int?
+            var targetingRuleId: String?
+
+        }
 
     }
 
@@ -97,6 +106,19 @@ extension FeatureEventsRequest.PaywallEvent {
         let exitOfferData = decodedPaywallEvent.exitOfferData
         let componentInteractionData = decodedPaywallEvent.componentInteractionData
 
+        let presentedContext: PresentedOfferingContextData?
+        if data.placementIdentifier != nil ||
+            data.targetingRevision != nil ||
+            data.targetingRuleId != nil {
+            presentedContext = PresentedOfferingContextData(
+                placementIdentifier: data.placementIdentifier,
+                targetingRevision: data.targetingRevision,
+                targetingRuleId: data.targetingRuleId
+            )
+        } else {
+            presentedContext = nil
+        }
+
         self.init(
             id: creationData.id.uuidString,
             version: Self.version,
@@ -111,6 +133,7 @@ extension FeatureEventsRequest.PaywallEvent {
             darkMode: data.darkMode,
             localeIdentifier: data.localeIdentifier,
             source: data.source,
+            presentedOfferingContext: presentedContext,
             exitOfferType: exitOfferData?.exitOfferType,
             exitOfferingID: exitOfferData?.exitOfferingIdentifier,
             packageId: data.packageId,
@@ -182,6 +205,7 @@ extension FeatureEventsRequest.PaywallEvent: Encodable {
         case darkMode
         case localeIdentifier = "locale"
         case source
+        case presentedOfferingContext
         case exitOfferType
         case exitOfferingID = "exitOfferingId"
         case packageId = "packageId"

--- a/Sources/Paywalls/Events/Networking/EventsRequest+Paywall.swift
+++ b/Sources/Paywalls/Events/Networking/EventsRequest+Paywall.swift
@@ -57,19 +57,19 @@ extension FeatureEventsRequest {
         var currentProductIdentifier: String?
         var resultingProductIdentifier: String?
 
-        struct PresentedOfferingContextData: Encodable {
-
-            var placementIdentifier: String?
-            var targetingRevision: Int?
-            var targetingRuleId: String?
-
-        }
-
     }
 
 }
 
 extension FeatureEventsRequest.PaywallEvent {
+
+    struct PresentedOfferingContextData: Encodable {
+
+        var placementIdentifier: String?
+        var targetingRevision: Int?
+        var targetingRuleId: String?
+
+    }
 
     enum EventType: String {
 

--- a/Sources/Paywalls/Events/PaywallEvent.swift
+++ b/Sources/Paywalls/Events/PaywallEvent.swift
@@ -167,7 +167,6 @@ extension PaywallEvent {
             locale: Locale,
             darkMode: Bool
         ) {
-            let context = offering.availablePackages.first?.presentedOfferingContext
             self.init(
                 paywallIdentifier: paywallComponentsData.id,
                 offeringIdentifier: offering.identifier,
@@ -177,9 +176,7 @@ extension PaywallEvent {
                 localeIdentifier: locale.identifier,
                 darkMode: darkMode,
                 source: nil,
-                placementIdentifier: context?.placementIdentifier,
-                targetingRevision: context?.targetingContext?.revision,
-                targetingRuleId: context?.targetingContext?.ruleId
+                presentedOfferingContext: offering.availablePackages.first?.presentedOfferingContext
             )
         }
 
@@ -193,7 +190,6 @@ extension PaywallEvent {
             darkMode: Bool,
             source: PaywallSource?
         ) {
-            let context = offering.availablePackages.first?.presentedOfferingContext
             self.init(
                 paywallIdentifier: paywallComponentsData.id,
                 offeringIdentifier: offering.identifier,
@@ -203,9 +199,7 @@ extension PaywallEvent {
                 localeIdentifier: locale.identifier,
                 darkMode: darkMode,
                 source: source,
-                placementIdentifier: context?.placementIdentifier,
-                targetingRevision: context?.targetingContext?.revision,
-                targetingRuleId: context?.targetingContext?.ruleId
+                presentedOfferingContext: offering.availablePackages.first?.presentedOfferingContext
             )
         }
         #endif
@@ -220,7 +214,6 @@ extension PaywallEvent {
             locale: Locale,
             darkMode: Bool
         ) {
-            let context = offering.availablePackages.first?.presentedOfferingContext
             self.init(
                 paywallIdentifier: paywall.id,
                 offeringIdentifier: offering.identifier,
@@ -230,9 +223,7 @@ extension PaywallEvent {
                 localeIdentifier: locale.identifier,
                 darkMode: darkMode,
                 source: nil,
-                placementIdentifier: context?.placementIdentifier,
-                targetingRevision: context?.targetingContext?.revision,
-                targetingRuleId: context?.targetingContext?.ruleId
+                presentedOfferingContext: offering.availablePackages.first?.presentedOfferingContext
             )
         }
 
@@ -246,7 +237,6 @@ extension PaywallEvent {
             darkMode: Bool,
             source: PaywallSource?
         ) {
-            let context = offering.availablePackages.first?.presentedOfferingContext
             self.init(
                 paywallIdentifier: paywall.id,
                 offeringIdentifier: offering.identifier,
@@ -256,9 +246,7 @@ extension PaywallEvent {
                 localeIdentifier: locale.identifier,
                 darkMode: darkMode,
                 source: source,
-                placementIdentifier: context?.placementIdentifier,
-                targetingRevision: context?.targetingContext?.revision,
-                targetingRuleId: context?.targetingContext?.ruleId
+                presentedOfferingContext: offering.availablePackages.first?.presentedOfferingContext
             )
         }
         // swiftlint:enable missing_docs
@@ -272,9 +260,7 @@ extension PaywallEvent {
             localeIdentifier: String,
             darkMode: Bool,
             source: PaywallSource? = nil,
-            placementIdentifier: String? = nil,
-            targetingRevision: Int? = nil,
-            targetingRuleId: String? = nil,
+            presentedOfferingContext: PresentedOfferingContext? = nil,
             packageId: String? = nil,
             productId: String? = nil,
             errorCode: Int? = nil,
@@ -288,9 +274,9 @@ extension PaywallEvent {
             self.localeIdentifier = localeIdentifier
             self.darkMode = darkMode
             self.source = source
-            self.placementIdentifier = placementIdentifier
-            self.targetingRevision = targetingRevision
-            self.targetingRuleId = targetingRuleId
+            self.placementIdentifier = presentedOfferingContext?.placementIdentifier
+            self.targetingRevision = presentedOfferingContext?.targetingContext?.revision
+            self.targetingRuleId = presentedOfferingContext?.targetingContext?.ruleId
             self.packageId = packageId
             self.productId = productId
             self.errorCode = errorCode
@@ -476,23 +462,12 @@ extension PaywallEvent.Data {
         errorCode: Int?,
         errorMessage: String?
     ) -> PaywallEvent.Data {
-        return PaywallEvent.Data(
-            paywallIdentifier: self.paywallIdentifier,
-            offeringIdentifier: self.offeringIdentifier,
-            paywallRevision: self.paywallRevision,
-            sessionID: self.sessionIdentifier,
-            displayMode: self.displayMode,
-            localeIdentifier: self.localeIdentifier,
-            darkMode: self.darkMode,
-            source: self.source,
-            placementIdentifier: self.placementIdentifier,
-            targetingRevision: self.targetingRevision,
-            targetingRuleId: self.targetingRuleId,
-            packageId: packageId,
-            productId: productId,
-            errorCode: errorCode,
-            errorMessage: errorMessage
-        )
+        var copy = self
+        copy.packageId = packageId
+        copy.productId = productId
+        copy.errorCode = errorCode
+        copy.errorMessage = errorMessage
+        return copy
     }
 
 }

--- a/Sources/Paywalls/Events/PaywallEvent.swift
+++ b/Sources/Paywalls/Events/PaywallEvent.swift
@@ -148,6 +148,9 @@ extension PaywallEvent {
         public var localeIdentifier: String
         public var darkMode: Bool
         @_spi(Internal) public var source: PaywallSource?
+        var placementIdentifier: String?
+        var targetingRevision: Int?
+        var targetingRuleId: String?
         var packageId: String?
         var productId: String?
         var errorCode: Int?
@@ -164,6 +167,7 @@ extension PaywallEvent {
             locale: Locale,
             darkMode: Bool
         ) {
+            let context = offering.availablePackages.first?.presentedOfferingContext
             self.init(
                 paywallIdentifier: paywallComponentsData.id,
                 offeringIdentifier: offering.identifier,
@@ -172,7 +176,10 @@ extension PaywallEvent {
                 displayMode: displayMode,
                 localeIdentifier: locale.identifier,
                 darkMode: darkMode,
-                source: nil
+                source: nil,
+                placementIdentifier: context?.placementIdentifier,
+                targetingRevision: context?.targetingContext?.revision,
+                targetingRuleId: context?.targetingContext?.ruleId
             )
         }
 
@@ -186,6 +193,7 @@ extension PaywallEvent {
             darkMode: Bool,
             source: PaywallSource?
         ) {
+            let context = offering.availablePackages.first?.presentedOfferingContext
             self.init(
                 paywallIdentifier: paywallComponentsData.id,
                 offeringIdentifier: offering.identifier,
@@ -194,7 +202,10 @@ extension PaywallEvent {
                 displayMode: displayMode,
                 localeIdentifier: locale.identifier,
                 darkMode: darkMode,
-                source: source
+                source: source,
+                placementIdentifier: context?.placementIdentifier,
+                targetingRevision: context?.targetingContext?.revision,
+                targetingRuleId: context?.targetingContext?.ruleId
             )
         }
         #endif
@@ -209,6 +220,7 @@ extension PaywallEvent {
             locale: Locale,
             darkMode: Bool
         ) {
+            let context = offering.availablePackages.first?.presentedOfferingContext
             self.init(
                 paywallIdentifier: paywall.id,
                 offeringIdentifier: offering.identifier,
@@ -217,7 +229,10 @@ extension PaywallEvent {
                 displayMode: displayMode,
                 localeIdentifier: locale.identifier,
                 darkMode: darkMode,
-                source: nil
+                source: nil,
+                placementIdentifier: context?.placementIdentifier,
+                targetingRevision: context?.targetingContext?.revision,
+                targetingRuleId: context?.targetingContext?.ruleId
             )
         }
 
@@ -231,6 +246,7 @@ extension PaywallEvent {
             darkMode: Bool,
             source: PaywallSource?
         ) {
+            let context = offering.availablePackages.first?.presentedOfferingContext
             self.init(
                 paywallIdentifier: paywall.id,
                 offeringIdentifier: offering.identifier,
@@ -239,7 +255,10 @@ extension PaywallEvent {
                 displayMode: displayMode,
                 localeIdentifier: locale.identifier,
                 darkMode: darkMode,
-                source: source
+                source: source,
+                placementIdentifier: context?.placementIdentifier,
+                targetingRevision: context?.targetingContext?.revision,
+                targetingRuleId: context?.targetingContext?.ruleId
             )
         }
         // swiftlint:enable missing_docs
@@ -252,7 +271,10 @@ extension PaywallEvent {
             displayMode: PaywallViewMode,
             localeIdentifier: String,
             darkMode: Bool,
-            source: PaywallSource?,
+            source: PaywallSource? = nil,
+            placementIdentifier: String? = nil,
+            targetingRevision: Int? = nil,
+            targetingRuleId: String? = nil,
             packageId: String? = nil,
             productId: String? = nil,
             errorCode: Int? = nil,
@@ -266,6 +288,9 @@ extension PaywallEvent {
             self.localeIdentifier = localeIdentifier
             self.darkMode = darkMode
             self.source = source
+            self.placementIdentifier = placementIdentifier
+            self.targetingRevision = targetingRevision
+            self.targetingRuleId = targetingRuleId
             self.packageId = packageId
             self.productId = productId
             self.errorCode = errorCode
@@ -460,6 +485,9 @@ extension PaywallEvent.Data {
             localeIdentifier: self.localeIdentifier,
             darkMode: self.darkMode,
             source: self.source,
+            placementIdentifier: self.placementIdentifier,
+            targetingRevision: self.targetingRevision,
+            targetingRuleId: self.targetingRuleId,
             packageId: packageId,
             productId: productId,
             errorCode: errorCode,

--- a/Tests/UnitTests/Paywalls/Events/BackendPaywallEventTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/BackendPaywallEventTests.swift
@@ -50,6 +50,29 @@ class BackendPaywallEventTests: BaseBackendTests {
         expect(error).to(beNil())
     }
 
+    func testPostPaywallEventsWithPlacementAndTargeting() throws {
+        let eventData: PaywallEvent.Data = .init(
+            paywallIdentifier: "test_paywall_id_1",
+            offeringIdentifier: "offering_1",
+            paywallRevision: 5,
+            sessionID: .init(uuidString: "98CC0F1D-7665-4093-9624-1D7308FFF4DB")!,
+            displayMode: .fullScreen,
+            localeIdentifier: "es_ES",
+            darkMode: true,
+            placementIdentifier: "home_banner",
+            targetingRevision: 3,
+            targetingRuleId: "rule_abc123"
+        )
+        let event = PaywallEvent.impression(Self.eventCreation1, eventData)
+        let storedEvent: StoredFeatureEvent = try Self.createStoredFeatureEvent(from: event)
+
+        let error = waitUntilValue { completion in
+            self.internalAPI.postFeatureEvents(events: [storedEvent], completion: completion)
+        }
+
+        expect(error).to(beNil())
+    }
+
     func testPostPaywallEventsWithMultipleEvents() throws {
         let event1 = PaywallEvent.impression(Self.eventCreation1, Self.eventData1)
         let storedEvent1: StoredFeatureEvent = try Self.createStoredFeatureEvent(from: event1)

--- a/Tests/UnitTests/Paywalls/Events/BackendPaywallEventTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/BackendPaywallEventTests.swift
@@ -59,9 +59,11 @@ class BackendPaywallEventTests: BaseBackendTests {
             displayMode: .fullScreen,
             localeIdentifier: "es_ES",
             darkMode: true,
-            placementIdentifier: "home_banner",
-            targetingRevision: 3,
-            targetingRuleId: "rule_abc123"
+            presentedOfferingContext: .init(
+                offeringIdentifier: "offering_1",
+                placementIdentifier: "home_banner",
+                targetingContext: .init(revision: 3, ruleId: "rule_abc123")
+            )
         )
         let event = PaywallEvent.impression(Self.eventCreation1, eventData)
         let storedEvent: StoredFeatureEvent = try Self.createStoredFeatureEvent(from: event)

--- a/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
@@ -273,6 +273,31 @@ class PaywallFeatureEventsRequestTests: TestCase {
         expect(requestEvent.timestamp).to(equal(1_694_029_328_234))
     }
 
+    // MARK: - Placement & Targeting Tests
+
+    func testImpressionEventWithPlacementAndTargeting() throws {
+        let event = PaywallEvent.impression(Self.eventCreationData, Self.eventDataWithPlacementAndTargeting)
+        let storedEvent = try Self.createStoredFeatureEvent(from: event)
+        let requestEvent: FeatureEventsRequest.PaywallEvent = try XCTUnwrap(.init(storedEvent: storedEvent))
+
+        assertSnapshot(of: requestEvent, as: .formattedJson)
+    }
+
+    func testWithPurchaseInfoPreservesPlacementAndTargeting() {
+        let data = Self.eventDataWithPlacementAndTargeting
+
+        let result = data.withPurchaseInfo(
+            packageId: "test_package",
+            productId: "test_product",
+            errorCode: nil,
+            errorMessage: nil
+        )
+
+        expect(result.placementIdentifier) == "home_banner"
+        expect(result.targetingRevision) == 3
+        expect(result.targetingRuleId) == "rule_abc123"
+    }
+
     // MARK: - Milliseconds Precision Tests
 
     func testPaywallEventImpressionPreservesMillisecondsInCreationDate() throws {
@@ -418,6 +443,19 @@ private extension PaywallFeatureEventsRequestTests {
         localeIdentifier: "es_ES",
         darkMode: true,
         source: nil
+    )
+
+    static let eventDataWithPlacementAndTargeting: PaywallEvent.Data = .init(
+        paywallIdentifier: "test_paywall_id_1",
+        offeringIdentifier: "offering_1",
+        paywallRevision: 5,
+        sessionID: .init(uuidString: "98CC0F1D-7665-4093-9624-1D7308FFF4DB")!,
+        displayMode: .fullScreen,
+        localeIdentifier: "es_ES",
+        darkMode: true,
+        placementIdentifier: "home_banner",
+        targetingRevision: 3,
+        targetingRuleId: "rule_abc123"
     )
 
     static let eventDataWithSource: PaywallEvent.Data = .init(

--- a/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
@@ -453,9 +453,11 @@ private extension PaywallFeatureEventsRequestTests {
         displayMode: .fullScreen,
         localeIdentifier: "es_ES",
         darkMode: true,
-        placementIdentifier: "home_banner",
-        targetingRevision: 3,
-        targetingRuleId: "rule_abc123"
+        presentedOfferingContext: .init(
+            offeringIdentifier: "offering_1",
+            placementIdentifier: "home_banner",
+            targetingContext: .init(revision: 3, ruleId: "rule_abc123")
+        )
     )
 
     static let eventDataWithSource: PaywallEvent.Data = .init(

--- a/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
@@ -352,6 +352,52 @@ class PaywallFeatureEventsRequestTests: TestCase {
         assertSnapshot(of: requestEvent, as: .formattedJson)
     }
 
+    // MARK: - Backward Compatibility Tests
+
+    func testOldStoredEventWithoutPlacementAndTargetingDeserializesCorrectly() throws {
+        // First, generate a valid stored event JSON using the current serializer,
+        // then strip the placement/targeting fields to simulate the old format.
+        let event = PaywallEvent.impression(
+            .init(
+                id: .init(uuidString: "72164C05-2BDC-4807-8918-A4105F727DEB")!,
+                date: .init(timeIntervalSince1970: 1694029328)
+            ),
+            .init(
+                paywallIdentifier: "test_paywall_id",
+                offeringIdentifier: "offering",
+                paywallRevision: 0,
+                sessionID: .init(uuidString: "98CC0F1D-7665-4093-9624-1D7308FFF4DB")!,
+                displayMode: .fullScreen,
+                localeIdentifier: "es_ES",
+                darkMode: true,
+                source: nil
+            )
+        )
+        let storedEvent = try XCTUnwrap(StoredFeatureEvent(
+            event: event,
+            userID: "test-user",
+            feature: .paywalls,
+            appSessionID: Self.appSessionID,
+            eventDiscriminator: "impression"
+        ))
+
+        // Serialize, then strip any placement/targeting keys from the inner event JSON
+        // to simulate an event stored before these fields existed
+        var serialized = try StoredFeatureEventSerializer.encode(storedEvent)
+        serialized = serialized
+            .replacingOccurrences(of: ",\"placement_identifier\":null", with: "")
+            .replacingOccurrences(of: ",\"targeting_revision\":null", with: "")
+            .replacingOccurrences(of: ",\"targeting_rule_id\":null", with: "")
+
+        let deserialized = try StoredFeatureEventSerializer.decode(serialized)
+        expect(deserialized.userID) == "test-user"
+        expect(deserialized.feature) == .paywalls
+
+        let requestEvent = try XCTUnwrap(FeatureEventsRequest.PaywallEvent(storedEvent: deserialized))
+        expect(requestEvent.offeringID) == "offering"
+        expect(requestEvent.presentedOfferingContext).to(beNil())
+    }
+
     // MARK: - Milliseconds Precision Tests
 
     func testPaywallEventImpressionPreservesMillisecondsInCreationDate() throws {

--- a/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
@@ -275,6 +275,44 @@ class PaywallFeatureEventsRequestTests: TestCase {
 
     // MARK: - Placement & Targeting Tests
 
+    func testCanInitFromDeserializedEventWithPlacementAndTargeting() throws {
+        let expectedUserID = "test-user"
+        let paywallEventCreationData: PaywallEvent.CreationData = .init(
+            id: .init(uuidString: "72164C05-2BDC-4807-8918-A4105F727DEB")!,
+            date: .init(timeIntervalSince1970: 1694029328)
+        )
+        let paywallEventData: PaywallEvent.Data = .init(
+            paywallIdentifier: "test_paywall_id_1",
+            offeringIdentifier: "offering_1",
+            paywallRevision: 5,
+            sessionID: .init(uuidString: "73616D70-6C65-2073-7472-696E67000000")!,
+            displayMode: .fullScreen,
+            localeIdentifier: "en_US",
+            darkMode: true,
+            source: nil,
+            presentedOfferingContext: .init(
+                offeringIdentifier: "offering_1",
+                placementIdentifier: "home_banner",
+                targetingContext: .init(revision: 3, ruleId: "rule_abc123")
+            )
+        )
+        let paywallEvent = PaywallEvent.impression(paywallEventCreationData, paywallEventData)
+
+        let storedEvent = try XCTUnwrap(StoredFeatureEvent(event: paywallEvent,
+                                                           userID: expectedUserID,
+                                                           feature: .paywalls,
+                                                           appSessionID: Self.appSessionID,
+                                                           eventDiscriminator: "impression"))
+        let serializedEvent = try StoredFeatureEventSerializer.encode(storedEvent)
+        let deserializedEvent = try StoredFeatureEventSerializer.decode(serializedEvent)
+        expect(deserializedEvent.userID) == expectedUserID
+        expect(deserializedEvent.feature) == .paywalls
+
+        let requestEvent = try XCTUnwrap(FeatureEventsRequest.PaywallEvent(storedEvent: deserializedEvent))
+
+        assertSnapshot(of: requestEvent, as: .formattedJson)
+    }
+
     func testImpressionEventWithPlacementAndTargeting() throws {
         let event = PaywallEvent.impression(Self.eventCreationData, Self.eventDataWithPlacementAndTargeting)
         let storedEvent = try Self.createStoredFeatureEvent(from: event)
@@ -296,6 +334,22 @@ class PaywallFeatureEventsRequestTests: TestCase {
         expect(result.placementIdentifier) == "home_banner"
         expect(result.targetingRevision) == 3
         expect(result.targetingRuleId) == "rule_abc123"
+    }
+
+    func testImpressionEventWithPlacementOnly() throws {
+        let event = PaywallEvent.impression(Self.eventCreationData, Self.eventDataWithPlacementOnly)
+        let storedEvent = try Self.createStoredFeatureEvent(from: event)
+        let requestEvent: FeatureEventsRequest.PaywallEvent = try XCTUnwrap(.init(storedEvent: storedEvent))
+
+        assertSnapshot(of: requestEvent, as: .formattedJson)
+    }
+
+    func testImpressionEventWithTargetingOnly() throws {
+        let event = PaywallEvent.impression(Self.eventCreationData, Self.eventDataWithTargetingOnly)
+        let storedEvent = try Self.createStoredFeatureEvent(from: event)
+        let requestEvent: FeatureEventsRequest.PaywallEvent = try XCTUnwrap(.init(storedEvent: storedEvent))
+
+        assertSnapshot(of: requestEvent, as: .formattedJson)
     }
 
     // MARK: - Milliseconds Precision Tests
@@ -456,6 +510,36 @@ private extension PaywallFeatureEventsRequestTests {
         presentedOfferingContext: .init(
             offeringIdentifier: "offering_1",
             placementIdentifier: "home_banner",
+            targetingContext: .init(revision: 3, ruleId: "rule_abc123")
+        )
+    )
+
+    static let eventDataWithPlacementOnly: PaywallEvent.Data = .init(
+        paywallIdentifier: "test_paywall_id_1",
+        offeringIdentifier: "offering_1",
+        paywallRevision: 5,
+        sessionID: .init(uuidString: "98CC0F1D-7665-4093-9624-1D7308FFF4DB")!,
+        displayMode: .fullScreen,
+        localeIdentifier: "es_ES",
+        darkMode: true,
+        presentedOfferingContext: .init(
+            offeringIdentifier: "offering_1",
+            placementIdentifier: "home_banner",
+            targetingContext: nil
+        )
+    )
+
+    static let eventDataWithTargetingOnly: PaywallEvent.Data = .init(
+        paywallIdentifier: "test_paywall_id_1",
+        offeringIdentifier: "offering_1",
+        paywallRevision: 5,
+        sessionID: .init(uuidString: "98CC0F1D-7665-4093-9624-1D7308FFF4DB")!,
+        displayMode: .fullScreen,
+        localeIdentifier: "es_ES",
+        darkMode: true,
+        presentedOfferingContext: .init(
+            offeringIdentifier: "offering_1",
+            placementIdentifier: nil,
             targetingContext: .init(revision: 3, ruleId: "rule_abc123")
         )
     )

--- a/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
@@ -352,52 +352,6 @@ class PaywallFeatureEventsRequestTests: TestCase {
         assertSnapshot(of: requestEvent, as: .formattedJson)
     }
 
-    // MARK: - Backward Compatibility Tests
-
-    func testOldStoredEventWithoutPlacementAndTargetingDeserializesCorrectly() throws {
-        // First, generate a valid stored event JSON using the current serializer,
-        // then strip the placement/targeting fields to simulate the old format.
-        let event = PaywallEvent.impression(
-            .init(
-                id: .init(uuidString: "72164C05-2BDC-4807-8918-A4105F727DEB")!,
-                date: .init(timeIntervalSince1970: 1694029328)
-            ),
-            .init(
-                paywallIdentifier: "test_paywall_id",
-                offeringIdentifier: "offering",
-                paywallRevision: 0,
-                sessionID: .init(uuidString: "98CC0F1D-7665-4093-9624-1D7308FFF4DB")!,
-                displayMode: .fullScreen,
-                localeIdentifier: "es_ES",
-                darkMode: true,
-                source: nil
-            )
-        )
-        let storedEvent = try XCTUnwrap(StoredFeatureEvent(
-            event: event,
-            userID: "test-user",
-            feature: .paywalls,
-            appSessionID: Self.appSessionID,
-            eventDiscriminator: "impression"
-        ))
-
-        // Serialize, then strip any placement/targeting keys from the inner event JSON
-        // to simulate an event stored before these fields existed
-        var serialized = try StoredFeatureEventSerializer.encode(storedEvent)
-        serialized = serialized
-            .replacingOccurrences(of: ",\"placement_identifier\":null", with: "")
-            .replacingOccurrences(of: ",\"targeting_revision\":null", with: "")
-            .replacingOccurrences(of: ",\"targeting_rule_id\":null", with: "")
-
-        let deserialized = try StoredFeatureEventSerializer.decode(serialized)
-        expect(deserialized.userID) == "test-user"
-        expect(deserialized.feature) == .paywalls
-
-        let requestEvent = try XCTUnwrap(FeatureEventsRequest.PaywallEvent(storedEvent: deserialized))
-        expect(requestEvent.offeringID) == "offering"
-        expect(requestEvent.presentedOfferingContext).to(beNil())
-    }
-
     // MARK: - Milliseconds Precision Tests
 
     func testPaywallEventImpressionPreservesMillisecondsInCreationDate() throws {

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS15-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS15-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -1,0 +1,52 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : {
+      "events" : [
+        {
+          "app_user_id" : "user",
+          "dark_mode" : true,
+          "display_mode" : "full_screen",
+          "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
+          "locale" : "es_ES",
+          "offering_id" : "offering_1",
+          "paywall_id" : "test_paywall_id_1",
+          "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "placement_identifier" : "home_banner",
+            "targeting_revision" : 3,
+            "targeting_rule_id" : "rule_abc123"
+          },
+          "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
+          "timestamp" : 1694029328000,
+          "type" : "paywall_impression",
+          "version" : 1
+        }
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api-paywalls.revenuecat.com/v1/events"
+  }
+}

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS16-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS16-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -1,0 +1,52 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : {
+      "events" : [
+        {
+          "app_user_id" : "user",
+          "dark_mode" : true,
+          "display_mode" : "full_screen",
+          "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
+          "locale" : "es_ES",
+          "offering_id" : "offering_1",
+          "paywall_id" : "test_paywall_id_1",
+          "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "placement_identifier" : "home_banner",
+            "targeting_revision" : 3,
+            "targeting_rule_id" : "rule_abc123"
+          },
+          "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
+          "timestamp" : 1694029328000,
+          "type" : "paywall_impression",
+          "version" : 1
+        }
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api-paywalls.revenuecat.com/v1/events"
+  }
+}

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS17-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS17-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -1,0 +1,52 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : {
+      "events" : [
+        {
+          "app_user_id" : "user",
+          "dark_mode" : true,
+          "display_mode" : "full_screen",
+          "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
+          "locale" : "es_ES",
+          "offering_id" : "offering_1",
+          "paywall_id" : "test_paywall_id_1",
+          "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "placement_identifier" : "home_banner",
+            "targeting_revision" : 3,
+            "targeting_rule_id" : "rule_abc123"
+          },
+          "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
+          "timestamp" : 1694029328000,
+          "type" : "paywall_impression",
+          "version" : 1
+        }
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api-paywalls.revenuecat.com/v1/events"
+  }
+}

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS18-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS18-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -1,0 +1,52 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : {
+      "events" : [
+        {
+          "app_user_id" : "user",
+          "dark_mode" : true,
+          "display_mode" : "full_screen",
+          "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
+          "locale" : "es_ES",
+          "offering_id" : "offering_1",
+          "paywall_id" : "test_paywall_id_1",
+          "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "placement_identifier" : "home_banner",
+            "targeting_revision" : 3,
+            "targeting_rule_id" : "rule_abc123"
+          },
+          "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
+          "timestamp" : 1694029328000,
+          "type" : "paywall_impression",
+          "version" : 1
+        }
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api-paywalls.revenuecat.com/v1/events"
+  }
+}

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS26-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS26-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -1,0 +1,52 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : {
+      "events" : [
+        {
+          "app_user_id" : "user",
+          "dark_mode" : true,
+          "display_mode" : "full_screen",
+          "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
+          "locale" : "es_ES",
+          "offering_id" : "offering_1",
+          "paywall_id" : "test_paywall_id_1",
+          "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "placement_identifier" : "home_banner",
+            "targeting_revision" : 3,
+            "targeting_rule_id" : "rule_abc123"
+          },
+          "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
+          "timestamp" : 1694029328000,
+          "type" : "paywall_impression",
+          "version" : 1
+        }
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api-paywalls.revenuecat.com/v1/events"
+  }
+}

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/macOS-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/macOS-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -1,0 +1,51 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : {
+      "events" : [
+        {
+          "app_user_id" : "user",
+          "dark_mode" : true,
+          "display_mode" : "full_screen",
+          "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
+          "locale" : "es_ES",
+          "offering_id" : "offering_1",
+          "paywall_id" : "test_paywall_id_1",
+          "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "placement_identifier" : "home_banner",
+            "targeting_revision" : 3,
+            "targeting_rule_id" : "rule_abc123"
+          },
+          "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
+          "timestamp" : 1694029328000,
+          "type" : "paywall_impression",
+          "version" : 1
+        }
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api-paywalls.revenuecat.com/v1/events"
+  }
+}

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/tvOS18-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/tvOS18-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -1,0 +1,52 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : {
+      "events" : [
+        {
+          "app_user_id" : "user",
+          "dark_mode" : true,
+          "display_mode" : "full_screen",
+          "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
+          "locale" : "es_ES",
+          "offering_id" : "offering_1",
+          "paywall_id" : "test_paywall_id_1",
+          "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "placement_identifier" : "home_banner",
+            "targeting_revision" : 3,
+            "targeting_rule_id" : "rule_abc123"
+          },
+          "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
+          "timestamp" : 1694029328000,
+          "type" : "paywall_impression",
+          "version" : 1
+        }
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api-paywalls.revenuecat.com/v1/events"
+  }
+}

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/watchOS-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/watchOS-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -1,0 +1,52 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : {
+      "events" : [
+        {
+          "app_user_id" : "user",
+          "dark_mode" : true,
+          "display_mode" : "full_screen",
+          "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
+          "locale" : "es_ES",
+          "offering_id" : "offering_1",
+          "paywall_id" : "test_paywall_id_1",
+          "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "placement_identifier" : "home_banner",
+            "targeting_revision" : 3,
+            "targeting_rule_id" : "rule_abc123"
+          },
+          "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
+          "timestamp" : 1694029328000,
+          "type" : "paywall_impression",
+          "version" : 1
+        }
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api-paywalls.revenuecat.com/v1/events"
+  }
+}

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testCanInitFromDeserializedEventWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testCanInitFromDeserializedEventWithPlacementAndTargeting.1.json
@@ -1,0 +1,19 @@
+{
+  "app_user_id" : "test-user",
+  "dark_mode" : true,
+  "display_mode" : "full_screen",
+  "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
+  "locale" : "en_US",
+  "offering_id" : "offering_1",
+  "paywall_id" : "test_paywall_id_1",
+  "paywall_revision" : 5,
+  "presented_offering_context" : {
+    "placement_identifier" : "home_banner",
+    "targeting_revision" : 3,
+    "targeting_rule_id" : "rule_abc123"
+  },
+  "session_id" : "73616D70-6C65-2073-7472-696E67000000",
+  "timestamp" : 1694029328000,
+  "type" : "paywall_impression",
+  "version" : 1
+}

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithPlacementAndTargeting.1.json
@@ -1,0 +1,19 @@
+{
+  "app_user_id" : "Jack Shepard",
+  "dark_mode" : true,
+  "display_mode" : "full_screen",
+  "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
+  "locale" : "es_ES",
+  "offering_id" : "offering_1",
+  "paywall_id" : "test_paywall_id_1",
+  "paywall_revision" : 5,
+  "presented_offering_context" : {
+    "placement_identifier" : "home_banner",
+    "targeting_revision" : 3,
+    "targeting_rule_id" : "rule_abc123"
+  },
+  "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
+  "timestamp" : 1694029328000,
+  "type" : "paywall_impression",
+  "version" : 1
+}

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithPlacementOnly.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithPlacementOnly.1.json
@@ -1,0 +1,17 @@
+{
+  "app_user_id" : "Jack Shepard",
+  "dark_mode" : true,
+  "display_mode" : "full_screen",
+  "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
+  "locale" : "es_ES",
+  "offering_id" : "offering_1",
+  "paywall_id" : "test_paywall_id_1",
+  "paywall_revision" : 5,
+  "presented_offering_context" : {
+    "placement_identifier" : "home_banner"
+  },
+  "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
+  "timestamp" : 1694029328000,
+  "type" : "paywall_impression",
+  "version" : 1
+}

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithTargetingOnly.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithTargetingOnly.1.json
@@ -1,0 +1,18 @@
+{
+  "app_user_id" : "Jack Shepard",
+  "dark_mode" : true,
+  "display_mode" : "full_screen",
+  "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
+  "locale" : "es_ES",
+  "offering_id" : "offering_1",
+  "paywall_id" : "test_paywall_id_1",
+  "paywall_revision" : 5,
+  "presented_offering_context" : {
+    "targeting_revision" : 3,
+    "targeting_rule_id" : "rule_abc123"
+  },
+  "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
+  "timestamp" : 1694029328000,
+  "type" : "paywall_impression",
+  "version" : 1
+}


### PR DESCRIPTION
Include presentedOfferingContext (placementIdentifier, targetingRevision, targetingRuleId) in paywall event serialization so that events & charts can utilize those dimensions.

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the JSON schema sent to the paywalls events endpoint by adding a new optional nested object, which could affect backend parsing/analytics if not handled, though the fields are additive and nil-safe.
> 
> **Overview**
> Paywall feature events now include an optional `presented_offering_context` payload (placement + targeting rule metadata) when serialized and posted to the paywalls events backend.
> 
> This threads `PresentedOfferingContext` data from `Offering`/`Package` into `PaywallEvent.Data`, encodes it via a new `PresentedOfferingContextData` wrapper that omits the object when all fields are `nil`, and updates `withPurchaseInfo` to preserve these new fields. Unit + snapshot tests were added to cover placement-only, targeting-only, and combined cases, including end-to-end backend request snapshots across platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ad31b9afa0a73cd9773888bb7e37b1538aa17ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->