### PR TITLE
Add Danger GitHub Actions workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,21 @@
+name: Danger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+jobs:
+  danger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.0'
+          bundler-cache: true
+
+      - name: Run Danger
+        run: bundle exec danger --verbose
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow to run Danger on PR metadata changes (title, description, labels)
- Currently Danger only runs via CircleCI on push events, so editing PR metadata doesn't re-trigger it
- This workflow triggers on `opened`, `synchronize`, `reopened`, `edited`, `labeled`, and `unlabeled` events

## Test plan
- [ ] Verify Danger runs on PR open
- [ ] Change PR title/description and confirm Danger re-runs
- [ ] Add/remove a label and confirm Danger re-runs