### PR TITLE
Fix concurrency error in CustomerCenterActionWrapperTests on Xcode 15

### DIFF
--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterActionWrapperTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterActionWrapperTests.swift
@@ -269,12 +269,12 @@ final class CustomerCenterActionWrapperTests: TestCase {
 
         let windowHolder = await WindowHolder()
 
-        var receivedOfferId: String?
+        let receivedOfferId: Atomic<String?> = .init(nil)
         await MainActor.run {
             let testView = Text("test")
                 .modifier(CustomerCenterActionViewModifier(actionWrapper: actionWrapper))
                 .onCustomerCenterPromotionalOfferSucceeded { _, _, offerId in
-                    receivedOfferId = offerId
+                    receivedOfferId.value = offerId
                     expectation.fulfill()
                 }
 
@@ -296,7 +296,7 @@ final class CustomerCenterActionWrapperTests: TestCase {
         }
 
         await fulfillment(of: [expectation], timeout: 1.0)
-        expect(receivedOfferId).to(equal("test_offer"))
+        expect(receivedOfferId.value).to(equal("test_offer"))
     }
 
     func testPromotionalOfferSucceededAlsoFiresDeprecatedHandler() async throws {


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
`testPromotionalOfferSucceeded` fails on CI (Xcode 14.3.1 and Xcode 15.4 / Swift 5.9–5.10) with:
> mutation of captured var 'receivedOfferId' in concurrently-executing code

This doesn't reproduce locally on Xcode 26 because Swift 6's region-based isolation analysis is smarter about proving the access is safe.

### Description
Replace the mutable `var receivedOfferId` with a `let receivedOfferId: Atomic<String?>` so the `@Sendable` closure captures an immutable reference to a thread-safe wrapper instead of mutating a captured local variable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that replaces a captured mutable local with a thread-safe `Atomic` to satisfy Swift/Xcode concurrency checks.
> 
> **Overview**
> Updates `testPromotionalOfferSucceeded` to use `Atomic<String?>` for `receivedOfferId` instead of mutating a captured `var` inside the promotional-offer callback, resolving Xcode/Swift concurrency diagnostics.
> 
> Assertions are updated to read `receivedOfferId.value` after the expectation is fulfilled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78aa8a89d1b81eae072e656a476fd5c3fa4b4688. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->