### PR TITLE
Refactor API key plumbing to use SystemInfo

### DIFF
--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -28,7 +28,6 @@ class Backend {
     private let config: BackendConfiguration
 
     convenience init(
-        apiKey: String,
         systemInfo: SystemInfo,
         httpClientTimeout: TimeInterval = Configuration.networkTimeoutDefault,
         eTagManager: ETagManager,
@@ -38,10 +37,9 @@ class Backend {
         diagnosticsTracker: DiagnosticsTrackerType?,
         dateProvider: DateProvider = DateProvider()
     ) {
-        let httpClient = HTTPClient(apiKey: apiKey,
-                                    systemInfo: systemInfo,
+        let httpClient = HTTPClient(systemInfo: systemInfo,
                                     eTagManager: eTagManager,
-                                    signing: Signing(apiKey: apiKey, clock: systemInfo.clock),
+                                    signing: Signing(apiKey: systemInfo.apiKey, clock: systemInfo.clock),
                                     diagnosticsTracker: diagnosticsTracker,
                                     requestTimeout: httpClientTimeout,
                                     operationDispatcher: OperationDispatcher.default)

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -23,7 +23,6 @@ class HTTPClient {
 
     let systemInfo: SystemInfo
     let timeout: TimeInterval
-    let apiKey: String
     let authHeaders: RequestHeaders
 
     private let session: URLSession
@@ -43,8 +42,7 @@ class HTTPClient {
         TimeInterval(3)
     ]
 
-    init(apiKey: String,
-         systemInfo: SystemInfo,
+    init(systemInfo: SystemInfo,
          eTagManager: ETagManager,
          signing: SigningType,
          diagnosticsTracker: DiagnosticsTrackerType?,
@@ -70,8 +68,7 @@ class HTTPClient {
         self.dnsChecker = dnsChecker
         self.retriableStatusCodes = retriableStatusCodes
         self.timeout = requestTimeout
-        self.apiKey = apiKey
-        self.authHeaders = HTTPClient.authorizationHeader(withAPIKey: apiKey)
+        self.authHeaders = HTTPClient.authorizationHeader(withAPIKey: systemInfo.apiKey)
         self.dateProvider = dateProvider
         self.operationDispatcher = operationDispatcher
         self.requestTimeoutManager = timeoutManager ?? HTTPRequestTimeoutManager(

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -391,7 +391,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let transactionFetcher = StoreKit2TransactionFetcher(diagnosticsTracker: diagnosticsTracker)
 
         let backend = Backend(
-            apiKey: apiKey,
             systemInfo: systemInfo,
             httpClientTimeout: networkTimeout,
             eTagManager: eTagManager,

--- a/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
+++ b/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
@@ -17,13 +17,11 @@ class MockBackendConfiguration: BackendConfiguration {
 
     init() {
         let systemInfo = MockSystemInfo(finishTransactions: false)
-        let mockAPIKey = "mockAPIKey"
         var diagnosticsTracker: DiagnosticsTrackerType?
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
             diagnosticsTracker = MockDiagnosticsTracker()
         }
-        let httpClient = MockHTTPClient(apiKey: mockAPIKey,
-                                        systemInfo: systemInfo,
+        let httpClient = MockHTTPClient(systemInfo: systemInfo,
                                         eTagManager: MockETagManager(),
                                         diagnosticsTracker: diagnosticsTracker,
                                         requestTimeout: 7)

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -59,8 +59,7 @@ class MockHTTPClient: HTTPClient {
     var calls: [Call] = []
     private var shouldAssertSnapshot: Bool = true
 
-    init(apiKey: String,
-         systemInfo: SystemInfo,
+    init(systemInfo: SystemInfo,
          eTagManager: ETagManager,
          diagnosticsTracker: DiagnosticsTrackerType?,
          dnsChecker: DNSCheckerType.Type = DNSChecker.self,
@@ -68,8 +67,7 @@ class MockHTTPClient: HTTPClient {
          sourceTestFile: StaticString = #file) {
         self.sourceTestFile = sourceTestFile
 
-        super.init(apiKey: apiKey,
-                   systemInfo: systemInfo,
+        super.init(systemInfo: systemInfo,
                    eTagManager: eTagManager,
                    signing: FakeSigning.default,
                    diagnosticsTracker: diagnosticsTracker,

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -132,8 +132,7 @@ extension BaseBackendTests {
             self.diagnosticsTracker = nil
         }
 
-        return MockHTTPClient(apiKey: Self.apiKey,
-                              systemInfo: self.systemInfo,
+        return MockHTTPClient(systemInfo: self.systemInfo,
                               eTagManager: eTagManager,
                               diagnosticsTracker: self.diagnosticsTracker,
                               sourceTestFile: file)

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -60,7 +60,7 @@ class BaseBackendTests: TestCase {
             finishTransactions: true,
             storefrontProvider: MockStorefrontProvider(),
             storeKitVersion: storeKitVersion,
-            apiKey: "api_key",
+            apiKey: Self.apiKey,
             responseVerificationMode: self.responseVerificationMode,
             dangerousSettings: dangerousSettings,
             isAppBackgrounded: false,

--- a/Tests/UnitTests/Networking/Backend/PostReceiptDataOperationFactoryTests.swift
+++ b/Tests/UnitTests/Networking/Backend/PostReceiptDataOperationFactoryTests.swift
@@ -29,7 +29,7 @@ class PostReceiptDataOperationFactoryTests: TestCase {
             finishTransactions: true,
             storefrontProvider: MockStorefrontProvider(),
             storeKitVersion: .default,
-            apiKey: "api_key",
+            apiKey: "test_key",
             responseVerificationMode: .disabled,
             isAppBackgrounded: false,
             preferredLocalesProvider: .mock()

--- a/Tests/UnitTests/Networking/Backend/PostReceiptDataOperationFactoryTests.swift
+++ b/Tests/UnitTests/Networking/Backend/PostReceiptDataOperationFactoryTests.swift
@@ -35,7 +35,6 @@ class PostReceiptDataOperationFactoryTests: TestCase {
             preferredLocalesProvider: .mock()
         )
         let httpClient = MockHTTPClient(
-            apiKey: "test_key",
             systemInfo: systemInfo,
             eTagManager: MockETagManager(),
             diagnosticsTracker: nil

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -75,8 +75,7 @@ class BaseHTTPClientTests<ETag: ETagManager, TimeoutManager: HTTPRequestTimeoutM
         _ systemInfo: SystemInfo,
         operationDispatcher: OperationDispatcher = MockOperationDispatcher()
     ) -> HTTPClient {
-        return HTTPClient(apiKey: self.apiKey,
-                          systemInfo: systemInfo,
+        return HTTPClient(systemInfo: systemInfo,
                           eTagManager: self.eTagManager,
                           signing: self.signing,
                           diagnosticsTracker: self.diagnosticsTracker,

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -35,8 +35,6 @@ class BaseHTTPClientTests<ETag: ETagManager, TimeoutManager: HTTPRequestTimeoutM
     // Something very specific on purpose to make sure we can differentiate it in tests from adjusted timeouts
     let defaultRequestTimeout: TimeInterval = 3.21
 
-    fileprivate let apiKey = "MockAPIKey"
-
     override func setUpWithError() throws {
         try super.setUpWithError()
 

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -74,9 +74,7 @@ class BasePurchasesTests: TestCase {
         self.mockPurchasedProductsFetcher = MockPurchasedProductsFetcher()
         self.mockTransactionFetcher = MockStoreKit2TransactionFetcher()
 
-        let apiKey = "mockAPIKey"
-        let httpClient = MockHTTPClient(apiKey: apiKey,
-                                        systemInfo: self.systemInfo,
+        let httpClient = MockHTTPClient(systemInfo: self.systemInfo,
                                         eTagManager: MockETagManager(),
                                         diagnosticsTracker: self.diagnosticsTracker)
         let config = BackendConfiguration(httpClient: httpClient,

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -650,8 +650,7 @@ class BackendSubscriberAttributesTests: TestCase {
             self.mockDiagnosticsTracker = MockDiagnosticsTracker()
         }
 
-        return MockHTTPClient(apiKey: Self.apiKey,
-                              systemInfo: self.systemInfo,
+        return MockHTTPClient(systemInfo: self.systemInfo,
                               eTagManager: self.mockETagManager,
                               diagnosticsTracker: self.mockDiagnosticsTracker,
                               sourceTestFile: file)

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -53,7 +53,7 @@ class BackendSubscriberAttributesTests: TestCase {
         finishTransactions: true,
         storefrontProvider: MockStorefrontProvider(),
         storeKitVersion: .versionForTests,
-        apiKey: "api_key",
+        apiKey: BackendSubscriberAttributesTests.apiKey,
         responseVerificationMode: .disabled,
         isAppBackgrounded: false,
         preferredLocalesProvider: .mock(locales: ["en-US"])


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Follow up on review feedback from PR1 to remove redundant API key parameter plumbing in networking constructors.

### Description
This refactor makes `HTTPClient` derive auth headers from `SystemInfo.apiKey` directly and removes duplicated `apiKey` constructor parameters where they were only forwarded.

Changes included:
- Remove `apiKey` parameter/property from `HTTPClient`
- Remove `apiKey` parameter from `Backend` convenience init
- Use `systemInfo.apiKey` for `Signing` construction in `Backend`
- Update `Purchases` and affected test/mocks call sites

Additional test-only fixes stacked with the refactor:
- Keep HTTP request snapshots stable by aligning `SystemInfo.apiKey` with each fixture where tests record request metadata (e.g. backend base tests, subscriber-attributes tests, post-receipt factory tests).
- Fix `PostReceiptDataOperationFactoryTests` for the updated `MockHTTPClient` initializer (no separate `apiKey` argument).
- Remove unused `MockAPIKey` / `fileprivate let apiKey` field from `BaseHTTPClientTests` in `HTTPClientTests.swift` now that auth uses `systemInfo.apiKey`.

#### How tested
- `swift build`
- `swiftlint`
- `xcodebuild test -workspace RevenueCat.xcworkspace -scheme RevenueCat -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' -testPlan RevenueCat` with targeted `UnitTests` cases (including backend snapshot–related suites and a compile smoke test)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how authentication headers and request signing obtain the API key, which could break all backend requests if `SystemInfo.apiKey` is incorrect or unset.
> 
> **Overview**
> Refactors API key plumbing so networking no longer passes an `apiKey` through constructors: `HTTPClient` now derives `Authorization` headers from `systemInfo.apiKey`, and `Backend` builds `Signing` with `systemInfo.apiKey`.
> 
> Updates `Purchases`, mocks, and unit tests to match the new initializers, removing redundant `apiKey` parameters and adjusting test `SystemInfo` setup accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be5f20bf8bd51cb324c76ff06d17585299e2705d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
