### PR TITLE
Add pr:other label to auto-generated snapshot PRs

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1448,7 +1448,7 @@ platform :ios do
           base: base_branch,
           api_token: ENV["GITHUB_TOKEN"],
           head: branch_name,
-          labels: ["test"]
+          labels: ["pr:other", "test"]
         )
       end
     ensure

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1448,7 +1448,7 @@ platform :ios do
           base: base_branch,
           api_token: ENV["GITHUB_TOKEN"],
           head: branch_name,
-          labels: ["pr:other", "test"]
+          labels: ["pr:other", "pr:changelog_ignore", "test"]
         )
       end
     ensure


### PR DESCRIPTION
## Summary
PRs opened by `fastlane create_snapshot_pr` (triggered by CircleCI snapshot-regen runs) only carried the `test` label. They didn't have any `pr:*` label, which means Danger would immediately fail on the PR.

Adds `pr:other` alongside the existing `test` label in the `push_snapshot_pr` private lane. Matches the convention already used by the sibling `create_swiftinterface_pr` lane (`fastlane/Fastfile:1371`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts GitHub PR labels for an automated fastlane lane; no product/runtime code paths are affected.
> 
> **Overview**
> Ensures snapshot-regeneration PRs created by `fastlane create_snapshot_pr` are labeled for automation checks by adding `pr:other` (and `pr:changelog_ignore`) alongside the existing `test` label when creating the PR in `push_snapshot_pr`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f19465b0db3d888955fe98f76bb2d04585778790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->