### PR TITLE
Fall back to getCustomerInfo when posting unfinished receipt fails

### DIFF
--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -415,6 +415,7 @@ private extension CustomerInfoManager {
 
     }
 
+    // swiftlint:disable:next function_body_length
     private func getCustomerInfoData(appUserID: String,
                                      isAppBackgrounded: Bool,
                                      completion: @escaping @Sendable (CustomerInfoDataResult) -> Void) {

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -459,7 +459,16 @@ private extension CustomerInfoManager {
                         postReceiptSource: Self.sourceForUnfinishedTransaction,
                         currentUserID: appUserID
                     )
-                    completion(CustomerInfoDataResult(result: result, hadUnsyncedPurchasesBefore: true))
+                    switch result {
+                    case .success:
+                        completion(CustomerInfoDataResult(result: result, hadUnsyncedPurchasesBefore: true))
+                    case .failure:
+                        self.requestCustomerInfo(appUserID: appUserID,
+                                                 isAppBackgrounded: isAppBackgrounded) { fallbackResult in
+                            completion(CustomerInfoDataResult(result: fallbackResult,
+                                                              hadUnsyncedPurchasesBefore: true))
+                        }
+                    }
                 } else {
                     self.requestCustomerInfo(appUserID: appUserID,
                                              isAppBackgrounded: isAppBackgrounded) { result in

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -463,7 +463,14 @@ private extension CustomerInfoManager {
                     switch result {
                     case .success:
                         completion(CustomerInfoDataResult(result: result, hadUnsyncedPurchasesBefore: true))
-                    case .failure:
+                    case .failure(let error):
+                        // If posting the unfinished transaction fails, fall back to fetching
+                        // CustomerInfo directly so observers are still notified instead of
+                        // being silently skipped.
+                        Logger.warn(
+                            // swiftlint:disable:next line_length
+                            Strings.customerInfo.posting_receipt_for_unfinished_transaction_failed_falling_back_to_get_customerinfo(error)
+                        )
                         self.requestCustomerInfo(appUserID: appUserID,
                                                  isAppBackgrounded: isAppBackgrounded) { fallbackResult in
                             completion(CustomerInfoDataResult(result: fallbackResult,

--- a/Sources/Logging/Strings/CustomerInfoStrings.swift
+++ b/Sources/Logging/Strings/CustomerInfoStrings.swift
@@ -31,6 +31,7 @@ enum CustomerInfoStrings {
     case customerinfo_updated_from_network_error(BackendError)
     case customerinfo_updated_offline
     case posting_transactions_in_lieu_of_fetching_customerinfo([StoreTransaction])
+    case posting_receipt_for_unfinished_transaction_failed_falling_back_to_get_customerinfo(BackendError)
     case updating_request_date(CustomerInfo, Date)
     case sending_latest_customerinfo_to_delegate
     case sending_updated_customerinfo_to_delegate
@@ -79,6 +80,9 @@ extension CustomerInfoStrings: LogMessage {
         case let .posting_transactions_in_lieu_of_fetching_customerinfo(transactions):
             return "Found \(transactions.count) unfinished transactions, will post receipt in lieu " +
             "of fetching CustomerInfo:\n\(transactions)"
+        case let .posting_receipt_for_unfinished_transaction_failed_falling_back_to_get_customerinfo(error):
+            return "Posting receipt for unfinished transaction failed " +
+            "(\(error.localizedDescription)); falling back to fetching CustomerInfo."
         case let .updating_request_date(info, newRequestDate):
             return "Updating CustomerInfo '\(info.originalAppUserId)' request date: \(newRequestDate)"
         case .sending_latest_customerinfo_to_delegate:

--- a/Tests/UnitTests/Identity/CustomerInfoManagerPostReceiptTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerPostReceiptTests.swift
@@ -75,6 +75,37 @@ class CustomerInfoManagerPostReceiptTests: BaseCustomerInfoManagerTests {
         expect(self.mockBackend.invokedGetSubscriberData) == true
     }
 
+    func testFallsBackToGetCustomerInfoWhenFirstOfMultipleUnfinishedTransactionPostsFails() async throws {
+        let transactions = [
+            Self.createTransaction(),
+            Self.createTransaction(),
+            Self.createTransaction()
+        ]
+
+        self.mockTransationFetcher.stubbedUnfinishedTransactions = transactions
+        // First transaction (posted synchronously, its result drives the caller's result) fails.
+        // The other two (posted in a `Task.detached`, fire-and-forget) succeed.
+        self.mockTransactionPoster.stubbedHandlePurchasedTransactionResults.value = [
+            .failure(.networkError(.serverDown())),
+            .success(self.mockCustomerInfo),
+            .success(self.mockCustomerInfo)
+        ]
+        self.mockBackend.stubbedGetCustomerInfoResult = .success(self.mockCustomerInfo)
+
+        let info = try await self.customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.userID,
+                                                                                isAppBackgrounded: false)
+        expect(info) === self.mockCustomerInfo
+
+        expect(self.mockTransactionPoster.invokedHandlePurchasedTransaction.value) == true
+        expect(self.mockBackend.invokedGetSubscriberData) == true
+
+        try await asyncWait(
+            description: "All unfinished transactions should be posted, including the two in the background"
+        ) { [poster = self.mockTransactionPoster!] in
+            poster.allHandledTransactions == Set(transactions)
+        }
+    }
+
     func testPostsSingleTransaction() async throws {
         let transaction = Self.createTransaction()
 

--- a/Tests/UnitTests/Identity/CustomerInfoManagerPostReceiptTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerPostReceiptTests.swift
@@ -39,11 +39,12 @@ class CustomerInfoManagerPostReceiptTests: BaseCustomerInfoManagerTests {
         expect(self.mockTransactionPoster.invokedHandlePurchasedTransaction.value) == false
     }
 
-    func testReturnsFailureIfPostingReceiptFails() async throws {
+    func testReturnsFailureWhenBothPostingReceiptAndFetchingCustomerInfoFail() async throws {
         self.mockTransationFetcher.stubbedUnfinishedTransactions = [Self.createTransaction()]
         self.mockTransactionPoster.stubbedHandlePurchasedTransactionResult.value = .failure(
             .networkError(.serverDown())
         )
+        self.mockBackend.stubbedGetCustomerInfoResult = .failure(.networkError(.serverDown()))
 
         do {
             _ = try await self.customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.userID,
@@ -52,11 +53,26 @@ class CustomerInfoManagerPostReceiptTests: BaseCustomerInfoManagerTests {
         } catch let BackendError.networkError(networkError) {
             expect(networkError.isServerDown) == true
 
-            expect(self.mockBackend.invokedGetSubscriberData) == false
+            expect(self.mockBackend.invokedGetSubscriberData) == true
             expect(self.mockTransactionPoster.invokedHandlePurchasedTransaction.value) == true
         } catch {
             fail("Unexpected error: \(error)")
         }
+    }
+
+    func testFallsBackToGetCustomerInfoWhenPostingReceiptFails() async throws {
+        self.mockTransationFetcher.stubbedUnfinishedTransactions = [Self.createTransaction()]
+        self.mockTransactionPoster.stubbedHandlePurchasedTransactionResult.value = .failure(
+            .networkError(.serverDown())
+        )
+        self.mockBackend.stubbedGetCustomerInfoResult = .success(self.mockCustomerInfo)
+
+        let info = try await self.customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.userID,
+                                                                                isAppBackgrounded: false)
+        expect(info) === self.mockCustomerInfo
+
+        expect(self.mockTransactionPoster.invokedHandlePurchasedTransaction.value) == true
+        expect(self.mockBackend.invokedGetSubscriberData) == true
     }
 
     func testPostsSingleTransaction() async throws {

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -1190,6 +1190,7 @@ class GetCustomerInfoTrackingTests: BaseCustomerInfoManagerTests {
 
         let backendError = BackendError.missingReceiptFile(URL(string: "file://receipt"))
         self.mockTransactionPoster.stubbedHandlePurchasedTransactionResult.value = .failure(backendError)
+        self.mockBackend.stubbedGetCustomerInfoResult = .failure(backendError)
 
         do {
             _ = try await self.customerInfoManager.customerInfo(appUserID: Self.appUserID,

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
@@ -165,6 +165,40 @@ class PurchasesDelegateTests: BasePurchasesTests {
         )
     }
 
+    func testDelegateIsNotifiedWhenReceiptPostFailsButGetCustomerInfoSucceeds() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        // Wait for the initial fetch from `setupPurchases` to deliver the default
+        // empty CustomerInfo to the delegate.
+        await expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(1))
+
+        // `MockTransaction` has an empty product identifier, which makes
+        // `TransactionPoster` return `.missingTransactionProductIdentifier` — a
+        // stand-in for a backend receipt rejection.
+        let unfinishedTransaction = StoreTransaction(sk1Transaction: MockTransaction())
+        expect(unfinishedTransaction.productIdentifier) == ""
+        self.mockTransactionFetcher.stubbedUnfinishedTransactions = [unfinishedTransaction]
+
+        // A different CustomerInfo so `sendUpdateIfChanged` fires again on the fallback.
+        let newerCustomerInfo = try CustomerInfo(data: [
+            "request_date": "2025-12-21T02:40:36Z",
+            "subscriber": [
+                "original_app_user_id": Self.appUserID,
+                "first_seen": "2019-06-17T16:05:33Z",
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
+                "original_application_version": NSNull()
+            ] as [String: Any]
+        ])
+        self.backend.overrideCustomerInfoResult = .success(newerCustomerInfo)
+
+        self.deviceCache.stubbedIsCustomerInfoCacheStale = true
+        self.notificationCenter.fireNotifications()
+
+        await expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(2))
+        expect(self.purchasesDelegate.customerInfo) === newerCustomerInfo
+    }
+
     // See https://github.com/RevenueCat/purchases-ios/issues/2410
     func testDelegateWithGetCustomerInfoCallDoesNotDeadlock() throws {
         final class GetCustomerInfoPurchasesDelegate: NSObject, PurchasesDelegate {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
@@ -171,13 +171,26 @@ class PurchasesDelegateTests: BasePurchasesTests {
         // Wait for the initial fetch from `setupPurchases` to deliver the default
         // empty CustomerInfo to the delegate.
         await expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(1))
+        let initialGetCustomerInfoCallCount = self.backend.getCustomerInfoCallCount
 
-        // `MockTransaction` has an empty product identifier, which makes
-        // `TransactionPoster` return `.missingTransactionProductIdentifier` — a
-        // stand-in for a backend receipt rejection.
-        let unfinishedTransaction = StoreTransaction(sk1Transaction: MockTransaction())
-        expect(unfinishedTransaction.productIdentifier) == ""
+        // An unfinished transaction with a real product identifier triggers the
+        // receipt-post path end-to-end.
+        let payment = SKMutablePayment()
+        payment.productIdentifier = "com.revenuecat.test.product"
+        let underlyingTransaction = MockTransaction()
+        underlyingTransaction.mockPayment = payment
+        let unfinishedTransaction = StoreTransaction(sk1Transaction: underlyingTransaction)
         self.mockTransactionFetcher.stubbedUnfinishedTransactions = [unfinishedTransaction]
+
+        // Simulate a backend-side rejection of the posted receipt (as with 7934).
+        self.backend.postReceiptResult = .failure(
+            .networkError(.errorResponse(
+                .init(code: .unknownBackendError,
+                      originalCode: BackendErrorCode.unknownBackendError.rawValue,
+                      message: nil),
+                .invalidRequest
+            ))
+        )
 
         // A different CustomerInfo so `sendUpdateIfChanged` fires again on the fallback.
         let newerCustomerInfo = try CustomerInfo(data: [
@@ -197,6 +210,10 @@ class PurchasesDelegateTests: BasePurchasesTests {
 
         await expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(2))
         expect(self.purchasesDelegate.customerInfo) === newerCustomerInfo
+
+        // The receipt was posted (and rejected) before the fallback GET ran.
+        expect(self.backend.postReceiptDataCalled) == true
+        expect(self.backend.getCustomerInfoCallCount) == initialGetCustomerInfoCallCount + 1
     }
 
     // See https://github.com/RevenueCat/purchases-ios/issues/2410


### PR DESCRIPTION
### Background

[purchases-kmp#816](https://github.com/RevenueCat/purchases-kmp/issues/816): on a fresh iOS install with an unfinished StoreKit transaction, `PurchasesDelegate.onCustomerInfoUpdated` silently fails to fire ~50% of the time. Reporter logs show the backend rejecting the posted receipt (error `7934`), after which `CustomerInfoManager.fetchAndCacheCustomerInfoData`'s `.failure` branch clears the cache timestamp and returns — never reaching `cache(customerInfo:)`, so `sendUpdateIfChanged` never notifies the delegate. Direct `getCustomerInfo()` / `restorePurchases()` calls fail for the same reason.

### Fix

When posting an unfinished receipt fails, fall back to a plain `requestCustomerInfo` (which hits `GET /v1/subscribers/{id}`) and surface its result. This matches what Android already does — see [`CustomerInfoHelper.postPendingPurchasesAndFetchCustomerInfo`](https://github.com/RevenueCat/purchases-android/blob/main/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt) routing `SyncPendingPurchaseResult.Error` into `getCustomerInfoFetchOnly`, covered by the existing test `` `if syncs pending purchases fails, queries backend and returns backend result` `` in [`EntitlementInfoHelperTest.kt`](https://github.com/RevenueCat/purchases-android/blob/main/purchases/src/test/java/com/revenuecat/purchases/EntitlementInfoHelperTest.kt).

### Tests

- New: `PurchasesDelegateTests.testDelegateIsNotifiedWhenReceiptPostFailsButGetCustomerInfoSucceeds` — delegate-level regression.
- New: `CustomerInfoManagerPostReceiptTests.testFallsBackToGetCustomerInfoWhenPostingReceiptFails` — unit test for the fallback (mirrors the Android test above).
- Updated: `testReturnsFailureIfPostingReceiptFails` → `testReturnsFailureWhenBothPostingReceiptAndFetchingCustomerInfoFail` — now stubs `getCustomerInfo` failure too so the error still surfaces when both paths fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the control flow for customer info refresh when unfinished transactions exist, adding an extra network call and altering error/success outcomes in a purchase-sync edge case; regressions would affect update delivery and caching behavior.
> 
> **Overview**
> Fixes a failure mode where `CustomerInfo` updates could be skipped when there are unfinished StoreKit 2 transactions and posting the receipt fails.
> 
> When the first unfinished-transaction receipt post returns an error, `CustomerInfoManager.getCustomerInfoData` now logs a warning and falls back to `requestCustomerInfo` (`GET /subscribers/{id}`), surfacing that result so caching and delegate observers can still be notified. Tests were updated/added to cover fallback success, fallback failure (both paths fail), multiple unfinished transactions, and a delegate-level regression ensuring `PurchasesDelegate` receives an update after a receipt-post rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43d961b3420071e0313f1b814e12e4288c649a76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->