### PR TITLE
Fix alert title showing raw error domain for non-ErrorCode errors

### DIFF
--- a/RevenueCatUI/Data/LocalizedAlertError.swift
+++ b/RevenueCatUI/Data/LocalizedAlertError.swift
@@ -23,11 +23,7 @@ struct LocalizedAlertError: LocalizedError {
     }
 
     var errorDescription: String? {
-        if self.underlyingError is ErrorCode {
-            return "Error"
-        } else {
-            return "\(self.underlyingError.domain) \(self.underlyingError.code)"
-        }
+        return "Error"
     }
 
     var failureReason: String? {

--- a/Tests/RevenueCatUITests/Data/LocalizedAlertErrorTests.swift
+++ b/Tests/RevenueCatUITests/Data/LocalizedAlertErrorTests.swift
@@ -19,7 +19,7 @@ class LocalizedAlertGenericErrorTests: TestCase {
     )
 
     func testErrorDescription() {
-        expect(Self.error.errorDescription) == "StoreKit.StoreKitError 0"
+        expect(Self.error.errorDescription) == "Error"
     }
 
     func testFailureReason() {


### PR DESCRIPTION
## Summary
- `LocalizedAlertError.errorDescription` previously returned the NSError domain and code as the alert title for non-`ErrorCode` errors (e.g., `"com.revenuecat.purchases.hybridcommon.purchaselogic 1"`). Now it always returns `"Error"`, consistent with how `ErrorCode` errors were already handled.
- This affects hybrid SDKs using `HybridPurchaseLogicBridge` from `purchases-hybrid-common`, where custom purchase logic errors were showing the raw domain as the alert title.

## Test plan
- [x] Updated `LocalizedAlertGenericErrorTests.testErrorDescription` to expect `"Error"` instead of `"StoreKit.StoreKitError 0"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the alert title string for generic `NSError`s and updates the corresponding unit test; no functional purchase or error-handling logic is altered.
> 
> **Overview**
> Makes `LocalizedAlertError.errorDescription` always return the generic title `"Error"` instead of showing the raw `NSError` domain/code for non-`ErrorCode` errors.
> 
> Updates `LocalizedAlertGenericErrorTests.testErrorDescription` to assert the new title behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a53a05d5df15a66946d0f7985216bd5a781e8a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->