### PR TITLE
Update backend integration test snapshots

### DIFF
--- a/Tests/BackendIntegrationTests/__Snapshots__/FallbackURLBackendIntegrationTests/testCanGetOfferingsFromFallbackURL.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/FallbackURLBackendIntegrationTests/testCanGetOfferingsFromFallbackURL.1.json
@@ -72,6 +72,7 @@
                         "top" : 0,
                         "trailing" : 24
                       },
+                      "name" : "",
                       "padding" : {
                         "bottom" : 0,
                         "leading" : 0,
@@ -104,6 +105,7 @@
                           "action" : {
                             "type" : "navigate_back"
                           },
+                          "name" : "",
                           "stack" : {
                             "components" : [
                               {
@@ -168,6 +170,7 @@
                               "top" : 0,
                               "trailing" : 0
                             },
+                            "name" : "",
                             "padding" : {
                               "bottom" : 4,
                               "leading" : 4,
@@ -185,7 +188,6 @@
                             "spacing" : 0,
                             "type" : "stack"
                           },
-                          "transition" : null,
                           "type" : "button"
                         }
                       ],
@@ -199,6 +201,7 @@
                         "top" : 24,
                         "trailing" : 24
                       },
+                      "name" : "",
                       "padding" : {
                         "bottom" : 0,
                         "leading" : 0,
@@ -236,6 +239,7 @@
                     "top" : 8,
                     "trailing" : 0
                   },
+                  "name" : "",
                   "padding" : {
                     "bottom" : 0,
                     "leading" : 0,
@@ -279,6 +283,7 @@
                     "top" : 0,
                     "trailing" : 0
                   },
+                  "name" : "",
                   "padding" : {
                     "bottom" : 0,
                     "leading" : 0,
@@ -308,6 +313,7 @@
                 "top" : 0,
                 "trailing" : 0
               },
+              "name" : "Content",
               "padding" : {
                 "bottom" : 0,
                 "leading" : 0,
@@ -352,6 +358,7 @@
                         "components" : [
                           {
                             "is_selected_by_default" : true,
+                            "name" : "",
                             "package_id" : "$rc_annual",
                             "stack" : {
                               "background" : {
@@ -398,6 +405,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -427,6 +435,7 @@
                                     "top" : 0,
                                     "trailing" : 12
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 4,
                                     "leading" : 8,
@@ -548,6 +557,7 @@
                                             "top" : 0,
                                             "trailing" : 0
                                           },
+                                          "name" : "",
                                           "padding" : {
                                             "bottom" : 0,
                                             "leading" : 0,
@@ -577,6 +587,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -619,6 +630,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -648,6 +660,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -690,6 +703,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -719,6 +733,7 @@
                                 "top" : 0,
                                 "trailing" : 0
                               },
+                              "name" : "",
                               "overrides" : [
                                 {
                                   "conditions" : [
@@ -780,6 +795,7 @@
                           },
                           {
                             "is_selected_by_default" : false,
+                            "name" : "",
                             "package_id" : "$rc_monthly",
                             "stack" : {
                               "background" : {
@@ -884,6 +900,7 @@
                                             "top" : 0,
                                             "trailing" : 0
                                           },
+                                          "name" : "",
                                           "padding" : {
                                             "bottom" : 0,
                                             "leading" : 0,
@@ -913,6 +930,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -955,6 +973,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -984,6 +1003,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -1026,6 +1046,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -1055,6 +1076,7 @@
                                 "top" : 0,
                                 "trailing" : 0
                               },
+                              "name" : "",
                               "overrides" : [
                                 {
                                   "conditions" : [
@@ -1126,6 +1148,7 @@
                           "top" : 0,
                           "trailing" : 0
                         },
+                        "name" : "Packages",
                         "padding" : {
                           "bottom" : 0,
                           "leading" : 0,
@@ -1155,6 +1178,7 @@
                       {
                         "components" : [
                           {
+                            "name" : "",
                             "stack" : {
                               "background" : {
                                 "type" : "color",
@@ -1182,6 +1206,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -1211,6 +1236,7 @@
                                 "top" : 0,
                                 "trailing" : 0
                               },
+                              "name" : "",
                               "padding" : {
                                 "bottom" : 14,
                                 "leading" : 8,
@@ -1243,6 +1269,7 @@
                             "action" : {
                               "type" : "restore_purchases"
                             },
+                            "name" : "",
                             "stack" : {
                               "components" : [
                                 {
@@ -1261,6 +1288,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -1290,6 +1318,7 @@
                                 "top" : 0,
                                 "trailing" : 0
                               },
+                              "name" : "",
                               "padding" : {
                                 "bottom" : 0,
                                 "leading" : 0,
@@ -1316,7 +1345,6 @@
                               "spacing" : 0,
                               "type" : "stack"
                             },
-                            "transition" : null,
                             "type" : "button"
                           }
                         ],
@@ -1331,6 +1359,7 @@
                           "top" : 0,
                           "trailing" : 0
                         },
+                        "name" : "Buttons",
                         "padding" : {
                           "bottom" : 0,
                           "leading" : 0,
@@ -1369,6 +1398,7 @@
                       "top" : 0,
                       "trailing" : 0
                     },
+                    "name" : "",
                     "padding" : {
                       "bottom" : 0,
                       "leading" : 0,
@@ -1407,6 +1437,7 @@
                   "top" : 0,
                   "trailing" : 0
                 },
+                "name" : "Footer",
                 "padding" : {
                   "bottom" : 0,
                   "leading" : 16,

--- a/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferingsFromLoadShedder.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferingsFromLoadShedder.1.json
@@ -65,6 +65,7 @@
                             "top" : 0,
                             "trailing" : 0
                           },
+                          "name" : "",
                           "padding" : {
                             "bottom" : 0,
                             "leading" : 0,
@@ -94,6 +95,7 @@
                         "top" : 0,
                         "trailing" : 24
                       },
+                      "name" : "",
                       "padding" : {
                         "bottom" : 0,
                         "leading" : 0,
@@ -126,6 +128,7 @@
                           "action" : {
                             "type" : "navigate_back"
                           },
+                          "name" : "",
                           "stack" : {
                             "components" : [
                               {
@@ -190,6 +193,7 @@
                               "top" : 0,
                               "trailing" : 0
                             },
+                            "name" : "",
                             "padding" : {
                               "bottom" : 4,
                               "leading" : 4,
@@ -207,7 +211,6 @@
                             "spacing" : 0,
                             "type" : "stack"
                           },
-                          "transition" : null,
                           "type" : "button"
                         }
                       ],
@@ -221,6 +224,7 @@
                         "top" : 24,
                         "trailing" : 24
                       },
+                      "name" : "",
                       "padding" : {
                         "bottom" : 0,
                         "leading" : 0,
@@ -258,6 +262,7 @@
                     "top" : 8,
                     "trailing" : 0
                   },
+                  "name" : "",
                   "padding" : {
                     "bottom" : 0,
                     "leading" : 0,
@@ -296,6 +301,7 @@
                 "top" : 0,
                 "trailing" : 0
               },
+              "name" : "Content",
               "padding" : {
                 "bottom" : 0,
                 "leading" : 0,
@@ -340,6 +346,7 @@
                         "components" : [
                           {
                             "is_selected_by_default" : true,
+                            "name" : "",
                             "package_id" : "$rc_lifetime",
                             "stack" : {
                               "background" : {
@@ -386,6 +393,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -415,6 +423,7 @@
                                     "top" : 0,
                                     "trailing" : 12
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 4,
                                     "leading" : 8,
@@ -537,6 +546,7 @@
                                             "top" : 0,
                                             "trailing" : 0
                                           },
+                                          "name" : "",
                                           "padding" : {
                                             "bottom" : 0,
                                             "leading" : 0,
@@ -566,6 +576,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -609,6 +620,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -638,6 +650,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -681,6 +694,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -710,6 +724,7 @@
                                 "top" : 0,
                                 "trailing" : 0
                               },
+                              "name" : "",
                               "overrides" : [
                                 {
                                   "conditions" : [
@@ -771,6 +786,7 @@
                           },
                           {
                             "is_selected_by_default" : false,
+                            "name" : "",
                             "package_id" : "$rc_monthly",
                             "stack" : {
                               "background" : {
@@ -875,6 +891,7 @@
                                             "top" : 0,
                                             "trailing" : 0
                                           },
+                                          "name" : "",
                                           "padding" : {
                                             "bottom" : 0,
                                             "leading" : 0,
@@ -904,6 +921,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -946,6 +964,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -975,6 +994,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -1017,6 +1037,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -1046,6 +1067,7 @@
                                 "top" : 0,
                                 "trailing" : 0
                               },
+                              "name" : "",
                               "overrides" : [
                                 {
                                   "conditions" : [
@@ -1117,6 +1139,7 @@
                           "top" : 0,
                           "trailing" : 0
                         },
+                        "name" : "Packages",
                         "padding" : {
                           "bottom" : 0,
                           "leading" : 0,
@@ -1146,6 +1169,7 @@
                       {
                         "components" : [
                           {
+                            "name" : "",
                             "stack" : {
                               "background" : {
                                 "type" : "color",
@@ -1173,6 +1197,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -1202,6 +1227,7 @@
                                 "top" : 0,
                                 "trailing" : 0
                               },
+                              "name" : "",
                               "padding" : {
                                 "bottom" : 14,
                                 "leading" : 8,
@@ -1234,6 +1260,7 @@
                             "action" : {
                               "type" : "restore_purchases"
                             },
+                            "name" : "",
                             "stack" : {
                               "components" : [
                                 {
@@ -1252,6 +1279,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -1281,6 +1309,7 @@
                                 "top" : 0,
                                 "trailing" : 0
                               },
+                              "name" : "",
                               "padding" : {
                                 "bottom" : 0,
                                 "leading" : 0,
@@ -1307,7 +1336,6 @@
                               "spacing" : 0,
                               "type" : "stack"
                             },
-                            "transition" : null,
                             "type" : "button"
                           }
                         ],
@@ -1322,6 +1350,7 @@
                           "top" : 0,
                           "trailing" : 0
                         },
+                        "name" : "Buttons",
                         "padding" : {
                           "bottom" : 0,
                           "leading" : 0,
@@ -1360,6 +1389,7 @@
                       "top" : 0,
                       "trailing" : 0
                     },
+                    "name" : "",
                     "padding" : {
                       "bottom" : 0,
                       "leading" : 0,
@@ -1398,6 +1428,7 @@
                   "top" : 0,
                   "trailing" : 0
                 },
+                "name" : "Footer",
                 "padding" : {
                   "bottom" : 0,
                   "leading" : 16,

--- a/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
@@ -72,6 +72,7 @@
                         "top" : 0,
                         "trailing" : 24
                       },
+                      "name" : "",
                       "padding" : {
                         "bottom" : 0,
                         "leading" : 0,
@@ -104,6 +105,7 @@
                           "action" : {
                             "type" : "navigate_back"
                           },
+                          "name" : "",
                           "stack" : {
                             "components" : [
                               {
@@ -168,6 +170,7 @@
                               "top" : 0,
                               "trailing" : 0
                             },
+                            "name" : "",
                             "padding" : {
                               "bottom" : 4,
                               "leading" : 4,
@@ -185,7 +188,6 @@
                             "spacing" : 0,
                             "type" : "stack"
                           },
-                          "transition" : null,
                           "type" : "button"
                         }
                       ],
@@ -199,6 +201,7 @@
                         "top" : 24,
                         "trailing" : 24
                       },
+                      "name" : "",
                       "padding" : {
                         "bottom" : 0,
                         "leading" : 0,
@@ -236,6 +239,7 @@
                     "top" : 8,
                     "trailing" : 0
                   },
+                  "name" : "",
                   "padding" : {
                     "bottom" : 0,
                     "leading" : 0,
@@ -279,6 +283,7 @@
                     "top" : 0,
                     "trailing" : 0
                   },
+                  "name" : "",
                   "padding" : {
                     "bottom" : 0,
                     "leading" : 0,
@@ -308,6 +313,7 @@
                 "top" : 0,
                 "trailing" : 0
               },
+              "name" : "Content",
               "padding" : {
                 "bottom" : 0,
                 "leading" : 0,
@@ -352,6 +358,7 @@
                         "components" : [
                           {
                             "is_selected_by_default" : true,
+                            "name" : "",
                             "package_id" : "$rc_annual",
                             "stack" : {
                               "background" : {
@@ -398,6 +405,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -427,6 +435,7 @@
                                     "top" : 0,
                                     "trailing" : 12
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 4,
                                     "leading" : 8,
@@ -548,6 +557,7 @@
                                             "top" : 0,
                                             "trailing" : 0
                                           },
+                                          "name" : "",
                                           "padding" : {
                                             "bottom" : 0,
                                             "leading" : 0,
@@ -577,6 +587,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -619,6 +630,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -648,6 +660,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -690,6 +703,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -719,6 +733,7 @@
                                 "top" : 0,
                                 "trailing" : 0
                               },
+                              "name" : "",
                               "overrides" : [
                                 {
                                   "conditions" : [
@@ -780,6 +795,7 @@
                           },
                           {
                             "is_selected_by_default" : false,
+                            "name" : "",
                             "package_id" : "$rc_monthly",
                             "stack" : {
                               "background" : {
@@ -884,6 +900,7 @@
                                             "top" : 0,
                                             "trailing" : 0
                                           },
+                                          "name" : "",
                                           "padding" : {
                                             "bottom" : 0,
                                             "leading" : 0,
@@ -913,6 +930,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -955,6 +973,7 @@
                                         "top" : 0,
                                         "trailing" : 0
                                       },
+                                      "name" : "",
                                       "padding" : {
                                         "bottom" : 0,
                                         "leading" : 0,
@@ -984,6 +1003,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -1026,6 +1046,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -1055,6 +1076,7 @@
                                 "top" : 0,
                                 "trailing" : 0
                               },
+                              "name" : "",
                               "overrides" : [
                                 {
                                   "conditions" : [
@@ -1126,6 +1148,7 @@
                           "top" : 0,
                           "trailing" : 0
                         },
+                        "name" : "Packages",
                         "padding" : {
                           "bottom" : 0,
                           "leading" : 0,
@@ -1155,6 +1178,7 @@
                       {
                         "components" : [
                           {
+                            "name" : "",
                             "stack" : {
                               "background" : {
                                 "type" : "color",
@@ -1182,6 +1206,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -1211,6 +1236,7 @@
                                 "top" : 0,
                                 "trailing" : 0
                               },
+                              "name" : "",
                               "padding" : {
                                 "bottom" : 14,
                                 "leading" : 8,
@@ -1243,6 +1269,7 @@
                             "action" : {
                               "type" : "restore_purchases"
                             },
+                            "name" : "",
                             "stack" : {
                               "components" : [
                                 {
@@ -1261,6 +1288,7 @@
                                     "top" : 0,
                                     "trailing" : 0
                                   },
+                                  "name" : "",
                                   "padding" : {
                                     "bottom" : 0,
                                     "leading" : 0,
@@ -1290,6 +1318,7 @@
                                 "top" : 0,
                                 "trailing" : 0
                               },
+                              "name" : "",
                               "padding" : {
                                 "bottom" : 0,
                                 "leading" : 0,
@@ -1316,7 +1345,6 @@
                               "spacing" : 0,
                               "type" : "stack"
                             },
-                            "transition" : null,
                             "type" : "button"
                           }
                         ],
@@ -1331,6 +1359,7 @@
                           "top" : 0,
                           "trailing" : 0
                         },
+                        "name" : "Buttons",
                         "padding" : {
                           "bottom" : 0,
                           "leading" : 0,
@@ -1369,6 +1398,7 @@
                       "top" : 0,
                       "trailing" : 0
                     },
+                    "name" : "",
                     "padding" : {
                       "bottom" : 0,
                       "leading" : 0,
@@ -1407,6 +1437,7 @@
                   "top" : 0,
                   "trailing" : 0
                 },
+                "name" : "Footer",
                 "padding" : {
                   "bottom" : 0,
                   "leading" : 16,


### PR DESCRIPTION
Combines the individual auto-generated snapshot PRs (#6626, #6627, #6628, #6629, #6630) into a single branch so CI can pass with all iOS version snapshots updated at once. The individual PRs are re-targeted to this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to auto-generated snapshot JSON updates in integration tests, with no production code modifications. Risk is mainly CI noise/false failures if snapshot updates are unintended.
> 
> **Overview**
> Updates backend integration test snapshots for offerings/paywall component payloads.
> 
> The refreshed JSON now includes a `name` field across many component nodes (some set to `""`, others labeled like `"Content"`, `"Packages"`, `"Buttons"`, `"Footer"`) and removes previously-recorded `"transition": null` entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e4014f44dd764dc4890b2d09b18530fd21a1ac6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->