### PR TITLE
Remove flaky low value tests

### DIFF
--- a/Tests/UnitTests/Ads/Events/AdEventStoreTests.swift
+++ b/Tests/UnitTests/Ads/Events/AdEventStoreTests.swift
@@ -33,10 +33,6 @@ class AdEventStoreTests: TestCase {
 
     // - MARK: -
 
-    func testCreateDefaultDoesNotThrow() throws {
-        _ = try AdEventStore.createDefault(persistenceDirectory: nil)
-    }
-
     func testPersistsEventsAcrossInitialization() async throws {
         let container = Self.temporaryFolder()
 

--- a/Tests/UnitTests/Events/FeatureEventStoreTests.swift
+++ b/Tests/UnitTests/Events/FeatureEventStoreTests.swift
@@ -33,10 +33,6 @@ class FeatureEventStoreTests: TestCase {
 
     // - MARK: -
 
-    func testCreateDefaultDoesNotThrow() throws {
-        _ = try FeatureEventStore.createDefault(persistenceDirectory: nil)
-    }
-
     func testPersistsEventsAcrossInitialization() async throws {
         let container = Self.temporaryFolder()
 


### PR DESCRIPTION
## Summary
- Remove `testCreateDefaultDoesNotThrow` from both `FeatureEventStoreTests` and `AdEventStoreTests`
- These are low-value smoke tests that only verify `createDefault(persistenceDirectory: nil)` doesn't throw — effectively just testing that the OS Caches directory exists and is writable
- The `createDefault` code path is already exercised by `testPersistsEventsAcrossInitialization` which uses explicit temp directories
- Example failing build [here](https://app.circleci.com/pipelines/gh/RevenueCat/purchases-ios/35731/workflows/51d8349c-2156-4904-a22f-2ae5ec8364f9/jobs/507501).

## Test plan
- [x] Verify existing event store tests still pass
- [x] Confirm no other tests depend on the removed test methods

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes two unit tests that asserted `createDefault(persistenceDirectory: nil)` does not throw, reducing coverage slightly but not affecting production code.
> 
> **Overview**
> Removes the `testCreateDefaultDoesNotThrow` smoke tests from `AdEventStoreTests` and `FeatureEventStoreTests`, which were flaky due to relying on OS-provided caches directory behavior.
> 
> Event store initialization is still covered via existing persistence tests that use explicit temporary directories (e.g., `testPersistsEventsAcrossInitialization`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b54210fd1f9bc06727c482ae91d1daabb98ff9d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->