### PR TITLE
Fix iOS 14.5 simulator runtime install retry logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1159,6 +1159,7 @@ jobs:
       - run:
           name: Wait for iOS 14.5 runtime installation
           command: scripts/wait-for-ios-runtime.sh
+          no_output_timeout: 30m
       - run:
           name: Run iOS 14 tests
           command: bundle exec fastlane test_ios skip_sk_tests:true

--- a/scripts/install-ios-runtime.sh
+++ b/scripts/install-ios-runtime.sh
@@ -3,6 +3,9 @@
 # Installs a simulator runtime with timeout detection and retry logic.
 # Designed to run in the background while other CI steps proceed.
 #
+# Uses sudo bash -c to capture the actual child PID (not the sudo wrapper),
+# since sudo on CI exits immediately while the child runs as root.
+#
 # Usage:
 #   ./install-ios-runtime.sh <runtime-name> [log-file] [ready-file] [failed-file]
 #
@@ -15,6 +18,7 @@ RUNTIME="${1:?Usage: $0 <runtime-name> [log-file] [ready-file] [failed-file]}"
 LOG="${2:-/tmp/runtime_install.log}"
 READY_FILE="${3:-/tmp/runtime_ready}"
 FAILED_FILE="${4:-/tmp/runtime_failed}"
+CHILD_PID_FILE="/tmp/runtime_child_pid"
 
 MAX_RETRIES=3
 INSTALL_TIMEOUT=180
@@ -26,18 +30,57 @@ ATTEMPT=1
 while [ "$ATTEMPT" -le "$MAX_RETRIES" ]; do
   echo "=== Installing $RUNTIME (attempt $ATTEMPT/$MAX_RETRIES) ===" >> "$LOG"
 
-  # Run in its own process group so we can kill the entire tree (sudo + xcodes)
-  set -m
-  sudo xcodes runtimes install "$RUNTIME" >> "$LOG" 2>&1 &
-  INSTALL_PID=$!
-  set +m
+  # Clean up root-owned PID file from previous attempt
+  sudo rm -f "$CHILD_PID_FILE"
+
+  # Launch via sudo bash -c to capture the actual child PID.
+  # The sudo wrapper exits immediately on CI, so $! is unreliable.
+  # Use positional args to avoid fragile quote-splicing.
+  sudo bash -c 'echo $$ > "$1"; shift; exec "$@"' -- \
+    "$CHILD_PID_FILE" xcodes runtimes install "$RUNTIME" >> "$LOG" 2>&1 &
+  SUDO_PID=$!
+
+  # Wait for the child PID file to be written
+  for i in $(seq 1 10); do
+    [ -f "$CHILD_PID_FILE" ] && break
+    sleep 0.5
+  done
+
+  if [ -f "$CHILD_PID_FILE" ]; then
+    CHILD_PID=$(cat "$CHILD_PID_FILE")
+  else
+    CHILD_PID=""
+  fi
+
+  # Monitor the actual child process, not the sudo wrapper
+  MONITOR_PID="${CHILD_PID:-$SUDO_PID}"
   ELAPSED=0
   TIMED_OUT=false
 
-  while kill -0 "$INSTALL_PID" 2>/dev/null; do
+  while sudo kill -0 "$MONITOR_PID" 2>/dev/null; do
     if [ "$ELAPSED" -ge "$INSTALL_TIMEOUT" ]; then
-      echo "Install hung after ${INSTALL_TIMEOUT}s — killing process group (attempt $ATTEMPT)" >> "$LOG"
-      sudo kill -9 -"$INSTALL_PID" 2>/dev/null || true
+      echo "Install hung after ${INSTALL_TIMEOUT}s — killing process tree (attempt $ATTEMPT)" >> "$LOG"
+      # Kill the entire process tree: find all descendants and kill them
+      DESCENDANTS=$(ps -eo pid,ppid | awk -v root="$MONITOR_PID" '
+        BEGIN { pids[root]=1 }
+        { parent[$1]=$2 }
+        END {
+          changed=1
+          while(changed) {
+            changed=0
+            for(p in parent) {
+              if((parent[p] in pids) && !(p in pids)) {
+                pids[p]=1
+                changed=1
+              }
+            }
+          }
+          for(p in pids) print p
+        }
+      ')
+      for PID_TO_KILL in $DESCENDANTS; do
+        sudo kill -9 "$PID_TO_KILL" 2>/dev/null || true
+      done
       TIMED_OUT=true
       break
     fi
@@ -45,17 +88,24 @@ while [ "$ATTEMPT" -le "$MAX_RETRIES" ]; do
     ELAPSED=$((ELAPSED + 10))
   done
 
-  # Reap the process
-  wait "$INSTALL_PID" 2>/dev/null
-  EXIT_CODE=$?
+  # Reap the sudo wrapper.
+  # Note: the sudo wrapper's exit code is unreliable since sudo exits
+  # immediately on CI while the child continues. Instead, verify the
+  # runtime was actually installed.
+  wait "$SUDO_PID" 2>/dev/null
 
-  if [ "$TIMED_OUT" = false ] && [ "$EXIT_CODE" -eq 0 ]; then
-    echo "Runtime $RUNTIME installed successfully" >> "$LOG"
-    touch "$READY_FILE"
-    exit 0
+  if [ "$TIMED_OUT" = false ]; then
+    # The child exited on its own — verify the runtime is now available.
+    # Convert "iOS 14.5" to the format simctl uses (e.g., "iOS 14.5").
+    if xcrun simctl list runtimes 2>/dev/null | grep -q "$RUNTIME"; then
+      echo "Runtime $RUNTIME installed successfully" >> "$LOG"
+      touch "$READY_FILE"
+      exit 0
+    fi
+    echo "Child exited but runtime not found — treating as failure" >> "$LOG"
   fi
 
-  echo "Attempt $ATTEMPT failed" >> "$LOG"
+  echo "Attempt $ATTEMPT failed (timed_out=$TIMED_OUT)" >> "$LOG"
   ATTEMPT=$((ATTEMPT + 1))
   [ "$ATTEMPT" -le "$MAX_RETRIES" ] && sleep 10
 done


### PR DESCRIPTION
## Summary
Follow-up to #6513 which added retry logic for the iOS 14.5 simulator runtime install. The retry mechanism wasn't actually working — CI still timed out on attempt 1/3 after 10 minutes.

### Root cause
On CircleCI macOS, `sudo xcodes runtimes install ... &` backgrounds the `sudo` wrapper, which exits immediately while the child (`xcodes`) continues running as root with a different PID. The original script monitored `$!` (the dead sudo wrapper), so:
1. `kill -0` returned false immediately — the wrapper was already gone
2. `wait` returned exit code 0 — the wrapper exited cleanly
3. The script declared success without the runtime actually being installed, and never retried

### Fix
- **Track actual child PID**: Use `sudo bash -c 'echo $$ > pidfile; exec xcodes ...'` to capture the real root-owned process PID
- **Monitor with `sudo kill -0`**: Check the actual child process, not the wrapper
- **Kill entire process tree**: Walk descendants via `ps`/`awk` and kill each to prevent orphaned processes
- **`sudo rm -f` for PID file cleanup**: The PID file is root-owned, so non-root `rm` silently fails between retries
- **`no_output_timeout: 30m`** on the CircleCI wait step as a safety net

### Validated on CI
Tested with `sudo sleep 600` simulating a hung install, confirming all 3 retry attempts execute correctly with clean process kills:
- [Debug CI run](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/36061/workflows/682a4d92-21a3-4bf1-b6b8-24d492b595d5/jobs/517116)

## Test plan
- [x] Verified retry logic on CI with simulated hangs (3/3 attempts fire, processes killed cleanly, no orphans)
- [x] Verify full test suite passes with real `xcodes runtimes install`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI runtime installation and process-killing logic; while scoped to test infrastructure, mistakes could cause flakiness or stuck/over-killed processes in macOS jobs.
> 
> **Overview**
> Fixes the iOS 14.5 simulator runtime install retry mechanism in CI by tracking and monitoring the *actual* root `xcodes` install process (via a PID file) instead of the short-lived `sudo` wrapper, and by killing the full descendant process tree when a hang is detected.
> 
> Updates the success criteria to verify installation by checking `simctl` for the runtime, and increases the CircleCI `Wait for iOS 14.5 runtime installation` step `no_output_timeout` to `30m` to avoid premature job termination during long installs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42e22ca961ed7c22ab9746abce53b9a46d353b9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->