### PR TITLE
Run paywalls V1 snapshot recording on main and release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2481,6 +2481,9 @@ workflows:
       - spm-revenuecat-ui-watchos:
           context:
             - slack-secrets
+      - record-and-upload-paywalls-v1-snapshots:
+          context:
+            - slack-secrets
       - installation-tests-all-but-carthage:
           context:
             - slack-secrets
@@ -2543,6 +2546,7 @@ workflows:
             - spm-revenuecat-ui-ios-16
             - run-revenuecat-ui-ios-18-and-17
             - spm-revenuecat-ui-watchos
+            - record-and-upload-paywalls-v1-snapshots
             - installation-tests-all-but-carthage
             - installation-tests-carthage
             - api-tests


### PR DESCRIPTION
## Summary
- Add `record-and-upload-paywalls-v1-snapshots` job to the `release-or-main` workflow so V1 paywall snapshots are recorded on main and release branches, not just feature branches
- Add it to the `all-tests-succeeded` gate so it's required before release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI workflow gating changes can block main/release pipelines if the snapshot job is flaky or slow. No production code paths are modified.
> 
> **Overview**
> Runs `record-and-upload-paywalls-v1-snapshots` as part of the `release-or-main` CircleCI workflow (main and `release/*` branches), instead of only being exercised in other workflows.
> 
> Updates the `all-tests-succeeded` gate in `release-or-main` to require this job to pass before release tagging can proceed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dc7c0a63f839f2f9fe97110c5d5ee4f3ceaa053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->