### PR TITLE
security: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,7 +10,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Enable the actionlint matcher
         run: echo "::add-matcher::.github/actionlint-matcher.json"
       - name: Lint GitHub Actions workflows

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,6 +13,6 @@ on:
 
 jobs:
   claude:
-    uses: revenuecat/sdk-github-workflows/.github/workflows/claude.yml@v5
+    uses: revenuecat/sdk-github-workflows/.github/workflows/claude.yml@2706a8a289c29c710a2d2b34178399253eddb221 # v5
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/issue-notifications.yml
+++ b/.github/workflows/issue-notifications.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   notify:
-    uses: revenuecat/sdk-github-workflows/.github/workflows/issue-notifications.yml@v2
+    uses: revenuecat/sdk-github-workflows/.github/workflows/issue-notifications.yml@acb41efc0045b05dd0517dc08200dd4112ea9bae # v2
     secrets:
       ACK_SLACK_WEBHOOK_URL: ${{ secrets.ACK_SLACK_WEBHOOK_URL }}
       ACK_ALERT_KEYWORDS: ${{ secrets.ACK_ALERT_KEYWORDS }}

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -10,7 +10,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2.0.1
+      - uses: dessant/lock-threads@63786a6c74ee3cfc4584f36de4360305c55e5126 # v2.0.1
         with:
           github-token: ${{ github.token }}
           issue-lock-inactive-days: "7"


### PR DESCRIPTION
## Summary
- Pin all `uses:` references in GitHub Actions workflows to full SHA hashes
- Prevents supply chain attacks via tag mutation or typosquatting

## Context
- https://rosesecurity.dev/2026/03/20/typosquatting-trivy.html
- Generated with [`pinact`](https://github.com/suzuki-shunsuke/pinact)

## Test plan
- [ ] Verify CI passes with pinned references
- [ ] Spot-check that pinned SHAs match expected release tags

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes GitHub Actions `uses:` references to immutable commit SHAs, with no application/runtime code impact; main risk is CI breakage if a pinned SHA is wrong or later revoked.
> 
> **Overview**
> Pins GitHub Actions dependencies to immutable SHAs across workflows (e.g., `actions/checkout`, `dessant/lock-threads`, and reusable workflows from `revenuecat/sdk-github-workflows`) while retaining the same tagged versions via comments.
> 
> No behavior changes are intended beyond making CI/workflows reproducible and less susceptible to tag changes; also fixes a missing newline in `claude.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69697d15f5bc09753bef17279fc2381f39335102. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->