### PR TITLE
Ignore `fallback_header` component

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -388,6 +388,8 @@ extension PaywallComponent {
             return component.containsUnsupportedConditions()
         case .countdown(let component):
             return component.containsUnsupportedConditions()
+        case .fallbackHeader:
+            return false
         }
     }
 

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -633,7 +633,10 @@ struct ViewModelFactory {
                     return backgroundInfo
                 }
 
-                guard let first = stack.components.first else {
+                guard let first = stack.components.first(where: {
+                    if case .fallbackHeader = $0 { return false }
+                    return true
+                }) else {
                     return nil
                 }
 

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -531,6 +531,9 @@ struct ViewModelFactory {
                     fallbackStackViewModel: fallbackStackViewModel
                 )
             )
+        case .fallbackHeader:
+            // fallbackHeader is filtered out in toStackViewModel and should never reach here.
+            fatalError("fallbackHeader should have been filtered before view model creation")
         }
     }
 
@@ -545,7 +548,12 @@ struct ViewModelFactory {
         offering: Offering,
         colorScheme: ColorScheme
     ) throws -> StackComponentViewModel {
-        let viewModels = try component.components.map { component in
+        let viewModels = try component.components.filter {
+            // fallback_header is injected by the dashboard for old SDK compatibility.
+            // New SDKs render the header from PaywallComponentsConfig.header instead.
+            if case .fallbackHeader = $0 { return false }
+            return true
+        }.map { component in
             try self.toViewModel(
                 component: component,
                 packageValidator: packageValidator,
@@ -698,6 +706,8 @@ struct ViewModelFactory {
                 return nil
             }
             return self.findFullWidthImageViewIfItsTheFirst(first)
+        case .fallbackHeader:
+            return nil
         }
     }
 

--- a/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
@@ -32,6 +32,8 @@ import Foundation
 
     case countdown(CountdownComponent)
 
+    case fallbackHeader
+
     public enum ComponentType: String, Codable, Sendable {
 
         case text
@@ -52,6 +54,7 @@ import Foundation
         case carousel
         case video
         case countdown
+        case fallbackHeader = "fallback_header"
 
     }
 
@@ -126,6 +129,8 @@ import Foundation
         case .countdown(let component):
             try container.encode(ComponentType.countdown, forKey: .type)
             try component.encode(to: encoder)
+        case .fallbackHeader:
+            try container.encode(ComponentType.fallbackHeader, forKey: .type)
         }
     }
 
@@ -211,6 +216,8 @@ import Foundation
             return .video(try VideoComponent(from: decoder))
         case .countdown:
             return .countdown(try CountdownComponent(from: decoder))
+        case .fallbackHeader:
+            return .fallbackHeader
         }
     }
 

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -189,6 +189,8 @@ extension PaywallComponentsData.PaywallComponentsConfig {
                         includeHighResInComponentHeirarchy: includeHighResInComponentHeirarchy
                     )
                 }
+            case .fallbackHeader:
+                break
             }
         }
 
@@ -244,6 +246,8 @@ extension PaywallComponentsData.PaywallComponentsConfig {
                 if let fallback = countdown.fallback {
                     urls += self.collectAllVideoURLs(in: fallback)
                 }
+            case .fallbackHeader:
+                break
             }
         }
 

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -197,7 +197,7 @@ extension PaywallComponentsData.PaywallComponentsConfig {
         return urls
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func collectAllVideoURLs(in stack: PaywallComponent.StackComponent) -> [URLWithValidation] {
 
         var urls: [URLWithValidation] = []

--- a/Tests/RevenueCatUITests/PaywallsV2/ViewModelFactoryTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/ViewModelFactoryTests.swift
@@ -794,10 +794,10 @@ class ViewModelFactoryTests: TestCase {
     func testFallbackHeaderIsSkippedWhenDetectingFirstFullWidthImage() throws {
         let imageComponent = PaywallComponent.ImageComponent(
             source: .init(light: .init(
+                width: 800, height: 600,
                 original: Self.sampleURL,
                 heic: Self.sampleURL,
-                heicLowRes: Self.sampleURL,
-                width: 800, height: 600
+                heicLowRes: Self.sampleURL
             )),
             size: .init(width: .fill, height: .fit)
         )

--- a/Tests/RevenueCatUITests/PaywallsV2/ViewModelFactoryTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/ViewModelFactoryTests.swift
@@ -755,6 +755,41 @@ class ViewModelFactoryTests: TestCase {
         expect(root.stickyFooterViewModel).to(beNil())
     }
 
+    // MARK: - Fallback Header Tests
+
+    @MainActor
+    func testFallbackHeaderIsFilteredOutFromStackViewModels() throws {
+        let stackComponent = PaywallComponent.StackComponent(
+            components: [
+                .fallbackHeader,
+                .text(.init(text: "text_lid", color: Self.black))
+            ],
+            dimension: .vertical(.leading, .start),
+            size: .init(width: .fill, height: .fit)
+        )
+
+        let factory = ViewModelFactory()
+        let viewModel = try factory.toStackViewModel(
+            component: stackComponent,
+            packageValidator: factory.packageValidator,
+            firstItemIgnoresSafeAreaInfo: nil,
+            purchaseButtonCollector: nil,
+            localizationProvider: .init(locale: .current, localizedStrings: [
+                "text_lid": .string("Hello")
+            ]),
+            uiConfigProvider: try Self.createUIConfigProvider(),
+            offering: Self.mockOffering,
+            colorScheme: .light
+        )
+
+        // Only the text component should remain; fallbackHeader should be filtered out
+        expect(viewModel.viewModels.count) == 1
+        guard case .text = viewModel.viewModels.first else {
+            fail("Expected a text view model but got \(String(describing: viewModel.viewModels.first))")
+            return
+        }
+    }
+
     // MARK: - Helpers
 
     private static let black = PaywallComponent.ColorScheme(

--- a/Tests/RevenueCatUITests/PaywallsV2/ViewModelFactoryTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/ViewModelFactoryTests.swift
@@ -790,6 +790,47 @@ class ViewModelFactoryTests: TestCase {
         }
     }
 
+    @MainActor
+    func testFallbackHeaderIsSkippedWhenDetectingFirstFullWidthImage() throws {
+        let imageComponent = PaywallComponent.ImageComponent(
+            source: .init(light: .init(
+                original: Self.sampleURL,
+                heic: Self.sampleURL,
+                heicLowRes: Self.sampleURL,
+                width: 800, height: 600
+            )),
+            size: .init(width: .fill, height: .fit)
+        )
+
+        let rootStack = PaywallComponent.StackComponent(
+            components: [
+                .fallbackHeader,
+                .image(imageComponent)
+            ],
+            dimension: .vertical(.leading, .start),
+            size: .init(width: .fill, height: .fit)
+        )
+
+        let componentsConfig = PaywallComponentsData.PaywallComponentsConfig(
+            stack: rootStack,
+            stickyFooter: nil,
+            background: .color(.init(light: .hex("#FFFFFF")))
+        )
+
+        var factory = ViewModelFactory()
+        let root = try factory.toRootViewModel(
+            componentsConfig: componentsConfig,
+            offering: Self.mockOffering,
+            localizationProvider: .init(locale: .current, localizedStrings: [:]),
+            uiConfigProvider: try Self.createUIConfigProvider(),
+            colorScheme: .light
+        )
+
+        // fallbackHeader should be skipped; the full-width image should be detected
+        expect(root.firstItemIgnoresSafeAreaInfo).toNot(beNil())
+        expect(root.firstItemIgnoresSafeAreaInfo?.imageComponent).toNot(beNil())
+    }
+
     // MARK: - Helpers
 
     private static let black = PaywallComponent.ColorScheme(

--- a/Tests/UnitTests/Paywalls/Components/FallbackComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/FallbackComponentTests.swift
@@ -182,6 +182,46 @@ class FallbackComponentTests: TestCase {
         }
     }
 
+    func testFallbackHeaderDecodesAsFallbackHeaderNotAsStack() throws {
+        let jsonString = """
+        {
+            "type": "fallback_header",
+            "fallback": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedComponent = try JSONDecoder.default.decode(PaywallComponent.self, from: jsonData)
+
+        switch decodedComponent {
+        case .fallbackHeader:
+            // Expected: SDK recognizes fallback_header and does not fall through to the fallback stack
+            break
+        default:
+            XCTFail("Expected .fallbackHeader but got \(decodedComponent)")
+        }
+    }
+
+    func testFallbackHeaderEncodesAndRedecodes() throws {
+        let jsonString = """
+        {
+            "type": "fallback_header",
+            "fallback": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedComponent = try JSONDecoder.default.decode(PaywallComponent.self, from: jsonData)
+
+        let encodedData = try JSONEncoder.default.encode(decodedComponent)
+        let redecodedComponent = try JSONDecoder.default.decode(PaywallComponent.self, from: encodedData)
+
+        switch redecodedComponent {
+        case .fallbackHeader:
+            break
+        default:
+            XCTFail("Expected .fallbackHeader but got \(redecodedComponent)")
+        }
+    }
+
 }
 
 #endif


### PR DESCRIPTION
### Motivation

The dashboard ([revenuecat-app#9235](https://github.com/RevenueCat/revenuecat-app/pull/9235)) now injects a `fallback_header` component as the first element of the body stack so old SDKs that don't support the `header` component can still render header content via the fallback mechanism. New SDKs that already render the header from `PaywallComponentsConfig.header` must skip `fallback_header` to avoid rendering the header content twice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall component decoding and view-model generation to explicitly handle and skip `fallback_header`, which could affect initial stack layout and safe-area/hero-media detection if filtering is incorrect. Covered by new unit/UI tests, but still touches core paywall rendering paths.
> 
> **Overview**
> Prevents duplicate header rendering by introducing an explicit `PaywallComponent.fallbackHeader` (`type: "fallback_header"`) and treating it as a no-op component.
> 
> `ViewModelFactory` now filters `fallbackHeader` out of stack view model creation and skips it when determining the first full-width hero media for safe-area behavior (with a defensive `fatalError` if it ever reaches `toViewModel`). Cache-warming URL collection and unsupported-condition scanning were updated to safely ignore this component.
> 
> Adds tests verifying `fallback_header` decodes/encodes as its own component (not via fallback stack decoding) and that it’s filtered out of stack view models and safe-area image detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c123aca3e7ea473afcea434a6d7c17ce83e81485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->