### PR TITLE
[EXTERNAL] Fix #5549: Use entitlement identifier as title for promotional entitlements (#6530) via @cruisediary

### DIFF
--- a/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Data/PurchaseInformation.swift
@@ -216,7 +216,9 @@ struct PurchaseInformation {
         let isSubscriptionType = transaction.isSubscription && transaction.store != .promotional
 
         self.title = Self.determineTitle(
+            entitlement: entitlement,
             subscribedProduct: subscribedProduct,
+            store: transaction.store,
             isSubscription: isSubscriptionType,
             localization: localization
         )
@@ -537,12 +539,18 @@ extension PurchaseInformation {
     }
 
     private static func determineTitle(
+        entitlement: EntitlementInfo?,
         subscribedProduct: StoreProduct?,
+        store: Store,
         isSubscription: Bool,
         localization: CustomerCenterConfigData.Localization
     ) -> String {
         if let localizedTitle = subscribedProduct?.localizedTitle, !localizedTitle.isEmpty {
             return localizedTitle
+        }
+
+        if store == .promotional, let identifier = entitlement?.identifier, !identifier.isEmpty {
+            return identifier
         }
 
         let purchaseTypeKey: CCLocalizedString = isSubscription ? .typeSubscription : .typeOneTimePurchase

--- a/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/PurchaseInformationTests.swift
@@ -545,8 +545,8 @@ final class PurchaseInformationTests: TestCase {
             )
         )
 
-        // title from entitlement instead of product identifier
-        expect(subscriptionInfo.title) == "One-time Purchase"
+        // title uses entitlement identifier when no StoreKit product is available for promotional store
+        expect(subscriptionInfo.title) == "premium"
         expect(subscriptionInfo.pricePaid) == .free
         expect(subscriptionInfo.renewalPrice).to(beNil())
         expect(subscriptionInfo.isLifetime).to(beFalse())
@@ -592,7 +592,7 @@ final class PurchaseInformationTests: TestCase {
             )
         )
 
-        expect(subscriptionInfo.title) == "One-time Purchase"
+        expect(subscriptionInfo.title) == "premium"
         expect(subscriptionInfo.pricePaid) == .free
         expect(subscriptionInfo.renewalPrice).to(beNil())
         // false - no way to know if its lifetime
@@ -600,6 +600,129 @@ final class PurchaseInformationTests: TestCase {
 
         expect(subscriptionInfo.productIdentifier) == entitlement.productIdentifier
         expect(subscriptionInfo.store) == .promotional
+    }
+
+    func testDetermineTitlePromotionalUsesEntitlementIdentifier() throws {
+        let customerInfo = CustomerInfoFixtures.customerInfoWithPromotional
+        let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
+
+        let mockTransaction = MockTransaction(
+            productIdentifier: entitlement.productIdentifier,
+            store: .promotional,
+            type: .subscription(
+                isActive: true,
+                willRenew: false,
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
+            ),
+            isCancelled: false,
+            managementURL: nil,
+            price: .init(currency: "USD", amount: 0),
+            displayName: nil,
+            periodType: .normal,
+            purchaseDate: Date(),
+            isSandbox: false,
+            isSubscription: true
+        )
+
+        let purchaseInfo = PurchaseInformation(
+            entitlement: entitlement,
+            subscribedProduct: nil,
+            transaction: mockTransaction,
+            customerInfoRequestedDate: Date(),
+            managementURL: nil,
+            localization: Self.mockLocalization
+        )
+
+        // Promotional store with no product: entitlement identifier is used as title
+        expect(purchaseInfo.title) == "premium"
+    }
+
+    func testDetermineTitlePromotionalNoEntitlementFallsBackToTypeLabel() throws {
+        let mockTransaction = MockTransaction(
+            productIdentifier: "rc_promo_some_product",
+            store: .promotional,
+            type: .subscription(
+                isActive: true,
+                willRenew: false,
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
+            ),
+            isCancelled: false,
+            managementURL: nil,
+            price: .init(currency: "USD", amount: 0),
+            displayName: nil,
+            periodType: .normal,
+            purchaseDate: Date(),
+            isSandbox: false,
+            isSubscription: true
+        )
+
+        let purchaseInfo = PurchaseInformation(
+            entitlement: nil,
+            subscribedProduct: nil,
+            transaction: mockTransaction,
+            customerInfoRequestedDate: Date(),
+            managementURL: nil,
+            localization: Self.mockLocalization
+        )
+
+        // With no entitlement, promotional guard is skipped.
+        // isSubscriptionType = false for .promotional store, so falls through to "One-time Purchase"
+        expect(purchaseInfo.title) == "One-time Purchase"
+    }
+
+    func testDetermineTitleProductTitleTakesPriorityOverEntitlementIdentifier() throws {
+        let customerInfo = CustomerInfoFixtures.customerInfoWithPromotional
+        let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
+
+        let mockProduct = TestStoreProduct(
+            localizedTitle: "Pro Access",
+            price: 0,
+            currencyCode: "USD",
+            localizedPriceString: "$0.00",
+            productIdentifier: entitlement.productIdentifier,
+            productType: .autoRenewableSubscription,
+            localizedDescription: "Pro access via promo",
+            subscriptionGroupIdentifier: nil,
+            subscriptionPeriod: nil,
+            introductoryDiscount: nil,
+            locale: Self.locale
+        )
+
+        let mockTransaction = MockTransaction(
+            productIdentifier: entitlement.productIdentifier,
+            store: .promotional,
+            type: .subscription(
+                isActive: true,
+                willRenew: false,
+                expiresDate: Self.mockDateFormatter.date(from: "Apr 12, 2062"),
+                isTrial: false,
+                ownershipType: PurchaseOwnershipType.unknown
+            ),
+            isCancelled: false,
+            managementURL: nil,
+            price: .init(currency: "USD", amount: 0),
+            displayName: nil,
+            periodType: .normal,
+            purchaseDate: Date(),
+            isSandbox: false,
+            isSubscription: true
+        )
+
+        let purchaseInfo = PurchaseInformation(
+            entitlement: entitlement,
+            subscribedProduct: mockProduct.toStoreProduct(),
+            transaction: mockTransaction,
+            customerInfoRequestedDate: Date(),
+            managementURL: nil,
+            localization: Self.mockLocalization
+        )
+
+        // StoreKit product title wins over entitlement identifier
+        expect(purchaseInfo.title) == "Pro Access"
     }
 
     func testInitWithStripeEntitlement() throws {
@@ -1105,8 +1228,8 @@ final class PurchaseInformationTests: TestCase {
 
     // MARK: - Tests for improved title and price determination logic
 
-    func testDetermineTitleWithEntitlementIdentifierFallback() throws {
-        // Use existing Google Play fixture which has entitlement identifier "premium"
+    func testDetermineTitlePlayStoreFallsBackToSubscriptionType() throws {
+        // Play Store transactions with no StoreKit product should fall back to type label, not entitlement identifier
         let customerInfo = CustomerInfoFixtures.customerInfoWithGoogleSubscriptions
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all.first?.value)
 


### PR DESCRIPTION
Merging https://github.com/RevenueCat/purchases-ios/pull/6530 on main

I investigated using entitlement display name instead of identifier for promotional entitlements in Customer Center. The display name is stored in the DB but not included in the CustomerInfo API response so adding it would require a backend serializer change that impacts every CustomerInfo request, which isn't worth the cost for this use case in my opinion.

I've decided to keep the current PR approach of using the entitlemen identifier as the fallback title. If we want proper display names long-term, the right solution is a separate cacheable endpoint for entitlement metadata, but that's out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to `PurchaseInformation` title fallback logic, only affecting promotional purchases when no StoreKit product title is available.
> 
> **Overview**
> Updates Customer Center purchase title resolution so that **promotional** purchases without a StoreKit product now display the entitlement `identifier` instead of the generic purchase-type label.
> 
> Refactors `determineTitle` to accept `entitlement` and `store`, and expands tests to cover promotional fallback behavior (including no-entitlement fallback and StoreKit-title precedence) while keeping non-promotional stores (e.g. Play Store) falling back to the subscription/one-time type label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32c28c4bdfc690f46cd4ef7d87ce60400d7764e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->