### PR TITLE
Fix promo offer optimistic eligibility hiding intro offer price

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -56,7 +56,7 @@ struct CarouselComponentView: View {
             isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                 package: self.packageContext.package
             ),
-            isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(
+            isEligibleForPromoOffer: self.paywallPromoOfferCache.isSignedEligible(
                 for: self.packageContext.package
             ),
             selectedPackageId: self.selectedPackageId,

--- a/RevenueCatUI/Templates/V2/Components/Icon/IconComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Icon/IconComponentView.swift
@@ -52,7 +52,7 @@ struct IconComponentView: View {
             isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                 package: self.packageContext.package
             ),
-            isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(
+            isEligibleForPromoOffer: self.paywallPromoOfferCache.isSignedEligible(
                 for: self.packageContext.package
             ),
             selectedPackageId: self.selectedPackageId,

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -54,7 +54,7 @@ struct ImageComponentView: View {
             isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                 package: self.packageContext.package
             ),
-            isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(
+            isEligibleForPromoOffer: self.paywallPromoOfferCache.isSignedEligible(
                 for: self.packageContext.package
             ),
             selectedPackageId: self.selectedPackageId,

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -73,7 +73,7 @@ struct StackComponentView: View {
             isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                 package: self.packageContext.package
             ),
-            isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(
+            isEligibleForPromoOffer: self.paywallPromoOfferCache.isSignedEligible(
                 for: self.packageContext.package
             ),
             selectedPackageId: self.selectedPackageId,

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
@@ -201,7 +201,7 @@ struct LoadedTabsComponentView: View {
             isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                 package: self.packageContext.package
             ),
-            isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(
+            isEligibleForPromoOffer: self.paywallPromoOfferCache.isSignedEligible(
                 for: self.packageContext.package
             ),
             selectedPackageId: self.selectedPackageId,

--- a/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentView.swift
@@ -58,7 +58,7 @@ struct TimelineComponentView: View {
             isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                 package: self.packageContext.package
             ),
-            isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(
+            isEligibleForPromoOffer: self.paywallPromoOfferCache.isSignedEligible(
                 for: self.packageContext.package
             ),
             selectedPackageId: self.selectedPackageId,
@@ -82,7 +82,7 @@ struct TimelineComponentView: View {
                     isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                         package: self.packageContext.package
                     ),
-                    isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(
+                    isEligibleForPromoOffer: self.paywallPromoOfferCache.isSignedEligible(
                         for: self.packageContext.package
                     ),
                     selectedPackageId: self.selectedPackageId,
@@ -109,7 +109,7 @@ struct TimelineComponentView: View {
                         isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                             package: self.packageContext.package
                         ),
-                        isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(
+                        isEligibleForPromoOffer: self.paywallPromoOfferCache.isSignedEligible(
                             for: self.packageContext.package
                         ),
                         selectedPackageId: self.selectedPackageId,

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
@@ -68,7 +68,7 @@ struct VideoComponentView: View {
                 isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                     package: self.packageContext.package
                 ),
-                isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(
+                isEligibleForPromoOffer: self.paywallPromoOfferCache.isSignedEligible(
                     for: self.packageContext.package
                 ),
                 selectedPackageId: self.selectedPackageId,

--- a/RevenueCatUI/Templates/V2/EnvironmentObjects/PaywallPromoOfferCache.swift
+++ b/RevenueCatUI/Templates/V2/EnvironmentObjects/PaywallPromoOfferCache.swift
@@ -66,6 +66,17 @@ internal final class PaywallPromoOfferCache: ObservableObject {
         }
     }
 
+    /// Returns `true` only when the promotional offer has been successfully signed.
+    ///
+    /// Use this for condition evaluation (determining which override applies) to avoid
+    /// activating the `promo_offer` condition prematurely based on optimistic eligibility.
+    /// Optimistic eligibility (`isMostLikelyEligible`) fires as soon as subscription history
+    /// is known — before signing completes — which can cause combined overrides like
+    /// `selected + promo_offer` to win over `intro_offer`, hiding the intro price display.
+    func isSignedEligible(for package: Package?) -> Bool {
+        return get(for: package) != nil
+    }
+
     func get(for package: Package?) -> PromotionalOffer? {
         guard let package else { return nil }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
@@ -1382,6 +1382,118 @@ class PresentedPartialsTests: TestCase {
         expect(result).to(beNil())
     }
 
+    // MARK: - Intro Offer Hidden by Optimistic Promo Offer
+
+    // Mirrors the Logia paywall override array:
+    //   #1 selected            → "regular_price"
+    //   #2 intro_offer         → "intro_price_strikethrough"   ← correct intro display
+    //   #3 promo_offer         → "promo_price_strikethrough"
+    //   #4 selected+promo_offer→ "offer_price_no_strikethrough" ← wins last, hides intro
+    private var logiaStyleOverrides: PresentedOverrides<TestPartial> {
+        [
+            PresentedOverride(conditions: [.selected],
+                              properties: TestPartial(value: "regular_price")),
+            PresentedOverride(conditions: [.introOffer],
+                              properties: TestPartial(value: "intro_price_strikethrough")),
+            PresentedOverride(conditions: [.promoOffer],
+                              properties: TestPartial(value: "promo_price_strikethrough")),
+            PresentedOverride(conditions: [.selected, .promoOffer],
+                              properties: TestPartial(value: "offer_price_no_strikethrough"))
+        ]
+    }
+
+    func testIntroOffer_WithoutPromoOffer_ShowsIntroPrice() throws {
+        // When only intro_offer is active (no promo), override #2 should win over #1.
+        let result = TestPartial.buildPartial(
+            state: .selected,
+            condition: .compact,
+            isEligibleForIntroOffer: true,
+            isEligibleForPromoOffer: false,
+            conditionContext: ConditionContext(),
+            with: logiaStyleOverrides
+        )
+
+        expect(result?.value).to(equal("intro_price_strikethrough"))
+    }
+
+    func testIntroOffer_WithOptimisticPromoOffer_HidesIntroPrice_BugRepro() throws {
+        // BUG: when promo_offer becomes optimistically true (subscription history exists
+        // but no signed offer yet), override #4 (selected+promo_offer) wins last and
+        // shows `{{ product.offer_price }}` — which falls back to the regular price,
+        // hiding the correct intro price + strikethrough display.
+        let result = TestPartial.buildPartial(
+            state: .selected,
+            condition: .compact,
+            isEligibleForIntroOffer: true,
+            isEligibleForPromoOffer: true, // optimistic — hasAnySubscriptionHistory=true, offer not signed
+            conditionContext: ConditionContext(),
+            with: logiaStyleOverrides
+        )
+
+        // The combined override wins, hiding the intro offer display.
+        expect(result?.value).to(equal("offer_price_no_strikethrough"))
+        // DESIRED: should equal "intro_price_strikethrough" when no actual signed offer exists.
+    }
+
+    func testIntroOffer_WithSignedPromoOffer_ShowsPromoPrice() throws {
+        // When promo offer is actually signed, the combined override correctly wins.
+        // This is the intended behavior — no bug here.
+        let result = TestPartial.buildPartial(
+            state: .selected,
+            condition: .compact,
+            isEligibleForIntroOffer: true,
+            isEligibleForPromoOffer: true, // actually signed
+            conditionContext: ConditionContext(),
+            with: logiaStyleOverrides
+        )
+
+        expect(result?.value).to(equal("offer_price_no_strikethrough"))
+    }
+
+    func testIntroOffer_WhenPromoEligibilityUsesActualSigning_ShowsIntroPrice() throws {
+        // FIX: when isEligibleForPromoOffer reflects actual signed eligibility
+        // (false until signed), override #2 (intro_offer) correctly wins even
+        // when the user has subscription history.
+        let result = TestPartial.buildPartial(
+            state: .selected,
+            condition: .compact,
+            isEligibleForIntroOffer: true,
+            isEligibleForPromoOffer: false, // fix: use isSignedEligible, not isMostLikelyEligible
+            conditionContext: ConditionContext(),
+            with: logiaStyleOverrides
+        )
+
+        expect(result?.value).to(equal("intro_price_strikethrough"))
+    }
+
+    func testPromoOffer_WithoutIntroOffer_ShowsPromoPrice() throws {
+        // Sanity check: promo_offer alone (no intro) shows promo display.
+        let result = TestPartial.buildPartial(
+            state: .selected,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: true,
+            conditionContext: ConditionContext(),
+            with: logiaStyleOverrides
+        )
+
+        expect(result?.value).to(equal("offer_price_no_strikethrough"))
+    }
+
+    func testNoOffers_ShowsRegularPrice() throws {
+        // Sanity check: neither offer active, selected shows regular price.
+        let result = TestPartial.buildPartial(
+            state: .selected,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: ConditionContext(),
+            with: logiaStyleOverrides
+        )
+
+        expect(result?.value).to(equal("regular_price"))
+    }
+
     // MARK: - Different Condition Types on Sibling Components (Bug Bash Section 6)
 
     func testDifferentConditionTypes_EvaluateIndependently() throws {


### PR DESCRIPTION
## Problem

On paywalls with both an intro offer and a promotional offer configured, users with subscription history see the intro price (`$23.88/yr ~$39.99/yr~`) flash briefly then disappear, reverting to the regular price (`$39.99/yr`).

## Root Cause

`PaywallPromoOfferCache.isMostLikelyEligible` returns `true` as soon as `SubscriptionHistoryTracker` fires `.hasHistory` — an async SK2 transaction check that can complete _after_ the intro offer eligibility check has already resolved and rendered the correct intro price.

Once `isMostLikelyEligible` becomes `true`, the `promo_offer` condition activates. If the paywall has a `selected + promo_offer` combined override (which sorts last in the array and therefore wins), it displaces the `intro_offer` override. That combined override commonly uses `{{ product.offer_price }}`, which falls back to the regular price when no signed offer is available — hiding the intro price and strikethrough entirely.

**Override evaluation for the Logia paywall (last match wins):**

| # | Conditions | Resolved value | Active when |
|---|---|---|---|
| 1 | `selected` | `$39.99/yr` | always |
| 2 | `intro_offer` | `$23.88/yr ~$39.99/yr~` | after intro eligibility check |
| 3 | `promo_offer` | `$23.88/yr ~$39.99/yr~` | after promo signing |
| **4** | **`selected + promo_offer`** | **`$39.99/yr` (fallback)** | **as soon as subscription history fires ← bug** |

**Sequence:**
1. Paywall renders → `$39.99/yr`
2. Intro eligibility resolves → override #2 wins → `$23.88/yr ~$39.99/yr~` ✅ user sees this
3. `SubscriptionHistoryTracker` fires → `isMostLikelyEligible = true` → override #4 wins → `$39.99/yr` ❌ disappears

## Fix

Add `isSignedEligible(for:)` to `PaywallPromoOfferCache` that returns `true` only when the offer is actually signed (`cache == .signedEligible`). All component views now pass this value as `isEligibleForPromoOffer` for condition evaluation instead of the optimistic `isMostLikelyEligible`.

This ensures the `promo_offer` condition only activates when a real signed offer exists, so `intro_offer` overrides are never prematurely displaced. `isMostLikelyEligible` is preserved for any future use in loading states or CTA text.

## Tests

Six new tests in `PresentedPartialsTests` using the exact Logia paywall override pattern:

- `testIntroOffer_WithOptimisticPromoOffer_HidesIntroPrice_BugRepro` — documents the bug (combined override wins, hiding intro)
- `testIntroOffer_WhenPromoEligibilityUsesActualSigning_ShowsIntroPrice` — documents the fix (intro correctly wins when `isSignedEligible` is used)
- 4 sanity checks covering no-offer, intro-only, promo-only, and signed-promo states

🤖 Generated with [Claude Code](https://claude.com/claude-code)