### PR TITLE
Fix macOS build in record_and_push_paywall_template_screenshots

### DIFF
--- a/Tests/RevenueCatUITests/PaywallsV2/PackageComponentViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PackageComponentViewTests.swift
@@ -14,10 +14,10 @@
 @_spi(Internal) import RevenueCat
 @testable import RevenueCatUI
 import SwiftUI
-import UIKit
 import XCTest
 
 #if os(iOS)
+import UIKit
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @MainActor


### PR DESCRIPTION
## Summary
- Moves `import UIKit` inside `#if os(iOS)` in `PackageComponentViewTests.swift`, fixing compilation failure when building `RevenueCatUITestsDev` for macOS native (`platform=macOS,arch=arm64`)

## Failing CI job
- [record-and-push-paywall-template-screenshots (mac-native step)](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/36509/workflows/4c6fbf4b-be2a-4461-b5d8-d072dce9b0c0/jobs/529111)
- Error: `PackageComponentViewTests.swift:17:8: no such module 'UIKit'`
- The `import UIKit` was outside the `#if os(iOS)` guard, causing the mac-native build to fail while iOS and Mac Catalyst builds passed

## Test plan
- [x] Verified build fails on `mac-native` destination before fix
- [x] Verified build succeeds on all 4 platforms after fix: iOS Simulator, mac-native, Mac Catalyst (optimized for Mac), Mac Catalyst (scaled to match iPad)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that just gates `UIKit` usage behind `#if os(iOS)` to avoid macOS compilation failures.
> 
> **Overview**
> Fixes macOS-native compilation of `RevenueCatUITestsDev` by moving `import UIKit` in `PackageComponentViewTests.swift` under the existing `#if os(iOS)` guard, preventing `no such module 'UIKit'` errors during non-iOS builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 852e13b0a94c144c635793765740f3f6b472e141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->