### PR TITLE
Replace custom tag-release-branch with orb's tag-current-branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 orbs:
   macos: circleci/macos@2.5.1
   slack: circleci/slack@5.0.0
-  revenuecat: revenuecat/sdks-common-config@3.15.0
+  revenuecat: revenuecat/sdks-common-config@3.16.0
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 
@@ -1738,26 +1738,6 @@ jobs:
           name: Run Danger
           command: bundle exec danger --verbose
 
-  tag-release-branch:
-    docker:
-      - image: cimg/ruby:3.2.0
-    working_directory: ~/purchases-ios
-    shell: /bin/bash --login -o pipefail
-    steps:
-      - checkout
-      - revenuecat/setup-git-credentials
-      - revenuecat/trust-github-key
-      - install-rubydocker-dependencies
-      - run:
-          name: Check Release PR is approved
-          command: |
-            echo "Verifying that the release PR has been approved by an org member with write permissions."
-            echo "This check prevents tagging a release before the PR is properly reviewed."
-            bundle exec fastlane run validate_pr_approved
-      - run:
-          name: Tag branch
-          command: bundle exec fastlane tag_current_branch
-
   release-train:
     executor:
       name: macos-executor
@@ -2612,13 +2592,13 @@ workflows:
             - release-checks
             - all-tests-succeeded
           <<: *release-branches
-      - tag-release-branch:
+      - revenuecat/tag-current-branch:
           requires:
             - approve-release
           <<: *release-branches
 
       - all-tasks-passed:
           requires:
-            - tag-release-branch
+            - revenuecat/tag-current-branch
           <<: *release-branches
 


### PR DESCRIPTION
## Motivation

The custom `tag-release-branch` job in this repo is now redundant. The orb's `tag-current-branch` job (as of `v3.16.0`) includes `validate_pr_approved` and defaults to Ruby 3.2.0, which matches what this repo was using.

## Description

- Bumps `revenuecat/sdks-common-config` orb from `@3.15.0` to `@3.16.0`
- Removes the custom `tag-release-branch` job and replaces it with the orb's `revenuecat/tag-current-branch` in the workflow

**Depends on:** https://github.com/RevenueCat/sdks-circleci-orb/pull/41

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release-branch tagging step in CircleCI by replacing an in-repo job with an orb-provided implementation, which could affect how/when release tags are created. Risk is limited to CI/release automation (no product code changes).
> 
> **Overview**
> Updates CircleCI to use `revenuecat/sdks-common-config@3.16.0` and switches release tagging from the repo’s custom `tag-release-branch` job to the orb’s `revenuecat/tag-current-branch` in the release workflow.
> 
> This removes the local job definition and rewires downstream workflow dependencies to rely on the orb job for the approval/validation + tagging step on `release/*` branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0a044bd1c6270f4dec0ae3e4864ee7db98c5839. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->