### PR TITLE
Fix CI: use SSH for private repo clones in paywall screenshot job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1845,7 +1845,7 @@ jobs:
           command: bundle exec fastlane ios fetch_paywall_preview_resources
       - run:
           name: Clone paywall-rendering-validation repository
-          command: git clone https://github.com/RevenueCat/paywall-rendering-validation.git ../Tests/paywall-rendering-validation
+          command: git clone git@github.com:RevenueCat/paywall-rendering-validation.git ../Tests/paywall-rendering-validation
       - run:
           name: Set GitHub token environment variable
           command: |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2134,7 +2134,7 @@ platform :ios do
     Dir.chdir("../Tests") do
       if !File.directory?(PAYWALL_PREVIEW_RESOURCES_REPO_NAME)
         UI.important("Cloning paywall-preview-resources repo")
-        sh "git", "clone", "https://github.com/RevenueCat/#{PAYWALL_PREVIEW_RESOURCES_REPO_NAME}.git"
+        sh "git", "clone", "git@github.com:RevenueCat/#{PAYWALL_PREVIEW_RESOURCES_REPO_NAME}.git"
       end
 
       commit = current_paywall_preview_resources_commit


### PR DESCRIPTION
## Summary

- Moved `revenuecat/setup-git-credentials` **before** the private repo clone steps in the `record-and-push-paywall-template-screenshots` CI job.
- The job was failing because it tried to clone `paywall-preview-resources` and `paywall-rendering-validation` via HTTPS without credentials, causing a username prompt that timed out after 10 minutes.

## Test plan

- [ ] Verify the `record-and-push-paywall-template-screenshots` job passes on this branch (triggered on `main` merges, or can be triggered manually).

Successful run [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/35866/workflows/de4e3194-5525-4403-98a8-005f0a46c1fd/jobs/511867)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts git auth setup and clone URLs; main risk is misconfigured SSH credentials causing the paywall screenshot job to fail to clone required repos.
> 
> **Overview**
> Fixes the `record-and-push-paywall-template-screenshots` CircleCI job by setting up git/SSH trust **before** any private repo access and switching the `paywall-rendering-validation` clone to use the SSH remote.
> 
> Updates the Fastlane `fetch_paywall_preview_resources` lane to clone `paywall-preview-resources` via SSH (`git@github.com:...`) instead of HTTPS to align with the CI credential flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 442ed38e5bcc5c68e518c3c6a9e33ccd7e27211b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->