### PR TITLE
[EXTERNAL] Fix #5549: Use entitlement identifier as title for promotional entitlements

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -216,7 +216,9 @@ struct PurchaseInformation {
         let isSubscriptionType = transaction.isSubscription && transaction.store != .promotional
 
         self.title = Self.determineTitle(
+            entitlement: entitlement,
             subscribedProduct: subscribedProduct,
+            store: transaction.store,
             isSubscription: isSubscriptionType,
             localization: localization
         )
@@ -537,12 +539,18 @@ extension PurchaseInformation {
     }
 
     private static func determineTitle(
+        entitlement: EntitlementInfo?,
         subscribedProduct: StoreProduct?,
+        store: Store,
         isSubscription: Bool,
         localization: CustomerCenterConfigData.Localization
     ) -> String {
         if let localizedTitle = subscribedProduct?.localizedTitle, !localizedTitle.isEmpty {
             return localizedTitle
+        }
+
+        if store == .promotional, let identifier = entitlement?.identifier, !identifier.isEmpty {
+            return identifier
         }
 
         let purchaseTypeKey: CCLocalizedString = isSubscription ? .typeSubscription : .typeOneTimePurchase

--- a/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
@@ -545,8 +545,8 @@ final class PurchaseInformationTests: TestCase {
             )
         )
 
-        // title from entitlement instead of product identifier
-        expect(subscriptionInfo.title) == "One-time Purchase"
+        // title uses entitlement identifier when no StoreKit product is available for promotional store
+        expect(subscriptionInfo.title) == "premium"
         expect(subscriptionInfo.pricePaid) == .free
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -592,7 +592,7 @@ final class PurchaseInformationTests: TestCase {
             )
         )
 
-        expect(subscriptionInfo.title) == "One-time Purchase"
+        expect(subscriptionInfo.title) == "premium"
         expect(subscriptionInfo.pricePaid) == .free
         expect(subscriptionInfo.renewalPrice).to(beNil())
         // false - no way to know if its lifetime
@@ -600,6 +600,129 @@ final class PurchaseInformationTests: TestCase {
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .promotional
+    }
+
+    func testDetermineTitlePromotionalUsesEntitlementIdentifier() throws {
+        let customerInfo = CustomerInfoFixtures.customerInfoWithPromotional
+        let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
+
+        let mockTransaction = MockTransaction(
+            productIdentifier: entitlement.productIdentifier,
+            store: .promotional,
+            type: .subscription(
+                isActive: true,
+                willRenew: false,
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
+            ),
+            isCancelled: false,
+            managementURL: nil,
+            price: .init(currency: "USD", amount: 0),
+            displayName: nil,
+            periodType: .normal,
+            purchaseDate: Date(),
+            isSandbox: false,
+            isSubscription: true
+        )
+
+        let purchaseInfo = PurchaseInformation(
+            entitlement: entitlement,
+            subscribedProduct: nil,
+            transaction: mockTransaction,
+            customerInfoRequestedDate: Date(),
+            managementURL: nil,
+            localization: Self.mockLocalization
+        )
+
+        // Promotional store with no product: entitlement identifier is used as title
+        expect(purchaseInfo.title) == "premium"
+    }
+
+    func testDetermineTitlePromotionalNoEntitlementFallsBackToTypeLabel() throws {
+        let mockTransaction = MockTransaction(
+            productIdentifier: "rc_promo_some_product",
+            store: .promotional,
+            type: .subscription(
+                isActive: true,
+                willRenew: false,
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
+            ),
+            isCancelled: false,
+            managementURL: nil,
+            price: .init(currency: "USD", amount: 0),
+            displayName: nil,
+            periodType: .normal,
+            purchaseDate: Date(),
+            isSandbox: false,
+            isSubscription: true
+        )
+
+        let purchaseInfo = PurchaseInformation(
+            entitlement: nil,
+            subscribedProduct: nil,
+            transaction: mockTransaction,
+            customerInfoRequestedDate: Date(),
+            managementURL: nil,
+            localization: Self.mockLocalization
+        )
+
+        // With no entitlement, promotional guard is skipped.
+        // isSubscriptionType = false for .promotional store, so falls through to "One-time Purchase"
+        expect(purchaseInfo.title) == "One-time Purchase"
+    }
+
+    func testDetermineTitleProductTitleTakesPriorityOverEntitlementIdentifier() throws {
+        let customerInfo = CustomerInfoFixtures.customerInfoWithPromotional
+        let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
+
+        let mockProduct = TestStoreProduct(
+            localizedTitle: "Pro Access",
+            price: 0,
+            currencyCode: "USD",
+            localizedPriceString: "$0.00",
+            productIdentifier: entitlement.productIdentifier,
+            productType: .autoRenewableSubscription,
+            localizedDescription: "Pro access via promo",
+            subscriptionGroupIdentifier: nil,
+            subscriptionPeriod: nil,
+            introductoryDiscount: nil,
+            locale: Self.locale
+        )
+
+        let mockTransaction = MockTransaction(
+            productIdentifier: entitlement.productIdentifier,
+            store: .promotional,
+            type: .subscription(
+                isActive: true,
+                willRenew: false,
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
+            ),
+            isCancelled: false,
+            managementURL: nil,
+            price: .init(currency: "USD", amount: 0),
+            displayName: nil,
+            periodType: .normal,
+            purchaseDate: Date(),
+            isSandbox: false,
+            isSubscription: true
+        )
+
+        let purchaseInfo = PurchaseInformation(
+            entitlement: entitlement,
+            subscribedProduct: mockProduct.toStoreProduct(),
+            transaction: mockTransaction,
+            customerInfoRequestedDate: Date(),
+            managementURL: nil,
+            localization: Self.mockLocalization
+        )
+
+        // StoreKit product title wins over entitlement identifier
+        expect(purchaseInfo.title) == "Pro Access"
     }
 
     func testInitWithStripeEntitlement() throws {
@@ -1105,8 +1228,8 @@ final class PurchaseInformationTests: TestCase {
 
     // MARK: - Tests for improved title and price determination logic
 
-    func testDetermineTitleWithEntitlementIdentifierFallback() throws {
-        // Use existing Google Play fixture which has entitlement identifier "premium"
+    func testDetermineTitlePlayStoreFallsBackToSubscriptionType() throws {
+        // Play Store transactions with no StoreKit product should fall back to type label, not entitlement identifier
         let customerInfo = CustomerInfoFixtures.customerInfoWithGoogleSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 


### PR DESCRIPTION
---

# PR Description

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Customer Center was displaying "One-time Purchase" for promotional/grandfathered entitlements because `determineTitle` had no awareness of the entitlement or store.

Resolves #5549

### Description

Passes `entitlement` and `store` parameters to the private `determineTitle` method in `PurchaseInformation.swift`. When `store == .promotional` and no StoreKit product title is available, the entitlement identifier is used as the title instead of the generic "One-time Purchase" fallback.

Other stores (Play Store, Stripe, etc.) retain the existing type-label fallback behavior unchanged.

**Changes:**
- `RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift` — updated `determineTitle` signature and added promotional guard clause; updated call site
- `Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift` — updated 2 existing tests that asserted the old broken behavior; renamed 1 misleading test; added 3 new tests covering the full fallback chain

**Testing:**
- `testInitWithPromotionalEntitlement` — now expects `"premium"` (entitlement identifier) instead of `"One-time Purchase"`
- `testInitWithPromotionalLifetimeEntitlement` — same update
- `testDetermineTitlePlayStoreFallsBackToSubscriptionType` (renamed) — verifies Play Store still uses type label
- `testDetermineTitlePromotionalUsesEntitlementIdentifier` (new) — promotional + no product → identifier
- `testDetermineTitlePromotionalNoEntitlementFallsBackToTypeLabel` (new) — promotional + no entitlement → type label
- `testDetermineTitleProductTitleTakesPriorityOverEntitlementIdentifier` (new) — StoreKit product title takes priority

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated change to Customer Center title fallback logic for `.promotional` purchases, covered by updated and new unit tests.
> 
> **Overview**
> Fixes Customer Center purchase title fallback for **promotional/grandfathered entitlements** by threading `entitlement` and `store` into `PurchaseInformation.determineTitle` and, when `store == .promotional` and no StoreKit product title exists, using the entitlement `identifier` instead of the generic "One-time Purchase" label.
> 
> Updates existing promotional entitlement tests and adds targeted coverage to ensure the fallback chain is correct (StoreKit title wins, promotional uses entitlement identifier, and non-promotional stores like Play Store still fall back to the type label).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 633881bb74ddce6b9e5c4704d69750398d8259e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->