### PR TITLE
Make RCAdMobFullScreenContentDelegate @MainActor

### DIFF
--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob+Completion.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob+Completion.swift
@@ -29,22 +29,17 @@ import GoogleMobileAds
         placement: String? = nil,
         fullScreenContentDelegate: (any GoogleMobileAds.FullScreenContentDelegate)? = nil,
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
-        completion: @escaping (GoogleMobileAds.InterstitialAd?, Error?) -> Void
+        completion: @escaping @MainActor (GoogleMobileAds.InterstitialAd?, Error?) -> Void
     ) {
-        Task {
-            do {
-                let loadedAd = try await self.loadAndTrack(
-                    withAdUnitID: adUnitID,
-                    request: request,
-                    placement: placement,
-                    fullScreenContentDelegate: fullScreenContentDelegate,
-                    paidEventHandler: paidEventHandler
-                )
-                completion(loadedAd, nil)
-            } catch {
-                completion(nil, error)
-            }
-        }
+        asyncToCompletion({
+            try await self.loadAndTrack(
+                withAdUnitID: adUnitID,
+                request: request,
+                placement: placement,
+                fullScreenContentDelegate: fullScreenContentDelegate,
+                paidEventHandler: paidEventHandler
+            )
+        }, completion: completion)
     }
 }
 
@@ -67,22 +62,17 @@ import GoogleMobileAds
         placement: String? = nil,
         fullScreenContentDelegate: (any GoogleMobileAds.FullScreenContentDelegate)? = nil,
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
-        completion: @escaping (GoogleMobileAds.AppOpenAd?, Error?) -> Void
+        completion: @escaping @MainActor (GoogleMobileAds.AppOpenAd?, Error?) -> Void
     ) {
-        Task {
-            do {
-                let loadedAd = try await self.loadAndTrack(
-                    withAdUnitID: adUnitID,
-                    request: request,
-                    placement: placement,
-                    fullScreenContentDelegate: fullScreenContentDelegate,
-                    paidEventHandler: paidEventHandler
-                )
-                completion(loadedAd, nil)
-            } catch {
-                completion(nil, error)
-            }
-        }
+        asyncToCompletion({
+            try await self.loadAndTrack(
+                withAdUnitID: adUnitID,
+                request: request,
+                placement: placement,
+                fullScreenContentDelegate: fullScreenContentDelegate,
+                paidEventHandler: paidEventHandler
+            )
+        }, completion: completion)
     }
 }
 
@@ -105,22 +95,17 @@ import GoogleMobileAds
         placement: String? = nil,
         fullScreenContentDelegate: (any GoogleMobileAds.FullScreenContentDelegate)? = nil,
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
-        completion: @escaping (GoogleMobileAds.RewardedAd?, Error?) -> Void
+        completion: @escaping @MainActor (GoogleMobileAds.RewardedAd?, Error?) -> Void
     ) {
-        Task {
-            do {
-                let loadedAd = try await self.loadAndTrack(
-                    withAdUnitID: adUnitID,
-                    request: request,
-                    placement: placement,
-                    fullScreenContentDelegate: fullScreenContentDelegate,
-                    paidEventHandler: paidEventHandler
-                )
-                completion(loadedAd, nil)
-            } catch {
-                completion(nil, error)
-            }
-        }
+        asyncToCompletion({
+            try await self.loadAndTrack(
+                withAdUnitID: adUnitID,
+                request: request,
+                placement: placement,
+                fullScreenContentDelegate: fullScreenContentDelegate,
+                paidEventHandler: paidEventHandler
+            )
+        }, completion: completion)
     }
 }
 
@@ -143,21 +128,31 @@ import GoogleMobileAds
         placement: String? = nil,
         fullScreenContentDelegate: (any GoogleMobileAds.FullScreenContentDelegate)? = nil,
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
-        completion: @escaping (GoogleMobileAds.RewardedInterstitialAd?, Error?) -> Void
+        completion: @escaping @MainActor (GoogleMobileAds.RewardedInterstitialAd?, Error?) -> Void
     ) {
-        Task {
-            do {
-                let loadedAd = try await self.loadAndTrack(
-                    withAdUnitID: adUnitID,
-                    request: request,
-                    placement: placement,
-                    fullScreenContentDelegate: fullScreenContentDelegate,
-                    paidEventHandler: paidEventHandler
-                )
-                completion(loadedAd, nil)
-            } catch {
-                completion(nil, error)
-            }
+        asyncToCompletion({
+            try await self.loadAndTrack(
+                withAdUnitID: adUnitID,
+                request: request,
+                placement: placement,
+                fullScreenContentDelegate: fullScreenContentDelegate,
+                paidEventHandler: paidEventHandler
+            )
+        }, completion: completion)
+    }
+}
+
+/// Bridges an `async throws` call to a `@MainActor` completion handler.
+internal func asyncToCompletion<T>(
+    _ method: @escaping () async throws -> T,
+    completion: @escaping @MainActor (T?, Error?) -> Void
+) {
+    Task {
+        do {
+            let result = try await method()
+            await completion(result, nil)
+        } catch {
+            await completion(nil, error)
         }
     }
 }

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob+Completion.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob+Completion.swift
@@ -1,0 +1,165 @@
+//
+//  FullScreenAd+RCAdMob+Completion.swift
+//
+//  Created by RevenueCat on 4/10/26.
+//
+
+import Foundation
+
+#if os(iOS) && canImport(GoogleMobileAds)
+import GoogleMobileAds
+@_spi(Experimental) import RevenueCat
+
+@available(iOS 15.0, *)
+@_spi(Experimental) public extension GoogleMobileAds.InterstitialAd {
+
+    /// Loads an interstitial ad, reports to RevenueCat, and forwards callbacks.
+    ///
+    /// - Parameters:
+    ///   - adUnitID: The ad unit identifier.
+    ///   - request: The AdMob request used to load the ad.
+    ///   - placement: Optional placement label used for RevenueCat analytics.
+    ///   - fullScreenContentDelegate: Optional delegate for full-screen content callbacks.
+    ///     Held **weakly** internally; the caller must retain this instance for the lifetime of the ad.
+    ///   - paidEventHandler: Optional handler invoked when a paid event is recorded.
+    ///   - completion: Called with the loaded ad or an error.
+    static func loadAndTrack(
+        withAdUnitID adUnitID: String,
+        request: GoogleMobileAds.Request,
+        placement: String? = nil,
+        fullScreenContentDelegate: (any GoogleMobileAds.FullScreenContentDelegate)? = nil,
+        paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
+        completion: @escaping (GoogleMobileAds.InterstitialAd?, Error?) -> Void
+    ) {
+        Task {
+            do {
+                let loadedAd = try await self.loadAndTrack(
+                    withAdUnitID: adUnitID,
+                    request: request,
+                    placement: placement,
+                    fullScreenContentDelegate: fullScreenContentDelegate,
+                    paidEventHandler: paidEventHandler
+                )
+                completion(loadedAd, nil)
+            } catch {
+                completion(nil, error)
+            }
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+@_spi(Experimental) public extension GoogleMobileAds.AppOpenAd {
+
+    /// Loads an app open ad, reports to RevenueCat, and forwards callbacks.
+    ///
+    /// - Parameters:
+    ///   - adUnitID: The ad unit identifier.
+    ///   - request: The AdMob request used to load the ad.
+    ///   - placement: Optional placement label used for RevenueCat analytics.
+    ///   - fullScreenContentDelegate: Optional delegate for full-screen content callbacks.
+    ///     Held **weakly** internally; the caller must retain this instance for the lifetime of the ad.
+    ///   - paidEventHandler: Optional handler invoked when a paid event is recorded.
+    ///   - completion: Called with the loaded ad or an error.
+    static func loadAndTrack(
+        withAdUnitID adUnitID: String,
+        request: GoogleMobileAds.Request,
+        placement: String? = nil,
+        fullScreenContentDelegate: (any GoogleMobileAds.FullScreenContentDelegate)? = nil,
+        paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
+        completion: @escaping (GoogleMobileAds.AppOpenAd?, Error?) -> Void
+    ) {
+        Task {
+            do {
+                let loadedAd = try await self.loadAndTrack(
+                    withAdUnitID: adUnitID,
+                    request: request,
+                    placement: placement,
+                    fullScreenContentDelegate: fullScreenContentDelegate,
+                    paidEventHandler: paidEventHandler
+                )
+                completion(loadedAd, nil)
+            } catch {
+                completion(nil, error)
+            }
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+@_spi(Experimental) public extension GoogleMobileAds.RewardedAd {
+
+    /// Loads a rewarded ad, reports to RevenueCat, and forwards callbacks.
+    ///
+    /// - Parameters:
+    ///   - adUnitID: The ad unit identifier.
+    ///   - request: The AdMob request used to load the ad.
+    ///   - placement: Optional placement label used for RevenueCat analytics.
+    ///   - fullScreenContentDelegate: Optional delegate for full-screen content callbacks.
+    ///     Held **weakly** internally; the caller must retain this instance for the lifetime of the ad.
+    ///   - paidEventHandler: Optional handler invoked when a paid event is recorded.
+    ///   - completion: Called with the loaded ad or an error.
+    static func loadAndTrack(
+        withAdUnitID adUnitID: String,
+        request: GoogleMobileAds.Request,
+        placement: String? = nil,
+        fullScreenContentDelegate: (any GoogleMobileAds.FullScreenContentDelegate)? = nil,
+        paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
+        completion: @escaping (GoogleMobileAds.RewardedAd?, Error?) -> Void
+    ) {
+        Task {
+            do {
+                let loadedAd = try await self.loadAndTrack(
+                    withAdUnitID: adUnitID,
+                    request: request,
+                    placement: placement,
+                    fullScreenContentDelegate: fullScreenContentDelegate,
+                    paidEventHandler: paidEventHandler
+                )
+                completion(loadedAd, nil)
+            } catch {
+                completion(nil, error)
+            }
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+@_spi(Experimental) public extension GoogleMobileAds.RewardedInterstitialAd {
+
+    /// Loads a rewarded interstitial ad, reports to RevenueCat, and forwards callbacks.
+    ///
+    /// - Parameters:
+    ///   - adUnitID: The ad unit identifier.
+    ///   - request: The AdMob request used to load the ad.
+    ///   - placement: Optional placement label used for RevenueCat analytics.
+    ///   - fullScreenContentDelegate: Optional delegate for full-screen content callbacks.
+    ///     Held **weakly** internally; the caller must retain this instance for the lifetime of the ad.
+    ///   - paidEventHandler: Optional handler invoked when a paid event is recorded.
+    ///   - completion: Called with the loaded ad or an error.
+    static func loadAndTrack(
+        withAdUnitID adUnitID: String,
+        request: GoogleMobileAds.Request,
+        placement: String? = nil,
+        fullScreenContentDelegate: (any GoogleMobileAds.FullScreenContentDelegate)? = nil,
+        paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
+        completion: @escaping (GoogleMobileAds.RewardedInterstitialAd?, Error?) -> Void
+    ) {
+        Task {
+            do {
+                let loadedAd = try await self.loadAndTrack(
+                    withAdUnitID: adUnitID,
+                    request: request,
+                    placement: placement,
+                    fullScreenContentDelegate: fullScreenContentDelegate,
+                    paidEventHandler: paidEventHandler
+                )
+                completion(loadedAd, nil)
+            } catch {
+                completion(nil, error)
+            }
+        }
+    }
+}
+
+#endif

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob+Completion.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob+Completion.swift
@@ -31,15 +31,20 @@ import GoogleMobileAds
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
         completion: @escaping (GoogleMobileAds.InterstitialAd?, Error?) -> Void
     ) {
-        asyncToCompletion({
-            try await self.loadAndTrack(
-                withAdUnitID: adUnitID,
-                request: request,
-                placement: placement,
-                fullScreenContentDelegate: fullScreenContentDelegate,
-                paidEventHandler: paidEventHandler
-            )
-        }, completion: completion)
+        Task {
+            do {
+                let loadedAd = try await self.loadAndTrack(
+                    withAdUnitID: adUnitID,
+                    request: request,
+                    placement: placement,
+                    fullScreenContentDelegate: fullScreenContentDelegate,
+                    paidEventHandler: paidEventHandler
+                )
+                completion(loadedAd, nil)
+            } catch {
+                completion(nil, error)
+            }
+        }
     }
 }
 
@@ -64,15 +69,20 @@ import GoogleMobileAds
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
         completion: @escaping (GoogleMobileAds.AppOpenAd?, Error?) -> Void
     ) {
-        asyncToCompletion({
-            try await self.loadAndTrack(
-                withAdUnitID: adUnitID,
-                request: request,
-                placement: placement,
-                fullScreenContentDelegate: fullScreenContentDelegate,
-                paidEventHandler: paidEventHandler
-            )
-        }, completion: completion)
+        Task {
+            do {
+                let loadedAd = try await self.loadAndTrack(
+                    withAdUnitID: adUnitID,
+                    request: request,
+                    placement: placement,
+                    fullScreenContentDelegate: fullScreenContentDelegate,
+                    paidEventHandler: paidEventHandler
+                )
+                completion(loadedAd, nil)
+            } catch {
+                completion(nil, error)
+            }
+        }
     }
 }
 
@@ -97,15 +107,20 @@ import GoogleMobileAds
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
         completion: @escaping (GoogleMobileAds.RewardedAd?, Error?) -> Void
     ) {
-        asyncToCompletion({
-            try await self.loadAndTrack(
-                withAdUnitID: adUnitID,
-                request: request,
-                placement: placement,
-                fullScreenContentDelegate: fullScreenContentDelegate,
-                paidEventHandler: paidEventHandler
-            )
-        }, completion: completion)
+        Task {
+            do {
+                let loadedAd = try await self.loadAndTrack(
+                    withAdUnitID: adUnitID,
+                    request: request,
+                    placement: placement,
+                    fullScreenContentDelegate: fullScreenContentDelegate,
+                    paidEventHandler: paidEventHandler
+                )
+                completion(loadedAd, nil)
+            } catch {
+                completion(nil, error)
+            }
+        }
     }
 }
 
@@ -130,28 +145,19 @@ import GoogleMobileAds
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
         completion: @escaping (GoogleMobileAds.RewardedInterstitialAd?, Error?) -> Void
     ) {
-        asyncToCompletion({
-            try await self.loadAndTrack(
-                withAdUnitID: adUnitID,
-                request: request,
-                placement: placement,
-                fullScreenContentDelegate: fullScreenContentDelegate,
-                paidEventHandler: paidEventHandler
-            )
-        }, completion: completion)
-    }
-}
-
-/// Bridges an `async throws` call to an Obj-C-style `(T?, Error?)` completion handler.
-internal func asyncToCompletion<T>(
-    _ method: @escaping () async throws -> T,
-    completion: @escaping (T?, Error?) -> Void
-) {
-    Task {
-        do {
-            completion(try await method(), nil)
-        } catch {
-            completion(nil, error)
+        Task {
+            do {
+                let loadedAd = try await self.loadAndTrack(
+                    withAdUnitID: adUnitID,
+                    request: request,
+                    placement: placement,
+                    fullScreenContentDelegate: fullScreenContentDelegate,
+                    paidEventHandler: paidEventHandler
+                )
+                completion(loadedAd, nil)
+            } catch {
+                completion(nil, error)
+            }
         }
     }
 }

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob+Completion.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob+Completion.swift
@@ -10,20 +10,6 @@ import Foundation
 import GoogleMobileAds
 @_spi(Experimental) import RevenueCat
 
-/// Bridges an `async throws` call to an Obj-C-style `(T?, Error?)` completion handler.
-internal func asyncToCompletion<T>(
-    _ method: @escaping () async throws -> T,
-    completion: @escaping (T?, Error?) -> Void
-) {
-    Task {
-        do {
-            completion(try await method(), nil)
-        } catch {
-            completion(nil, error)
-        }
-    }
-}
-
 @available(iOS 15.0, *)
 @_spi(Experimental) public extension GoogleMobileAds.InterstitialAd {
 
@@ -153,6 +139,20 @@ internal func asyncToCompletion<T>(
                 paidEventHandler: paidEventHandler
             )
         }, completion: completion)
+    }
+}
+
+/// Bridges an `async throws` call to an Obj-C-style `(T?, Error?)` completion handler.
+internal func asyncToCompletion<T>(
+    _ method: @escaping () async throws -> T,
+    completion: @escaping (T?, Error?) -> Void
+) {
+    Task {
+        do {
+            completion(try await method(), nil)
+        } catch {
+            completion(nil, error)
+        }
     }
 }
 

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob+Completion.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob+Completion.swift
@@ -10,6 +10,20 @@ import Foundation
 import GoogleMobileAds
 @_spi(Experimental) import RevenueCat
 
+/// Bridges an `async throws` call to an Obj-C-style `(T?, Error?)` completion handler.
+internal func asyncToCompletion<T>(
+    _ method: @escaping () async throws -> T,
+    completion: @escaping (T?, Error?) -> Void
+) {
+    Task {
+        do {
+            completion(try await method(), nil)
+        } catch {
+            completion(nil, error)
+        }
+    }
+}
+
 @available(iOS 15.0, *)
 @_spi(Experimental) public extension GoogleMobileAds.InterstitialAd {
 
@@ -31,20 +45,15 @@ import GoogleMobileAds
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
         completion: @escaping (GoogleMobileAds.InterstitialAd?, Error?) -> Void
     ) {
-        Task {
-            do {
-                let loadedAd = try await self.loadAndTrack(
-                    withAdUnitID: adUnitID,
-                    request: request,
-                    placement: placement,
-                    fullScreenContentDelegate: fullScreenContentDelegate,
-                    paidEventHandler: paidEventHandler
-                )
-                completion(loadedAd, nil)
-            } catch {
-                completion(nil, error)
-            }
-        }
+        asyncToCompletion({
+            try await self.loadAndTrack(
+                withAdUnitID: adUnitID,
+                request: request,
+                placement: placement,
+                fullScreenContentDelegate: fullScreenContentDelegate,
+                paidEventHandler: paidEventHandler
+            )
+        }, completion: completion)
     }
 }
 
@@ -69,20 +78,15 @@ import GoogleMobileAds
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
         completion: @escaping (GoogleMobileAds.AppOpenAd?, Error?) -> Void
     ) {
-        Task {
-            do {
-                let loadedAd = try await self.loadAndTrack(
-                    withAdUnitID: adUnitID,
-                    request: request,
-                    placement: placement,
-                    fullScreenContentDelegate: fullScreenContentDelegate,
-                    paidEventHandler: paidEventHandler
-                )
-                completion(loadedAd, nil)
-            } catch {
-                completion(nil, error)
-            }
-        }
+        asyncToCompletion({
+            try await self.loadAndTrack(
+                withAdUnitID: adUnitID,
+                request: request,
+                placement: placement,
+                fullScreenContentDelegate: fullScreenContentDelegate,
+                paidEventHandler: paidEventHandler
+            )
+        }, completion: completion)
     }
 }
 
@@ -107,20 +111,15 @@ import GoogleMobileAds
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
         completion: @escaping (GoogleMobileAds.RewardedAd?, Error?) -> Void
     ) {
-        Task {
-            do {
-                let loadedAd = try await self.loadAndTrack(
-                    withAdUnitID: adUnitID,
-                    request: request,
-                    placement: placement,
-                    fullScreenContentDelegate: fullScreenContentDelegate,
-                    paidEventHandler: paidEventHandler
-                )
-                completion(loadedAd, nil)
-            } catch {
-                completion(nil, error)
-            }
-        }
+        asyncToCompletion({
+            try await self.loadAndTrack(
+                withAdUnitID: adUnitID,
+                request: request,
+                placement: placement,
+                fullScreenContentDelegate: fullScreenContentDelegate,
+                paidEventHandler: paidEventHandler
+            )
+        }, completion: completion)
     }
 }
 
@@ -145,20 +144,15 @@ import GoogleMobileAds
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
         completion: @escaping (GoogleMobileAds.RewardedInterstitialAd?, Error?) -> Void
     ) {
-        Task {
-            do {
-                let loadedAd = try await self.loadAndTrack(
-                    withAdUnitID: adUnitID,
-                    request: request,
-                    placement: placement,
-                    fullScreenContentDelegate: fullScreenContentDelegate,
-                    paidEventHandler: paidEventHandler
-                )
-                completion(loadedAd, nil)
-            } catch {
-                completion(nil, error)
-            }
-        }
+        asyncToCompletion({
+            try await self.loadAndTrack(
+                withAdUnitID: adUnitID,
+                request: request,
+                placement: placement,
+                fullScreenContentDelegate: fullScreenContentDelegate,
+                paidEventHandler: paidEventHandler
+            )
+        }, completion: completion)
     }
 }
 

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob.swift
@@ -22,24 +22,18 @@ internal extension GoogleMobileAds.InterstitialAd {
         placement: String?,
         fullScreenContentDelegate: GoogleMobileAds.FullScreenContentDelegate?,
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)?,
-        rcAdMob: RCAdMob,
-        completion: @escaping (GoogleMobileAds.InterstitialAd?, Error?) -> Void
-    ) {
-        Self.load(with: adUnitID, request: request) { loadedAd, error in
-            rcAdMob.handleLoadOutcome(
-                loadedAd: loadedAd,
-                error: error,
-                context: FullScreenLoadContext(
-                    placement: placement,
-                    adUnitID: adUnitID,
-                    adFormat: RevenueCat.AdFormat.interstitial,
-                    fullScreenContentDelegate: fullScreenContentDelegate,
-                    paidEventHandler: paidEventHandler,
-                    responseInfo: loadedAd?.responseInfo
-                ),
-                completion: completion
+        rcAdMob: RCAdMob
+    ) async throws -> GoogleMobileAds.InterstitialAd {
+        try await rcAdMob.handleLoadOutcome(
+            loadAd: { try await Self.load(with: adUnitID, request: request) },
+            context: FullScreenLoadContext(
+                placement: placement,
+                adUnitID: adUnitID,
+                adFormat: RevenueCat.AdFormat.interstitial,
+                fullScreenContentDelegate: fullScreenContentDelegate,
+                paidEventHandler: paidEventHandler
             )
-        }
+        )
     }
 }
 
@@ -55,23 +49,20 @@ internal extension GoogleMobileAds.InterstitialAd {
     ///   - fullScreenContentDelegate: Optional delegate for full-screen content callbacks.
     ///     Held **weakly** internally; the caller must retain this instance for the lifetime of the ad.
     ///   - paidEventHandler: Optional handler invoked when a paid event is recorded.
-    ///   - completion: Called with the loaded ad or an error.
     static func loadAndTrack(
         withAdUnitID adUnitID: String,
         request: GoogleMobileAds.Request,
         placement: String? = nil,
         fullScreenContentDelegate: (any GoogleMobileAds.FullScreenContentDelegate)? = nil,
-        paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
-        completion: @escaping (GoogleMobileAds.InterstitialAd?, Error?) -> Void
-    ) {
-        self.loadAndTrack(
+        paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil
+    ) async throws -> GoogleMobileAds.InterstitialAd {
+        try await self.loadAndTrack(
             withAdUnitID: adUnitID,
             request: request,
             placement: placement,
             fullScreenContentDelegate: fullScreenContentDelegate,
             paidEventHandler: paidEventHandler,
-            rcAdMob: .shared,
-            completion: completion
+            rcAdMob: .shared
         )
     }
 
@@ -97,24 +88,18 @@ internal extension GoogleMobileAds.AppOpenAd {
         placement: String?,
         fullScreenContentDelegate: GoogleMobileAds.FullScreenContentDelegate?,
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)?,
-        rcAdMob: RCAdMob,
-        completion: @escaping (GoogleMobileAds.AppOpenAd?, Error?) -> Void
-    ) {
-        Self.load(with: adUnitID, request: request) { loadedAd, error in
-            rcAdMob.handleLoadOutcome(
-                loadedAd: loadedAd,
-                error: error,
-                context: FullScreenLoadContext(
-                    placement: placement,
-                    adUnitID: adUnitID,
-                    adFormat: RevenueCat.AdFormat.appOpen,
-                    fullScreenContentDelegate: fullScreenContentDelegate,
-                    paidEventHandler: paidEventHandler,
-                    responseInfo: loadedAd?.responseInfo
-                ),
-                completion: completion
+        rcAdMob: RCAdMob
+    ) async throws -> GoogleMobileAds.AppOpenAd {
+        try await rcAdMob.handleLoadOutcome(
+            loadAd: { try await Self.load(with: adUnitID, request: request) },
+            context: FullScreenLoadContext(
+                placement: placement,
+                adUnitID: adUnitID,
+                adFormat: RevenueCat.AdFormat.appOpen,
+                fullScreenContentDelegate: fullScreenContentDelegate,
+                paidEventHandler: paidEventHandler
             )
-        }
+        )
     }
 }
 
@@ -130,23 +115,20 @@ internal extension GoogleMobileAds.AppOpenAd {
     ///   - fullScreenContentDelegate: Optional delegate for full-screen content callbacks.
     ///     Held **weakly** internally; the caller must retain this instance for the lifetime of the ad.
     ///   - paidEventHandler: Optional handler invoked when a paid event is recorded.
-    ///   - completion: Called with the loaded ad or an error.
     static func loadAndTrack(
         withAdUnitID adUnitID: String,
         request: GoogleMobileAds.Request,
         placement: String? = nil,
         fullScreenContentDelegate: (any GoogleMobileAds.FullScreenContentDelegate)? = nil,
-        paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
-        completion: @escaping (GoogleMobileAds.AppOpenAd?, Error?) -> Void
-    ) {
-        self.loadAndTrack(
+        paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil
+    ) async throws -> GoogleMobileAds.AppOpenAd {
+        try await self.loadAndTrack(
             withAdUnitID: adUnitID,
             request: request,
             placement: placement,
             fullScreenContentDelegate: fullScreenContentDelegate,
             paidEventHandler: paidEventHandler,
-            rcAdMob: .shared,
-            completion: completion
+            rcAdMob: .shared
         )
     }
 
@@ -172,24 +154,18 @@ internal extension GoogleMobileAds.RewardedAd {
         placement: String?,
         fullScreenContentDelegate: GoogleMobileAds.FullScreenContentDelegate?,
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)?,
-        rcAdMob: RCAdMob,
-        completion: @escaping (GoogleMobileAds.RewardedAd?, Error?) -> Void
-    ) {
-        Self.load(with: adUnitID, request: request) { loadedAd, error in
-            rcAdMob.handleLoadOutcome(
-                loadedAd: loadedAd,
-                error: error,
-                context: FullScreenLoadContext(
-                    placement: placement,
-                    adUnitID: adUnitID,
-                    adFormat: RevenueCat.AdFormat.rewarded,
-                    fullScreenContentDelegate: fullScreenContentDelegate,
-                    paidEventHandler: paidEventHandler,
-                    responseInfo: loadedAd?.responseInfo
-                ),
-                completion: completion
+        rcAdMob: RCAdMob
+    ) async throws -> GoogleMobileAds.RewardedAd {
+        try await rcAdMob.handleLoadOutcome(
+            loadAd: { try await Self.load(with: adUnitID, request: request) },
+            context: FullScreenLoadContext(
+                placement: placement,
+                adUnitID: adUnitID,
+                adFormat: RevenueCat.AdFormat.rewarded,
+                fullScreenContentDelegate: fullScreenContentDelegate,
+                paidEventHandler: paidEventHandler
             )
-        }
+        )
     }
 }
 
@@ -205,23 +181,20 @@ internal extension GoogleMobileAds.RewardedAd {
     ///   - fullScreenContentDelegate: Optional delegate for full-screen content callbacks.
     ///     Held **weakly** internally; the caller must retain this instance for the lifetime of the ad.
     ///   - paidEventHandler: Optional handler invoked when a paid event is recorded.
-    ///   - completion: Called with the loaded ad or an error.
     static func loadAndTrack(
         withAdUnitID adUnitID: String,
         request: GoogleMobileAds.Request,
         placement: String? = nil,
         fullScreenContentDelegate: (any GoogleMobileAds.FullScreenContentDelegate)? = nil,
-        paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
-        completion: @escaping (GoogleMobileAds.RewardedAd?, Error?) -> Void
-    ) {
-        self.loadAndTrack(
+        paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil
+    ) async throws -> GoogleMobileAds.RewardedAd {
+        try await self.loadAndTrack(
             withAdUnitID: adUnitID,
             request: request,
             placement: placement,
             fullScreenContentDelegate: fullScreenContentDelegate,
             paidEventHandler: paidEventHandler,
-            rcAdMob: .shared,
-            completion: completion
+            rcAdMob: .shared
         )
     }
 
@@ -251,24 +224,18 @@ internal extension GoogleMobileAds.RewardedInterstitialAd {
         placement: String?,
         fullScreenContentDelegate: GoogleMobileAds.FullScreenContentDelegate?,
         paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)?,
-        rcAdMob: RCAdMob,
-        completion: @escaping (GoogleMobileAds.RewardedInterstitialAd?, Error?) -> Void
-    ) {
-        Self.load(with: adUnitID, request: request) { loadedAd, error in
-            rcAdMob.handleLoadOutcome(
-                loadedAd: loadedAd,
-                error: error,
-                context: FullScreenLoadContext(
-                    placement: placement,
-                    adUnitID: adUnitID,
-                    adFormat: RevenueCat.AdFormat.rewardedInterstitial,
-                    fullScreenContentDelegate: fullScreenContentDelegate,
-                    paidEventHandler: paidEventHandler,
-                    responseInfo: loadedAd?.responseInfo
-                ),
-                completion: completion
+        rcAdMob: RCAdMob
+    ) async throws -> GoogleMobileAds.RewardedInterstitialAd {
+        try await rcAdMob.handleLoadOutcome(
+            loadAd: { try await Self.load(with: adUnitID, request: request) },
+            context: FullScreenLoadContext(
+                placement: placement,
+                adUnitID: adUnitID,
+                adFormat: RevenueCat.AdFormat.rewardedInterstitial,
+                fullScreenContentDelegate: fullScreenContentDelegate,
+                paidEventHandler: paidEventHandler
             )
-        }
+        )
     }
 }
 
@@ -284,23 +251,20 @@ internal extension GoogleMobileAds.RewardedInterstitialAd {
     ///   - fullScreenContentDelegate: Optional delegate for full-screen content callbacks.
     ///     Held **weakly** internally; the caller must retain this instance for the lifetime of the ad.
     ///   - paidEventHandler: Optional handler invoked when a paid event is recorded.
-    ///   - completion: Called with the loaded ad or an error.
     static func loadAndTrack(
         withAdUnitID adUnitID: String,
         request: GoogleMobileAds.Request,
         placement: String? = nil,
         fullScreenContentDelegate: (any GoogleMobileAds.FullScreenContentDelegate)? = nil,
-        paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil,
-        completion: @escaping (GoogleMobileAds.RewardedInterstitialAd?, Error?) -> Void
-    ) {
-        self.loadAndTrack(
+        paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? = nil
+    ) async throws -> GoogleMobileAds.RewardedInterstitialAd {
+        try await self.loadAndTrack(
             withAdUnitID: adUnitID,
             request: request,
             placement: placement,
             fullScreenContentDelegate: fullScreenContentDelegate,
             paidEventHandler: paidEventHandler,
-            rcAdMob: .shared,
-            completion: completion
+            rcAdMob: .shared
         )
     }
 
@@ -322,6 +286,7 @@ internal extension GoogleMobileAds.RewardedInterstitialAd {
 internal protocol RCFullScreenAdTracking: AnyObject {
     var fullScreenContentDelegate: GoogleMobileAds.FullScreenContentDelegate? { get set }
     var paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)? { get set }
+    var responseInfo: GoogleMobileAds.ResponseInfo { get }
 }
 
 @available(iOS 15.0, *)
@@ -340,7 +305,6 @@ internal struct FullScreenLoadContext {
     let adFormat: RevenueCat.AdFormat
     let fullScreenContentDelegate: GoogleMobileAds.FullScreenContentDelegate?
     let paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)?
-    let responseInfo: GoogleMobileAds.ResponseInfo?
 }
 
 #endif

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/FullScreenAd+RCAdMob.swift
@@ -70,6 +70,7 @@ internal extension GoogleMobileAds.InterstitialAd {
     ///
     /// Call this instead of `present(from:)` when you want to specify or override the placement at show time.
     /// The placement passed here takes precedence over any placement provided at load time.
+    @MainActor
     func present(from viewController: UIViewController, placement: String?) {
         RCAdMob.shared.retrieveFullScreenDelegate(for: self)?.placement = placement
         self.present(from: viewController)
@@ -136,6 +137,7 @@ internal extension GoogleMobileAds.AppOpenAd {
     ///
     /// Call this instead of `present(from:)` when you want to specify or override the placement at show time.
     /// The placement passed here takes precedence over any placement provided at load time.
+    @MainActor
     func present(from viewController: UIViewController, placement: String?) {
         RCAdMob.shared.retrieveFullScreenDelegate(for: self)?.placement = placement
         self.present(from: viewController)
@@ -202,6 +204,7 @@ internal extension GoogleMobileAds.RewardedAd {
     ///
     /// Call this instead of `present(from:userDidEarnRewardHandler:)` when you want to specify or override
     /// the placement at show time. The placement passed here takes precedence over any placement provided at load time.
+    @MainActor
     func present(
         from viewController: UIViewController,
         placement: String?,
@@ -272,6 +275,7 @@ internal extension GoogleMobileAds.RewardedInterstitialAd {
     ///
     /// Call this instead of `present(from:userDidEarnRewardHandler:)` when you want to specify or override
     /// the placement at show time. The placement passed here takes precedence over any placement provided at load time.
+    @MainActor
     func present(
         from viewController: UIViewController,
         placement: String?,

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RCAdMob.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RCAdMob.swift
@@ -221,27 +221,29 @@ internal final class RCAdMob {
         let fullScreenContentDelegate = context.fullScreenContentDelegate
         let paidEventHandler = context.paidEventHandler
 
-        let trackingDelegate = RCAdMobFullScreenContentDelegate(
-            rcAdMob: self,
-            delegate: fullScreenContentDelegate,
-            placement: placement,
-            adUnitID: adUnitID,
-            adFormat: adFormat,
-            responseInfoProvider: { responseInfo }
-        )
-        self.retainFullScreenDelegate(trackingDelegate, for: loadedAd)
-        loadedAd.fullScreenContentDelegate = trackingDelegate
-        loadedAd.paidEventHandler = { [weak self, weak trackingDelegate] adValue in
-            self?.trackRevenue(
-                placement: trackingDelegate?.placement,
+        return await MainActor.run {
+            let trackingDelegate = RCAdMobFullScreenContentDelegate(
+                rcAdMob: self,
+                delegate: fullScreenContentDelegate,
+                placement: placement,
                 adUnitID: adUnitID,
                 adFormat: adFormat,
-                responseInfo: responseInfo,
-                adValue: adValue
+                responseInfoProvider: { responseInfo }
             )
-            paidEventHandler?(adValue)
+            self.retainFullScreenDelegate(trackingDelegate, for: loadedAd)
+            loadedAd.fullScreenContentDelegate = trackingDelegate
+            loadedAd.paidEventHandler = { [weak self, weak trackingDelegate] adValue in
+                self?.trackRevenue(
+                    placement: trackingDelegate?.placement,
+                    adUnitID: adUnitID,
+                    adFormat: adFormat,
+                    responseInfo: responseInfo,
+                    adValue: adValue
+                )
+                paidEventHandler?(adValue)
+            }
+            return loadedAd
         }
-        return loadedAd
     }
 
     // MARK: - Private helpers

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RCAdMob.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RCAdMob.swift
@@ -190,30 +190,26 @@ internal final class RCAdMob {
     // MARK: - handleLoadOutcome
 
     func handleLoadOutcome<Ad: AnyObject & RCFullScreenAdTracking>(
-        loadedAd: Ad?,
-        error: Error?,
-        context: FullScreenLoadContext,
-        completion: (Ad?, Error?) -> Void
-    ) {
-        if let error {
+        loadAd: () async throws -> Ad,
+        context: FullScreenLoadContext
+    ) async throws -> Ad {
+        let loadedAd: Ad
+        do {
+            loadedAd = try await loadAd()
+        } catch {
             self.trackFailedToLoad(
                 placement: context.placement,
                 adUnitID: context.adUnitID,
                 adFormat: context.adFormat,
                 error: error
             )
-            completion(nil, error)
-            return
+            throw error
         }
 
-        guard let loadedAd else {
-            // SDK contract is success (ad, nil) or failure (nil, error). (nil, nil) is not documented; forward as-is.
-            completion(nil, nil)
-            return
-        }
+        let responseInfo = loadedAd.responseInfo
 
         self.trackLoaded(
-            responseInfo: context.responseInfo,
+            responseInfo: responseInfo,
             placement: context.placement,
             adUnitID: context.adUnitID,
             adFormat: context.adFormat
@@ -224,7 +220,6 @@ internal final class RCAdMob {
         let adFormat = context.adFormat
         let fullScreenContentDelegate = context.fullScreenContentDelegate
         let paidEventHandler = context.paidEventHandler
-        let responseInfo = context.responseInfo
 
         let trackingDelegate = RCAdMobFullScreenContentDelegate(
             rcAdMob: self,
@@ -246,7 +241,7 @@ internal final class RCAdMob {
             )
             paidEventHandler?(adValue)
         }
-        completion(loadedAd, nil)
+        return loadedAd
     }
 
     // MARK: - Private helpers

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RCAdMobFullScreenContentDelegate.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RCAdMobFullScreenContentDelegate.swift
@@ -10,6 +10,7 @@ import Foundation
 import GoogleMobileAds
 @_spi(Experimental) import RevenueCat
 
+@MainActor
 @available(iOS 15.0, *)
 internal final class RCAdMobFullScreenContentDelegate: NSObject, GoogleMobileAds.FullScreenContentDelegate {
 

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobAPISurfaceTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobAPISurfaceTests.swift
@@ -29,7 +29,7 @@ final class RCAdMobAPISurfaceTests: RCAdMobTestCase {
         XCTAssertNotNil(nativeLoadAndTrackWithDelegate)
     }
 
-    func testFullScreenEntryPointsRemainAvailableInSwift() {
+    func testFullScreenCompletionEntryPointsRemainAvailableInSwift() {
         let interstitialLoadAndTrack: (
             String,
             GoogleMobileAds.Request,
@@ -75,6 +75,80 @@ final class RCAdMobAPISurfaceTests: RCAdMobTestCase {
         XCTAssertNotNil(appOpenLoadAndTrack)
         XCTAssertNotNil(rewardedLoadAndTrack)
         XCTAssertNotNil(rewardedInterstitialLoadAndTrack)
+    }
+
+    func testFullScreenAsyncEntryPointsRemainAvailableInSwift() {
+        let interstitialLoadAndTrack: (
+            String,
+            GoogleMobileAds.Request,
+            String?,
+            GoogleMobileAds.FullScreenContentDelegate?,
+            ((GoogleMobileAds.AdValue) -> Void)?
+        ) async throws -> GoogleMobileAds.InterstitialAd = GoogleMobileAds.InterstitialAd.loadAndTrack(
+            withAdUnitID:request:placement:fullScreenContentDelegate:paidEventHandler:
+        )
+        let appOpenLoadAndTrack: (
+            String,
+            GoogleMobileAds.Request,
+            String?,
+            GoogleMobileAds.FullScreenContentDelegate?,
+            ((GoogleMobileAds.AdValue) -> Void)?
+        ) async throws -> GoogleMobileAds.AppOpenAd = GoogleMobileAds.AppOpenAd.loadAndTrack(
+            withAdUnitID:request:placement:fullScreenContentDelegate:paidEventHandler:
+        )
+        let rewardedLoadAndTrack: (
+            String,
+            GoogleMobileAds.Request,
+            String?,
+            GoogleMobileAds.FullScreenContentDelegate?,
+            ((GoogleMobileAds.AdValue) -> Void)?
+        ) async throws -> GoogleMobileAds.RewardedAd = GoogleMobileAds.RewardedAd.loadAndTrack(
+            withAdUnitID:request:placement:fullScreenContentDelegate:paidEventHandler:
+        )
+        let rewardedInterstitialLoadAndTrack: (
+            String,
+            GoogleMobileAds.Request,
+            String?,
+            GoogleMobileAds.FullScreenContentDelegate?,
+            ((GoogleMobileAds.AdValue) -> Void)?
+        ) async throws -> GoogleMobileAds.RewardedInterstitialAd
+            = GoogleMobileAds.RewardedInterstitialAd.loadAndTrack(
+                withAdUnitID:request:placement:fullScreenContentDelegate:paidEventHandler:
+            )
+
+        XCTAssertNotNil(interstitialLoadAndTrack)
+        XCTAssertNotNil(appOpenLoadAndTrack)
+        XCTAssertNotNil(rewardedLoadAndTrack)
+        XCTAssertNotNil(rewardedInterstitialLoadAndTrack)
+    }
+
+    func testFullScreenPresentWithPlacementRemainAvailableInSwift() {
+        let interstitialPresent: (
+            GoogleMobileAds.InterstitialAd
+        ) -> (UIViewController, String?) -> Void = GoogleMobileAds.InterstitialAd.present(
+            from:placement:
+        )
+        let appOpenPresent: (
+            GoogleMobileAds.AppOpenAd
+        ) -> (UIViewController, String?) -> Void = GoogleMobileAds.AppOpenAd.present(
+            from:placement:
+        )
+        let rewardedPresent: (
+            GoogleMobileAds.RewardedAd
+        ) -> (UIViewController, String?, @escaping () -> Void) -> Void = GoogleMobileAds.RewardedAd.present(
+            from:placement:userDidEarnRewardHandler:
+        )
+        let rewardedInterstitialPresent: (
+            GoogleMobileAds.RewardedInterstitialAd
+        ) -> (UIViewController, String?, @escaping () -> Void)
+            -> Void = GoogleMobileAds.RewardedInterstitialAd.present(
+                from:placement:userDidEarnRewardHandler:
+            )
+
+        XCTAssertNotNil(interstitialPresent)
+        XCTAssertNotNil(appOpenPresent)
+        XCTAssertNotNil(rewardedPresent)
+        XCTAssertNotNil(rewardedInterstitialPresent)
     }
 
 }

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobAPISurfaceTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobAPISurfaceTests.swift
@@ -36,7 +36,7 @@ final class RCAdMobAPISurfaceTests: RCAdMobTestCase {
             String?,
             GoogleMobileAds.FullScreenContentDelegate?,
             ((GoogleMobileAds.AdValue) -> Void)?,
-            @escaping (GoogleMobileAds.InterstitialAd?, Error?) -> Void
+            @escaping @MainActor (GoogleMobileAds.InterstitialAd?, Error?) -> Void
         ) -> Void = GoogleMobileAds.InterstitialAd.loadAndTrack(
             withAdUnitID:request:placement:fullScreenContentDelegate:paidEventHandler:completion:
         )
@@ -46,7 +46,7 @@ final class RCAdMobAPISurfaceTests: RCAdMobTestCase {
             String?,
             GoogleMobileAds.FullScreenContentDelegate?,
             ((GoogleMobileAds.AdValue) -> Void)?,
-            @escaping (GoogleMobileAds.AppOpenAd?, Error?) -> Void
+            @escaping @MainActor (GoogleMobileAds.AppOpenAd?, Error?) -> Void
         ) -> Void = GoogleMobileAds.AppOpenAd.loadAndTrack(
             withAdUnitID:request:placement:fullScreenContentDelegate:paidEventHandler:completion:
         )
@@ -56,7 +56,7 @@ final class RCAdMobAPISurfaceTests: RCAdMobTestCase {
             String?,
             GoogleMobileAds.FullScreenContentDelegate?,
             ((GoogleMobileAds.AdValue) -> Void)?,
-            @escaping (GoogleMobileAds.RewardedAd?, Error?) -> Void
+            @escaping @MainActor (GoogleMobileAds.RewardedAd?, Error?) -> Void
         ) -> Void = GoogleMobileAds.RewardedAd.loadAndTrack(
             withAdUnitID:request:placement:fullScreenContentDelegate:paidEventHandler:completion:
         )
@@ -66,7 +66,7 @@ final class RCAdMobAPISurfaceTests: RCAdMobTestCase {
             String?,
             GoogleMobileAds.FullScreenContentDelegate?,
             ((GoogleMobileAds.AdValue) -> Void)?,
-            @escaping (GoogleMobileAds.RewardedInterstitialAd?, Error?) -> Void
+            @escaping @MainActor (GoogleMobileAds.RewardedInterstitialAd?, Error?) -> Void
         ) -> Void = GoogleMobileAds.RewardedInterstitialAd.loadAndTrack(
             withAdUnitID:request:placement:fullScreenContentDelegate:paidEventHandler:completion:
         )

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobAPISurfaceTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobAPISurfaceTests.swift
@@ -122,6 +122,7 @@ final class RCAdMobAPISurfaceTests: RCAdMobTestCase {
         XCTAssertNotNil(rewardedInterstitialLoadAndTrack)
     }
 
+    @MainActor
     func testFullScreenPresentWithPlacementRemainAvailableInSwift() {
         let interstitialPresent: (
             GoogleMobileAds.InterstitialAd

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobFullScreenDelegateForwardingTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobFullScreenDelegateForwardingTests.swift
@@ -5,6 +5,7 @@ import GoogleMobileAds
 @_spi(Experimental) import RevenueCat
 @_spi(Experimental) @testable import RevenueCatAdMob
 
+@MainActor
 @available(iOS 15.0, *)
 final class RCAdMobFullScreenDelegateForwardingTests: RCAdMobTestCase {
 

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobTrackingTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobTrackingTests.swift
@@ -172,29 +172,26 @@ final class RCAdMobTrackingTests: RCAdMobTestCase {
         XCTAssertTrue(self.mockTracker.calls.isEmpty)
     }
 
-    func testHandleLoadOutcomeOnErrorTracksFailedToLoad() {
+    func testHandleLoadOutcomeOnErrorTracksFailedToLoad() async {
         let error = NSError(domain: "com.google.ads", code: 2, userInfo: nil)
         let context = FullScreenLoadContext(
             placement: "test_placement",
             adUnitID: "ca-app-pub-test",
             adFormat: .interstitial,
             fullScreenContentDelegate: nil,
-            paidEventHandler: nil,
-            responseInfo: nil
+            paidEventHandler: nil
         )
 
-        var completionCalled = false
-        self.rcAdMob.handleLoadOutcome(
-            loadedAd: nil as FakeFullScreenAd?,
-            error: error,
-            context: context
-        ) { loadedAd, completionError in
-            XCTAssertNil(loadedAd)
-            XCTAssertNotNil(completionError)
-            completionCalled = true
+        do {
+            let _: FakeFullScreenAd = try await self.rcAdMob.handleLoadOutcome(
+                loadAd: { throw error },
+                context: context
+            )
+            XCTFail("Expected error to be thrown")
+        } catch let caughtError as NSError {
+            XCTAssertEqual(caughtError.code, 2)
         }
 
-        XCTAssertTrue(completionCalled)
         XCTAssertEqual(self.mockTracker.calls.count, 1)
         XCTAssertEqual(self.mockTracker.calls.first, MockAdTracker.Call(
             method: "trackAdFailedToLoad",
@@ -204,54 +201,22 @@ final class RCAdMobTrackingTests: RCAdMobTestCase {
         ))
     }
 
-    func testHandleLoadOutcomeNilAdNilErrorForwardsBothNils() {
-        let context = FullScreenLoadContext(
-            placement: nil,
-            adUnitID: "unit",
-            adFormat: .appOpen,
-            fullScreenContentDelegate: nil,
-            paidEventHandler: nil,
-            responseInfo: nil
-        )
-
-        var completionCalled = false
-        self.rcAdMob.handleLoadOutcome(
-            loadedAd: nil as FakeFullScreenAd?,
-            error: nil,
-            context: context
-        ) { loadedAd, completionError in
-            XCTAssertNil(loadedAd)
-            XCTAssertNil(completionError)
-            completionCalled = true
-        }
-
-        XCTAssertTrue(completionCalled)
-        XCTAssertTrue(self.mockTracker.calls.isEmpty)
-    }
-
-    func testHandleLoadOutcomeOnSuccessTracksLoaded() {
+    func testHandleLoadOutcomeOnSuccessTracksLoaded() async throws {
         let fakeAd = FakeFullScreenAd()
         let context = FullScreenLoadContext(
             placement: "reward_screen",
             adUnitID: "ca-app-pub-reward",
             adFormat: .rewarded,
             fullScreenContentDelegate: nil,
-            paidEventHandler: nil,
-            responseInfo: nil
+            paidEventHandler: nil
         )
 
-        var completionCalled = false
-        self.rcAdMob.handleLoadOutcome(
-            loadedAd: fakeAd,
-            error: nil,
+        let result = try await self.rcAdMob.handleLoadOutcome(
+            loadAd: { fakeAd },
             context: context
-        ) { loadedAd, completionError in
-            XCTAssertNotNil(loadedAd)
-            XCTAssertNil(completionError)
-            completionCalled = true
-        }
+        )
 
-        XCTAssertTrue(completionCalled)
+        XCTAssertTrue(result === fakeAd)
         XCTAssertEqual(self.mockTracker.calls.count, 1)
         XCTAssertEqual(self.mockTracker.calls.first, MockAdTracker.Call(
             method: "trackAdLoaded",
@@ -261,31 +226,31 @@ final class RCAdMobTrackingTests: RCAdMobTestCase {
         ))
     }
 
-    func testHandleLoadOutcomeOnSuccessInstallsFullScreenDelegate() {
+    func testHandleLoadOutcomeOnSuccessInstallsFullScreenDelegate() async throws {
         let fakeAd = FakeFullScreenAd()
         let context = FullScreenLoadContext(
             placement: nil, adUnitID: "unit", adFormat: .interstitial,
-            fullScreenContentDelegate: nil, paidEventHandler: nil, responseInfo: nil
+            fullScreenContentDelegate: nil, paidEventHandler: nil
         )
 
-        self.rcAdMob.handleLoadOutcome(
-            loadedAd: fakeAd, error: nil, context: context
-        ) { _, _ in }
+        _ = try await self.rcAdMob.handleLoadOutcome(
+            loadAd: { fakeAd }, context: context
+        )
 
         XCTAssertNotNil(fakeAd.fullScreenContentDelegate)
         XCTAssertTrue(fakeAd.fullScreenContentDelegate is RCAdMobFullScreenContentDelegate)
     }
 
-    func testHandleLoadOutcomeOnSuccessInstallsPaidEventHandler() {
+    func testHandleLoadOutcomeOnSuccessInstallsPaidEventHandler() async throws {
         let fakeAd = FakeFullScreenAd()
         let context = FullScreenLoadContext(
             placement: nil, adUnitID: "unit", adFormat: .interstitial,
-            fullScreenContentDelegate: nil, paidEventHandler: nil, responseInfo: nil
+            fullScreenContentDelegate: nil, paidEventHandler: nil
         )
 
-        self.rcAdMob.handleLoadOutcome(
-            loadedAd: fakeAd, error: nil, context: context
-        ) { _, _ in }
+        _ = try await self.rcAdMob.handleLoadOutcome(
+            loadAd: { fakeAd }, context: context
+        )
 
         XCTAssertNotNil(fakeAd.paidEventHandler)
     }
@@ -326,20 +291,19 @@ final class RCAdMobTrackingTests: RCAdMobTestCase {
         XCTAssertTrue(self.mockTracker.revenueData.isEmpty)
     }
 
-    func testHandleLoadOutcomeOnSuccessPaidHandlerTracksRevenue() {
+    func testHandleLoadOutcomeOnSuccessPaidHandlerTracksRevenue() async throws {
         let fakeAd = FakeFullScreenAd()
         let context = FullScreenLoadContext(
             placement: "reward_screen",
             adUnitID: "ca-app-pub-reward",
             adFormat: .rewarded,
             fullScreenContentDelegate: nil,
-            paidEventHandler: nil,
-            responseInfo: nil
+            paidEventHandler: nil
         )
 
-        self.rcAdMob.handleLoadOutcome(
-            loadedAd: fakeAd, error: nil, context: context
-        ) { _, _ in }
+        _ = try await self.rcAdMob.handleLoadOutcome(
+            loadAd: { fakeAd }, context: context
+        )
 
         fakeAd.paidEventHandler?(Self.makeAdValuePlaceholder())
 
@@ -353,7 +317,7 @@ final class RCAdMobTrackingTests: RCAdMobTestCase {
         XCTAssertEqual(revenue.adUnitId, "ca-app-pub-reward")
     }
 
-    func testHandleLoadOutcomeOnSuccessPaidHandlerForwardsToUserHandler() {
+    func testHandleLoadOutcomeOnSuccessPaidHandlerForwardsToUserHandler() async throws {
         let fakeAd = FakeFullScreenAd()
         var userHandlerCalled = false
         let context = FullScreenLoadContext(
@@ -361,13 +325,12 @@ final class RCAdMobTrackingTests: RCAdMobTestCase {
             adUnitID: "ca-app-pub-reward",
             adFormat: .rewarded,
             fullScreenContentDelegate: nil,
-            paidEventHandler: { _ in userHandlerCalled = true },
-            responseInfo: nil
+            paidEventHandler: { _ in userHandlerCalled = true }
         )
 
-        self.rcAdMob.handleLoadOutcome(
-            loadedAd: fakeAd, error: nil, context: context
-        ) { _, _ in }
+        _ = try await self.rcAdMob.handleLoadOutcome(
+            loadAd: { fakeAd }, context: context
+        )
 
         fakeAd.paidEventHandler?(Self.makeAdValuePlaceholder())
 
@@ -417,7 +380,7 @@ final class RCAdMobTrackingTests: RCAdMobTestCase {
         XCTAssertEqual(revenue.impressionId, "resp-id-abc")
     }
 
-    func testHandleLoadOutcomeForwardsCallbacksToUserDelegate() {
+    func testHandleLoadOutcomeForwardsCallbacksToUserDelegate() async throws {
         let fakeAd = FakeFullScreenAd()
         let spy = FullScreenContentDelegateSpy()
         let context = FullScreenLoadContext(
@@ -425,13 +388,12 @@ final class RCAdMobTrackingTests: RCAdMobTestCase {
             adUnitID: "unit",
             adFormat: .interstitial,
             fullScreenContentDelegate: spy,
-            paidEventHandler: nil,
-            responseInfo: nil
+            paidEventHandler: nil
         )
 
-        self.rcAdMob.handleLoadOutcome(
-            loadedAd: fakeAd, error: nil, context: context
-        ) { _, _ in }
+        _ = try await self.rcAdMob.handleLoadOutcome(
+            loadAd: { fakeAd }, context: context
+        )
 
         let presentingAd = FakeFullScreenPresentingAd()
         fakeAd.fullScreenContentDelegate?.adDidRecordImpression?(presentingAd)
@@ -461,20 +423,19 @@ final class RCAdMobTrackingTests: RCAdMobTestCase {
 
     // MARK: - Show-time placement override
 
-    func testShowTimePlacementOverrideIsUsedInRevenueEvent() {
-        // Verifies that the paidEventHandler closure (set up at load time) reads placement
-        // from the delegate at fire time, so a show-time override is reflected in revenue tracking.
+    func testShowTimePlacementOverrideIsUsedInRevenueEvent() async throws {
         let fakeAd = FakeFullScreenAd()
         let context = FullScreenLoadContext(
             placement: "load_time_placement",
             adUnitID: "ca-app-pub-test",
             adFormat: .rewarded,
             fullScreenContentDelegate: nil,
-            paidEventHandler: nil,
-            responseInfo: nil
+            paidEventHandler: nil
         )
 
-        self.rcAdMob.handleLoadOutcome(loadedAd: fakeAd, error: nil, context: context) { _, _ in }
+        _ = try await self.rcAdMob.handleLoadOutcome(
+            loadAd: { fakeAd }, context: context
+        )
         (fakeAd.fullScreenContentDelegate as? RCAdMobFullScreenContentDelegate)?.placement = "show_time_placement"
         fakeAd.paidEventHandler?(Self.makeAdValuePlaceholder())
 
@@ -635,6 +596,16 @@ final class RCAdMobDelegateTrackingTests: RCAdMobTestCase {
 private final class FakeFullScreenAd: NSObject, RCFullScreenAdTracking {
     var fullScreenContentDelegate: GoogleMobileAds.FullScreenContentDelegate?
     var paidEventHandler: ((GoogleMobileAds.AdValue) -> Void)?
+    let responseInfo: GoogleMobileAds.ResponseInfo = unsafeBitCast(
+        FakeResponseInfo(),
+        to: GoogleMobileAds.ResponseInfo.self
+    )
+}
+
+@available(iOS 15.0, *)
+private final class FakeResponseInfo: NSObject {
+    @objc var responseIdentifier: String? { nil }
+    @objc var loadedAdNetworkResponseInfo: AnyObject? { nil }
 }
 
 @available(iOS 15.0, *)

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobTrackingTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobTrackingTests.swift
@@ -396,11 +396,11 @@ final class RCAdMobTrackingTests: RCAdMobTestCase {
         )
 
         let presentingAd = FakeFullScreenPresentingAd()
-        fakeAd.fullScreenContentDelegate?.adDidRecordImpression?(presentingAd)
-        fakeAd.fullScreenContentDelegate?.adDidRecordClick?(presentingAd)
-        fakeAd.fullScreenContentDelegate?.adWillPresentFullScreenContent?(presentingAd)
-        fakeAd.fullScreenContentDelegate?.adWillDismissFullScreenContent?(presentingAd)
-        fakeAd.fullScreenContentDelegate?.adDidDismissFullScreenContent?(presentingAd)
+        await fakeAd.fullScreenContentDelegate?.adDidRecordImpression?(presentingAd)
+        await fakeAd.fullScreenContentDelegate?.adDidRecordClick?(presentingAd)
+        await fakeAd.fullScreenContentDelegate?.adWillPresentFullScreenContent?(presentingAd)
+        await fakeAd.fullScreenContentDelegate?.adWillDismissFullScreenContent?(presentingAd)
+        await fakeAd.fullScreenContentDelegate?.adDidDismissFullScreenContent?(presentingAd)
 
         XCTAssertTrue(spy.didRecordImpression)
         XCTAssertTrue(spy.didRecordClick)

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobTrackingTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RCAdMobTrackingTests.swift
@@ -78,6 +78,7 @@ final class MockAdTracker: AdTracking {
 
 // MARK: - Core RCAdMob tracking tests
 
+@MainActor
 @available(iOS 15.0, *)
 // swiftlint:disable:next type_body_length
 final class RCAdMobTrackingTests: RCAdMobTestCase {
@@ -436,7 +437,9 @@ final class RCAdMobTrackingTests: RCAdMobTestCase {
         _ = try await self.rcAdMob.handleLoadOutcome(
             loadAd: { fakeAd }, context: context
         )
-        (fakeAd.fullScreenContentDelegate as? RCAdMobFullScreenContentDelegate)?.placement = "show_time_placement"
+        await MainActor.run {
+            (fakeAd.fullScreenContentDelegate as? RCAdMobFullScreenContentDelegate)?.placement = "show_time_placement"
+        }
         fakeAd.paidEventHandler?(Self.makeAdValuePlaceholder())
 
         XCTAssertEqual(self.mockTracker.revenueData.count, 1)
@@ -462,6 +465,7 @@ final class RCAdMobTrackingTests: RCAdMobTestCase {
 
 // MARK: - Delegate tracking tests
 
+@MainActor
 @available(iOS 15.0, *)
 final class RCAdMobDelegateTrackingTests: RCAdMobTestCase {
 


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

`RCAdMobFullScreenContentDelegate` manages UI-related state (delegate references, paid event handlers) that Google's Mobile Ads SDK expects on the main thread. Marking the class `@MainActor` ensures thread safety for these operations.

### Description

Adds `@MainActor` isolation to `RCAdMobFullScreenContentDelegate` and propagates the required changes:

- `@MainActor` on the delegate class declaration
- Delegate creation in `handleLoadOutcome` wrapped in `await MainActor.run { ... }`
- `@MainActor` on all `present(from:placement:)` methods (they access the delegate's `placement` property)
- Test classes annotated with `@MainActor`

**Depends on**: #6592 (convert full-screen ad loading to async/throws)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces `@MainActor` isolation to full-screen ad delegate and presentation APIs, which can surface new main-thread requirements (and potential compile-time/runtime issues) for callers and tests. Functional behavior is unchanged but concurrency semantics around delegate setup and paid-event handling are tightened.
> 
> **Overview**
> Ensures AdMob full-screen tracking/forwarding is main-thread safe by marking `RCAdMobFullScreenContentDelegate` as `@MainActor` and creating/installing it inside `await MainActor.run` in `RCAdMob.handleLoadOutcome`.
> 
> Propagates the actor isolation to show-time placement overrides by marking all `present(..., placement:)` helpers as `@MainActor`, and updates tests to run on the main actor (including a main-actor hop when mutating `placement`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdf17d3d5f7432c73faf99dd1c0d1ffb2771c55a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->