### PR TITLE
Sort no-paywall offerings to bottom of list in PaywallsTester

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -141,7 +141,13 @@ struct APIKeyDashboardList: View {
 
             self.offerings = .success(
                 .init(
-                    sections: Array(offeringsBySection.keys).sorted { $0.description < $1.description },
+                    sections: Array(offeringsBySection.keys).sorted {
+                        switch ($0.name, $1.name) {
+                        case (nil, _): return false
+                        case (_, nil): return true
+                        default: return $0.description < $1.description
+                        }
+                    },
                     offeringsBySection: offeringsBySection
                 )
             )


### PR DESCRIPTION
### Motivation
Offerings without paywalls clutter the top of the offerings list in the PaywallsTester app, making it harder to find the ones you actually want to test.

### Description
Sorts the offerings sections so that the "No paywall" group always appears at the bottom of the list, while all other template sections remain sorted alphabetically. This is a PaywallsTester-only change with no impact on the SDK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts section sorting in the PaywallsTester app; no SDK logic or data handling is modified.
> 
> **Overview**
> Updates the PaywallsTester offerings list section sort so the `No paywall` (nil template) section is always ordered last, while all other template sections remain alphabetically sorted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b9cca518003f58901f2eecccdb127657c1c46fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->