### PR TITLE
Use PNG instead of HEIC for icon URLs

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Icon/IconComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Icon/IconComponentViewModel.swift
@@ -188,7 +188,7 @@ struct IconComponentStyle {
         colorScheme: ColorScheme
     ) {
         self.visible = visible
-        self.url = URL(string: "\(baseUrl)/\(formats.heic)")!
+        self.url = URL(string: "\(baseUrl)/\(formats.png)")!
         self.size = size
         self.padding = (padding ?? .zero).edgeInsets
         self.margin = (margin ?? .zero).edgeInsets

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -268,7 +268,7 @@ extension PaywallComponent.IconComponent.Formats {
 
     func imageUrls(base: URL) -> [URL] {
         return [
-            base.appendingPathComponent(heic)
+            base.appendingPathComponent(png)
         ]
     }
 


### PR DESCRIPTION
Switch icon image references from HEIC to PNG. We have a rendering issue because HEIC images are lossy. When icons are rendered, switched to template format, then resized, we have some rough edges. This should resolve that.

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
