### PR TITLE
Fixes incorrect icon reuse in legacy Paywalls

### DIFF
--- a/RevenueCatUI/Templates/Template3View.swift
+++ b/RevenueCatUI/Templates/Template3View.swift
@@ -124,7 +124,7 @@ struct Template3View: TemplateViewType {
 
     private var features: some View {
         VStack(spacing: 40) {
-            ForEach(self.localization.features, id: \.title) { feature in
+            ForEach(self.localization.features, id: \.self) { feature in
                 FeatureView(feature: feature,
                             colors: self.configuration.colors,
                             fonts: self.configuration.fonts)

--- a/RevenueCatUI/Templates/Template5View.swift
+++ b/RevenueCatUI/Templates/Template5View.swift
@@ -174,7 +174,7 @@ struct Template5View: TemplateViewType {
     @ViewBuilder
     private var features: some View {
         VStack(spacing: self.defaultVerticalPaddingLength) {
-            ForEach(self.selectedLocalization.features, id: \.title) { feature in
+            ForEach(self.selectedLocalization.features, id: \.self) { feature in
                 HStack {
                     Rectangle()
                         .foregroundStyle(.clear)

--- a/RevenueCatUI/Templates/Template7View.swift
+++ b/RevenueCatUI/Templates/Template7View.swift
@@ -285,7 +285,7 @@ struct Template7View: TemplateViewType {
     @ViewBuilder
     private func features(package: TemplateViewConfiguration.Package) -> some View {
         VStack(spacing: self.defaultVerticalPaddingLength) {
-            ForEach(package.localization.features, id: \.title) { feature in
+            ForEach(package.localization.features, id: \.self) { feature in
                 HStack {
                     Rectangle()
                         .foregroundStyle(.clear)


### PR DESCRIPTION
## Bug
In certain legacy Paywall templates, the feature list incorrectly shows the same icon for features with the same title, even if the features are configured to have different icons. This issue does not exist on Android.

## Cause
This is caused by the fact that the feature title is used as `ForEach` id.

## Fix
The fix is to use the full feature (`self`) as `ForEach` id. 


| Before | After |
|-------|-------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-04-14 at 18 04 20" src="https://github.com/user-attachments/assets/8f680946-e756-42cd-b4f4-4ab27a1a77f2" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-04-14 at 18 08 24" src="https://github.com/user-attachments/assets/393ae938-b31a-4259-905a-0ec392f6c998" /> |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adjusts SwiftUI `ForEach` identity for feature rows to avoid diffing/cell-reuse issues; main risk is minor animation/state reset if feature ordering/identity changes.
> 
> **Overview**
> Fixes a legacy paywall rendering bug where feature rows could reuse the wrong icon when multiple features shared the same title.
> 
> Templates 3, 5, and 7 now key the features `ForEach` by the full feature value (`id: \.self`) instead of `title`, ensuring each row is uniquely identified and rendered with its correct icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d22157c32f22f579baac6893e0da0855300d9f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->