### PR TITLE
Fix rcgitbot_please_test token permissions for PR comments

### DIFF
--- a/.github/workflows/rcgitbot_please_test.yml
+++ b/.github/workflows/rcgitbot_please_test.yml
@@ -16,8 +16,7 @@ jobs:
       github.repository == 'RevenueCat/purchases-ios' &&
       github.event.comment.author_association == 'MEMBER'
     permissions:
-      issues: write
-      pull-requests: read
+      pull-requests: write
 
     steps:
       # GitHub Actions `issue_comment` workflows always run from the default branch,
@@ -128,8 +127,7 @@ jobs:
       github.repository == 'RevenueCat/purchases-ios' &&
       github.event.comment.author_association == 'MEMBER'
     permissions:
-      issues: write
-      pull-requests: read
+      pull-requests: write
 
     steps:
       - name: Parse job names


### PR DESCRIPTION
## Summary

Follow-up to #6649. After that PR merged, on-demand job triggering worked, but the `Post pipeline link` and `React to comment` steps both started failing with:

```
gh: Resource not accessible by integration (HTTP 403)
```

Root cause is a subtlety in GitHub's token permission model: a comment on a pull request belongs to the **pull requests** resource, not the **issues** resource, even though the REST API path is `/repos/…/issues/comments/…`. #6649 scoped the `GITHUB_TOKEN` to `issues: write` + `pull-requests: read`, which gives `write` on the wrong resource and `read` on the one we actually need to mutate, hence the 403.

This workflow only ever operates on PRs (the whole thing is gated on `github.event.issue.pull_request`). The fix is to collapse both jobs' permissions to a single scope that's actually sufficient for everything we do against GitHub:

```yaml
permissions:
  pull-requests: write
```

That covers:
- `gh pr view` — reading PR metadata (`approve-full-tests` + `run-specific-jobs`).
- `gh api …/issues/$ISSUE_NUMBER/comments` — posting the pipeline link as a PR comment (`run-specific-jobs`).
- `gh api …/issues/comments/$COMMENT_ID/reactions` — reacting to the triggering PR comment (both jobs).

`issues:` is no longer granted at all, since we never touch the `issues` resource.

## Notes

Same constraint as #6649 — `issue_comment` workflows run from the default branch, so end-to-end validation has to happen post-merge on a throwaway PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions token permissions (write scope) for an automation workflow; while narrowly scoped to PRs, permission adjustments can affect repo security if misused.
> 
> **Overview**
> Fixes the `@RCGitBot please test` `issue_comment` workflow by updating both jobs’ `GITHUB_TOKEN` scopes to `pull-requests: write` (removing the prior `issues: write` + `pull-requests: read` split), so posting PR comments and adding reactions no longer fails with 403s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 914023eba8971063408f2c89a0b6e884ce3b9140. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->