### PR TITLE
Fix image size/render flow 

### DIFF
--- a/RevenueCatUI/Helpers/DualColorImageGenerator.swift
+++ b/RevenueCatUI/Helpers/DualColorImageGenerator.swift
@@ -33,6 +33,7 @@ enum DualColorImageGenerator {
     static let redGreen = create(color1: .red, color2: .green)!
     static let blueGreen = create(color1: .blue, color2: .green)!
     static let purpleOrange = create(color1: .purple, color2: .orange)!
+    static let purpleOrangeWide = create(color1: .purple, color2: .orange, size: .init(width: 400, height: 200))!
     static let blackWhite = create(color1: .black, color2: .white)!
     // swiftlint:enable force_unwrapping
 

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -213,7 +213,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                 )
             ),
             size: estimatedImageComponentSize(
-                previewWidth: previewDimension,
+                previewWidth: previewDimension - 20,
                 width: width,
                 height: height,
                 size: size,
@@ -372,6 +372,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                                 heicLowRes: catUrl
                             )
                         ),
+                        size: .init(width: .fixed(200), height: .fixed(141)),
                         fitMode: .fit,
                         border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
                         shadow: .init(
@@ -382,6 +383,15 @@ struct ImageComponentView_Previews: PreviewProvider {
                             radius: 5, x: 5, y: 5
                         )
                     )
+                ),
+                size: estimatedImageComponentSize(
+                    previewWidth: previewDimension - 20,
+                    width: 750,
+                    height: 530,
+                    size: .init(width: .fixed(200), height: .fixed(200)),
+                    fitMode: .fit,
+                    horizontalInsets: CGFloat(8),
+                    verticalInsets: CGFloat(8)
                 )
             )
         }
@@ -409,6 +419,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                                 heicLowRes: catUrl
                             )
                         ),
+                        size: .init(width: .fixed(200), height: .fixed(141)),
                         fitMode: .fill,
                         border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
                         shadow: .init(
@@ -419,6 +430,15 @@ struct ImageComponentView_Previews: PreviewProvider {
                             radius: 5, x: 5, y: 5
                         )
                     )
+                ),
+                size: estimatedImageComponentSize(
+                    previewWidth: previewDimension - 20,
+                    width: 750,
+                    height: 530,
+                    size: .init(width: .fixed(200), height: .fixed(200)),
+                    fitMode: .fill,
+                    horizontalInsets: CGFloat(8),
+                    verticalInsets: CGFloat(8)
                 )
             )
         }
@@ -446,6 +466,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                                 heicLowRes: catUrl
                             )
                         ),
+                        size: .init(width: .fixed(200), height: .fixed(141)),
                         fitMode: .fill,
                         colorOverlay: .init(light: .linear(0, [
                             .init(color: "#ffffff", percent: 0),
@@ -460,6 +481,15 @@ struct ImageComponentView_Previews: PreviewProvider {
                             radius: 5, x: 5, y: 5
                         )
                     )
+                ),
+                size: estimatedImageComponentSize(
+                    previewWidth: previewDimension - 20,
+                    width: 750,
+                    height: 530,
+                    size: .init(width: .fixed(200), height: .fixed(200)),
+                    fitMode: .fill,
+                    horizontalInsets: CGFloat(8),
+                    verticalInsets: CGFloat(8)
                 )
             )
         }
@@ -487,6 +517,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                                 heicLowRes: catUrl
                             )
                         ),
+                        size: .init(width: .fixed(200), height: .fixed(141)),
                         fitMode: .fit,
                         maskShape: .rectangle(.init(topLeading: 40,
                                                     topTrailing: 40,
@@ -501,6 +532,15 @@ struct ImageComponentView_Previews: PreviewProvider {
                             radius: 5, x: 5, y: 5
                         )
                     )
+                ),
+                size: estimatedImageComponentSize(
+                    previewWidth: previewDimension - 20,
+                    width: 750,
+                    height: 530,
+                    size: .init(width: .fixed(200), height: .fixed(200)),
+                    fitMode: .fit,
+                    horizontalInsets: CGFloat(8),
+                    verticalInsets: CGFloat(8)
                 )
             )
         }
@@ -528,6 +568,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                                 heicLowRes: catUrl
                             )
                         ),
+                        size: .init(width: .fixed(200), height: .fixed(141)),
                         fitMode: .fit,
                         maskShape: .circle,
                         border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
@@ -539,6 +580,15 @@ struct ImageComponentView_Previews: PreviewProvider {
                             radius: 5, x: 5, y: 5
                         )
                     )
+                ),
+                size: estimatedImageComponentSize(
+                    previewWidth: previewDimension - 20,
+                    width: 750,
+                    height: 530,
+                    size: .init(width: .fixed(200), height: .fixed(200)),
+                    fitMode: .fit,
+                    horizontalInsets: CGFloat(8),
+                    verticalInsets: CGFloat(8)
                 )
             )
         }
@@ -566,6 +616,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                                 heicLowRes: catUrl
                             )
                         ),
+                        size: .init(width: .fixed(200), height: .fixed(141)),
                         fitMode: .fit,
                         maskShape: .convex,
                         border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
@@ -577,6 +628,15 @@ struct ImageComponentView_Previews: PreviewProvider {
                             radius: 5, x: 5, y: 5
                         )
                     )
+                ),
+                size: estimatedImageComponentSize(
+                    previewWidth: previewDimension - 20,
+                    width: 750,
+                    height: 530,
+                    size: .init(width: .fixed(200), height: .fixed(200)),
+                    fitMode: .fit,
+                    horizontalInsets: CGFloat(8),
+                    verticalInsets: CGFloat(8)
                 )
             )
         }
@@ -604,6 +664,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                                 heicLowRes: catUrl
                             )
                         ),
+                        size: .init(width: .fixed(200), height: .fixed(141)),
                         fitMode: .fit,
                         maskShape: .concave,
                         border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
@@ -615,6 +676,15 @@ struct ImageComponentView_Previews: PreviewProvider {
                             radius: 5, x: 5, y: 5
                         )
                     )
+                ),
+                size: estimatedImageComponentSize(
+                    previewWidth: previewDimension - 20,
+                    width: 750,
+                    height: 530,
+                    size: .init(width: .fixed(200), height: .fixed(200)),
+                    fitMode: .fit,
+                    horizontalInsets: CGFloat(8),
+                    verticalInsets: CGFloat(8)
                 )
             )
         }

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -71,6 +71,12 @@ struct ImageComponentView: View {
                         // We cannot correctly render the image until we know the space the image can fill
                         // this will fill the space so we can get the correct measurements and render the image
                         self.decorate(Color.clear, with: style)
+                    } else if ProcessInfo.isRunningForPreviews {
+                        #if DEBUG
+                        self.decorate(DualColorImageGenerator.purpleOrange.image.resizable(), with: style)
+                        #else
+                        EmptyView()
+                        #endif
                     } else {
                         self.decorate(
                             RemoteImage(
@@ -120,6 +126,7 @@ struct ImageComponentView: View {
             .padding(style.padding.extend(by: style.border?.width ?? 0))
             .shape(border: style.border,
                    shape: style.shape)
+            .compositingGroup() // ensure borders and images are a single layer that gets shaded.
             .applyIfLet(style.shadow, apply: { view, shadow in
                 // We need to use the normal shadow modifier and not our custom one for png images
                 view.shadow(color: shadow.color, radius: shadow.radius, x: shadow.x, y: shadow.y)

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -66,60 +66,63 @@ struct ImageComponentView: View {
                     width: self.imageSize(style: style).width,
                     height: self.imageSize(style: style).height
                 )
-
                 ZStack {
-                    // IMPORTANT: Please keep this... needed to force size
-                    //
-                    // We need the max width of the parent view an image of a fill or
-                    // fixed width doesn't push passed the bounds.
-                    //
-                    // Once we have the size once, we can remove the Color.clear
-                    if self.size == nil {
-                        Color.clear
-                    }
-
-                    RemoteImage(
-                        url: style.url,
-                        lowResUrl: style.lowResUrl,
-                        darkUrl: style.darkUrl,
-                        darkLowResUrl: style.darkLowResUrl,
-                        // The expectedSize is important
-                        // It renders a clear image if actual image is being fetched
-                        expectedSize: expectedSize
-                    ) { (image, size) in
-                        self.renderImage(
-                            image,
-                            size,
-                            maxWidth: self.calculateMaxWidth(
-                                parentWidth: self.size?.width ?? 0,
-                                style: style
-                            ),
+                    if style.size.width == .fill && self.size == nil {
+                        self.decorate(Color.clear, with: style)
+                    } else {
+                        self.decorate(
+                            RemoteImage(
+                                url: style.url,
+                                lowResUrl: style.lowResUrl,
+                                darkUrl: style.darkUrl,
+                                darkLowResUrl: style.darkLowResUrl,
+                                // The expectedSize is important
+                                // It renders a clear image if actual image is being fetched
+                                expectedSize: expectedSize
+                            ) { (image, size) in
+                                self.renderImage(
+                                    image,
+                                    size,
+                                    maxWidth: self.calculateMaxWidth(
+                                        parentWidth: self.size?.width ?? 0,
+                                        style: style
+                                    ),
+                                    with: style
+                                )
+                            },
                             with: style
                         )
                     }
-                    .applyMediaWidth(size: style.size)
-                    .applyMediaHeight(size: style.size, aspectRatio: self.aspectRatio(style: style))
-                    .applyIfLet(style.colorOverlay, apply: { view, colorOverlay in
-                        view.overlay(
-                            Color.clear
-                                .backgroundStyle(.color(colorOverlay))
-                        )
-                    })
-                    .clipped()
-                    .padding(style.padding.extend(by: style.border?.width ?? 0))
-                    .shape(border: style.border,
-                           shape: style.shape)
-                    .applyIfLet(style.shadow, apply: { view, shadow in
-                        // We need to use the normal shadow modifier and not our custom one for png images
-                        view.shadow(color: shadow.color, radius: shadow.radius, x: shadow.x, y: shadow.y)
-                    })
-                    .padding(style.margin)
                 }
                 .id(style.url)
                 .onSizeChange({ size = $0 })
 
             }
         }
+    }
+
+    private func decorate<Content: View>(
+        _ content: Content,
+        with style: ImageComponentStyle
+    ) -> some View {
+        content
+            .applyMediaWidth(size: style.size)
+            .applyMediaHeight(size: style.size, aspectRatio: self.aspectRatio(style: style))
+            .applyIfLet(style.colorOverlay, apply: { view, colorOverlay in
+                view.overlay(
+                    Color.clear
+                        .backgroundStyle(.color(colorOverlay))
+                )
+            })
+            .clipped()
+            .padding(style.padding.extend(by: style.border?.width ?? 0))
+            .shape(border: style.border,
+                   shape: style.shape)
+            .applyIfLet(style.shadow, apply: { view, shadow in
+                // We need to use the normal shadow modifier and not our custom one for png images
+                view.shadow(color: shadow.color, radius: shadow.radius, x: shadow.x, y: shadow.y)
+            })
+            .padding(style.margin)
     }
 
     private func calculateMaxWidth(parentWidth: CGFloat, style: ImageComponentStyle) -> CGFloat {

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -45,6 +45,14 @@ struct ImageComponentView: View {
 
     let viewModel: ImageComponentViewModel
 
+    var renderForPreview: Bool {
+        #if DEBUG
+        return ProcessInfo.isRunningForPreviews
+        #else
+        false
+        #endif
+    }
+
     @State var size: CGSize?
 
     var body: some View {
@@ -71,7 +79,7 @@ struct ImageComponentView: View {
                         // We cannot correctly render the image until we know the space the image can fill
                         // this will fill the space so we can get the correct measurements and render the image
                         self.decorate(Color.clear, with: style)
-                    } else if ProcessInfo.isRunningForPreviews {
+                    } else if renderForPreview {
                         #if DEBUG
                         self.decorate(
                             self.renderImage(

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -73,7 +73,18 @@ struct ImageComponentView: View {
                         self.decorate(Color.clear, with: style)
                     } else if ProcessInfo.isRunningForPreviews {
                         #if DEBUG
-                        self.decorate(DualColorImageGenerator.purpleOrange.image.resizable(), with: style)
+                        self.decorate(
+                            self.renderImage(
+                                DualColorImageGenerator.purpleOrangeWide.image.resizable(),
+                                size ?? .zero,
+                                maxWidth: self.calculateMaxWidth(
+                                    parentWidth: self.size?.width ?? 0,
+                                    style: style
+                                ),
+                                with: style
+                            ),
+                            with: style
+                        )
                         #else
                         EmptyView()
                         #endif
@@ -359,144 +370,71 @@ struct ImageComponentView_Previews: PreviewProvider {
         .previewLayout(.fixed(width: previewDimension, height: previewDimension))
         .previewDisplayName("Image streching vertically when height=fit")
 
-        // Light - Fit
-        VStack {
-            ImageComponentView(
-                // swiftlint:disable:next force_try
-                viewModel: try! .init(
-                    localizationProvider: .init(
-                        locale: Locale.current,
-                        localizedStrings: [:]
-                    ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
-                    component: .init(
-                        source: .init(
-                            light: .init(
-                                width: 750,
-                                height: 530,
-                                original: catUrl,
-                                heic: catUrl,
-                                heicLowRes: catUrl
-                            )
-                        ),
-                        size: .init(width: .fixed(200), height: .fixed(141)),
-                        fitMode: .fit,
-                        border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
-                        shadow: .init(
-                            color: .init(
-                                light: .hex("#000000"),
-                                dark: .hex("#000000")
-                            ),
-                            radius: 5, x: 5, y: 5
-                        )
-                    )
-                ),
-                size: estimatedImageComponentSize(
-                    previewWidth: previewDimension,
-                    width: 750,
-                    height: 530,
-                    size: .init(width: .fixed(200), height: .fixed(200)),
-                    fitMode: .fit,
-                    horizontalInsets: CGFloat(8),
-                    verticalInsets: CGFloat(8)
-                )
-            )
-        }
-        .previewRequiredPaywallsV2Properties()
-        .previewLayout(.fixed(width: previewDimension, height: previewDimension))
-        .previewDisplayName("Light - Fit")
-
         // Light - Fill
         VStack {
-            ImageComponentView(
-                // swiftlint:disable:next force_try
-                viewModel: try! .init(
-                    localizationProvider: .init(
-                        locale: Locale.current,
-                        localizedStrings: [:]
+            createImage(
+                fitMode: .fit,
+                maskShape: nil,
+                colorOverlay: nil,
+                border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
+                shadow: .init(
+                    color: .init(
+                        light: .hex("#000000"),
+                        dark: .hex("#000000")
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
-                    component: .init(
-                        source: .init(
-                            light: .init(
-                                width: 750,
-                                height: 530,
-                                original: catUrl,
-                                heic: catUrl,
-                                heicLowRes: catUrl
-                            )
-                        ),
-                        size: .init(width: .fixed(200), height: .fixed(141)),
-                        fitMode: .fill,
-                        border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
-                        shadow: .init(
-                            color: .init(
-                                light: .hex("#000000"),
-                                dark: .hex("#000000")
-                            ),
-                            radius: 5, x: 5, y: 5
-                        )
-                    )
-                ),
-                size: estimatedImageComponentSize(
-                    previewWidth: previewDimension,
-                    width: 750,
-                    height: 530,
-                    size: .init(width: .fixed(200), height: .fixed(200)),
-                    fitMode: .fill,
-                    horizontalInsets: CGFloat(8),
-                    verticalInsets: CGFloat(8)
+                    radius: 5, x: 5, y: 5
+                )
+            )
+            createImage(
+                fitMode: .fill,
+                maskShape: nil,
+                colorOverlay: nil,
+                border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
+                shadow: .init(
+                    color: .init(
+                        light: .hex("#000000"),
+                        dark: .hex("#000000")
+                    ),
+                    radius: 5, x: 5, y: 5
                 )
             )
         }
         .previewRequiredPaywallsV2Properties()
         .previewLayout(.fixed(width: previewDimension, height: previewDimension))
-        .previewDisplayName("Light - Fill")
+        .previewDisplayName("Light")
 
         // Light - Gradient
         VStack {
-            ImageComponentView(
-                // swiftlint:disable:next force_try
-                viewModel: try! .init(
-                    localizationProvider: .init(
-                        locale: Locale.current,
-                        localizedStrings: [:]
+            createImage(
+                fitMode: .fit,
+                maskShape: nil,
+                colorOverlay: .init(light: .linear(0, [
+                    .init(color: "#ffffff", percent: 0),
+                    .init(color: "#ffffff00", percent: 40)
+                ])),
+                border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
+                shadow: .init(
+                    color: .init(
+                        light: .hex("#000000"),
+                        dark: .hex("#000000")
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
-                    component: .init(
-                        source: .init(
-                            light: .init(
-                                width: 750,
-                                height: 530,
-                                original: catUrl,
-                                heic: catUrl,
-                                heicLowRes: catUrl
-                            )
-                        ),
-                        size: .init(width: .fixed(200), height: .fixed(141)),
-                        fitMode: .fill,
-                        colorOverlay: .init(light: .linear(0, [
-                            .init(color: "#ffffff", percent: 0),
-                            .init(color: "#ffffff00", percent: 40)
-                        ])),
-                        border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
-                        shadow: .init(
-                            color: .init(
-                                light: .hex("#000000"),
-                                dark: .hex("#000000")
-                            ),
-                            radius: 5, x: 5, y: 5
-                        )
-                    )
-                ),
-                size: estimatedImageComponentSize(
-                    previewWidth: previewDimension,
-                    width: 750,
-                    height: 530,
-                    size: .init(width: .fixed(200), height: .fixed(200)),
-                    fitMode: .fill,
-                    horizontalInsets: CGFloat(8),
-                    verticalInsets: CGFloat(8)
+                    radius: 5, x: 5, y: 5
+                )
+            )
+            createImage(
+                fitMode: .fill,
+                maskShape: nil,
+                colorOverlay: .init(light: .linear(0, [
+                    .init(color: "#ffffff", percent: 0),
+                    .init(color: "#ffffff00", percent: 40)
+                ])),
+                border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
+                shadow: .init(
+                    color: .init(
+                        light: .hex("#000000"),
+                        dark: .hex("#000000")
+                    ),
+                    radius: 5, x: 5, y: 5
                 )
             )
         }
@@ -506,48 +444,30 @@ struct ImageComponentView_Previews: PreviewProvider {
 
         // Light - Fit with Rounded Corner
         VStack {
-            ImageComponentView(
-                // swiftlint:disable:next force_try
-                viewModel: try! .init(
-                    localizationProvider: .init(
-                        locale: Locale.current,
-                        localizedStrings: [:]
+            createImage(
+                fitMode: .fit,
+                maskShape: .rectangle(.init(topLeading: 40, topTrailing: 40, bottomLeading: 40, bottomTrailing: 40)),
+                colorOverlay: nil,
+                border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
+                shadow: .init(
+                    color: .init(
+                        light: .hex("#000000"),
+                        dark: .hex("#000000")
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
-                    component: .init(
-                        source: .init(
-                            light: .init(
-                                width: 750,
-                                height: 530,
-                                original: catUrl,
-                                heic: catUrl,
-                                heicLowRes: catUrl
-                            )
-                        ),
-                        size: .init(width: .fixed(200), height: .fixed(141)),
-                        fitMode: .fit,
-                        maskShape: .rectangle(.init(topLeading: 40,
-                                                    topTrailing: 40,
-                                                    bottomLeading: 40,
-                                                    bottomTrailing: 40)),
-                        border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
-                        shadow: .init(
-                            color: .init(
-                                light: .hex("#000000"),
-                                dark: .hex("#000000")
-                            ),
-                            radius: 5, x: 5, y: 5
-                        )
-                    )
-                ),
-                size: estimatedImageComponentSize(
-                    previewWidth: previewDimension,
-                    width: 750,
-                    height: 530,
-                    size: .init(width: .fixed(200), height: .fixed(200)),
-                    fitMode: .fit,
-                    horizontalInsets: CGFloat(8),
-                    verticalInsets: CGFloat(8)
+                    radius: 5, x: 5, y: 5
+                )
+            )
+            createImage(
+                fitMode: .fill,
+                maskShape: .rectangle(.init(topLeading: 40, topTrailing: 40, bottomLeading: 40, bottomTrailing: 40)),
+                colorOverlay: nil,
+                border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
+                shadow: .init(
+                    color: .init(
+                        light: .hex("#000000"),
+                        dark: .hex("#000000")
+                    ),
+                    radius: 5, x: 5, y: 5
                 )
             )
         }
@@ -557,45 +477,30 @@ struct ImageComponentView_Previews: PreviewProvider {
 
         // Light - Fit with Circle
         VStack {
-            ImageComponentView(
-                // swiftlint:disable:next force_try
-                viewModel: try! .init(
-                    localizationProvider: .init(
-                        locale: Locale.current,
-                        localizedStrings: [:]
+            createImage(
+                fitMode: .fit,
+                maskShape: .circle,
+                colorOverlay: nil,
+                border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
+                shadow: .init(
+                    color: .init(
+                        light: .hex("#000000"),
+                        dark: .hex("#000000")
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
-                    component: .init(
-                        source: .init(
-                            light: .init(
-                                width: 750,
-                                height: 530,
-                                original: catUrl,
-                                heic: catUrl,
-                                heicLowRes: catUrl
-                            )
-                        ),
-                        size: .init(width: .fixed(200), height: .fixed(141)),
-                        fitMode: .fit,
-                        maskShape: .circle,
-                        border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
-                        shadow: .init(
-                            color: .init(
-                                light: .hex("#000000"),
-                                dark: .hex("#000000")
-                            ),
-                            radius: 5, x: 5, y: 5
-                        )
-                    )
-                ),
-                size: estimatedImageComponentSize(
-                    previewWidth: previewDimension,
-                    width: 750,
-                    height: 530,
-                    size: .init(width: .fixed(200), height: .fixed(200)),
-                    fitMode: .fit,
-                    horizontalInsets: CGFloat(8),
-                    verticalInsets: CGFloat(8)
+                    radius: 5, x: 5, y: 5
+                )
+            )
+            createImage(
+                fitMode: .fill,
+                maskShape: .circle,
+                colorOverlay: nil,
+                border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
+                shadow: .init(
+                    color: .init(
+                        light: .hex("#000000"),
+                        dark: .hex("#000000")
+                    ),
+                    radius: 5, x: 5, y: 5
                 )
             )
         }
@@ -605,99 +510,115 @@ struct ImageComponentView_Previews: PreviewProvider {
 
         // Light - Fit with Convex
         VStack {
-            ImageComponentView(
-                // swiftlint:disable:next force_try
-                viewModel: try! .init(
-                    localizationProvider: .init(
-                        locale: Locale.current,
-                        localizedStrings: [:]
+            createImage(
+                fitMode: .fit,
+                maskShape: .convex,
+                colorOverlay: nil,
+                border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
+                shadow: .init(
+                    color: .init(
+                        light: .hex("#000000"),
+                        dark: .hex("#000000")
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
-                    component: .init(
-                        source: .init(
-                            light: .init(
-                                width: 750,
-                                height: 530,
-                                original: catUrl,
-                                heic: catUrl,
-                                heicLowRes: catUrl
-                            )
-                        ),
-                        size: .init(width: .fixed(200), height: .fixed(141)),
-                        fitMode: .fit,
-                        maskShape: .convex,
-                        border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
-                        shadow: .init(
-                            color: .init(
-                                light: .hex("#000000"),
-                                dark: .hex("#000000")
-                            ),
-                            radius: 5, x: 5, y: 5
-                        )
-                    )
-                ),
-                size: estimatedImageComponentSize(
-                    previewWidth: previewDimension,
-                    width: 750,
-                    height: 530,
-                    size: .init(width: .fixed(200), height: .fixed(200)),
-                    fitMode: .fit,
-                    horizontalInsets: CGFloat(8),
-                    verticalInsets: CGFloat(8)
+                    radius: 5, x: 5, y: 5
+                )
+            )
+            createImage(
+                fitMode: .fill,
+                maskShape: .convex,
+                colorOverlay: nil,
+                border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
+                shadow: .init(
+                    color: .init(
+                        light: .hex("#000000"),
+                        dark: .hex("#000000")
+                    ),
+                    radius: 5, x: 5, y: 5
                 )
             )
         }
         .previewRequiredPaywallsV2Properties()
         .previewLayout(.fixed(width: previewDimension, height: previewDimension))
-        .previewDisplayName("Light - Fit with Convex")
+        .previewDisplayName("Light - Fit/Fill with Convex")
 
         // Light - Fit with Concave
         VStack {
-            ImageComponentView(
-                // swiftlint:disable:next force_try
-                viewModel: try! .init(
-                    localizationProvider: .init(
-                        locale: Locale.current,
-                        localizedStrings: [:]
+            createImage(
+                fitMode: .fit,
+                maskShape: .concave,
+                colorOverlay: nil,
+                border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
+                shadow: .init(
+                    color: .init(
+                        light: .hex("#000000"),
+                        dark: .hex("#000000")
                     ),
-                    uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
-                    component: .init(
-                        source: .init(
-                            light: .init(
-                                width: 750,
-                                height: 530,
-                                original: catUrl,
-                                heic: catUrl,
-                                heicLowRes: catUrl
-                            )
-                        ),
-                        size: .init(width: .fixed(200), height: .fixed(141)),
-                        fitMode: .fit,
-                        maskShape: .concave,
-                        border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
-                        shadow: .init(
-                            color: .init(
-                                light: .hex("#000000"),
-                                dark: .hex("#000000")
-                            ),
-                            radius: 5, x: 5, y: 5
-                        )
-                    )
-                ),
-                size: estimatedImageComponentSize(
-                    previewWidth: previewDimension,
-                    width: 750,
-                    height: 530,
-                    size: .init(width: .fixed(200), height: .fixed(200)),
-                    fitMode: .fit,
-                    horizontalInsets: CGFloat(8),
-                    verticalInsets: CGFloat(8)
+                    radius: 5, x: 5, y: 5
+                )
+            )
+
+            createImage(
+                fitMode: .fill,
+                maskShape: .concave,
+                colorOverlay: nil,
+                border: .init(color: .init(light: .hex("#f8f81b")), width: 4),
+                shadow: .init(
+                    color: .init(
+                        light: .hex("#000000"),
+                        dark: .hex("#000000")
+                    ),
+                    radius: 5, x: 5, y: 5
                 )
             )
         }
         .previewRequiredPaywallsV2Properties()
         .previewLayout(.fixed(width: previewDimension, height: previewDimension))
-        .previewDisplayName("Light - Fit with Concave")
+        .previewDisplayName("Light - Fit and Fill with Concave")
+    }
+
+    static func createImage(
+        fitMode: PaywallComponent.FitMode,
+        maskShape: PaywallComponent.MaskShape?,
+        colorOverlay: PaywallComponent.ColorScheme?,
+        border: PaywallComponent.Border?,
+        shadow: PaywallComponent.Shadow?
+    ) -> some View {
+        ImageComponentView(
+            // swiftlint:disable:next force_try
+            viewModel: try! .init(
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [:]
+                ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                component: .init(
+                    source: .init(
+                        light: .init(
+                            width: 750,
+                            height: 530,
+                            original: catUrl,
+                            heic: catUrl,
+                            heicLowRes: catUrl
+                        )
+                    ),
+                    size: .init(width: .fixed(200), height: .fixed(141)),
+                    fitMode: fitMode,
+                    maskShape: maskShape,
+                    colorOverlay: colorOverlay,
+                    border: border,
+                    shadow: shadow
+                )
+            ),
+            size: estimatedImageComponentSize(
+                previewWidth: previewDimension,
+                width: 750,
+                height: 530,
+                size: .init(width: .fixed(200), height: .fixed(200)),
+                fitMode: .fill,
+                horizontalInsets: CGFloat(8),
+                verticalInsets: CGFloat(8)
+            )
+        )
     }
 }
 

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -187,6 +187,8 @@ struct ImageComponentView_Previews: PreviewProvider {
         width: Int,
         height: Int
     ) -> some View {
+        let borderWidth: UInt = 4
+
         ImageComponentView(
             // swiftlint:disable:next force_try
             viewModel: try! .init(
@@ -207,8 +209,17 @@ struct ImageComponentView_Previews: PreviewProvider {
                     ),
                     size: size,
                     fitMode: fitMode,
-                    border: .init(color: .init(light: .hex("#ff0000")), width: 4)
+                    border: .init(color: .init(light: .hex("#ff0000")), width: Double(borderWidth))
                 )
+            ),
+            size: estimatedImageComponentSize(
+                previewWidth: previewDimension,
+                width: width,
+                height: height,
+                size: size,
+                fitMode: fitMode,
+                horizontalInsets: CGFloat(borderWidth) * 2,
+                verticalInsets: CGFloat(borderWidth) * 2
             )
         )
         Text(.init("width: **\(size.width)** height: **\(size.height)**\n" +
@@ -216,7 +227,63 @@ struct ImageComponentView_Previews: PreviewProvider {
                    "width: **\(width)** height: **\(height)**"))
     }
 
+    // For the Emerge snapshot pipeline, we have to have the image available on first pass
+    // This is for prepopulating the size of the view so the snapshot test can be taken
+    // locally, the estimated size will be overwritten and the preview will render the
+    // actual computed size.
+    static func estimatedImageComponentSize(
+        previewWidth: CGFloat,
+        width: Int,
+        height: Int,
+        size: PaywallComponent.Size,
+        fitMode: PaywallComponent.FitMode,
+        horizontalInsets: CGFloat = 0,
+        verticalInsets: CGFloat = 0
+    ) -> CGSize {
+        _ = fitMode
+
+        let intrinsicWidth = max(CGFloat(width), 1)
+        let intrinsicHeight = max(CGFloat(height), 1)
+        let aspectRatio = intrinsicWidth / intrinsicHeight
+        let availableContentWidth = max(0, previewWidth - horizontalInsets)
+
+        let estimatedContentWidth: CGFloat
+        switch size.width {
+        case .fixed(let value):
+            estimatedContentWidth = CGFloat(value)
+        case .fill:
+            estimatedContentWidth = availableContentWidth
+        case .fit:
+            switch size.height {
+            case .fixed(let value):
+                estimatedContentWidth = min(availableContentWidth, CGFloat(value) * aspectRatio)
+            case .fit, .fill:
+                estimatedContentWidth = min(availableContentWidth, intrinsicWidth)
+            case .relative:
+                estimatedContentWidth = min(availableContentWidth, intrinsicWidth)
+            }
+        case .relative(let value):
+            estimatedContentWidth = max(0, availableContentWidth * CGFloat(value))
+        }
+
+        let estimatedContentHeight: CGFloat
+        switch size.height {
+        case .fixed(let value):
+            estimatedContentHeight = CGFloat(value)
+        case .fit, .fill:
+            estimatedContentHeight = estimatedContentWidth / aspectRatio
+        case .relative:
+            estimatedContentHeight = estimatedContentWidth / aspectRatio
+        }
+
+        return CGSize(
+            width: estimatedContentWidth + horizontalInsets,
+            height: estimatedContentHeight + verticalInsets
+        )
+    }
+
     static var fixedHeight: UInt = 360
+    static var previewDimension: CGFloat = 400
 
     // Need to wrap in VStack otherwise preview rerenders and images won't show
     static var previews: some View {
@@ -251,7 +318,7 @@ struct ImageComponentView_Previews: PreviewProvider {
             }.background(.blue)
         }
         .previewRequiredPaywallsV2Properties()
-        .previewLayout(.fixed(width: 400, height: 400))
+        .previewLayout(.fixed(width: previewDimension, height: previewDimension))
         .previewDisplayName("Image stretching horizontally beyond bounds")
 
         ScrollView {
@@ -282,7 +349,7 @@ struct ImageComponentView_Previews: PreviewProvider {
             }.background(.blue)
         }
         .previewRequiredPaywallsV2Properties()
-        .previewLayout(.fixed(width: 400, height: 400))
+        .previewLayout(.fixed(width: previewDimension, height: previewDimension))
         .previewDisplayName("Image streching vertically when height=fit")
 
         // Light - Fit
@@ -319,7 +386,7 @@ struct ImageComponentView_Previews: PreviewProvider {
             )
         }
         .previewRequiredPaywallsV2Properties()
-        .previewLayout(.fixed(width: 400, height: 400))
+        .previewLayout(.fixed(width: previewDimension, height: previewDimension))
         .previewDisplayName("Light - Fit")
 
         // Light - Fill
@@ -356,7 +423,7 @@ struct ImageComponentView_Previews: PreviewProvider {
             )
         }
         .previewRequiredPaywallsV2Properties()
-        .previewLayout(.fixed(width: 400, height: 400))
+        .previewLayout(.fixed(width: previewDimension, height: previewDimension))
         .previewDisplayName("Light - Fill")
 
         // Light - Gradient
@@ -397,7 +464,7 @@ struct ImageComponentView_Previews: PreviewProvider {
             )
         }
         .previewRequiredPaywallsV2Properties()
-        .previewLayout(.fixed(width: 400, height: 400))
+        .previewLayout(.fixed(width: previewDimension, height: previewDimension))
         .previewDisplayName("Light - Gradient")
 
         // Light - Fit with Rounded Corner
@@ -438,7 +505,7 @@ struct ImageComponentView_Previews: PreviewProvider {
             )
         }
         .previewRequiredPaywallsV2Properties()
-        .previewLayout(.fixed(width: 400, height: 400))
+        .previewLayout(.fixed(width: previewDimension, height: previewDimension))
         .previewDisplayName("Light - Rounded Corner")
 
         // Light - Fit with Circle
@@ -476,7 +543,7 @@ struct ImageComponentView_Previews: PreviewProvider {
             )
         }
         .previewRequiredPaywallsV2Properties()
-        .previewLayout(.fixed(width: 400, height: 400))
+        .previewLayout(.fixed(width: previewDimension, height: previewDimension))
         .previewDisplayName("Light - Circle")
 
         // Light - Fit with Convex
@@ -514,7 +581,7 @@ struct ImageComponentView_Previews: PreviewProvider {
             )
         }
         .previewRequiredPaywallsV2Properties()
-        .previewLayout(.fixed(width: 400, height: 400))
+        .previewLayout(.fixed(width: previewDimension, height: previewDimension))
         .previewDisplayName("Light - Fit with Convex")
 
         // Light - Fit with Concave
@@ -552,7 +619,7 @@ struct ImageComponentView_Previews: PreviewProvider {
             )
         }
         .previewRequiredPaywallsV2Properties()
-        .previewLayout(.fixed(width: 400, height: 400))
+        .previewLayout(.fixed(width: previewDimension, height: previewDimension))
         .previewDisplayName("Light - Fit with Concave")
     }
 }

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -68,6 +68,8 @@ struct ImageComponentView: View {
                 )
                 ZStack {
                     if style.size.width == .fill && self.size == nil {
+                        // We cannot correctly render the image until we know the space the image can fill
+                        // this will fill the space so we can get the correct measurements and render the image
                         self.decorate(Color.clear, with: style)
                     } else {
                         self.decorate(

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -213,7 +213,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                 )
             ),
             size: estimatedImageComponentSize(
-                previewWidth: previewDimension - 20,
+                previewWidth: previewDimension,
                 width: width,
                 height: height,
                 size: size,
@@ -385,7 +385,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                     )
                 ),
                 size: estimatedImageComponentSize(
-                    previewWidth: previewDimension - 20,
+                    previewWidth: previewDimension,
                     width: 750,
                     height: 530,
                     size: .init(width: .fixed(200), height: .fixed(200)),
@@ -432,7 +432,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                     )
                 ),
                 size: estimatedImageComponentSize(
-                    previewWidth: previewDimension - 20,
+                    previewWidth: previewDimension,
                     width: 750,
                     height: 530,
                     size: .init(width: .fixed(200), height: .fixed(200)),
@@ -483,7 +483,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                     )
                 ),
                 size: estimatedImageComponentSize(
-                    previewWidth: previewDimension - 20,
+                    previewWidth: previewDimension,
                     width: 750,
                     height: 530,
                     size: .init(width: .fixed(200), height: .fixed(200)),
@@ -534,7 +534,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                     )
                 ),
                 size: estimatedImageComponentSize(
-                    previewWidth: previewDimension - 20,
+                    previewWidth: previewDimension,
                     width: 750,
                     height: 530,
                     size: .init(width: .fixed(200), height: .fixed(200)),
@@ -582,7 +582,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                     )
                 ),
                 size: estimatedImageComponentSize(
-                    previewWidth: previewDimension - 20,
+                    previewWidth: previewDimension,
                     width: 750,
                     height: 530,
                     size: .init(width: .fixed(200), height: .fixed(200)),
@@ -630,7 +630,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                     )
                 ),
                 size: estimatedImageComponentSize(
-                    previewWidth: previewDimension - 20,
+                    previewWidth: previewDimension,
                     width: 750,
                     height: 530,
                     size: .init(width: .fixed(200), height: .fixed(200)),
@@ -678,7 +678,7 @@ struct ImageComponentView_Previews: PreviewProvider {
                     )
                 ),
                 size: estimatedImageComponentSize(
-                    previewWidth: previewDimension - 20,
+                    previewWidth: previewDimension,
                     width: 750,
                     height: 530,
                     size: .init(width: .fixed(200), height: .fixed(200)),

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -67,7 +67,7 @@ struct ImageComponentView: View {
                     height: self.imageSize(style: style).height
                 )
                 ZStack {
-                    if style.size.width == .fill && self.size == nil {
+                    if self.size == nil {
                         // We cannot correctly render the image until we know the space the image can fill
                         // this will fill the space so we can get the correct measurements and render the image
                         self.decorate(Color.clear, with: style)


### PR DESCRIPTION

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

resolves #6569 

A recent issue re-highlighted some image rendering issues that we've experienced in the past. 

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

The image view no longer mounts `RemoteImage` until the view has a real measured size; it shows only a decorated placeholder for the first layout pass, then swaps in the image once `onSizeChange` has populated size.
  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the rendering flow for Paywalls V2 images, which can affect layout, sizing, and when remote images start loading. Risk is limited to UI behavior but could cause regressions in image visibility or sizing in edge cases.
> 
> **Overview**
> **Fixes Paywalls V2 image sizing/rendering by deferring `RemoteImage` creation until the view has a measured size.** The image now renders a styled placeholder on the first layout pass, then swaps in the real remote image once `onSizeChange` populates dimensions; previews can render a deterministic local test image instead of fetching network assets.
> 
> Refactors repeated styling into a shared `decorate` helper (including a `compositingGroup` to keep border/image/shadow shading consistent), adds a wide dual-color generator preset for previews, and updates preview helpers to precompute an estimated component size for snapshot pipelines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c8fe8666caff98d6436992492309484c8e9f5e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->