### PR TITLE
Rollback changes in #5660 -> Didn't work, other fix in place

### DIFF
--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -113,6 +113,7 @@ struct PaywallsV2View: View {
     private let purchaseHandler: PurchaseHandler
     private let onDismiss: () -> Void
     private let fallbackContent: FallbackContent
+    @State private var didFinishEligibilityCheck: Bool = false
 
     @StateObject
     private var paywallPromoOfferCache: PaywallPromoOfferCache
@@ -219,6 +220,10 @@ struct PaywallsV2View: View {
                         }
                     }
                     .task {
+                        guard !didFinishEligibilityCheck else {
+                            return
+                        }
+
                         async let introCheck: Void = introOfferEligibilityContext.computeEligibility(
                             for: paywallState.packages
                         )
@@ -226,6 +231,7 @@ struct PaywallsV2View: View {
                             for: paywallState.packageInfos.map { ($0.package, $0.promotionalOfferProductCode) }
                         )
                         _ = await (introCheck, promoCheck)
+                        didFinishEligibilityCheck = true
                     }
                     // Note: preferences need to be applied after `.toolbar` call
                     .preference(key: PurchaseInProgressPreferenceKey.self,


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

using #5980 instead. This also is likely the culprit for a flutter rendering hang.


### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SwiftUI view identity behavior for Paywalls V2, which could affect when promo/intro offer text appears or refreshes during eligibility checks.
> 
> **Overview**
> Removes the SwiftUI `.id`-based redraw workaround in `PaywallsV2View` that forced a full view re-render after intro/promo eligibility checks.
> 
> The paywall now keeps a stable view identity while eligibility and promo-offer caches are computed, avoiding the previous forced refresh behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d43c9bba512c1ab09ba5150e39b9afb6e1cd17f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->