### PR TITLE
Replace fatalError with assertionFailure + throw for fallbackHeader

### DIFF
--- a/RevenueCatUI/Data/Errors/TemplateError.swift
+++ b/RevenueCatUI/Data/Errors/TemplateError.swift
@@ -35,6 +35,9 @@ enum TemplateError: Error {
     /// No packages from the `PackageType` list could be found.
     case couldNotFindAnyPackages(expectedTypes: [String])
 
+    /// A component that should have been filtered out reached view model creation.
+    case unexpectedComponent
+
 }
 
 extension TemplateError: CustomNSError {
@@ -64,6 +67,9 @@ extension TemplateError: CustomNSError {
 
         case let .couldNotFindAnyPackages(expectedTypes):
             return "Couldn't find any requested packages: \(expectedTypes)"
+
+        case .unexpectedComponent:
+            return "A component that should have been filtered reached view model creation."
         }
     }
 

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -513,7 +513,8 @@ struct ViewModelFactory {
             )
         case .fallbackHeader:
             // fallbackHeader is filtered out in toStackViewModel and should never reach here.
-            fatalError("fallbackHeader should have been filtered before view model creation")
+            assertionFailure("fallbackHeader should have been filtered before view model creation")
+            throw TemplateError.unexpectedComponent
         }
     }
 


### PR DESCRIPTION
## Summary

- Replaces `fatalError` in the `.fallbackHeader` case of `ViewModelFactory.toViewModel` with `assertionFailure` + `throw TemplateError.unexpectedComponent`
- Adds `TemplateError.unexpectedComponent` for components that bypass the expected filter

## Motivation

`fatalError` crashes production apps unconditionally. Since `toViewModel` is already a `throws` function, the appropriate pattern is:
- `assertionFailure` — catches the invariant violation in debug builds and CI
- `throw TemplateError.unexpectedComponent` — allows the paywall to fail gracefully in release builds instead of crashing

## Coverage note

The throw path itself can't be unit tested directly — `assertionFailure` would terminate the test process in debug builds before the `throw` is reached. The two existing tests in `ViewModelFactoryTests` (`testFallbackHeaderIsFilteredOutFromStackViewModels`, `testFallbackHeaderIsSkippedWhenDetectingFirstFullWidthImage`) cover the primary defense (the filter in `toStackViewModel`). This case is intentionally unreachable in normal operation.

> **Note:** This should be merged after #6609, which introduces the `.fallbackHeader` component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes error handling from `fatalError` to `assertionFailure` + `throw`, affecting an invariant/edge case rather than normal rendering paths.
> 
> **Overview**
> Prevents production crashes when a `.fallbackHeader` component accidentally reaches `ViewModelFactory.toViewModel` by replacing `fatalError` with `assertionFailure` and a thrown `TemplateError`.
> 
> Adds `TemplateError.unexpectedComponent` to represent components that should have been filtered out before view model creation, enabling graceful failure instead of a hard termination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c11265078312af145b794a6956b8c8a0e3d48c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->