### PR TITLE
[AUD-59] Add SDK workflow rule runtime

### DIFF
--- a/Sources/Workflows/Rules/WorkflowRuleBundle.swift
+++ b/Sources/Workflows/Rules/WorkflowRuleBundle.swift
@@ -1,0 +1,212 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WorkflowRuleBundle.swift
+//
+//  Created by Codex on 3/31/26.
+
+import Foundation
+
+/// A versioned bundle of workflow targeting rules delivered to the SDK.
+@_spi(Internal) public struct WorkflowRuleBundle: Codable, Equatable, Sendable {
+
+    /// Version of the artifact schema.
+    @_spi(Internal) public let artifactVersion: Int
+    /// Stable identifier for the bundle payload.
+    @_spi(Internal) public let bundleKey: String
+    /// RFC3339 timestamp indicating when the bundle was generated.
+    @_spi(Internal) public let generatedAt: String
+    /// Rule artifacts available in this bundle.
+    @_spi(Internal) public let rules: [WorkflowRule]
+
+    /// Creates a workflow rule bundle.
+    @_spi(Internal) public init(
+        artifactVersion: Int,
+        bundleKey: String,
+        generatedAt: String,
+        rules: [WorkflowRule]
+    ) {
+        self.artifactVersion = artifactVersion
+        self.bundleKey = bundleKey
+        self.generatedAt = generatedAt
+        self.rules = rules
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case artifactVersion = "artifact_version"
+        case bundleKey = "bundle_key"
+        case generatedAt = "generated_at"
+        case rules
+    }
+
+}
+
+/// A single workflow rule artifact containing trigger, predicate, and action data.
+@_spi(Internal) public struct WorkflowRule: Codable, Equatable, Sendable {
+
+    /// Action to perform when the rule matches.
+    @_spi(Internal) public let action: WorkflowRuleAction
+    /// Version of the artifact schema for this rule.
+    @_spi(Internal) public let artifactVersion: Int
+    /// Rule kind, such as targeting or branching.
+    @_spi(Internal) public let kind: String
+    /// Canonical JsonLogic predicate represented as a JSON-compatible value.
+    @_spi(Internal) public let predicate: WorkflowRuleValue
+    /// Evaluation context fields needed by this rule.
+    @_spi(Internal) public let requiredFields: [String]
+    /// Stable identifier for the rule.
+    @_spi(Internal) public let ruleID: String
+    /// Version of the rule contents.
+    @_spi(Internal) public let ruleVersion: Int
+    /// Runtime support flags for this rule.
+    @_spi(Internal) public let supportedRuntimes: WorkflowSupportedRuntimes
+    /// Trigger metadata associated with this rule.
+    @_spi(Internal) public let trigger: WorkflowRuleTrigger
+
+    private enum CodingKeys: String, CodingKey {
+        case action
+        case artifactVersion = "artifact_version"
+        case kind
+        case predicate
+        case requiredFields = "required_fields"
+        case ruleID = "rule_id"
+        case ruleVersion = "rule_version"
+        case supportedRuntimes = "supported_runtimes"
+        case trigger
+    }
+
+}
+
+/// The action to take when a workflow rule matches.
+@_spi(Internal) public struct WorkflowRuleAction: Codable, Equatable, Sendable {
+
+    /// Action type.
+    @_spi(Internal) public let type: String
+    /// Target workflow public identifier.
+    @_spi(Internal) public let workflowID: String
+    /// Human-readable workflow name.
+    @_spi(Internal) public let workflowName: String
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case workflowID = "workflow_id"
+        case workflowName = "workflow_name"
+    }
+
+}
+
+/// Runtime support flags for a workflow rule.
+@_spi(Internal) public struct WorkflowSupportedRuntimes: Codable, Equatable, Sendable {
+
+    /// Whether ClickHouse can evaluate the rule.
+    @_spi(Internal) public let clickhouse: Bool
+    /// Whether the SDK can evaluate the rule.
+    @_spi(Internal) public let sdk: Bool
+    /// Whether the backend server evaluator can evaluate the rule.
+    @_spi(Internal) public let server: Bool
+
+}
+
+/// Trigger metadata associated with a workflow rule.
+@_spi(Internal) public struct WorkflowRuleTrigger: Codable, Equatable, Sendable {
+
+    /// Trigger-supplied fields referenced by the rule.
+    @_spi(Internal) public let fields: [String]
+    /// Trigger type name.
+    @_spi(Internal) public let type: String
+
+}
+
+/// A JSON-compatible value used to represent workflow predicates and evaluation context.
+@_spi(Internal) public enum WorkflowRuleValue: Codable, Equatable, Sendable {
+
+    /// A string value.
+    case string(String)
+    /// An integer value.
+    case int(Int)
+    /// A floating-point value.
+    case double(Double)
+    /// A boolean value.
+    case bool(Bool)
+    /// An object value keyed by strings.
+    case object([String: WorkflowRuleValue])
+    /// An array value.
+    case array([WorkflowRuleValue])
+    /// A null value.
+    case null
+
+    /// Resolves a dotted path inside an object-backed rule value.
+    @_spi(Internal) public subscript(path path: String) -> WorkflowRuleValue? {
+        return self[pathSegments: path.split(separator: ".").map(String.init)]
+    }
+
+    private subscript(pathSegments pathSegments: [String]) -> WorkflowRuleValue? {
+        guard let segment = pathSegments.first else { return self }
+
+        switch self {
+        case let .object(value):
+            guard let next = value[segment] else { return nil }
+            return next[pathSegments: Array(pathSegments.dropFirst())]
+        default:
+            return nil
+        }
+    }
+
+    /// Decodes a JSON-compatible workflow rule value.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([String: WorkflowRuleValue].self) {
+            self = .object(value)
+        } else if let value = try? container.decode([WorkflowRuleValue].self) {
+            self = .array(value)
+        } else {
+            throw DecodingError.typeMismatch(
+                WorkflowRuleValue.self,
+                .init(
+                    codingPath: container.codingPath,
+                    debugDescription: "Unexpected rule value at \(container.codingPath)"
+                )
+            )
+        }
+    }
+
+    /// Encodes a JSON-compatible workflow rule value.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case let .string(value):
+            try container.encode(value)
+        case let .int(value):
+            try container.encode(value)
+        case let .double(value):
+            try container.encode(value)
+        case let .bool(value):
+            try container.encode(value)
+        case let .object(value):
+            try container.encode(value)
+        case let .array(value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+}

--- a/Sources/Workflows/Rules/WorkflowRuleEvaluator.swift
+++ b/Sources/Workflows/Rules/WorkflowRuleEvaluator.swift
@@ -1,0 +1,85 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WorkflowRuleEvaluator.swift
+//
+//  Created by Codex on 3/31/26.
+
+import Foundation
+
+/// Evaluates workflow rule predicates against an SDK-provided context.
+@_spi(Internal) public enum WorkflowRuleEvaluator {
+
+    /// Returns the first matching action in a rule bundle for the given trigger and context.
+    @_spi(Internal) public static func firstMatchingAction(
+        in bundle: WorkflowRuleBundle,
+        triggerType: String,
+        evaluationContext: WorkflowRuleValue
+    ) -> WorkflowRuleAction? {
+        return bundle.rules.first {
+            $0.supportedRuntimes.sdk &&
+            Self.evaluate(rule: $0, triggerType: triggerType, evaluationContext: evaluationContext)
+        }?.action
+    }
+
+    /// Evaluates a single workflow rule for the given trigger and context.
+    @_spi(Internal) public static func evaluate(
+        rule: WorkflowRule,
+        triggerType: String,
+        evaluationContext: WorkflowRuleValue
+    ) -> Bool {
+        guard rule.trigger.type == triggerType else { return false }
+        return Self.evaluate(expression: rule.predicate, context: evaluationContext)
+    }
+
+}
+
+private extension WorkflowRuleEvaluator {
+
+    static func evaluate(expression: WorkflowRuleValue, context: WorkflowRuleValue) -> Bool {
+        guard case let .object(value) = expression else { return false }
+
+        if let clauses = value["and"] {
+            guard case let .array(items) = clauses else { return false }
+            return items.allSatisfy { self.evaluate(expression: $0, context: context) }
+        }
+
+        if let equality = value["=="] {
+            return self.evaluateEquality(expression: equality, context: context)
+        }
+
+        return false
+    }
+
+    static func evaluateEquality(expression: WorkflowRuleValue, context: WorkflowRuleValue) -> Bool {
+        guard case let .array(operands) = expression,
+              operands.count == 2,
+              let left = self.resolve(operand: operands[0], context: context),
+              let right = self.resolve(operand: operands[1], context: context) else {
+            return false
+        }
+
+        return left == right
+    }
+
+    static func resolve(operand: WorkflowRuleValue, context: WorkflowRuleValue) -> WorkflowRuleValue? {
+        if case let .object(value) = operand,
+           case let .string(path)? = value["var"] {
+            return context[path: path]
+        }
+
+        switch operand {
+        case .string, .int, .double, .bool, .null:
+            return operand
+        case .object, .array:
+            return nil
+        }
+    }
+
+}

--- a/Tests/UnitTests/Workflows/WorkflowRuleEvaluatorTests.swift
+++ b/Tests/UnitTests/Workflows/WorkflowRuleEvaluatorTests.swift
@@ -1,0 +1,204 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WorkflowRuleEvaluatorTests.swift
+//
+//  Created by Codex on 3/31/26.
+
+import Nimble
+import XCTest
+
+@_spi(Internal) @testable import RevenueCat
+
+final class WorkflowRuleEvaluatorTests: TestCase {
+
+    func testDecodesWeatherCatDemoBundle() throws {
+        let bundle = try JSONDecoder.default.decode(
+            WorkflowRuleBundle.self,
+            from: Self.weatherCatDemoBundle.asData
+        )
+
+        expect(bundle.bundleKey) == "weathercat-demo"
+        expect(bundle.rules).to(haveCount(1))
+        expect(bundle.rules[0].trigger.type) == "attempt_change_environment"
+        expect(bundle.rules[0].action.workflowID) == "wf_weathercat_demo"
+    }
+
+    func testMatchesFirstPremiumThemeAttempt() throws {
+        let bundle = try self.decodeBundle()
+
+        let action = WorkflowRuleEvaluator.firstMatchingAction(
+            in: bundle,
+            triggerType: "attempt_change_environment",
+            evaluationContext: Self.context(
+                premiumEntitlementIsActive: false,
+                premiumThemeAttemptCount: 1,
+                environmentName: "Electric Storm",
+                environmentRequiresEntitlement: true
+            )
+        )
+
+        expect(action?.workflowID) == "wf_weathercat_demo"
+        expect(action?.workflowName) == "WeatherCat Premium Theme Interstitial"
+    }
+
+    func testDoesNotMatchForPremiumUser() throws {
+        let bundle = try self.decodeBundle()
+
+        let action = WorkflowRuleEvaluator.firstMatchingAction(
+            in: bundle,
+            triggerType: "attempt_change_environment",
+            evaluationContext: Self.context(
+                premiumEntitlementIsActive: true,
+                premiumThemeAttemptCount: 1,
+                environmentName: "Electric Storm",
+                environmentRequiresEntitlement: true
+            )
+        )
+
+        expect(action).to(beNil())
+    }
+
+    func testDoesNotMatchAfterFirstAttempt() throws {
+        let bundle = try self.decodeBundle()
+
+        let action = WorkflowRuleEvaluator.firstMatchingAction(
+            in: bundle,
+            triggerType: "attempt_change_environment",
+            evaluationContext: Self.context(
+                premiumEntitlementIsActive: false,
+                premiumThemeAttemptCount: 2,
+                environmentName: "Polar Aurora",
+                environmentRequiresEntitlement: true
+            )
+        )
+
+        expect(action).to(beNil())
+    }
+
+    func testDoesNotMatchDifferentTriggerType() throws {
+        let bundle = try self.decodeBundle()
+
+        let action = WorkflowRuleEvaluator.firstMatchingAction(
+            in: bundle,
+            triggerType: "app_launch",
+            evaluationContext: Self.context(
+                premiumEntitlementIsActive: false,
+                premiumThemeAttemptCount: 1,
+                environmentName: "Electric Storm",
+                environmentRequiresEntitlement: true
+            )
+        )
+
+        expect(action).to(beNil())
+    }
+
+}
+
+private extension WorkflowRuleEvaluatorTests {
+
+    func decodeBundle() throws -> WorkflowRuleBundle {
+        return try JSONDecoder.default.decode(
+            WorkflowRuleBundle.self,
+            from: Self.weatherCatDemoBundle.asData
+        )
+    }
+
+    static func context(
+        premiumEntitlementIsActive: Bool,
+        premiumThemeAttemptCount: Int,
+        environmentName: String,
+        environmentRequiresEntitlement: Bool
+    ) -> WorkflowRuleValue {
+        return .object([
+            "subscriber": .object([
+                "entitlements": .object([
+                    "premium": .object([
+                        "is_active": .bool(premiumEntitlementIsActive)
+                    ])
+                ])
+            ]),
+            "session": .object([
+                "premium_theme_attempt_count": .int(premiumThemeAttemptCount)
+            ]),
+            "trigger": .object([
+                "environment_name": .string(environmentName),
+                "environment_requires_entitlement": .bool(environmentRequiresEntitlement)
+            ])
+        ])
+    }
+
+    static let weatherCatDemoBundle = #"""
+    {
+      "artifact_version": 1,
+      "bundle_key": "weathercat-demo",
+      "generated_at": "2026-03-30T23:26:01.212282+00:00",
+      "rules": [
+        {
+          "action": {
+            "type": "launch_workflow",
+            "workflow_id": "wf_weathercat_demo",
+            "workflow_name": "WeatherCat Premium Theme Interstitial"
+          },
+          "artifact_version": 1,
+          "kind": "targeting",
+          "predicate": {
+            "and": [
+              {
+                "==": [
+                  {
+                    "var": "trigger.environment_requires_entitlement"
+                  },
+                  true
+                ]
+              },
+              {
+                "==": [
+                  {
+                    "var": "subscriber.entitlements.premium.is_active"
+                  },
+                  false
+                ]
+              },
+              {
+                "==": [
+                  {
+                    "var": "session.premium_theme_attempt_count"
+                  },
+                  1
+                ]
+              }
+            ]
+          },
+          "required_fields": [
+            "trigger.environment_name",
+            "trigger.environment_requires_entitlement",
+            "subscriber.entitlements.premium.is_active",
+            "session.premium_theme_attempt_count"
+          ],
+          "rule_id": "weathercat_premium_environment_first_attempt",
+          "rule_version": 1,
+          "supported_runtimes": {
+            "clickhouse": false,
+            "sdk": true,
+            "server": false
+          },
+          "trigger": {
+            "fields": [
+              "trigger.environment_name",
+              "trigger.environment_requires_entitlement"
+            ],
+            "type": "attempt_change_environment"
+          }
+        }
+      ]
+    }
+    """#
+
+}


### PR DESCRIPTION
## Summary
- add internal workflow rule artifact models for SDK-delivered targeting rules
- add a small native evaluator for the WeatherCat demo subset (`and`, `==`, `var`)
- add focused unit tests covering the demo rule bundle and matching behavior

## Testing
- xcodebuild build -workspace RevenueCat.xcworkspace -scheme RevenueCat -destination 'generic/platform=iOS Simulator'
- xcodebuild test -workspace RevenueCat.xcworkspace -scheme RevenueCat -destination 'platform=iOS Simulator,id=75B6F762-E275-44AA-9762-32B5E62887DD' -only-testing:UnitTests/WorkflowRuleEvaluatorTests
