### PR TITLE
POC: presentDynamicPaywall modifier with upgrade behavior

### DIFF
--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -14,7 +14,7 @@
 import Foundation
 import RevenueCat
 
-// swiftlint:disable identifier_name
+// swiftlint:disable identifier_name file_length
 
 enum Strings {
 
@@ -118,6 +118,14 @@ enum Strings {
 
     // Conditional Configurability
     case paywall_contains_unsupported_condition
+
+    // Dynamic Paywall
+    case dynamicPaywall_noActiveSubscriptions
+    case dynamicPaywall_purchasesNotConfigured
+    case dynamicPaywall_couldNotFetchActiveProducts
+    case dynamicPaywall_noSubscriptionGroupFound
+    case dynamicPaywall_noUpgradeCandidates
+    case dynamicPaywall_foundUpgradeCandidates(Int)
 
 }
 
@@ -378,6 +386,21 @@ extension Strings: CustomStringConvertible {
         case .paywall_contains_unsupported_condition:
             return "Unsupported paywall rule encountered. " +
             "Rendering paywall without conditional configurability rules."
+
+        case .dynamicPaywall_noActiveSubscriptions:
+            return "Dynamic paywall (upgrade): user has no active subscriptions. Paywall will not be presented."
+        case .dynamicPaywall_purchasesNotConfigured:
+            return "Dynamic paywall: Purchases SDK is not configured."
+        case .dynamicPaywall_couldNotFetchActiveProducts:
+            return "Dynamic paywall (upgrade): could not fetch StoreProducts for active subscriptions."
+        case .dynamicPaywall_noSubscriptionGroupFound:
+            return "Dynamic paywall (upgrade): active subscriptions have no subscription group. " +
+            "Only auto-renewable subscriptions support upgrades."
+        case .dynamicPaywall_noUpgradeCandidates:
+            return "Dynamic paywall (upgrade): no packages with a higher price found in the offering. " +
+            "Paywall will not be presented."
+        case let .dynamicPaywall_foundUpgradeCandidates(count):
+            return "Dynamic paywall (upgrade): found \(count) upgrade candidate(s)."
         }
     }
 

--- a/RevenueCatUI/DynamicPaywall/DynamicPaywallBehavior.swift
+++ b/RevenueCatUI/DynamicPaywall/DynamicPaywallBehavior.swift
@@ -1,0 +1,39 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DynamicPaywallBehavior.swift
+
+import Foundation
+
+/// Defines how a dynamic paywall filters the packages in an offering before presentation.
+///
+/// Use with `presentDynamicPaywallIfNeeded(behavior:offering:...)` to present paywalls
+/// whose visible packages are determined at runtime.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct DynamicPaywallBehavior: Sendable {
+
+    let kind: Kind
+
+    enum Kind: Sendable {
+        case upgrade
+    }
+
+    /// Presents only packages that represent an upgrade from the user's current subscription.
+    ///
+    /// The filter:
+    /// 1. Identifies the user's active auto-renewable subscription(s) from `CustomerInfo`.
+    /// 2. Resolves the corresponding `StoreProduct` to read its subscription group and price.
+    /// 3. Keeps only packages whose product belongs to the same subscription group
+    ///    and has a higher price than the current subscription.
+    ///
+    /// If the user has no active subscription, or no upgrade candidates exist,
+    /// the paywall is not presented.
+    public static let upgrade = DynamicPaywallBehavior(kind: .upgrade)
+
+}

--- a/RevenueCatUI/DynamicPaywall/DynamicPaywallFilter.swift
+++ b/RevenueCatUI/DynamicPaywall/DynamicPaywallFilter.swift
@@ -1,0 +1,91 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DynamicPaywallFilter.swift
+
+import Foundation
+import RevenueCat
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+enum DynamicPaywallFilter {
+
+    /// Applies the given behavior's filtering logic to the offering.
+    ///
+    /// - Returns: A new `Offering` with only the packages that pass the filter,
+    ///   or `nil` if no packages survive (meaning the paywall should not be presented).
+    static func apply(
+        behavior: DynamicPaywallBehavior,
+        to offering: Offering,
+        customerInfo: CustomerInfo
+    ) async -> Offering? {
+        switch behavior.kind {
+        case .upgrade:
+            return await applyUpgradeFilter(to: offering, customerInfo: customerInfo)
+        }
+    }
+
+    // MARK: - Upgrade
+
+    private static func applyUpgradeFilter(
+        to offering: Offering,
+        customerInfo: CustomerInfo
+    ) async -> Offering? {
+        let activeSubscriptionIDs = customerInfo.activeSubscriptions
+        guard !activeSubscriptionIDs.isEmpty else {
+            Logger.debug(Strings.dynamicPaywall_noActiveSubscriptions)
+            return nil
+        }
+
+        guard Purchases.isConfigured else {
+            Logger.warning(Strings.dynamicPaywall_purchasesNotConfigured)
+            return nil
+        }
+
+        let activeProducts = await Purchases.shared.products(Array(activeSubscriptionIDs))
+        guard !activeProducts.isEmpty else {
+            Logger.debug(Strings.dynamicPaywall_couldNotFetchActiveProducts)
+            return nil
+        }
+
+        // Build a map of subscription group -> maximum active price in that group
+        var maxPriceByGroup: [String: Decimal] = [:]
+        for product in activeProducts {
+            guard let groupID = product.subscriptionGroupIdentifier else { continue }
+            let existing = maxPriceByGroup[groupID] ?? -1
+            if product.price > existing {
+                maxPriceByGroup[groupID] = product.price
+            }
+        }
+
+        guard !maxPriceByGroup.isEmpty else {
+            Logger.debug(Strings.dynamicPaywall_noSubscriptionGroupFound)
+            return nil
+        }
+
+        let filteredPackages: [Package] = offering.availablePackages.filter { package in
+            guard let groupID = package.storeProduct.subscriptionGroupIdentifier else {
+                return false
+            }
+            guard let activePrice = maxPriceByGroup[groupID] else {
+                return false
+            }
+            return package.storeProduct.price > activePrice
+        }
+
+        guard !filteredPackages.isEmpty else {
+            Logger.debug(Strings.dynamicPaywall_noUpgradeCandidates)
+            return nil
+        }
+
+        Logger.debug(Strings.dynamicPaywall_foundUpgradeCandidates(filteredPackages.count))
+
+        return offering.copyWithFilteredPackages(filteredPackages)
+    }
+
+}

--- a/RevenueCatUI/DynamicPaywall/Offering+DynamicFiltering.swift
+++ b/RevenueCatUI/DynamicPaywall/Offering+DynamicFiltering.swift
@@ -1,0 +1,33 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Offering+DynamicFiltering.swift
+
+@_spi(Internal) import RevenueCat
+
+extension Offering {
+
+    /// Creates a copy of this offering containing only the specified packages.
+    ///
+    /// All other properties (identifier, description, paywall, paywallComponents, metadata, etc.)
+    /// are preserved. The convenience typed accessors (`annual`, `monthly`, etc.) are
+    /// re-derived from the filtered package list by `Offering.init`.
+    func copyWithFilteredPackages(_ packages: [Package]) -> Offering {
+        return Offering(
+            identifier: self.identifier,
+            serverDescription: self.serverDescription,
+            metadata: self.metadata,
+            paywall: self.paywall,
+            paywallComponents: self.paywallComponents,
+            availablePackages: packages,
+            webCheckoutUrl: self.webCheckoutUrl
+        )
+    }
+
+}

--- a/RevenueCatUI/View+PresentDynamicPaywall.swift
+++ b/RevenueCatUI/View+PresentDynamicPaywall.swift
@@ -1,0 +1,520 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  View+PresentDynamicPaywall.swift
+
+import RevenueCat
+import SwiftUI
+
+// swiftlint:disable file_length
+
+#if !os(tvOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
+extension View {
+
+    // MARK: - presentDynamicPaywallIfNeeded
+
+    /// Presents a ``PaywallView`` with packages filtered by the given ``DynamicPaywallBehavior``.
+    ///
+    /// The modifier fetches `CustomerInfo`, resolves the offering, and applies the behavior's
+    /// filter to determine which packages to show. If no packages survive the filter, the
+    /// paywall is not presented.
+    ///
+    /// Example — show only upgrade options:
+    /// ```swift
+    /// var body: some View {
+    ///     YourApp()
+    ///         .presentDynamicPaywallIfNeeded(behavior: .upgrade)
+    /// }
+    /// ```
+    ///
+    /// With a placement-resolved offering:
+    /// ```swift
+    /// var body: some View {
+    ///     YourApp()
+    ///         .presentDynamicPaywallIfNeeded(
+    ///             behavior: .upgrade,
+    ///             offering: myPlacementOffering
+    ///         )
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - behavior: The ``DynamicPaywallBehavior`` that determines which packages to show.
+    ///   - offering: The `Offering` to filter. If `nil`, `Offerings.current` is used.
+    ///   - fonts: An optional ``PaywallFontProvider``.
+    ///   - presentationMode: The desired presentation mode. Defaults to `.sheet`.
+    ///   - purchaseStarted: Called when a purchase is initiated.
+    ///   - purchaseCompleted: Called when a purchase completes successfully.
+    ///   - purchaseCancelled: Called when a purchase is cancelled.
+    ///   - restoreStarted: Called when a restore is initiated.
+    ///   - restoreCompleted: Called when a restore completes successfully.
+    ///   - purchaseFailure: Called when a purchase fails.
+    ///   - restoreFailure: Called when a restore fails.
+    ///   - onDismiss: Called when the paywall is dismissed.
+    public func presentDynamicPaywallIfNeeded(
+        behavior: DynamicPaywallBehavior,
+        offering: Offering? = nil,
+        fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        presentationMode: PaywallPresentationMode = .default,
+        myAppPurchaseLogic: MyAppPurchaseLogic? = nil,
+        purchaseStarted: PurchaseOfPackageStartedHandler? = nil,
+        purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        purchaseCancelled: PurchaseCancelledHandler? = nil,
+        restoreStarted: RestoreStartedHandler? = nil,
+        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        purchaseFailure: PurchaseFailureHandler? = nil,
+        restoreFailure: PurchaseFailureHandler? = nil,
+        onDismiss: (() -> Void)? = nil
+    ) -> some View {
+        return self.modifier(PresentingDynamicPaywallModifier(
+            behavior: behavior,
+            content: .optionalOffering(offering),
+            myAppPurchaseLogic: myAppPurchaseLogic,
+            presentationMode: presentationMode,
+            fontProvider: fonts,
+            purchaseStarted: purchaseStarted,
+            purchaseCompleted: purchaseCompleted,
+            purchaseCancelled: purchaseCancelled,
+            restoreStarted: restoreStarted,
+            restoreCompleted: restoreCompleted,
+            purchaseFailure: purchaseFailure,
+            restoreFailure: restoreFailure,
+            onDismiss: onDismiss
+        ))
+    }
+
+    // MARK: - presentDynamicPaywall (Binding-based)
+
+    /// Presents a ``PaywallView`` with packages filtered by the given ``DynamicPaywallBehavior``
+    /// when the provided offering binding is non-nil.
+    ///
+    /// When the binding is set to a non-nil `Offering`, the behavior filter is applied.
+    /// If no packages survive the filter, the binding is cleared and no paywall is shown.
+    ///
+    /// Example:
+    /// ```swift
+    /// @State private var offeringToPresent: Offering?
+    ///
+    /// var body: some View {
+    ///     Button("Show Upgrade Options") {
+    ///         offeringToPresent = myOffering
+    ///     }
+    ///     .presentDynamicPaywall(
+    ///         behavior: .upgrade,
+    ///         offering: $offeringToPresent
+    ///     )
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - behavior: The ``DynamicPaywallBehavior`` that determines which packages to show.
+    ///   - offering: A binding to the offering to filter and display.
+    ///   - fonts: An optional ``PaywallFontProvider``.
+    ///   - presentationMode: The desired presentation mode. Defaults to `.sheet`.
+    ///   - purchaseStarted: Called when a purchase is initiated.
+    ///   - purchaseCompleted: Called when a purchase completes successfully.
+    ///   - purchaseCancelled: Called when a purchase is cancelled.
+    ///   - restoreStarted: Called when a restore is initiated.
+    ///   - restoreCompleted: Called when a restore completes successfully.
+    ///   - purchaseFailure: Called when a purchase fails.
+    ///   - restoreFailure: Called when a restore fails.
+    ///   - onDismiss: Called when the paywall is dismissed.
+    public func presentDynamicPaywall(
+        behavior: DynamicPaywallBehavior,
+        offering: Binding<Offering?>,
+        fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        presentationMode: PaywallPresentationMode = .default,
+        myAppPurchaseLogic: MyAppPurchaseLogic? = nil,
+        purchaseStarted: PurchaseOfPackageStartedHandler? = nil,
+        purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        purchaseCancelled: PurchaseCancelledHandler? = nil,
+        restoreStarted: RestoreStartedHandler? = nil,
+        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        purchaseFailure: PurchaseFailureHandler? = nil,
+        restoreFailure: PurchaseFailureHandler? = nil,
+        onDismiss: (() -> Void)? = nil
+    ) -> some View {
+        return self.modifier(PresentingDynamicPaywallBindingModifier(
+            behavior: behavior,
+            offering: offering,
+            myAppPurchaseLogic: myAppPurchaseLogic,
+            presentationMode: presentationMode,
+            fontProvider: fonts,
+            purchaseStarted: purchaseStarted,
+            purchaseCompleted: purchaseCompleted,
+            purchaseCancelled: purchaseCancelled,
+            restoreStarted: restoreStarted,
+            restoreCompleted: restoreCompleted,
+            purchaseFailure: purchaseFailure,
+            restoreFailure: restoreFailure,
+            onDismiss: onDismiss
+        ))
+    }
+
+}
+
+// MARK: - PresentingDynamicPaywallModifier
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(tvOS, unavailable)
+private struct PresentingDynamicPaywallModifier: ViewModifier {
+
+    let behavior: DynamicPaywallBehavior
+    let content: PaywallViewConfiguration.Content
+    var presentationMode: PaywallPresentationMode
+    var fontProvider: PaywallFontProvider
+
+    var purchaseStarted: PurchaseOfPackageStartedHandler?
+    var purchaseCompleted: PurchaseOrRestoreCompletedHandler?
+    var purchaseCancelled: PurchaseCancelledHandler?
+    var restoreStarted: RestoreStartedHandler?
+    var restoreCompleted: PurchaseOrRestoreCompletedHandler?
+    var purchaseFailure: PurchaseFailureHandler?
+    var restoreFailure: PurchaseFailureHandler?
+    var onDismiss: (() -> Void)?
+
+    @StateObject
+    private var purchaseHandler: PurchaseHandler
+
+    @StateObject
+    private var promoOfferCache: PaywallPromoOfferCache
+
+    @State
+    private var filteredOffering: Offering?
+
+    init(
+        behavior: DynamicPaywallBehavior,
+        content: PaywallViewConfiguration.Content,
+        myAppPurchaseLogic: MyAppPurchaseLogic?,
+        presentationMode: PaywallPresentationMode,
+        fontProvider: PaywallFontProvider,
+        purchaseStarted: PurchaseOfPackageStartedHandler?,
+        purchaseCompleted: PurchaseOrRestoreCompletedHandler?,
+        purchaseCancelled: PurchaseCancelledHandler?,
+        restoreStarted: RestoreStartedHandler?,
+        restoreCompleted: PurchaseOrRestoreCompletedHandler?,
+        purchaseFailure: PurchaseFailureHandler?,
+        restoreFailure: PurchaseFailureHandler?,
+        onDismiss: (() -> Void)?
+    ) {
+        self.behavior = behavior
+        self.content = content
+        self.presentationMode = presentationMode
+        self.fontProvider = fontProvider
+        self.purchaseStarted = purchaseStarted
+        self.purchaseCompleted = purchaseCompleted
+        self.purchaseCancelled = purchaseCancelled
+        self.restoreStarted = restoreStarted
+        self.restoreCompleted = restoreCompleted
+        self.purchaseFailure = purchaseFailure
+        self.restoreFailure = restoreFailure
+        self.onDismiss = onDismiss
+        let handler = PurchaseHandler.default(performPurchase: myAppPurchaseLogic?.performPurchase,
+                                              performRestore: myAppPurchaseLogic?.performRestore)
+        self._purchaseHandler = .init(wrappedValue: handler)
+        self._promoOfferCache = .init(wrappedValue: PaywallPromoOfferCache(
+            subscriptionHistoryTracker: handler.subscriptionHistoryTracker
+        ))
+    }
+
+    func body(content: Content) -> some View {
+        Group {
+            switch presentationMode {
+            case .sheet:
+                content
+                    .sheet(item: self.$filteredOffering, onDismiss: self.handleDismiss) { offering in
+                        self.paywallView(for: offering)
+                        #if targetEnvironment(macCatalyst) || os(macOS)
+                            .frame(height: 667)
+                        #endif
+                    }
+            #if !os(macOS)
+            case .fullScreen:
+                content
+                    .fullScreenCover(item: self.$filteredOffering, onDismiss: self.handleDismiss) { offering in
+                        self.paywallView(for: offering)
+                    }
+            #endif
+            }
+        }
+        .task {
+            await self.resolveAndFilter()
+        }
+    }
+
+    private func resolveAndFilter() async {
+        guard Purchases.isConfigured else {
+            Logger.warning(Strings.dynamicPaywall_purchasesNotConfigured)
+            return
+        }
+
+        guard let offering = await self.content.resolveOffering() else {
+            return
+        }
+
+        let customerInfo: CustomerInfo
+        do {
+            customerInfo = try await Purchases.shared.customerInfo()
+        } catch {
+            Logger.warning(Strings.dynamicPaywall_purchasesNotConfigured)
+            return
+        }
+
+        Logger.debug(Strings.determining_whether_to_display_paywall)
+
+        if let filtered = await DynamicPaywallFilter.apply(
+            behavior: self.behavior,
+            to: offering,
+            customerInfo: customerInfo
+        ) {
+            Logger.debug(Strings.displaying_paywall)
+            self.filteredOffering = filtered
+        } else {
+            Logger.debug(Strings.not_displaying_paywall)
+        }
+    }
+
+    private func paywallView(for offering: Offering) -> some View {
+        PaywallView(
+            configuration: .init(
+                content: .offering(offering),
+                fonts: self.fontProvider,
+                displayCloseButton: true,
+                purchaseHandler: self.purchaseHandler,
+                promoOfferCache: self.promoOfferCache
+            )
+        )
+        .onPurchaseStarted {
+            self.purchaseStarted?($0)
+        }
+        .onPurchaseCompleted { customerInfo in
+            self.purchaseCompleted?(customerInfo)
+            self.close()
+        }
+        .onPurchaseCancelled {
+            self.purchaseCancelled?()
+        }
+        .onRestoreStarted {
+            self.restoreStarted?()
+        }
+        .onRestoreCompleted { customerInfo in
+            self.restoreCompleted?(customerInfo)
+        }
+        .onPreferenceChange(RestoredCustomerInfoPreferenceKey.self) { result in
+            guard let result, result.success else { return }
+            self.close()
+        }
+        .onPurchaseFailure {
+            self.purchaseFailure?($0)
+        }
+        .onRestoreFailure {
+            self.restoreFailure?($0)
+        }
+        .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
+    }
+
+    private func close() {
+        Logger.debug(Strings.dismissing_paywall)
+        self.filteredOffering = nil
+    }
+
+    private func handleDismiss() {
+        self.purchaseHandler.trackPaywallClose()
+        self.purchaseHandler.resetForNewSession()
+        self.onDismiss?()
+    }
+
+}
+
+// MARK: - PresentingDynamicPaywallBindingModifier
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(tvOS, unavailable)
+private struct PresentingDynamicPaywallBindingModifier: ViewModifier {
+
+    let behavior: DynamicPaywallBehavior
+    @Binding var offering: Offering?
+
+    var presentationMode: PaywallPresentationMode
+    var fontProvider: PaywallFontProvider
+
+    var purchaseStarted: PurchaseOfPackageStartedHandler?
+    var purchaseCompleted: PurchaseOrRestoreCompletedHandler?
+    var purchaseCancelled: PurchaseCancelledHandler?
+    var restoreStarted: RestoreStartedHandler?
+    var restoreCompleted: PurchaseOrRestoreCompletedHandler?
+    var purchaseFailure: PurchaseFailureHandler?
+    var restoreFailure: PurchaseFailureHandler?
+    var onDismiss: (() -> Void)?
+
+    @State
+    private var filteredOffering: Offering?
+
+    @StateObject
+    private var purchaseHandler: PurchaseHandler
+
+    @StateObject
+    private var promoOfferCache: PaywallPromoOfferCache
+
+    init(
+        behavior: DynamicPaywallBehavior,
+        offering: Binding<Offering?>,
+        myAppPurchaseLogic: MyAppPurchaseLogic?,
+        presentationMode: PaywallPresentationMode,
+        fontProvider: PaywallFontProvider,
+        purchaseStarted: PurchaseOfPackageStartedHandler?,
+        purchaseCompleted: PurchaseOrRestoreCompletedHandler?,
+        purchaseCancelled: PurchaseCancelledHandler?,
+        restoreStarted: RestoreStartedHandler?,
+        restoreCompleted: PurchaseOrRestoreCompletedHandler?,
+        purchaseFailure: PurchaseFailureHandler?,
+        restoreFailure: PurchaseFailureHandler?,
+        onDismiss: (() -> Void)?
+    ) {
+        self.behavior = behavior
+        self._offering = offering
+        self.presentationMode = presentationMode
+        self.fontProvider = fontProvider
+        self.purchaseStarted = purchaseStarted
+        self.purchaseCompleted = purchaseCompleted
+        self.purchaseCancelled = purchaseCancelled
+        self.restoreStarted = restoreStarted
+        self.restoreCompleted = restoreCompleted
+        self.purchaseFailure = purchaseFailure
+        self.restoreFailure = restoreFailure
+        self.onDismiss = onDismiss
+        let handler = PurchaseHandler.default(performPurchase: myAppPurchaseLogic?.performPurchase,
+                                              performRestore: myAppPurchaseLogic?.performRestore)
+        self._purchaseHandler = .init(wrappedValue: handler)
+        self._promoOfferCache = .init(wrappedValue: PaywallPromoOfferCache(
+            subscriptionHistoryTracker: handler.subscriptionHistoryTracker
+        ))
+    }
+
+    func body(content: Content) -> some View {
+        Group {
+            switch presentationMode {
+            case .sheet:
+                content
+                    .sheet(item: self.$filteredOffering, onDismiss: self.handleDismiss) { offering in
+                        self.paywallView(for: offering)
+                        #if targetEnvironment(macCatalyst) || os(macOS)
+                            .frame(minHeight: 667)
+                        #endif
+                    }
+            #if !os(macOS)
+            case .fullScreen:
+                content
+                    .fullScreenCover(item: self.$filteredOffering, onDismiss: self.handleDismiss) { offering in
+                        self.paywallView(for: offering)
+                    }
+            #endif
+            }
+        }
+        .onChange(of: self.offering?.id) { offeringID in
+            guard offeringID != nil, let sourceOffering = self.offering else {
+                self.filteredOffering = nil
+                return
+            }
+            Task {
+                await self.applyFilter(to: sourceOffering)
+            }
+        }
+    }
+
+    private func applyFilter(to offering: Offering) async {
+        guard Purchases.isConfigured else {
+            Logger.warning(Strings.dynamicPaywall_purchasesNotConfigured)
+            self.offering = nil
+            return
+        }
+
+        let customerInfo: CustomerInfo
+        do {
+            customerInfo = try await Purchases.shared.customerInfo()
+        } catch {
+            Logger.warning(Strings.dynamicPaywall_purchasesNotConfigured)
+            self.offering = nil
+            return
+        }
+
+        if let filtered = await DynamicPaywallFilter.apply(
+            behavior: self.behavior,
+            to: offering,
+            customerInfo: customerInfo
+        ) {
+            Logger.debug(Strings.displaying_paywall)
+            self.filteredOffering = filtered
+        } else {
+            Logger.debug(Strings.not_displaying_paywall)
+            self.offering = nil
+        }
+    }
+
+    private func paywallView(for offering: Offering) -> some View {
+        PaywallView(
+            configuration: .init(
+                content: .offering(offering),
+                fonts: self.fontProvider,
+                displayCloseButton: true,
+                purchaseHandler: self.purchaseHandler,
+                promoOfferCache: self.promoOfferCache
+            )
+        )
+        .onPurchaseStarted {
+            self.purchaseStarted?($0)
+        }
+        .onPurchaseCompleted { customerInfo in
+            self.purchaseCompleted?(customerInfo)
+            self.close()
+        }
+        .onPurchaseCancelled {
+            self.purchaseCancelled?()
+        }
+        .onRestoreStarted {
+            self.restoreStarted?()
+        }
+        .onRestoreCompleted { customerInfo in
+            self.restoreCompleted?(customerInfo)
+        }
+        .onPreferenceChange(RestoredCustomerInfoPreferenceKey.self) { result in
+            guard let result, result.success else { return }
+            self.close()
+        }
+        .onPurchaseFailure {
+            self.purchaseFailure?($0)
+        }
+        .onRestoreFailure {
+            self.restoreFailure?($0)
+        }
+        .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
+    }
+
+    private func close() {
+        Logger.debug(Strings.dismissing_paywall)
+        self.filteredOffering = nil
+        self.offering = nil
+    }
+
+    private func handleDismiss() {
+        self.filteredOffering = nil
+        self.offering = nil
+        self.purchaseHandler.trackPaywallClose()
+        self.purchaseHandler.resetForNewSession()
+        self.onDismiss?()
+    }
+
+}
+
+#endif
+
+// swiftlint:enable file_length


### PR DESCRIPTION
## Summary

- Adds a new `presentDynamicPaywall(behavior:)` SwiftUI modifier that filters an offering's packages at presentation time based on a behavior strategy
- The first behavior, `.upgrade`, identifies the user's active subscription, finds packages in the same subscription group with a higher price, and presents only those as upgrade options
- If no upgrade candidates exist (or the user has no active subscription), the paywall is not presented
- Supports placements via the existing `Offerings.currentOffering(forPlacement:)` pattern

## New files

| File | Purpose |
|------|---------|
| `RevenueCatUI/DynamicPaywall/DynamicPaywallBehavior.swift` | Behavior type (struct + static constants, not enum) |
| `RevenueCatUI/DynamicPaywall/DynamicPaywallFilter.swift` | Upgrade filter: match subscription groups, compare prices |
| `RevenueCatUI/DynamicPaywall/Offering+DynamicFiltering.swift` | `Offering.copyWithFilteredPackages` helper |
| `RevenueCatUI/View+PresentDynamicPaywall.swift` | `presentDynamicPaywallIfNeeded` + `presentDynamicPaywall` modifiers |

## Test plan

- [ ] Test with a user that has no active subscription — paywall should not present
- [ ] Test with a user that has an active subscription — paywall should show only higher-priced packages in the same subscription group
- [ ] Test with a user whose subscription is already the highest tier — paywall should not present
- [ ] Test with a placement-resolved offering
- [ ] Verify purchase flow works correctly through the filtered paywall


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new SwiftUI presentation modifiers and runtime filtering logic that can change when/which paywalls are shown, affecting upgrade flows and user-facing purchase options. Risk is moderate due to async SDK calls and offering mutation (filtered packages) at presentation time.
> 
> **Overview**
> Adds a new *dynamic paywall* capability: SwiftUI modifiers `presentDynamicPaywallIfNeeded(behavior:offering:...)` and binding-based `presentDynamicPaywall(behavior:offering:...)` that resolve an `Offering`, fetch `CustomerInfo`, filter the offering’s packages at runtime, and present `PaywallView` only if the filter yields results.
> 
> Introduces `DynamicPaywallBehavior` (initial behavior: `.upgrade`) and `DynamicPaywallFilter` which limits visible packages to higher-priced options within the same subscription group as the user’s active subscription(s); if the user has no active subscription, SDK isn’t configured, products can’t be resolved, or no upgrade candidates exist, the paywall is skipped. Adds `Offering.copyWithFilteredPackages` plus new `Strings` log messages for dynamic paywall filtering outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff357bdd2a76ed90a9c2acb147aa48c550f34c59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->