### PR TITLE
Skip external dependencies in tuist install on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -513,6 +513,9 @@ commands:
           name: Generate Tuist workspace
           command: |
             export PATH="$HOME/.local/share/mise/shims:$PATH"
+            # Skip external test/dev dependencies to speed up tuist install.
+            # No CI job currently needs them (tests run via SPM, not Tuist).
+            export TUIST_INCLUDE_TEST_DEPENDENCIES=false
             if [ -n "<< parameters.query >>" ]; then
               tuist install && tuist generate << parameters.query >> --no-open
             else

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -1,5 +1,14 @@
 // swift-tools-version: 6.0
 @preconcurrency import PackageDescription
+import Foundation
+
+// When set to "false", skips downloading external test/dev dependencies
+// to speed up `tuist install` in CI jobs that only build app targets.
+let includeTestDependencies = ProcessInfo.processInfo.environment["TUIST_INCLUDE_TEST_DEPENDENCIES"]?.lowercased() != "false"
+
+if !includeTestDependencies {
+    print("⚠️ TUIST_INCLUDE_TEST_DEPENDENCIES=false: skipping external dependencies. Set to true or unset to include them.")
+}
 
 #if TUIST
     import ProjectDescription
@@ -30,7 +39,7 @@
 
 let package = Package(
     name: "Dependencies",
-    dependencies: [
+    dependencies: includeTestDependencies ? [
         .package(
             url: "https://github.com/quick/nimble",
             exact: "13.7.1"
@@ -52,5 +61,5 @@ let package = Package(
             url: "https://github.com/AliSoftware/OHHTTPStubs",
             revision: "9.1.0"
         )
-    ]
+    ] : []
 )

--- a/Tuist/ProjectDescriptionHelpers/Environment.swift
+++ b/Tuist/ProjectDescriptionHelpers/Environment.swift
@@ -42,6 +42,14 @@ extension Environment {
         }
     }
 
+    /// Returns whether to include external test/dev dependencies (Nimble, SnapshotTesting, OHHTTPStubs, GoogleMobileAds, etc.)
+    /// and the projects that depend on them (RevenueCatTests, RevenueCatAdMob, AdMobIntegrationSample).
+    /// Defaults to `true`. Set `TUIST_INCLUDE_TEST_DEPENDENCIES=false` to skip them and speed up `tuist install` on CI.
+    public static var includeTestDependencies: Bool {
+        let envValue = ProcessInfo.processInfo.environment["TUIST_INCLUDE_TEST_DEPENDENCIES"] ?? "true"
+        return envValue.lowercased() != "false"
+    }
+
     /// Returns whether to include the XCFrameworkInstallationTests project in the workspace.
     /// This is determined by the `TUIST_INCLUDE_XCFRAMEWORK_INSTALLATION_TESTS` environment variable, defaulting to `false` if not set.
     ///

--- a/Workspace.swift
+++ b/Workspace.swift
@@ -8,17 +8,20 @@ var projects: [Path] = [
     "./Examples/MagicWeatherSwiftUI/",
     "./Examples/testCustomEntitlementsComputation/",
     "./Examples/PurchaseTester/",
-    "./Projects/AdMobIntegrationSample",
     "./Projects/PaywallsTester",
     "./Projects/APITesters",
     "./Projects/PaywallValidationTester",
-    "./Projects/RevenueCatTests",
     "./Projects/BinarySizeTest",
     "./Projects/RCTTester"
 ]
 
-// RevenueCatAdMob is a standalone package (not in root SPM), so always include its Tuist project.
-projects.append("./Projects/RevenueCatAdMob")
+// These projects depend on external packages (Nimble, SnapshotTesting, OHHTTPStubs, GoogleMobileAds).
+// Exclude them when TUIST_INCLUDE_TEST_DEPENDENCIES=false to allow skipping those downloads on CI.
+if Environment.includeTestDependencies {
+    projects.append("./Projects/RevenueCatTests")
+    projects.append("./Projects/RevenueCatAdMob")
+    projects.append("./Projects/AdMobIntegrationSample")
+}
 
 // Include RevenueCat/RevenueCatUI Tuist projects only when using local Xcode project dependencies.
 // In all other modes (localSwiftPackage, remoteSwiftPackage, remoteXcodeProject), the SPM package


### PR DESCRIPTION
## Summary
- Adds `TUIST_INCLUDE_TEST_DEPENDENCIES` env var to conditionally skip external package downloads (Nimble, SnapshotTesting, OHHTTPStubs, GoogleMobileAds, purchases-ios self-reference) during `tuist install`
- Sets `TUIST_INCLUDE_TEST_DEPENDENCIES=false` in the CI `tuist-generate-workspace` command since no CI job that uses Tuist needs these dependencies (tests run via SPM)
- Excludes projects that depend on those packages (RevenueCatTests, RevenueCatAdMob, AdMobIntegrationSample) from the workspace when the flag is off
- All `tuist install` calls on CI went from ~1:45 to ~20s

## Test plan
- [x] Verify local `tuist install && tuist generate` still works without the env var (includes all dependencies)
- [x] Verify local `TUIST_INCLUDE_TEST_DEPENDENCIES=false tuist install && tuist generate Maestro --no-open` works
- [x] Verify `api-tests` CI job passes
- [x] Verify `maestro-e2e-tests` CI job passes
- [x] Verify `emerge_binary_size_analysis` CI job passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: build/CI configuration only, with default behavior unchanged unless `TUIST_INCLUDE_TEST_DEPENDENCIES=false` is explicitly set. Main risk is CI/Tuist jobs missing projects or packages if they unexpectedly require the excluded test/dev dependencies.
> 
> **Overview**
> Speeds up CI `tuist install` by exporting `TUIST_INCLUDE_TEST_DEPENDENCIES=false` in the `tuist-generate-workspace` CircleCI command.
> 
> Makes Tuist dependency resolution and workspace composition conditional on `TUIST_INCLUDE_TEST_DEPENDENCIES`: `Tuist/Package.swift` skips external test/dev SPM packages when disabled, and `Workspace.swift` omits the projects that rely on them (e.g. `RevenueCatTests`, `RevenueCatAdMob`, `AdMobIntegrationSample`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e746374e3145ff54a3ddc46bfcbcf0f1621aa62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->