### PR TITLE
Fix: Use DefaultPaywallView in all the places

### DIFF
--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -17,6 +17,10 @@ struct PaywallViewConfiguration {
     var customerInfo: CustomerInfo?
     var mode: PaywallViewMode
     var fonts: PaywallFontProvider
+
+    /// This is a configuration value that is for V1 paywalls and the fallback paywall. V2 paywalls
+    /// can have their own close buttons configured via the dashboard, so it's not used by the
+    /// PaywallsV2View success path.
     var displayCloseButton: Bool
     let useDraftPaywall: Bool
     var introEligibility: TrialOrIntroEligibilityChecker?

--- a/RevenueCatUI/Helpers/PaywallData+Default.swift
+++ b/RevenueCatUI/Helpers/PaywallData+Default.swift
@@ -112,6 +112,9 @@ private extension PaywallData {
                 )
         )
     }
+}
+
+internal extension PaywallData {
 
     static let backgroundImage = "background.jpg"
     static let defaultTemplateBaseURL = Bundle.revenueCatUI.resourceURL ?? Bundle.revenueCatUI.bundleURL

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -579,7 +579,18 @@ struct LoadedOfferingPaywallView: View {
             .environmentObject(self.introEligibility)
             .environmentObject(self.purchaseHandler)
             .disabled(self.purchaseHandler.actionInProgress)
-            .onAppear { self.purchaseHandler.trackPaywallImpression(self.createEventData()) }
+            .onAppear {
+                if error != nil {
+                    self.purchaseHandler.trackPaywallImpression(self.createEventData(forDefaultPaywall: true))
+                } else {
+                    switch configuration {
+                    case .success:
+                        self.purchaseHandler.trackPaywallImpression(self.createEventData(forDefaultPaywall: false))
+                    case .failure:
+                        self.purchaseHandler.trackPaywallImpression(self.createEventData(forDefaultPaywall: true))
+                    }
+                }
+            }
             .onDisappear { self.purchaseHandler.trackPaywallClose() }
             .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
                 if hasPurchased {
@@ -624,10 +635,10 @@ struct LoadedOfferingPaywallView: View {
         }
     }
 
-    private func createEventData() -> PaywallEvent.Data {
+    private func createEventData(forDefaultPaywall: Bool) -> PaywallEvent.Data {
         return .init(
             offering: self.offering,
-            paywall: self.paywall,
+            paywall: forDefaultPaywall ? self.paywall.toDefaultPaywallData() : self.paywall,
             sessionID: .init(),
             displayMode: self.mode,
             locale: .current,
@@ -666,6 +677,21 @@ struct LoadedOfferingPaywallView: View {
         }
     }
 
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension PaywallData {
+    func toDefaultPaywallData() -> PaywallData {
+        PaywallData(
+            id: self.id,
+            templateName: PaywallData.defaultTemplate.rawValue,
+            config: self.config,
+            localization: self.localizedConfiguration ?? .init(title: "", callToAction: ""),
+            assetBaseURL: PaywallData.defaultTemplateBaseURL,
+            revision: PaywallData.revisionID,
+            locale: .current
+        )
+    }
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -354,7 +354,6 @@ public struct PaywallView: View {
                         }
                         onRequestedDismissal()
                     },
-                    fallbackContent: .paywallV1View(dataForV1DefaultPaywall),
                     failedToLoadFont: { fontConfig in
                         if Purchases.isConfigured {
                             Purchases.shared.failedToLoadFontWithConfig(fontConfig)
@@ -571,6 +570,7 @@ struct LoadedOfferingPaywallView: View {
                     template: self.template,
                     configuration: configuration,
                     introEligibility: self.introEligibility,
+                    mode: self.mode,
                     purchaseHandler: purchaseHandler
                 )
         }

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -566,10 +566,13 @@ struct LoadedOfferingPaywallView: View {
             )
         } else {
             self.paywall
-                .createView(for: self.offering,
-                            template: self.template,
-                            configuration: configuration,
-                            introEligibility: self.introEligibility)
+                .createView(
+                    for: self.offering,
+                    template: self.template,
+                    configuration: configuration,
+                    introEligibility: self.introEligibility,
+                    purchaseHandler: purchaseHandler
+                )
         }
     }
 

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -327,19 +327,6 @@ public struct PaywallView: View {
             #endif
             // Show the actually V2 paywall for full screen
             case .fullScreen:
-                let dataForV1DefaultPaywall = DataForV1DefaultPaywall(
-                    offering: offering,
-                    activelySubscribedProductIdentifiers: activelySubscribedProductIdentifiers,
-                    paywall: paywall,
-                    template: PaywallData.defaultTemplate,
-                    mode: self.mode,
-                    fonts: fonts,
-                    displayCloseButton: self.displayCloseButton,
-                    introEligibility: checker,
-                    purchaseHandler: purchaseHandler,
-                    locale: purchaseHandler.preferredLocaleOverride ?? .current,
-                    showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
-                )
 
                 PaywallsV2View(
                     paywallComponents: paywallComponents,

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -334,6 +334,7 @@ public struct PaywallView: View {
                     purchaseHandler: purchaseHandler,
                     introEligibilityChecker: checker,
                     showZeroDecimalPlacePrices: showZeroDecimalPlacePrices,
+                    displayCloseButton: self.displayCloseButton,
                     onDismiss: {
                         guard let onRequestedDismissal = self.onRequestedDismissal else {
                             self.dismiss()

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -64,10 +64,13 @@ extension TemplateViewType {
 extension PaywallData {
 
     @ViewBuilder
-    func createView(for offering: Offering,
-                    template: PaywallTemplate,
-                    configuration: Result<TemplateViewConfiguration, Error>,
-                    introEligibility: IntroEligibilityViewModel) -> some View {
+    func createView(
+        for offering: Offering,
+        template: PaywallTemplate,
+        configuration: Result<TemplateViewConfiguration, Error>,
+        introEligibility: IntroEligibilityViewModel,
+        purchaseHandler: PurchaseHandler
+    ) -> some View {
         switch configuration {
         case let .success(configuration):
             Self.createView(template: template, configuration: configuration)
@@ -77,7 +80,7 @@ extension PaywallData {
                 }
 
         case let .failure(error):
-            DebugErrorView(error, releaseBehavior: .emptyView)
+            DefaultPaywallView(handler: purchaseHandler, warning: .from(error: error), offering: offering)
         }
     }
 

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -63,12 +63,13 @@ extension TemplateViewType {
 @available(tvOS, unavailable)
 extension PaywallData {
 
-    @ViewBuilder
+    @ViewBuilder // swiftlint:disable:next function_parameter_count
     func createView(
         for offering: Offering,
         template: PaywallTemplate,
         configuration: Result<TemplateViewConfiguration, Error>,
         introEligibility: IntroEligibilityViewModel,
+        mode: PaywallViewMode,
         purchaseHandler: PurchaseHandler
     ) -> some View {
         switch configuration {
@@ -80,7 +81,12 @@ extension PaywallData {
                 }
 
         case let .failure(error):
-            DefaultPaywallView(handler: purchaseHandler, warning: .from(error: error), offering: offering)
+            DefaultPaywallView(
+                handler: purchaseHandler,
+                warning: .from(error: error),
+                offering: offering,
+                isFooterPaywall: mode != .fullScreen
+            )
         }
     }
 

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -34,56 +34,6 @@ struct PaywallState {
     var packages: [Package] {
         self.packageInfos.map(\.package)
     }
-
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-struct DataForV1DefaultPaywall {
-
-    let offering: Offering
-    let activelySubscribedProductIdentifiers: Set<String>
-    let paywall: PaywallData
-    let template: PaywallTemplate
-    let mode: PaywallViewMode
-    let fonts: PaywallFontProvider
-    let displayCloseButton: Bool
-    let introEligibility: TrialOrIntroEligibilityChecker
-    let purchaseHandler: PurchaseHandler
-    let locale: Locale
-    let showZeroDecimalPlacePrices: Bool
-
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-enum FallbackContent {
-    case paywallV1View(DataForV1DefaultPaywall)
-    case customView(AnyView)
-
-    @ViewBuilder
-    func view() -> some View {
-        switch self {
-        case .paywallV1View(let data):
-            #if os(macOS)
-            DebugErrorView("Fallback paywalls are unsupported on macOS.", releaseBehavior: .errorView)
-            #else
-            LoadedOfferingPaywallView(
-                offering: data.offering,
-                activelySubscribedProductIdentifiers: data.activelySubscribedProductIdentifiers,
-                paywall: data.paywall,
-                template: data.template,
-                mode: data.mode,
-                fonts: data.fonts,
-                displayCloseButton: data.displayCloseButton,
-                introEligibility: data.introEligibility,
-                purchaseHandler: data.purchaseHandler,
-                locale: data.locale,
-                showZeroDecimalPlacePrices: data.showZeroDecimalPlacePrices
-            )
-            #endif
-        case .customView(let view):
-            view
-        }
-    }
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -249,7 +249,7 @@ struct PaywallsV2View: View {
         .disabled(self.purchaseHandler.actionInProgress)
         .onAppear {
             self.purchaseHandler.trackPaywallImpression(
-                self.createEventData()
+                self.createEventData(forDefaultPaywall: true)
             )
         }
         .onDisappear { self.purchaseHandler.trackPaywallClose() }
@@ -277,10 +277,27 @@ struct PaywallsV2View: View {
                         value: self.purchaseHandler.restoreError as NSError?)
     }
 
-    private func createEventData() -> PaywallEvent.Data {
+    private func createEventData(forDefaultPaywall: Bool = false) -> PaywallEvent.Data {
+        let compontentsData: PaywallComponentsData
+        if forDefaultPaywall {
+            // The old default paywall was logged as a default template like this.
+            // Until we have a new log event for the new default paywall we need to contiunue
+            // logging the events like they used to be for data integrity.
+            compontentsData = .init(
+                templateName: PaywallData.defaultTemplate.rawValue,
+                assetBaseURL: PaywallData.defaultTemplateBaseURL,
+                componentsConfig: self.paywallComponentsData.componentsConfig,
+                componentsLocalizations: self.paywallComponentsData.componentsLocalizations,
+                revision: PaywallData.revisionID,
+                defaultLocaleIdentifier: self.paywallComponentsData.defaultLocale
+            )
+        } else {
+            compontentsData = self.paywallComponentsData
+        }
+
         return .init(
             offering: self.offering,
-            paywallComponentsData: self.paywallComponentsData,
+            paywallComponentsData: compontentsData,
             sessionID: .init(),
             displayMode: .fullScreen,
             locale: .current,

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -186,72 +186,98 @@ struct PaywallsV2View: View {
     public var body: some View {
         VStack(spacing: 0) {
             if let errorInfo = self.paywallComponentsData.errorInfo, !errorInfo.isEmpty {
-                DefaultPaywallView(
-                    handler: purchaseHandler,
+                self.fallbackPaywallView(
                     warning: .from(error: PaywallFallbackError(
                         // Trim up the error value to not flood the screen with too much content
                         reason: String("\(errorInfo)".prefix(130))
-                    )),
-                    offering: offering
+                    ))
                 )
             } else {
                 switch self.paywallStateManager.state {
                 case .success(let paywallState):
-                    LoadedPaywallsV2View(
-                        introOfferEligibilityContext: introOfferEligibilityContext,
-                        paywallState: paywallState,
-                        uiConfigProvider: self.uiConfigProvider,
-                        selectedPackageContext: self.selectedPackageContext,
-                        onDismiss: self.onDismiss
-                    )
-                    .environment(\.screenCondition, ScreenCondition.from(self.horizontalSizeClass))
-                    .environmentObject(self.purchaseHandler)
-                    .environmentObject(self.introOfferEligibilityContext)
-                    .environmentObject(self.paywallPromoOfferCache)
-                    .disabled(self.purchaseHandler.actionInProgress)
-                    .onAppear {
-                        self.purchaseHandler.trackPaywallImpression(
-                            self.createEventData()
+                    self.addPurchaseStatePreferences(
+                        to: LoadedPaywallsV2View(
+                            introOfferEligibilityContext: introOfferEligibilityContext,
+                            paywallState: paywallState,
+                            uiConfigProvider: self.uiConfigProvider,
+                            selectedPackageContext: self.selectedPackageContext,
+                            onDismiss: self.onDismiss
                         )
-                    }
-                    .onDisappear { self.purchaseHandler.trackPaywallClose() }
-                    .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
-                        if hasPurchased {
-                            self.onDismiss()
+                        .environment(\.screenCondition, ScreenCondition.from(self.horizontalSizeClass))
+                        .environmentObject(self.purchaseHandler)
+                        .environmentObject(self.introOfferEligibilityContext)
+                        .environmentObject(self.paywallPromoOfferCache)
+                        .disabled(self.purchaseHandler.actionInProgress)
+                        .onAppear {
+                            self.purchaseHandler.trackPaywallImpression(
+                                self.createEventData()
+                            )
                         }
-                    }
-                    .task {
-                        guard !didFinishEligibilityCheck else {
-                            return
+                        .onDisappear { self.purchaseHandler.trackPaywallClose() }
+                        .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
+                            if hasPurchased {
+                                self.onDismiss()
+                            }
                         }
+                        .task {
+                            guard !didFinishEligibilityCheck else {
+                                return
+                            }
 
-                        async let introCheck: Void = introOfferEligibilityContext.computeEligibility(
-                            for: paywallState.packages
-                        )
-                        async let promoCheck: Void = paywallPromoOfferCache.computeEligibility(
-                            for: paywallState.packageInfos.map { ($0.package, $0.promotionalOfferProductCode) }
-                        )
-                        _ = await (introCheck, promoCheck)
-                        didFinishEligibilityCheck = true
-                    }
-                    // Note: preferences need to be applied after `.toolbar` call
-                    .preference(key: PurchaseInProgressPreferenceKey.self,
-                                value: self.purchaseHandler.packageBeingPurchased)
-                    .preference(key: PurchasedResultPreferenceKey.self,
-                                value: .init(data: self.purchaseHandler.sessionPurchaseResult))
-                    .preference(key: RestoredCustomerInfoPreferenceKey.self,
-                                value: self.purchaseHandler.restoredCustomerInfo)
-                    .preference(key: RestoreInProgressPreferenceKey.self,
-                                value: self.purchaseHandler.restoreInProgress)
-                    .preference(key: PurchaseErrorPreferenceKey.self,
-                                value: self.purchaseHandler.purchaseError as NSError?)
-                    .preference(key: RestoreErrorPreferenceKey.self,
-                                value: self.purchaseHandler.restoreError as NSError?)
+                            async let introCheck: Void = introOfferEligibilityContext.computeEligibility(
+                                for: paywallState.packages
+                            )
+                            async let promoCheck: Void = paywallPromoOfferCache.computeEligibility(
+                                for: paywallState.packageInfos.map { ($0.package, $0.promotionalOfferProductCode) }
+                            )
+                            _ = await (introCheck, promoCheck)
+                            didFinishEligibilityCheck = true
+                        }
+                    )
                 case .failure(let error):
-                    DefaultPaywallView(handler: purchaseHandler, warning: .from(error: error), offering: offering)
+                    self.fallbackPaywallView(warning: .from(error: error))
                 }
             }
         }
+    }
+
+    private func fallbackPaywallView(warning: PaywallWarning) -> some View {
+        self.addPurchaseStatePreferences(
+            to: DefaultPaywallView(
+                handler: self.purchaseHandler,
+                warning: warning,
+                offering: self.offering
+            )
+            .disabled(self.purchaseHandler.actionInProgress)
+            .onAppear {
+                self.purchaseHandler.trackPaywallImpression(
+                    self.createEventData()
+                )
+            }
+            .onDisappear { self.purchaseHandler.trackPaywallClose() }
+            .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
+                if hasPurchased {
+                    self.onDismiss()
+                }
+            }
+        )
+    }
+
+    private func addPurchaseStatePreferences<Content: View>(to content: Content) -> some View {
+        content
+            // Note: preferences need to be applied after `.toolbar` call
+            .preference(key: PurchaseInProgressPreferenceKey.self,
+                        value: self.purchaseHandler.packageBeingPurchased)
+            .preference(key: PurchasedResultPreferenceKey.self,
+                        value: .init(data: self.purchaseHandler.sessionPurchaseResult))
+            .preference(key: RestoredCustomerInfoPreferenceKey.self,
+                        value: self.purchaseHandler.restoredCustomerInfo)
+            .preference(key: RestoreInProgressPreferenceKey.self,
+                        value: self.purchaseHandler.restoreInProgress)
+            .preference(key: PurchaseErrorPreferenceKey.self,
+                        value: self.purchaseHandler.purchaseError as NSError?)
+            .preference(key: RestoreErrorPreferenceKey.self,
+                        value: self.purchaseHandler.restoreError as NSError?)
     }
 
     private func createEventData() -> PaywallEvent.Data {

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -226,7 +226,9 @@ struct PaywallsV2View: View {
                 .font(.system(size: 14, weight: .bold))
                 .foregroundStyle(.primary)
                 .frame(width: 32, height: 32)
+                #if !os(watchOS)
                 .background(.ultraThinMaterial, in: Circle())
+                #endif
         }
         .buttonStyle(.plain)
         .disabled(self.purchaseHandler.actionInProgress)

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -112,7 +112,6 @@ struct PaywallsV2View: View {
     private let offering: Offering
     private let purchaseHandler: PurchaseHandler
     private let onDismiss: () -> Void
-    private let fallbackContent: FallbackContent
     @State private var didFinishEligibilityCheck: Bool = false
 
     @StateObject
@@ -125,7 +124,6 @@ struct PaywallsV2View: View {
         introEligibilityChecker: TrialOrIntroEligibilityChecker,
         showZeroDecimalPlacePrices: Bool,
         onDismiss: @escaping () -> Void,
-        fallbackContent: FallbackContent,
         failedToLoadFont: @escaping UIConfigProvider.FailedToLoadFont,
         colorScheme: ColorScheme,
         promoOfferCache: PaywallPromoOfferCache? = nil,
@@ -141,7 +139,6 @@ struct PaywallsV2View: View {
         self.offering = offering
         self.purchaseHandler = purchaseHandler
         self.onDismiss = onDismiss
-        self.fallbackContent = fallbackContent
         self._paywallPromoOfferCache = .init(wrappedValue: promoOfferCache ?? PaywallPromoOfferCache(
             subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
         ))
@@ -255,23 +252,6 @@ struct PaywallsV2View: View {
                 }
             }
         }
-    }
-
-    @ViewBuilder
-    func fallbackViewWithErrorMessage(_ errorMessage: String) -> some View {
-        let fullMessage = """
-        \(errorMessage)
-        Validate your paywall is correct in the RevenueCat dashboard,
-        update your SDK, or contact RevenueCat support.
-        View console logs for full detail.
-        The displayed paywall contains default configuration.
-        This error will be hidden in production.
-        """
-
-        DebugErrorView(
-            fullMessage,
-            replacement: self.fallbackContent.view()
-        )
     }
 
     private func createEventData() -> PaywallEvent.Data {

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -172,17 +172,10 @@ struct PaywallsV2View: View {
         .environmentObject(self.purchaseHandler)
         .environmentObject(self.introOfferEligibilityContext)
         .environmentObject(self.paywallPromoOfferCache)
-        .disabled(self.purchaseHandler.actionInProgress)
         .onAppear {
             self.purchaseHandler.trackPaywallImpression(
                 self.createEventData()
             )
-        }
-        .onDisappear { self.purchaseHandler.trackPaywallClose() }
-        .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
-            if hasPurchased {
-                self.onDismiss()
-            }
         }
         .task {
             guard !didFinishEligibilityCheck else {
@@ -248,17 +241,10 @@ struct PaywallsV2View: View {
                 offering: self.offering
             )
         )
-        .disabled(self.purchaseHandler.actionInProgress)
         .onAppear {
             self.purchaseHandler.trackPaywallImpression(
                 self.createEventData(forDefaultPaywall: true)
             )
-        }
-        .onDisappear { self.purchaseHandler.trackPaywallClose() }
-        .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
-            if hasPurchased {
-                self.onDismiss()
-            }
         }
     }
 
@@ -277,6 +263,14 @@ struct PaywallsV2View: View {
                         value: self.purchaseHandler.purchaseError as NSError?)
             .preference(key: RestoreErrorPreferenceKey.self,
                         value: self.purchaseHandler.restoreError as NSError?)
+            .disabled(self.purchaseHandler.actionInProgress)
+            .onDisappear { self.purchaseHandler.trackPaywallClose() }
+            .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
+                if hasPurchased {
+                    self.onDismiss()
+                }
+            }
+
     }
 
     private func createEventData(forDefaultPaywall: Bool = false) -> PaywallEvent.Data {

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -139,7 +139,7 @@ struct PaywallsV2View: View {
     }
 
     public var body: some View {
-        self.addPurchaseStatePreferences(to:
+        self.addPaywallModifiers(to:
             VStack(spacing: 0) {
                 if let errorInfo = self.paywallComponentsData.errorInfo, !errorInfo.isEmpty {
                     self.defaultPaywallView(
@@ -260,7 +260,7 @@ struct PaywallsV2View: View {
         }
     }
 
-    private func addPurchaseStatePreferences<Content: View>(to content: Content) -> some View {
+    private func addPaywallModifiers<Content: View>(to content: Content) -> some View {
         content
             // Note: preferences need to be applied after `.toolbar` call
             .preference(key: PurchaseInProgressPreferenceKey.self,
@@ -557,8 +557,8 @@ fileprivate extension PaywallsV2View {
     }
 }
 
-#endif
-
 private struct PaywallFallbackError: Error {
     let reason: String
 }
+
+#endif

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -136,7 +136,7 @@ struct PaywallsV2View: View {
     public var body: some View {
         VStack(spacing: 0) {
             if let errorInfo = self.paywallComponentsData.errorInfo, !errorInfo.isEmpty {
-                self.fallbackPaywallView(
+                self.defaultPaywallView(
                     warning: .from(error: PaywallFallbackError(
                         // Trim up the error value to not flood the screen with too much content
                         reason: String("\(errorInfo)".prefix(130))
@@ -185,13 +185,13 @@ struct PaywallsV2View: View {
                         }
                     )
                 case .failure(let error):
-                    self.fallbackPaywallView(warning: .from(error: error))
+                    self.defaultPaywallView(warning: .from(error: error))
                 }
             }
         }
     }
 
-    private func fallbackPaywallView(warning: PaywallWarning) -> some View {
+    private func defaultPaywallView(warning: PaywallWarning) -> some View {
         self.addPurchaseStatePreferences(
             to: DefaultPaywallView(
                 handler: self.purchaseHandler,

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -189,10 +189,13 @@ struct PaywallsV2View: View {
     public var body: some View {
         VStack(spacing: 0) {
             if let errorInfo = self.paywallComponentsData.errorInfo, !errorInfo.isEmpty {
-                // Show fallback paywall and debug error message that
-                // occurred while decoding the paywall
-                self.fallbackViewWithErrorMessage(
-                    "Error decoding paywall response on: \(errorInfo.keys.joined(separator: ", "))"
+                DefaultPaywallView(
+                    handler: purchaseHandler,
+                    warning: .from(error: PaywallFallbackError(
+                        // Trim up the error value to not flood the screen with too much content
+                        reason: String("\(errorInfo)".prefix(130))
+                    )),
+                    offering: offering
                 )
             } else {
                 switch self.paywallStateManager.state {
@@ -248,11 +251,7 @@ struct PaywallsV2View: View {
                     .preference(key: RestoreErrorPreferenceKey.self,
                                 value: self.purchaseHandler.restoreError as NSError?)
                 case .failure(let error):
-                    // Show fallback paywall and debug error message that
-                    // occurred while validating data and view models
-                    self.fallbackViewWithErrorMessage(
-                        "Error validating paywall: \(error.localizedDescription)"
-                    )
+                    DefaultPaywallView(handler: purchaseHandler, warning: .from(error: error), offering: offering)
                 }
             }
         }
@@ -539,3 +538,7 @@ fileprivate extension PaywallsV2View {
 }
 
 #endif
+
+private struct PaywallFallbackError: Error {
+    let reason: String
+}

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -61,6 +61,9 @@ struct PaywallsV2View: View {
     private let uiConfigProvider: UIConfigProvider
     private let offering: Offering
     private let purchaseHandler: PurchaseHandler
+    /// This is a configuration value from PaywallsV1, but it's important to include here just in case the
+    /// default paywall is shown. This is not used in the success path
+    private let displayCloseButton: Bool
     private let onDismiss: () -> Void
     @State private var didFinishEligibilityCheck: Bool = false
 
@@ -73,6 +76,7 @@ struct PaywallsV2View: View {
         purchaseHandler: PurchaseHandler,
         introEligibilityChecker: TrialOrIntroEligibilityChecker,
         showZeroDecimalPlacePrices: Bool,
+        displayCloseButton: Bool = false,
         onDismiss: @escaping () -> Void,
         failedToLoadFont: @escaping UIConfigProvider.FailedToLoadFont,
         colorScheme: ColorScheme,
@@ -88,6 +92,7 @@ struct PaywallsV2View: View {
         self.uiConfigProvider = uiConfigProvider
         self.offering = offering
         self.purchaseHandler = purchaseHandler
+        self.displayCloseButton = displayCloseButton
         self.onDismiss = onDismiss
         self._paywallPromoOfferCache = .init(wrappedValue: promoOfferCache ?? PaywallPromoOfferCache(
             subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
@@ -134,83 +139,125 @@ struct PaywallsV2View: View {
     }
 
     public var body: some View {
-        VStack(spacing: 0) {
-            if let errorInfo = self.paywallComponentsData.errorInfo, !errorInfo.isEmpty {
-                self.defaultPaywallView(
-                    warning: .from(error: PaywallFallbackError(
-                        // Trim up the error value to not flood the screen with too much content
-                        reason: String("\(errorInfo)".prefix(130))
-                    ))
-                )
-            } else {
-                switch self.paywallStateManager.state {
-                case .success(let paywallState):
-                    self.addPurchaseStatePreferences(
-                        to: LoadedPaywallsV2View(
-                            introOfferEligibilityContext: introOfferEligibilityContext,
-                            paywallState: paywallState,
-                            uiConfigProvider: self.uiConfigProvider,
-                            selectedPackageContext: self.selectedPackageContext,
-                            onDismiss: self.onDismiss
-                        )
-                        .environment(\.screenCondition, ScreenCondition.from(self.horizontalSizeClass))
-                        .environmentObject(self.purchaseHandler)
-                        .environmentObject(self.introOfferEligibilityContext)
-                        .environmentObject(self.paywallPromoOfferCache)
-                        .disabled(self.purchaseHandler.actionInProgress)
-                        .onAppear {
-                            self.purchaseHandler.trackPaywallImpression(
-                                self.createEventData()
-                            )
-                        }
-                        .onDisappear { self.purchaseHandler.trackPaywallClose() }
-                        .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
-                            if hasPurchased {
-                                self.onDismiss()
-                            }
-                        }
-                        .task {
-                            guard !didFinishEligibilityCheck else {
-                                return
-                            }
-
-                            async let introCheck: Void = introOfferEligibilityContext.computeEligibility(
-                                for: paywallState.packages
-                            )
-                            async let promoCheck: Void = paywallPromoOfferCache.computeEligibility(
-                                for: paywallState.packageInfos.map { ($0.package, $0.promotionalOfferProductCode) }
-                            )
-                            _ = await (introCheck, promoCheck)
-                            didFinishEligibilityCheck = true
-                        }
+        self.addPurchaseStatePreferences(to:
+            VStack(spacing: 0) {
+                if let errorInfo = self.paywallComponentsData.errorInfo, !errorInfo.isEmpty {
+                    self.defaultPaywallView(
+                        warning: .from(error: PaywallFallbackError(
+                            // Trim up the error value to not flood the screen with too much content
+                            reason: String("\(errorInfo)".prefix(130))
+                        ))
                     )
-                case .failure(let error):
-                    self.defaultPaywallView(warning: .from(error: error))
+                } else {
+                    switch self.paywallStateManager.state {
+                    case .success(let paywallState):
+                        self.loadedPaywallView(paywallState: paywallState)
+                    case .failure(let error):
+                        self.defaultPaywallView(warning: .from(error: error))
+                    }
                 }
             }
+        )
+    }
+
+    private func loadedPaywallView(paywallState: PaywallState) -> some View {
+        LoadedPaywallsV2View(
+            introOfferEligibilityContext: introOfferEligibilityContext,
+            paywallState: paywallState,
+            uiConfigProvider: self.uiConfigProvider,
+            selectedPackageContext: self.selectedPackageContext,
+            onDismiss: self.onDismiss
+        )
+        .environment(\.screenCondition, ScreenCondition.from(self.horizontalSizeClass))
+        .environmentObject(self.purchaseHandler)
+        .environmentObject(self.introOfferEligibilityContext)
+        .environmentObject(self.paywallPromoOfferCache)
+        .disabled(self.purchaseHandler.actionInProgress)
+        .onAppear {
+            self.purchaseHandler.trackPaywallImpression(
+                self.createEventData()
+            )
+        }
+        .onDisappear { self.purchaseHandler.trackPaywallClose() }
+        .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
+            if hasPurchased {
+                self.onDismiss()
+            }
+        }
+        .task {
+            guard !didFinishEligibilityCheck else {
+                return
+            }
+
+            async let introCheck: Void = introOfferEligibilityContext.computeEligibility(
+                for: paywallState.packages
+            )
+            async let promoCheck: Void = paywallPromoOfferCache.computeEligibility(
+                for: paywallState.packageInfos.map { ($0.package, $0.promotionalOfferProductCode) }
+            )
+            _ = await (introCheck, promoCheck)
+            didFinishEligibilityCheck = true
         }
     }
 
+    @ViewBuilder
+    private func addCloseButtonIfNeeded<Content: View>(to content: Content) -> some View {
+        if self.displayCloseButton {
+            content
+                .safeAreaInset(edge: .top, spacing: 0) {
+                    HStack {
+                        Spacer()
+                        self.makeCloseButton()
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 8)
+                    .padding(.bottom, 8)
+                }
+        } else {
+            content
+        }
+    }
+
+    private func makeCloseButton() -> some View {
+        Button {
+            self.onDismiss()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundStyle(.primary)
+                .frame(width: 32, height: 32)
+                .background(.ultraThinMaterial, in: Circle())
+        }
+        .buttonStyle(.plain)
+        .disabled(self.purchaseHandler.actionInProgress)
+        .opacity(
+            self.purchaseHandler.actionInProgress
+            ? Constants.purchaseInProgressButtonOpacity
+            : 1
+        )
+        .accessibilityLabel("Dismiss")
+    }
+
     private func defaultPaywallView(warning: PaywallWarning) -> some View {
-        self.addPurchaseStatePreferences(
-            to: DefaultPaywallView(
+        addCloseButtonIfNeeded(to:
+            DefaultPaywallView(
                 handler: self.purchaseHandler,
                 warning: warning,
                 offering: self.offering
             )
-            .disabled(self.purchaseHandler.actionInProgress)
-            .onAppear {
-                self.purchaseHandler.trackPaywallImpression(
-                    self.createEventData()
-                )
-            }
-            .onDisappear { self.purchaseHandler.trackPaywallClose() }
-            .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
-                if hasPurchased {
-                    self.onDismiss()
-                }
-            }
         )
+        .disabled(self.purchaseHandler.actionInProgress)
+        .onAppear {
+            self.purchaseHandler.trackPaywallImpression(
+                self.createEventData()
+            )
+        }
+        .onDisappear { self.purchaseHandler.trackPaywallClose() }
+        .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
+            if hasPurchased {
+                self.onDismiss()
+            }
+        }
     }
 
     private func addPurchaseStatePreferences<Content: View>(to content: Content) -> some View {

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/ButtonWithFooterPreview.swift
@@ -507,7 +507,6 @@ struct ButtonWithSheetPreview_Previews: PreviewProvider {
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },
-            fallbackContent: .customView(AnyView(Text("Fallback paywall"))),
             failedToLoadFont: { _ in },
             colorScheme: .light
         )

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/FamilySharingTogglePreview.swift
@@ -397,7 +397,6 @@ struct FamilySharingTogglePreview_Previews: PreviewProvider {
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },
-            fallbackContent: .customView(AnyView(Text("Fallback paywall"))),
             failedToLoadFont: { _ in },
             colorScheme: .light
         )

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/MultiTierPreview.swift
@@ -404,7 +404,6 @@ struct MultiTierPreview_Previews: PreviewProvider {
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },
-            fallbackContent: .customView(AnyView(Text("Fallback paywall"))),
             failedToLoadFont: { _ in },
             colorScheme: .light
         )

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/PackageVisibilityPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/PackageVisibilityPreview.swift
@@ -166,7 +166,6 @@ private enum PackageVisibilityPreview {
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },
-            fallbackContent: .customView(AnyView(Text("Fallback paywall"))),
             failedToLoadFont: { _ in },
             colorScheme: .light,
             introEligibilityContext: .forPreview(packages: availablePackages, eligibility: eligibility)

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/PurchaseButtonInPackagePreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/PurchaseButtonInPackagePreview.swift
@@ -346,7 +346,6 @@ struct PurchaseButtonInPackagePreview_Previews: PreviewProvider {
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },
-            fallbackContent: .customView(AnyView(Text("Fallback paywall"))),
             failedToLoadFont: { _ in },
             colorScheme: .light
         )

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/Template1Preview.swift
@@ -224,7 +224,6 @@ struct Template1Preview_Previews: PreviewProvider {
             introEligibilityChecker: .default(),
             showZeroDecimalPlacePrices: true,
             onDismiss: { },
-            fallbackContent: .customView(AnyView(Text("Fallback paywall"))),
             failedToLoadFont: { _ in },
             colorScheme: .light
         )


### PR DESCRIPTION

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

I missed a few spots where a default paywall may show up. This fixes that.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fallback rendering and impression logging for paywalls, which can affect what users see when V2 payloads fail and can impact analytics integrity. Core purchase flows are unchanged but these paths are exercised during errors and misconfigurations.
> 
> **Overview**
> Ensures **all Paywalls V2 failure paths** render the standard `DefaultPaywallView` (instead of debug/error-only views or a separate fallback-content mechanism), including decode/validation failures.
> 
> Propagates the V1 `displayCloseButton` option into `PaywallsV2View` so the default/fallback paywall can still show a close button, and removes the old `FallbackContent`/`DataForV1DefaultPaywall` plumbing.
> 
> Adjusts paywall impression tracking to log **default-template metadata** when the default/fallback paywall is shown (via `toDefaultPaywallData()` / overridden `PaywallComponentsData`), keeping analytics consistent, and updates V2 previews for the new initializer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a7c985fce79678790bea161ae175baf1b34f22a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->