### PR TITLE
Defer paywall dismissal after purchase callbacks

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -600,16 +600,9 @@ struct LoadedOfferingPaywallView: View {
             }
             .onDisappear { self.purchaseHandler.trackPaywallClose() }
             .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
-                if hasPurchased {
-                    guard let onRequestedDismissal = self.onRequestedDismissal else {
-                        if self.mode.isFullScreen {
-                            Logger.debug(Strings.dismissing_paywall)
-                            self.dismiss()
-                        }
-                        return
-                    }
-                    onRequestedDismissal()
-                }
+                guard hasPurchased else { return }
+
+                self.dismissAfterPurchaseCompletionCallbacks()
             }
 
         if self.displayCloseButton {
@@ -660,6 +653,23 @@ struct LoadedOfferingPaywallView: View {
             return configuration.colors.closeButtonColor
         case .failure:
             return nil
+        }
+    }
+
+    private func dismissAfterPurchaseCompletionCallbacks() {
+        // Defer dismissal so purchase completion preferences propagate to parent modifiers first.
+        DispatchQueue.main.async {
+            guard self.purchaseHandler.hasPurchasedInSession else { return }
+
+            guard let onRequestedDismissal = self.onRequestedDismissal else {
+                if self.mode.isFullScreen {
+                    Logger.debug(Strings.dismissing_paywall)
+                    self.dismiss()
+                }
+                return
+            }
+
+            onRequestedDismissal()
         }
     }
 

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -286,11 +286,20 @@ struct PaywallsV2View: View {
                 self.purchaseHandler.componentInteractionLogger(sessionID: self.paywallSessionID)
             )
             .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
-                if hasPurchased {
-                    self.onDismiss()
-                }
+                guard hasPurchased else { return }
+
+                self.dismissAfterPurchaseCompletionCallbacks()
             }
 
+    }
+
+    private func dismissAfterPurchaseCompletionCallbacks() {
+        // Defer dismissal so purchase completion preferences propagate to parent modifiers first.
+        DispatchQueue.main.async {
+            guard self.purchaseHandler.hasPurchasedInSession else { return }
+
+            self.onDismiss()
+        }
     }
 
     private func createEventData(forDefaultPaywall: Bool = false) -> PaywallEvent.Data {

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -255,6 +255,33 @@ class PurchaseCompletedHandlerTests: TestCase {
         expect(error).toEventually(matchError(Self.failureError))
     }
 
+    func testOnPurchaseCompletedInvokedBeforeRequestedDismissal() throws {
+        let handler: PurchaseHandler = .mock()
+        var callbackOrder: [String] = []
+
+        let dispose = try PaywallView(
+            offering: Self.offering.withLocalImages,
+            customerInfo: TestData.customerInfo,
+            introEligibility: .producing(eligibility: .eligible),
+            purchaseHandler: handler
+        )
+            .onPurchaseCompleted { _ in
+                callbackOrder.append("onPurchaseCompleted")
+            }
+            .onRequestedDismissal {
+                callbackOrder.append("onRequestedDismissal")
+            }
+            .addToHierarchy()
+
+        defer { dispose() }
+
+        Task {
+            _ = try await handler.purchase(package: Self.package)
+        }
+
+        expect(callbackOrder).toEventually(equal(["onPurchaseCompleted", "onRequestedDismissal"]))
+    }
+
     private static let purchaseHandler: PurchaseHandler = .mock()
     private static let failingHandler: PurchaseHandler = .failing(failureError)
     private static let offering = TestData.offeringWithNoIntroOffer


### PR DESCRIPTION


<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

customers have said they don't get their callbacks in time. 

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

Race Condition…

Delay paywall dismissal until purchase completion callbacks have run by moving dismissal into a DispatchQueue.main.async helper (dismissAfterPurchaseCompletionCallbacks) in LoadedOfferingPaywallView and PaywallsV2View. This ensures onPurchaseCompleted handlers and related state propagate to parent modifiers before invoking onRequestedDismissal or automatic dismissal. Adds a unit test to verify onPurchaseCompleted is called before requested dismissal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change limited to the paywall dismissal timing after a successful purchase; main risk is subtle lifecycle timing differences in downstream integrations.
> 
> **Overview**
> Ensures paywalls don’t dismiss *immediately* on purchase completion by deferring dismissal via a new `DispatchQueue.main.async` helper in both `LoadedOfferingPaywallView` (`PaywallView.swift`) and `PaywallsV2View.swift`.
> 
> This reduces a race where `onPurchaseCompleted`/preference propagation could be skipped or observed late by parents before `onRequestedDismissal` or auto-dismiss runs, and adds a unit test asserting `onPurchaseCompleted` fires before `onRequestedDismissal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e525eace04e1ed2b0d9ab19d293fd95e1cf2078d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->