### PR TITLE
Resolve the issue around tab control context identity (PWENG-31)

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1319,6 +1319,7 @@
 		B3E26A4A26BE0A8E003ACCF3 /* Error+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E26A4926BE0A8E003ACCF3 /* Error+Extensions.swift */; };
 		B3F3E8DA277158FE0047A5B9 /* DNSChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F3E8D9277158FE0047A5B9 /* DNSChecker.swift */; };
 		B3F8418F26F3A93400E560FB /* ErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F8418E26F3A93400E560FB /* ErrorCodeTests.swift */; };
+		B413E5A02F97B3B900B5F0CA /* CarouselTabSwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B413E59F2F97B3B900B5F0CA /* CarouselTabSwitchTests.swift */; };
 		C074AAE036B449898E1FEF58 /* CustomPaywallVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B46553B99148F3A60B8BFB /* CustomPaywallVariables.swift */; };
 		D0DA209A2F23BBEC00BA3B77 /* AdEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DA20992F23BBEC00BA3B77 /* AdEventTests.swift */; };
 		DB36994E2F435CDC00B1F049 /* PriceFormatterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */; };
@@ -2868,6 +2869,7 @@
 		B3E26A4926BE0A8E003ACCF3 /* Error+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Extensions.swift"; sourceTree = "<group>"; };
 		B3F3E8D9277158FE0047A5B9 /* DNSChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNSChecker.swift; sourceTree = "<group>"; };
 		B3F8418E26F3A93400E560FB /* ErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorCodeTests.swift; sourceTree = "<group>"; };
+		B413E59F2F97B3B900B5F0CA /* CarouselTabSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselTabSwitchTests.swift; sourceTree = "<group>"; };
 		CC1A2B3C2E1234AB00AABBCC /* CustomVariablesEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariablesEditorView.swift; sourceTree = "<group>"; };
 		D0DA20992F23BBEC00BA3B77 /* AdEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdEventTests.swift; sourceTree = "<group>"; };
 		DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatterExtensions.swift; sourceTree = "<group>"; };
@@ -3126,6 +3128,7 @@
 				75909EAA2E74286E009ABBA7 /* UIConfigProviderTests.swift */,
 				077AC81FEBE38D1468AE8670 /* VideoAutoplayHandlerTests.swift */,
 				B29E428C04E073334CD13B58 /* CarouselStateTests.swift */,
+				B413E59F2F97B3B900B5F0CA /* CarouselTabSwitchTests.swift */,
 			);
 			path = PaywallsV2;
 			sourceTree = "<group>";
@@ -8187,6 +8190,7 @@
 				887A63432C1D177800E1A461 /* LocalizationTests.swift in Sources */,
 				030890842D2B77E70069677B /* VariableHandlerV2Tests.swift in Sources */,
 				FACD00022F61A1230073D2DE /* TextComponentLocalizationTests.swift in Sources */,
+				B413E5A02F97B3B900B5F0CA /* CarouselTabSwitchTests.swift in Sources */,
 				FACD00042F61A1230073D2DE /* ViewModelFactoryBadgeTests.swift in Sources */,
 				FB5A72022F65F5B9005C64A1 /* ViewModelFactoryTests.swift in Sources */,
 				FACD00082F61A1230073D2DE /* PackageComponentViewTests.swift in Sources */,

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -98,6 +98,9 @@ struct CarouselComponentView: View {
                 .onPreferenceChange(HeightPreferenceKey.self) { newHeight in
                     self.carouselHeight = newHeight
                 }
+                .onAppear {
+                    self.viewModel.onViewAppear?()
+                }
                 // Style the carousel
                 .size(style.size)
                 .padding(style.padding.extend(by: style.border?.width ?? 0))

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -98,11 +98,12 @@ struct CarouselComponentView: View {
                 .onPreferenceChange(HeightPreferenceKey.self) { newHeight in
                     self.carouselHeight = newHeight
                 }
+                #if DEBUG
+                // Hook for running tests
                 .onAppear {
-                    #if DEBUG
                     self.viewModel.onViewAppear?()
-                    #endif
                 }
+                #endif
                 // Style the carousel
                 .size(style.size)
                 .padding(style.padding.extend(by: style.border?.width ?? 0))

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -99,11 +99,14 @@ struct CarouselComponentView: View {
                     self.carouselHeight = newHeight
                 }
                 #if DEBUG
-                // Hook for running tests
                 .onAppear {
                     self.viewModel.onViewAppear?()
                 }
                 #endif
+                // Recreate CarouselView (resetting its @State) when the ViewModel instance changes,
+                // e.g. on a tab switch. Scoped here so only the carousel is torn down, not the
+                // entire tab subtree.
+                .id(ObjectIdentifier(self.viewModel))
                 // Style the carousel
                 .size(style.size)
                 .padding(style.padding.extend(by: style.border?.width ?? 0))

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -99,7 +99,9 @@ struct CarouselComponentView: View {
                     self.carouselHeight = newHeight
                 }
                 .onAppear {
+                    #if DEBUG
                     self.viewModel.onViewAppear?()
+                    #endif
                 }
                 // Style the carousel
                 .size(style.size)

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
@@ -56,6 +56,10 @@ class CarouselComponentViewModel {
         return self.pageContextNames[index]
     }
 
+    /// Invoked each time the carousel's `onAppear` fires. Set in tests to detect that the
+    /// carousel view was recreated (and its `@State` reset) after a tab switch.
+    var onViewAppear: (() -> Void)?
+
     @ViewBuilder
     // swiftlint:disable:next function_parameter_count
     func styles(

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
@@ -58,7 +58,9 @@ class CarouselComponentViewModel {
 
     /// Invoked each time the carousel's `onAppear` fires. Set in tests to detect that the
     /// carousel view was recreated (and its `@State` reset) after a tab switch.
+    #if DEBUG
     var onViewAppear: (() -> Void)?
+    #endif
 
     @ViewBuilder
     // swiftlint:disable:next function_parameter_count

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
@@ -249,7 +249,6 @@ struct LoadedTabsComponentView: View {
                 },
                 onDismiss: self.onDismiss
             )
-            .id(self.tabControlContext.selectedTabId)
             .environmentObject(self.tabControlContext)
             .environmentObject(tierPackageContext)
             .environment(\.planSelectionDefaultPackage, activeTabViewModel.defaultSelectedPackage)

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
@@ -160,13 +160,16 @@ struct LoadedTabsComponentView: View {
         }
     }
 
+    /// `tabControlContext` is nil in production (the view owns its context); tests may pass
+    /// an external instance to drive tab switches programmatically without UI interaction.
     init(viewModel: TabsComponentViewModel,
          parentPackageContext: PackageContext,
-         onDismiss: @escaping () -> Void) {
+         onDismiss: @escaping () -> Void,
+         tabControlContext: TabControlContext? = nil) {
         self.viewModel = viewModel
         self.onDismiss = onDismiss
 
-        self._tabControlContext = .init(wrappedValue: TabControlContext(
+        self._tabControlContext = .init(wrappedValue: tabControlContext ?? TabControlContext(
             controlStackViewModel: viewModel.controlStackViewModel,
             tabIds: viewModel.tabIds,
             defaultTabId: viewModel.defaultTabId,
@@ -246,6 +249,7 @@ struct LoadedTabsComponentView: View {
                 },
                 onDismiss: self.onDismiss
             )
+            .id(self.tabControlContext.selectedTabId)
             .environmentObject(self.tabControlContext)
             .environmentObject(tierPackageContext)
             .environment(\.planSelectionDefaultPackage, activeTabViewModel.defaultSelectedPackage)

--- a/Tests/RevenueCatUITests/PaywallsV2/CarouselTabSwitchTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/CarouselTabSwitchTests.swift
@@ -165,7 +165,8 @@ private extension CarouselTabSwitchTests {
         let tabControlContext = TabControlContext(
             controlStackViewModel: tabsViewModel.controlStackViewModel,
             tabIds: tabsViewModel.tabIds,
-            defaultTabId: tabsViewModel.defaultTabId
+            defaultTabId: tabsViewModel.defaultTabId,
+            name: nil
         )
 
         return (tabsViewModel, tab2CarouselVM, tabControlContext)

--- a/Tests/RevenueCatUITests/PaywallsV2/CarouselTabSwitchTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/CarouselTabSwitchTests.swift
@@ -1,0 +1,223 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CarouselTabSwitchTests.swift
+//
+//  Created by RevenueCat on 4/16/26.
+
+@_spi(Internal) import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if os(iOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class CarouselTabSwitchTests: TestCase {
+
+    /// Regression test for a bug in `TabsComponentView.swift` where `LoadedTabComponentView`
+    /// was rendered without an `.id()` modifier keyed on the selected tab ID.
+    ///
+    /// Without `.id()`, SwiftUI preserved `CarouselView`'s `@State` (including `data` and `index`)
+    /// when switching between tabs, so the carousel continued to display the previous tab's content.
+    /// Only a manual swipe inside the carousel would update the stale `@State`.
+    ///
+    /// Fix: `.id(tabControlContext.selectedTabId)` was added to `LoadedTabComponentView` in
+    /// `LoadedTabsComponentView.body` (`TabsComponentView.swift`). This forces SwiftUI to
+    /// recreate `CarouselView` on each tab switch, triggering `onAppear` and `setupData()`.
+    ///
+    /// The test verifies the fix by counting how many times the Tab 2 carousel's `onAppear`
+    /// fires. With the fix the carousel is destroyed and recreated on tab switch → count = 1.
+    /// Without the fix the carousel instance is reused → count = 0.
+    func testCarouselAppearsAfterTabSwitch() throws {
+        let (viewModel, tab2CarouselVM, tabControlContext) = try Self.makeViewModelAndContext()
+
+        var tab2CarouselAppearCount = 0
+        tab2CarouselVM.onViewAppear = { tab2CarouselAppearCount += 1 }
+
+        let packageContext = PackageContext(package: nil, variableContext: .init(packages: []))
+        let view = LoadedTabsComponentView(
+            viewModel: viewModel,
+            parentPackageContext: packageContext,
+            onDismiss: {},
+            tabControlContext: tabControlContext
+        )
+        .environmentObject(packageContext)
+        .environmentObject(IntroOfferEligibilityContext(
+            introEligibilityChecker: BaseSnapshotTest.eligibleChecker
+        ))
+        .environmentObject(PaywallPromoOfferCache(
+            subscriptionHistoryTracker: SubscriptionHistoryTracker()
+        ))
+        .environment(\.screenCondition, .compact)
+        .environment(\.componentViewState, .default)
+        .environment(\.safeAreaInsets, EdgeInsets())
+        .environment(\.selectedPackageId, nil)
+        .frame(width: 400, height: 600)
+
+        let (window, _) = Self.host(view)
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+
+        // Tab 2 has not been shown yet — its carousel should not have appeared
+        XCTAssertEqual(tab2CarouselAppearCount, 0, "Tab 2 carousel must not appear before switching to Tab 2")
+
+        // Switch to Tab 2 programmatically
+        tabControlContext.selectedTabId = "tab2"
+
+        RunLoop.main.run(until: Date().addingTimeInterval(0.3))
+        window.rootViewController?.view.setNeedsLayout()
+        window.rootViewController?.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        // After switching tabs the Tab 2 carousel must have appeared exactly once.
+        //
+        // BUG (now fixed): without `.id(tabControlContext.selectedTabId)` on
+        // `LoadedTabComponentView`, SwiftUI reuses the existing view — `onAppear`
+        // never fires for the Tab 2 carousel, `setupData()` is never called, and
+        // the carousel keeps showing Tab 1's stale `@State`. Count stays at 0.
+        //
+        // FIX: `.id(tabControlContext.selectedTabId)` forces SwiftUI to destroy and
+        // recreate `LoadedTabComponentView` on every tab switch. The new carousel's
+        // `onAppear` fires and `setupData()` runs with Tab 2's pages. Count becomes 1.
+        XCTAssertEqual(
+            tab2CarouselAppearCount,
+            1,
+            "Tab 2 carousel must appear exactly once after switching to Tab 2"
+        )
+    }
+
+}
+
+// MARK: - Helpers
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension CarouselTabSwitchTests {
+
+    /// Returns the tabs view model, the Tab 2 carousel view model (so the test can set its
+    /// `onViewAppear` callback), and the injected `TabControlContext`.
+    static func makeViewModelAndContext() throws -> (
+        TabsComponentViewModel,
+        CarouselComponentViewModel,
+        TabControlContext
+    ) {
+        let uiConfigProvider = UIConfigProvider(uiConfig: PreviewUIConfig.make())
+        let localization = LocalizationProvider(locale: Locale(identifier: "en_US"), localizedStrings: [:])
+        let factory = ViewModelFactory()
+        let offering = Offering(
+            identifier: "test",
+            serverDescription: "",
+            availablePackages: [],
+            webCheckoutUrl: nil
+        )
+
+        let tab1Id = "tab1"
+        let tab2Id = "tab2"
+
+        let tabsComponent = PaywallComponent.TabsComponent(
+            control: .init(
+                type: .buttons,
+                stack: PaywallComponent.StackComponent(components: [
+                    .tabControlButton(PaywallComponent.TabControlButtonComponent(
+                        tabId: tab1Id,
+                        stack: makeTextStack(text: "Monthly")
+                    )),
+                    .tabControlButton(PaywallComponent.TabControlButtonComponent(
+                        tabId: tab2Id,
+                        stack: makeTextStack(text: "Annual")
+                    ))
+                ])
+            ),
+            tabs: [
+                .init(id: tab1Id, stack: makeStackWithCarousel()),
+                .init(id: tab2Id, stack: makeStackWithCarousel())
+            ],
+            defaultTabId: tab1Id
+        )
+
+        guard case .tabs(let tabsViewModel) = try factory.toViewModel(
+            component: .tabs(tabsComponent),
+            packageValidator: factory.packageValidator,
+            offering: offering,
+            localizationProvider: localization,
+            uiConfigProvider: uiConfigProvider,
+            colorScheme: .light
+        ) else {
+            XCTFail("Expected a .tabs PaywallComponentViewModel")
+            throw XCTSkip("Test setup failed")
+        }
+
+        // Dig out the Tab 2 CarouselComponentViewModel so we can set the onViewAppear hook
+        let tab2CarouselVM = try XCTUnwrap(
+            tab2CarouselViewModel(from: tabsViewModel, tabId: tab2Id),
+            "Expected to find a CarouselComponentViewModel in Tab 2"
+        )
+
+        let tabControlContext = TabControlContext(
+            controlStackViewModel: tabsViewModel.controlStackViewModel,
+            tabIds: tabsViewModel.tabIds,
+            defaultTabId: tabsViewModel.defaultTabId
+        )
+
+        return (tabsViewModel, tab2CarouselVM, tabControlContext)
+    }
+
+    /// Walks the view model tree under the given tab to find its `CarouselComponentViewModel`.
+    static func tab2CarouselViewModel(
+        from tabsVM: TabsComponentViewModel,
+        tabId: String
+    ) -> CarouselComponentViewModel? {
+        guard let tabViewModel = tabsVM.tabViewModels[tabId] else { return nil }
+        return carouselViewModel(in: tabViewModel.stackViewModel)
+    }
+
+    static func carouselViewModel(in stackVM: StackComponentViewModel) -> CarouselComponentViewModel? {
+        for childVM in stackVM.viewModels {
+            switch childVM {
+            case .carousel(let viewModel): return viewModel
+            case .stack(let nested): if let found = carouselViewModel(in: nested) { return found }
+            default: break
+            }
+        }
+        return nil
+    }
+
+    static func makeStackWithCarousel() -> PaywallComponent.StackComponent {
+        PaywallComponent.StackComponent(
+            components: [.carousel(PaywallComponent.CarouselComponent(
+                pages: [makeTextStack(text: "page")]
+            ))]
+        )
+    }
+
+    static func makeTextStack(text: String) -> PaywallComponent.StackComponent {
+        PaywallComponent.StackComponent(
+            components: [.text(PaywallComponent.TextComponent(
+                text: text,
+                color: .init(light: .hex("#000000"))
+            ))]
+        )
+    }
+
+    static func host<Content: View>(_ view: Content) -> (UIWindow, UIView) {
+        let controller = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(origin: .zero, size: CGSize(width: 400, height: 600)))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.2))
+        return (window, controller.view)
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/CarouselTabSwitchTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/CarouselTabSwitchTests.swift
@@ -22,16 +22,19 @@ import XCTest
 @MainActor
 final class CarouselTabSwitchTests: TestCase {
 
-    /// Regression test for a bug in `TabsComponentView.swift` where `LoadedTabComponentView`
-    /// was rendered without an `.id()` modifier keyed on the selected tab ID.
-    ///
-    /// Without `.id()`, SwiftUI preserved `CarouselView`'s `@State` (including `data` and `index`)
-    /// when switching between tabs, so the carousel continued to display the previous tab's content.
+    /// Regression test for a bug where `CarouselView`'s `@State` (`data`, `index`) was not
+    /// reset when switching tabs, so the carousel continued to display the previous tab's content.
     /// Only a manual swipe inside the carousel would update the stale `@State`.
     ///
-    /// Fix: `.id(tabControlContext.selectedTabId)` was added to `LoadedTabComponentView` in
-    /// `LoadedTabsComponentView.body` (`TabsComponentView.swift`). This forces SwiftUI to
-    /// recreate `CarouselView` on each tab switch, triggering `onAppear` and `setupData()`.
+    /// Root cause: `CarouselView` initialises its page data in `onAppear` via `setupData()`.
+    /// Without a view-identity change, SwiftUI reuses the same `CarouselView` instance across
+    /// tab switches and `onAppear` never re-fires.
+    ///
+    /// Fix: `.id(ObjectIdentifier(viewModel))` is applied to the `GeometryReader`/`CarouselView`
+    /// block inside `CarouselComponentView`. When the tab switches, `CarouselComponentView`
+    /// receives a new `CarouselComponentViewModel` instance, the ID changes, SwiftUI recreates
+    /// only `CarouselView` (not the entire tab subtree), and `onAppear`/`setupData()` run with
+    /// the new tab's pages.
     ///
     /// The test verifies the fix by counting how many times the Tab 2 carousel's `onAppear`
     /// fires. With the fix the carousel is destroyed and recreated on tab switch → count = 1.
@@ -81,13 +84,12 @@ final class CarouselTabSwitchTests: TestCase {
 
         // After switching tabs the Tab 2 carousel must have appeared exactly once.
         //
-        // BUG (now fixed): without `.id(tabControlContext.selectedTabId)` on
-        // `LoadedTabComponentView`, SwiftUI reuses the existing view — `onAppear`
-        // never fires for the Tab 2 carousel, `setupData()` is never called, and
-        // the carousel keeps showing Tab 1's stale `@State`. Count stays at 0.
+        // BUG (now fixed): SwiftUI reused `CarouselView` across tab switches — `onAppear`
+        // never fired for Tab 2's carousel, `setupData()` was never called, and the carousel
+        // kept showing Tab 1's stale `@State`. Count stayed at 0.
         //
-        // FIX: `.id(tabControlContext.selectedTabId)` forces SwiftUI to destroy and
-        // recreate `LoadedTabComponentView` on every tab switch. The new carousel's
+        // FIX: `.id(ObjectIdentifier(viewModel))` in `CarouselComponentView` forces SwiftUI
+        // to recreate only `CarouselView` when the ViewModel instance changes on tab switch.
         // `onAppear` fires and `setupData()` runs with Tab 2's pages. Count becomes 1.
         XCTAssertEqual(
             tab2CarouselAppearCount,


### PR DESCRIPTION
### Checklist
- [X] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids - n/a, this is a bug in the iOS implementation

### Motivation
Resolves PWENG-31

Carousel content in a tabbed paywall was not updating when switching tabs. The carousel kept showing the previous tab's pages and only updated after a manual swipe. Root cause: without a `.id()` modifier, SwiftUI reused the same `CarouselView` instance across tab switches, preserving its `@State` (`data`, `index`, `isInitialized`) from the previous tab. Because `setupData()` runs only in `onAppear`, and `onAppear` doesn't fire on a reused view, the carousel never loaded the new tab's pages.

### Description
- Added `.id(tabControlContext.selectedTabId)` to `LoadedTabComponentView` in `LoadedTabsComponentView.body` — this forces SwiftUI to destroy and recreate the tab content view (including `CarouselView` and its `@State`) on every tab switch, so onAppear fires and `setupData()` runs with the new tab's pages.
- Added `tabControlContext: TabControlContext? = nil` optional parameter to `LoadedTabsComponentView.init` as a test seam. Production callers are unaffected (default `nil` creates the context internally as before), tests inject an external `TabControlContext` to drive tab switches programmatically.
- Added var `onViewAppear: (() -> Void)?` to `CarouselComponentViewModel` and wired it via `.onAppear` in `CarouselComponentView` — a nil-by-default hook that fires each time the carousel appears, letting tests verify view recreation without depending on UIKit text rendering.
- Added `CarouselTabSwitchTests.testCarouselAppearsAfterTabSwitch` — injects a `TabControlContext`, switches to Tab 2 programmatically, and asserts the Tab 2 carousel's `onAppear` fires exactly once (would stay at 0 without the `.id()` fix).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SwiftUI view identity/lifecycle for the carousel on tab switches, which can subtly affect UI state, animations, and performance; behavior is covered by a new regression test.
> 
> **Overview**
> Fixes a tabbed-paywall bug where the carousel could keep showing the previous tab’s pages by **forcing the carousel subtree to be recreated** when its `CarouselComponentViewModel` instance changes (via `.id(ObjectIdentifier(viewModel))`).
> 
> Adds a small DEBUG-only test seam (`CarouselComponentViewModel.onViewAppear`) and allows injecting a `TabControlContext` into `LoadedTabsComponentView` so a new `CarouselTabSwitchTests` regression test can programmatically switch tabs and assert the carousel re-appears after the switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8da09a69170c705a4158a809a8fa9c0c287921ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->