### PR TITLE
Add purchase button interaction tracking

### DIFF
--- a/RevenueCatUI/Data/ComponentInteractionData+PaywallControls.swift
+++ b/RevenueCatUI/Data/ComponentInteractionData+PaywallControls.swift
@@ -130,6 +130,25 @@ extension PaywallEvent.ComponentInteractionData {
         )
     }
 
+    // MARK: - Button (purchase)
+
+    static func paywallPurchaseButtonAction(
+        componentName: String?,
+        componentValue: String,
+        componentURL: URL? = nil,
+        currentPackageIdentifier: String? = nil,
+        currentProductIdentifier: String? = nil
+    ) -> Self {
+        return .init(
+            componentType: .purchaseButton,
+            componentName: componentName,
+            componentValue: componentValue,
+            componentURL: componentURL,
+            currentPackageIdentifier: currentPackageIdentifier,
+            currentProductIdentifier: currentProductIdentifier
+        )
+    }
+
     // MARK: - Text
 
     static func paywallTextMarkdownLinkTap(
@@ -143,5 +162,4 @@ extension PaywallEvent.ComponentInteractionData {
             componentURL: url
         )
     }
-
 }

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -35,6 +35,9 @@ struct PurchaseButtonComponentView: View {
     @EnvironmentObject
     private var purchaseHandler: PurchaseHandler
 
+    @Environment(\.componentInteractionLogger)
+    private var componentInteractionLogger
+
     @State private var inAppBrowserURL: URL?
 
     private let viewModel: PurchaseButtonComponentViewModel
@@ -66,6 +69,13 @@ struct PurchaseButtonComponentView: View {
 
     var body: some View {
         AsyncButton {
+            componentInteractionLogger(.paywallPurchaseButtonAction(
+                componentName: viewModel.componentName,
+                componentValue: viewModel.method?.description ?? "",
+                componentURL: viewModel.customWebCheckoutUrl,
+                currentPackageIdentifier: packageContext.package?.identifier,
+                currentProductIdentifier: packageContext.package?.storeProduct.productIdentifier
+            ))
             try await self.purchase()
         } label: {
             // Not passing an onDismiss - nothing in this stack should be able to dismiss
@@ -216,7 +226,8 @@ struct PurchaseButtonComponentView_Previews: PreviewProvider {
                         ))
                     ]),
                     action: .inAppCheckout,
-                    method: .inAppCheckout
+                    method: .inAppCheckout,
+                    name: nil
                 ),
                 localizationProvider: .init(
                     locale: Locale.current,
@@ -265,7 +276,8 @@ struct PurchaseButtonComponentView_Previews: PreviewProvider {
                                                 bottomTrailing: 8))
                     ),
                     action: .inAppCheckout,
-                    method: .inAppCheckout
+                    method: .inAppCheckout,
+                    name: nil
                 ),
                 localizationProvider: .init(
                     locale: Locale.current,

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -72,7 +72,7 @@ struct PurchaseButtonComponentView: View {
             componentInteractionLogger(.paywallPurchaseButtonAction(
                 componentName: viewModel.componentName,
                 componentValue: viewModel.method?.description ?? "",
-                componentURL: viewModel.customWebCheckoutUrl,
+                componentURL: viewModel.urlForWebCheckout(packageContext: packageContext)?.url,
                 currentPackageIdentifier: packageContext.package?.identifier,
                 currentProductIdentifier: packageContext.package?.storeProduct.productIdentifier
             ))

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentViewModel.swift
@@ -20,11 +20,14 @@ import SwiftUI
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class PurchaseButtonComponentViewModel {
 
+    var componentName: String? {
+        component.name
+    }
     private let component: PaywallComponent.PurchaseButtonComponent
     private let offering: Offering
     let stackViewModel: StackComponentViewModel
 
-    private let customWebCheckoutUrl: URL?
+    let customWebCheckoutUrl: URL?
 
     init(
         localizationProvider: LocalizationProvider,

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
@@ -125,7 +125,8 @@ private enum ButtonWithSheetPreview {
             shape: .pill
         ),
         action: nil,
-        method: nil
+        method: nil,
+        name: nil
     )
 
     static let viewAllButton = PaywallComponent.ButtonComponent(
@@ -195,7 +196,8 @@ private enum ButtonWithSheetPreview {
                                             shape: .pill
                                         ),
                                         action: .inAppCheckout,
-                                        method: .inAppCheckout
+                                        method: .inAppCheckout,
+                                        name: nil
                                     )),
                                     .purchaseButton(.init(
                                         stack: .init(
@@ -216,7 +218,8 @@ private enum ButtonWithSheetPreview {
                                             shape: .pill
                                         ),
                                         action: .webCheckout,
-                                        method: .webCheckout(.init())
+                                        method: .webCheckout(.init()),
+                                        name: nil
                                     )),
                                     .purchaseButton(.init(
                                         stack: .init(
@@ -237,7 +240,8 @@ private enum ButtonWithSheetPreview {
                                             shape: .pill
                                         ),
                                         action: .webProductSelection,
-                                        method: .webProductSelection(.init())
+                                        method: .webProductSelection(.init()),
+                                        name: nil
                                     )),
                                     .purchaseButton(.init(
                                         stack: .init(
@@ -260,7 +264,8 @@ private enum ButtonWithSheetPreview {
                                         action: .webCheckout,
                                         method: .customWebCheckout(
                                             .init(customUrl: .init(url: "web_checkout_url", packageParam: "rc_package"))
-                                        )
+                                        ),
+                                        name: nil
                                     )),
                                     .purchaseButton(.init(
                                         stack: .init(
@@ -283,7 +288,8 @@ private enum ButtonWithSheetPreview {
                                         action: .webProductSelection,
                                         method: .customWebCheckout(
                                             .init(customUrl: .init(url: "web_checkout_url"))
-                                        )
+                                        ),
+                                        name: nil
                                     ))
                                 ],
                                 size: .init(width: .fill, height: .fit),

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
@@ -304,7 +304,8 @@ private enum FamilySharingTogglePreview {
                                     bottomTrailing: 16))
         ),
         action: .inAppCheckout,
-        method: .inAppCheckout
+        method: .inAppCheckout,
+        name: nil
     )
 
     static let purchaseButtonStack = PaywallComponent.StackComponent(

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
@@ -294,7 +294,8 @@ private enum MultiTierPreview {
                                     bottomTrailing: 16))
         ),
         action: .inAppCheckout,
-        method: .inAppCheckout
+        method: .inAppCheckout,
+        name: nil
     )
 
     static let purchaseButtonStack = PaywallComponent.StackComponent(

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/PurchaseButtonInPackagePreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/PurchaseButtonInPackagePreview.swift
@@ -121,7 +121,8 @@ private enum PurchaseButtonInPackagePreview {
                         shape: .pill
                     ),
                     action: .inAppCheckout,
-                    method: .inAppCheckout
+                    method: .inAppCheckout,
+                    name: nil
                 ))
             ],
             dimension: .vertical(.center, .start),
@@ -226,7 +227,8 @@ private enum PurchaseButtonInPackagePreview {
                     shape: .pill
                 ),
                 action: .inAppCheckout,
-                method: .inAppCheckout
+                method: .inAppCheckout,
+                name: nil
             )),
             .text(orText),
             .package(.init(

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -125,7 +125,8 @@ private enum Template1Preview {
             shape: .pill
         ),
         action: .inAppCheckout,
-        method: .inAppCheckout
+        method: .inAppCheckout,
+        name: nil
     )
 
     static let contentStack = PaywallComponent.StackComponent(

--- a/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
@@ -12,6 +12,7 @@ import Foundation
 
     final class PurchaseButtonComponent: PaywallComponentBase {
 
+        public let name: String?
         let type: ComponentType
         public let stack: PaywallComponent.StackComponent
 
@@ -25,7 +26,22 @@ import Foundation
             case webProductSelection = "web_product_selection"
         }
 
-        public enum Method: Codable, Sendable, Hashable, Equatable {
+        public enum Method: Codable, Sendable, Hashable, Equatable, CustomStringConvertible {
+            public var description: String {
+                switch self {
+                case .inAppCheckout:
+                    "in_app_checkout"
+                case .webCheckout:
+                    "web_checkout"
+                case .webProductSelection:
+                    "web_product_selection"
+                case .customWebCheckout:
+                    "custom_web_checkout"
+                case .unknown:
+                    "unknown"
+                }
+            }
+
             case inAppCheckout
             case webCheckout(WebCheckout)
             case webProductSelection(WebCheckout)
@@ -133,12 +149,14 @@ import Foundation
         public init(
             stack: PaywallComponent.StackComponent,
             action: Action?,
-            method: Method?
+            method: Method?,
+            name: String?
         ) {
             self.type = .purchaseButton
             self.stack = stack
             self.action = action
             self.method = method
+            self.name = name
         }
 
         public func hash(into hasher: inout Hasher) {
@@ -155,5 +173,4 @@ import Foundation
                 lhs.method == rhs.method
         }
     }
-
 }

--- a/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
@@ -164,13 +164,15 @@ import Foundation
             hasher.combine(stack)
             hasher.combine(action)
             hasher.combine(method)
+            hasher.combine(name)
         }
 
         public static func == (lhs: PurchaseButtonComponent, rhs: PurchaseButtonComponent) -> Bool {
             return lhs.type == rhs.type &&
                 lhs.stack == rhs.stack &&
                 lhs.action == rhs.action &&
-                lhs.method == rhs.method
+                lhs.method == rhs.method &&
+                lhs.name == rhs.name
         }
     }
 }

--- a/Sources/Paywalls/Events/PaywallEvent.swift
+++ b/Sources/Paywalls/Events/PaywallEvent.swift
@@ -42,6 +42,8 @@ public enum ComponentInteractionType: String, Codable, Sendable, Hashable {
     case package
     /// Package-selection bottom sheet lifecycle (`component_value` is `open` / `close`), not a package row tap.
     case packageSelectionSheet = "package_selection_sheet"
+    /// Purchase button of any type was tapped
+    case purchaseButton = "purchase_button"
 
 }
 

--- a/Tests/RevenueCatUITests/Purchasing/ControlInteractionLoggerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/ControlInteractionLoggerTests.swift
@@ -85,6 +85,115 @@ class ComponentInteractionLoggerTests: TestCase {
         expect(interaction.componentURL) == URL(string: "https://example.com/docs")
     }
 
+    // MARK: - paywallPurchaseButtonAction factory
+
+    func testPurchaseButtonActionFactory_setsComponentTypeToPurchaseButton() {
+        let data = PaywallEvent.ComponentInteractionData.paywallPurchaseButtonAction(
+            componentName: "buy_button",
+            componentValue: "in_app_checkout"
+        )
+
+        expect(data.componentType) == .purchaseButton
+    }
+
+    func testPurchaseButtonActionFactory_setsComponentName() {
+        let data = PaywallEvent.ComponentInteractionData.paywallPurchaseButtonAction(
+            componentName: "my_button",
+            componentValue: "in_app_checkout"
+        )
+
+        expect(data.componentName) == "my_button"
+    }
+
+    func testPurchaseButtonActionFactory_nilComponentNameIsPreserved() {
+        let data = PaywallEvent.ComponentInteractionData.paywallPurchaseButtonAction(
+            componentName: nil,
+            componentValue: "in_app_checkout"
+        )
+
+        expect(data.componentName).to(beNil())
+    }
+
+    func testPurchaseButtonActionFactory_setsComponentValue() {
+        let data = PaywallEvent.ComponentInteractionData.paywallPurchaseButtonAction(
+            componentName: nil,
+            componentValue: "web_checkout"
+        )
+
+        expect(data.componentValue) == "web_checkout"
+    }
+
+    func testPurchaseButtonActionFactory_setsComponentURL() throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com/checkout"))
+
+        let data = PaywallEvent.ComponentInteractionData.paywallPurchaseButtonAction(
+            componentName: nil,
+            componentValue: "custom_web_checkout",
+            componentURL: url
+        )
+
+        expect(data.componentURL) == url
+    }
+
+    func testPurchaseButtonActionFactory_nilComponentURLIsPreserved() {
+        let data = PaywallEvent.ComponentInteractionData.paywallPurchaseButtonAction(
+            componentName: nil,
+            componentValue: "in_app_checkout",
+            componentURL: nil
+        )
+
+        expect(data.componentURL).to(beNil())
+    }
+
+    func testPurchaseButtonActionFactory_setsCurrentPackageIdentifier() {
+        let data = PaywallEvent.ComponentInteractionData.paywallPurchaseButtonAction(
+            componentName: nil,
+            componentValue: "in_app_checkout",
+            currentPackageIdentifier: "annual"
+        )
+
+        expect(data.currentPackageIdentifier) == "annual"
+    }
+
+    func testPurchaseButtonActionFactory_setsCurrentProductIdentifier() {
+        let data = PaywallEvent.ComponentInteractionData.paywallPurchaseButtonAction(
+            componentName: nil,
+            componentValue: "in_app_checkout",
+            currentProductIdentifier: "com.app.annual"
+        )
+
+        expect(data.currentProductIdentifier) == "com.app.annual"
+    }
+
+    func testPurchaseButtonActionFactory_nilPackageAndProductIdentifiersArePreserved() {
+        let data = PaywallEvent.ComponentInteractionData.paywallPurchaseButtonAction(
+            componentName: nil,
+            componentValue: "in_app_checkout"
+        )
+
+        expect(data.currentPackageIdentifier).to(beNil())
+        expect(data.currentProductIdentifier).to(beNil())
+    }
+
+    func testPurchaseButtonActionFactory_allFieldsPopulated() throws {
+        let url = try XCTUnwrap(URL(string: "https://rc.example.com/checkout"))
+
+        let data = PaywallEvent.ComponentInteractionData.paywallPurchaseButtonAction(
+            componentName: "cta_button",
+            componentValue: "custom_web_checkout",
+            componentURL: url,
+            currentPackageIdentifier: "monthly",
+            currentProductIdentifier: "com.app.monthly"
+        )
+
+        expect(data.componentType) == .purchaseButton
+        expect(data.componentName) == "cta_button"
+        expect(data.componentValue) == "custom_web_checkout"
+        expect(data.componentURL) == url
+        expect(data.currentPackageIdentifier) == "monthly"
+        expect(data.currentProductIdentifier) == "com.app.monthly"
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/RevenueCatUITests/Purchasing/PaywallEventTrackerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PaywallEventTrackerTests.swift
@@ -379,6 +379,74 @@ class PaywallEventTrackerTests: TestCase {
         }
     }
 
+    func testTrackComponentInteraction_IncludesPurchaseButtonMetadataWhenProvided() async throws {
+        let (tracker, trackedEvents) = Self.makeTracker()
+        let sessionID = Self.eventData.sessionIdentifier
+
+        tracker.trackPaywallImpression(Self.eventData)
+
+        expect(tracker.trackComponentInteraction(
+            .paywallPurchaseButtonAction(
+                componentName: "subscribe_button",
+                componentValue: "in_app_checkout",
+                currentPackageIdentifier: "annual",
+                currentProductIdentifier: "com.app.annual"
+            ),
+            sessionID: sessionID
+        )) == true
+
+        await expect(trackedEvents.value).toEventually(haveCount(2), timeout: .seconds(2))
+
+        let interactionEvent = try XCTUnwrap(trackedEvents.value.first(where: {
+            if case .componentInteraction = $0 { return true }
+            return false
+        }))
+
+        guard case let .componentInteraction(_, _, interaction) = interactionEvent else {
+            fail("Expected componentInteraction event")
+            return
+        }
+
+        expect(interaction.componentType) == .purchaseButton
+        expect(interaction.componentName) == "subscribe_button"
+        expect(interaction.componentValue) == "in_app_checkout"
+        expect(interaction.currentPackageIdentifier) == "annual"
+        expect(interaction.currentProductIdentifier) == "com.app.annual"
+    }
+
+    func testTrackComponentInteraction_PurchaseButtonWithNilNameAndNoPackage() async throws {
+        let (tracker, trackedEvents) = Self.makeTracker()
+        let sessionID = Self.eventData.sessionIdentifier
+
+        tracker.trackPaywallImpression(Self.eventData)
+
+        expect(tracker.trackComponentInteraction(
+            .paywallPurchaseButtonAction(
+                componentName: nil,
+                componentValue: "web_checkout"
+            ),
+            sessionID: sessionID
+        )) == true
+
+        await expect(trackedEvents.value).toEventually(haveCount(2), timeout: .seconds(2))
+
+        let interactionEvent = try XCTUnwrap(trackedEvents.value.first(where: {
+            if case .componentInteraction = $0 { return true }
+            return false
+        }))
+
+        guard case let .componentInteraction(_, _, interaction) = interactionEvent else {
+            fail("Expected componentInteraction event")
+            return
+        }
+
+        expect(interaction.componentType) == .purchaseButton
+        expect(interaction.componentName).to(beNil())
+        expect(interaction.componentValue) == "web_checkout"
+        expect(interaction.currentPackageIdentifier).to(beNil())
+        expect(interaction.currentProductIdentifier).to(beNil())
+    }
+
     func testConcurrentCloseAndComponentInteractionAreThreadSafe() async throws {
         let (tracker, trackedEvents) = Self.makeTracker()
         let sessionID = Self.eventData.sessionIdentifier

--- a/Tests/UnitTests/Paywalls/Components/PurchaseButtonComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/PurchaseButtonComponentTests.swift
@@ -52,10 +52,40 @@ class PurchaseButtonComponentCodableTests: TestCase {
                 size: .init(width: .fill, height: .fill)
             ),
             action: nil,
-            method: nil
+            method: nil,
+            name: nil
         )
 
         XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
+    }
+
+    func testDecodingWithName() throws {
+        let jsonString = """
+        {
+            "type": "purchase_button",
+            "name": "my_purchase_button",
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPurchaseButton = try JSONDecoder.default.decode(PaywallComponent.PurchaseButtonComponent.self,
+                                                                   from: jsonData)
+
+        XCTAssertEqual(decodedPurchaseButton.name, "my_purchase_button")
+    }
+
+    func testDecodingWithNameAbsentIsNil() throws {
+        let jsonString = """
+        {
+            "type": "purchase_button",
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPurchaseButton = try JSONDecoder.default.decode(PaywallComponent.PurchaseButtonComponent.self,
+                                                                   from: jsonData)
+
+        XCTAssertNil(decodedPurchaseButton.name)
     }
 
     func testMethodInAppCheckoutDecoding() throws {
@@ -79,7 +109,8 @@ class PurchaseButtonComponentCodableTests: TestCase {
                 size: .init(width: .fill, height: .fill)
             ),
             action: nil,
-            method: .inAppCheckout
+            method: .inAppCheckout,
+            name: nil
         )
 
         XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
@@ -106,7 +137,8 @@ class PurchaseButtonComponentCodableTests: TestCase {
                 size: .init(width: .fill, height: .fill)
             ),
             action: nil,
-            method: .webCheckout(.init(autoDismiss: nil, openMethod: nil))
+            method: .webCheckout(.init(autoDismiss: nil, openMethod: nil)),
+            name: nil
         )
 
         XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
@@ -135,7 +167,8 @@ class PurchaseButtonComponentCodableTests: TestCase {
                 size: .init(width: .fill, height: .fill)
             ),
             action: nil,
-            method: .webCheckout(.init(autoDismiss: false, openMethod: .inAppBrowser))
+            method: .webCheckout(.init(autoDismiss: false, openMethod: .inAppBrowser)),
+            name: nil
         )
 
         XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
@@ -162,7 +195,8 @@ class PurchaseButtonComponentCodableTests: TestCase {
                 size: .init(width: .fill, height: .fill)
             ),
             action: nil,
-            method: .webProductSelection(.init(autoDismiss: nil, openMethod: nil))
+            method: .webProductSelection(.init(autoDismiss: nil, openMethod: nil)),
+            name: nil
         )
 
         XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
@@ -191,7 +225,8 @@ class PurchaseButtonComponentCodableTests: TestCase {
                 size: .init(width: .fill, height: .fill)
             ),
             action: nil,
-            method: .webProductSelection(.init(autoDismiss: false, openMethod: .inAppBrowser))
+            method: .webProductSelection(.init(autoDismiss: false, openMethod: .inAppBrowser)),
+            name: nil
         )
 
         XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
@@ -227,7 +262,8 @@ class PurchaseButtonComponentCodableTests: TestCase {
                     autoDismiss: nil,
                     openMethod: nil
                 )
-            )
+            ),
+            name: nil
         )
 
         XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
@@ -266,10 +302,50 @@ class PurchaseButtonComponentCodableTests: TestCase {
                     autoDismiss: false,
                     openMethod: .inAppBrowser
                 )
-            )
+            ),
+            name: nil
         )
 
         XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
+    }
+
+    // MARK: - Method.description
+
+    func testMethodDescriptionInAppCheckout() {
+        XCTAssertEqual(PaywallComponent.PurchaseButtonComponent.Method.inAppCheckout.description, "in_app_checkout")
+    }
+
+    func testMethodDescriptionWebCheckout() {
+        XCTAssertEqual(
+            PaywallComponent.PurchaseButtonComponent.Method.webCheckout(.init()).description,
+            "web_checkout"
+        )
+    }
+
+    func testMethodDescriptionWebProductSelection() {
+        XCTAssertEqual(
+            PaywallComponent.PurchaseButtonComponent.Method.webProductSelection(.init()).description,
+            "web_product_selection"
+        )
+    }
+
+    func testMethodDescriptionCustomWebCheckout() {
+        XCTAssertEqual(
+            PaywallComponent.PurchaseButtonComponent.Method.customWebCheckout(
+                .init(customUrl: .init(url: "url", packageParam: nil))
+            ).description,
+            "custom_web_checkout"
+        )
+    }
+
+    func testMethodDescriptionUnknown() {
+        XCTAssertEqual(PaywallComponent.PurchaseButtonComponent.Method.unknown.description, "unknown")
+    }
+
+    // MARK: - ComponentInteractionType raw value
+
+    func testPurchaseButtonInteractionTypeRawValue() {
+        XCTAssertEqual(ComponentInteractionType.purchaseButton.rawValue, "purchase_button")
     }
 
 }

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -88,6 +88,7 @@ public enum ComponentInteractionType : Swift.String, Swift.Codable, Swift.Sendab
   case text
   case package
   case packageSelectionSheet
+  case purchaseButton
   #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.String)
   #endif

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -88,6 +88,7 @@ public enum ComponentInteractionType : Swift.String, Swift.Codable, Swift.Sendab
   case text
   case package
   case packageSelectionSheet
+  case purchaseButton
   #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.String)
   #endif

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -89,6 +89,7 @@ public enum ComponentInteractionType : Swift.String, Swift.Codable, Swift.Sendab
   case text
   case package
   case packageSelectionSheet
+  case purchaseButton
   #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.String)
   #endif

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -87,6 +87,7 @@ public enum ComponentInteractionType : Swift.String, Swift.Codable, Swift.Sendab
   case text
   case package
   case packageSelectionSheet
+  case purchaseButton
   #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.String)
   #endif

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -87,6 +87,7 @@ public enum ComponentInteractionType : Swift.String, Swift.Codable, Swift.Sendab
   case text
   case package
   case packageSelectionSheet
+  case purchaseButton
   #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.String)
   #endif

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -88,6 +88,7 @@ public enum ComponentInteractionType : Swift.String, Swift.Codable, Swift.Sendab
   case text
   case package
   case packageSelectionSheet
+  case purchaseButton
   #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.String)
   #endif

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -88,6 +88,7 @@ public enum ComponentInteractionType : Swift.String, Swift.Codable, Swift.Sendab
   case text
   case package
   case packageSelectionSheet
+  case purchaseButton
   #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.String)
   #endif

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -88,6 +88,7 @@ public enum ComponentInteractionType : Swift.String, Swift.Codable, Swift.Sendab
   case text
   case package
   case packageSelectionSheet
+  case purchaseButton
   #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.String)
   #endif

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -88,6 +88,7 @@ public enum ComponentInteractionType : Swift.String, Swift.Codable, Swift.Sendab
   case text
   case package
   case packageSelectionSheet
+  case purchaseButton
   #if compiler(>=5.3) && $NonescapableTypes
   public init?(rawValue: Swift.String)
   #endif


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids - Note: waiting for the Android PR to be a little more stable, then will follow-up with the Android implementation

### Motivation
Resolves PWENG-30

### Description
Add tracking for purchase button taps: introduce `ComponentInteractionType.purchaseButton` and a `paywallPurchaseButtonAction` factory that captures `componentName`, `componentValue`, `componentURL`, `currentPackageIdentifier` and `currentProductIdentifier`. Expose `componentName` and `customWebCheckoutUrl` on the `PurchaseButtonViewModel` and log the interaction from `PurchaseButtonComponentView` before initiating the purchase. Extend `PurchaseButtonComponent` to include an optional name and make `Method` conform to `CustomStringConvertible` to provide stable string values for logging and event tracking. Update previews to include the new name field where applicable.

Tested manually using a live paywall and inspecting whether the correct log appears in console.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new analytics event type and logs purchase button taps (including package/product identifiers) before starting purchases, which changes event schema and component decoding/equality behavior.
> 
> **Overview**
> Adds first-class tracking for purchase button taps by introducing `ComponentInteractionType.purchaseButton` plus a new `paywallPurchaseButtonAction` factory that captures button name, method/value, optional URL, and current package/product identifiers.
> 
> Updates `PurchaseButtonComponentView` to emit this interaction event before initiating in-app/web purchase, and extends `PurchaseButtonComponent` to carry an optional `name` and provide stable `Method.description` strings used for logging. Tests and SwiftUI previews are updated accordingly, and public `.swiftinterface` outputs reflect the new enum case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a651d2f695f11008750c21c2fbc1b0b1e248c1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->