### PR TITLE
Fix iOS 15 snapshot-generation job hanging indefinitely

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1121,9 +1121,23 @@ jobs:
             echo "Started iOS 14.5 runtime installation in background"
 
       # === iOS 15 tests ===
+      # When generating snapshots, skip StoreKit tests on iOS 15.
+      #
+      # During snapshot-generation pipelines this job has been observed to
+      # sometimes run indefinitely in an infinite loop: the first test from a
+      # `StoreKitConfigTestCase`-derived class stalls inside `setUp` (before
+      # any test body runs), hits the test plan's 180s
+      # `maximumTestExecutionTimeAllowance`, and xcodebuild's built-in
+      # runner-crash recovery then retries the same tests and stalls again —
+      # indefinitely. Root cause is not confirmed.
+      #
+      # Skipping SK tests here costs no snapshot coverage: the only snapshot-
+      # producing test in the StoreKit test target is `DebugViewSwiftUITests`,
+      # which is `@available(iOS 16.0, *)` and is recorded by the iOS 16+
+      # jobs.
       - run:
           name: Run iOS 15 tests
-          command: bundle exec fastlane test_ios
+          command: bundle exec fastlane test_ios skip_sk_tests:<< pipeline.parameters.generate_snapshots >>
           no_output_timeout: 5m
           environment:
             SCAN_DEVICE: iPhone 13 (15.5)

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -2032,15 +2032,13 @@ workflows:
   generate-snapshot:
     when: << pipeline.parameters.generate_snapshots >>
     jobs:
-      # TEMP: only run the ios-15-and-14 job while verifying the skip_sk_tests
-      # fix under snapshot-generation pipelines. Revert before merging.
-      # - run-test-ios-26
-      # - run-test-ios-18-and-17
-      # - run-test-ios-16
+      - run-test-ios-26
+      - run-test-ios-18-and-17
+      - run-test-ios-16
       - run-test-ios-15-and-14
-      # - run-test-tvos-and-macos
-      # - run-test-watchos
-      # - backend-integration-tests-SK2 # Snapshots from this job are shared with all BackendIntegrationTests
+      - run-test-tvos-and-macos
+      - run-test-watchos
+      - backend-integration-tests-SK2 # Snapshots from this job are shared with all BackendIntegrationTests
 
 
   generate_revenuecatui_snapshots:

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -2032,13 +2032,15 @@ workflows:
   generate-snapshot:
     when: << pipeline.parameters.generate_snapshots >>
     jobs:
-      - run-test-ios-26
-      - run-test-ios-18-and-17
-      - run-test-ios-16
+      # TEMP: only run the ios-15-and-14 job while verifying the skip_sk_tests
+      # fix under snapshot-generation pipelines. Revert before merging.
+      # - run-test-ios-26
+      # - run-test-ios-18-and-17
+      # - run-test-ios-16
       - run-test-ios-15-and-14
-      - run-test-tvos-and-macos
-      - run-test-watchos
-      - backend-integration-tests-SK2 # Snapshots from this job are shared with all BackendIntegrationTests
+      # - run-test-tvos-and-macos
+      # - run-test-watchos
+      # - backend-integration-tests-SK2 # Snapshots from this job are shared with all BackendIntegrationTests
 
 
   generate_revenuecatui_snapshots:

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1135,13 +1135,9 @@ jobs:
       # producing test in the StoreKit test target is `DebugViewSwiftUITests`,
       # which is `@available(iOS 16.0, *)` and is recorded by the iOS 16+
       # jobs.
-      #
-      # The command is additionally wrapped in a 10-minute `timeout` as a
-      # defensive cap: `no_output_timeout` does not fire in the observed
-      # retry-loop scenario (xcodebuild keeps emitting output every retry).
       - run:
           name: Run iOS 15 tests
-          command: timeout 10m bundle exec fastlane test_ios skip_sk_tests:<< pipeline.parameters.generate_snapshots >>
+          command: bundle exec fastlane test_ios skip_sk_tests:<< pipeline.parameters.generate_snapshots >>
           no_output_timeout: 5m
           environment:
             SCAN_DEVICE: iPhone 13 (15.5)

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1135,9 +1135,13 @@ jobs:
       # producing test in the StoreKit test target is `DebugViewSwiftUITests`,
       # which is `@available(iOS 16.0, *)` and is recorded by the iOS 16+
       # jobs.
+      #
+      # The command is additionally wrapped in a 10-minute `timeout` as a
+      # defensive cap: `no_output_timeout` does not fire in the observed
+      # retry-loop scenario (xcodebuild keeps emitting output every retry).
       - run:
           name: Run iOS 15 tests
-          command: bundle exec fastlane test_ios skip_sk_tests:<< pipeline.parameters.generate_snapshots >>
+          command: timeout 10m bundle exec fastlane test_ios skip_sk_tests:<< pipeline.parameters.generate_snapshots >>
           no_output_timeout: 5m
           environment:
             SCAN_DEVICE: iPhone 13 (15.5)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -688,6 +688,12 @@ platform :ios do
     # See https://developer.apple.com/forums/thread/724068 and `FB12223404`.
     skip_sk_tests = options[:skip_sk_tests]
 
+    # TEMP DEBUG: verify CircleCI pipeline parameter interpolation into skip_sk_tests.
+    UI.message("[DEBUG test_ios] options = #{options.inspect}")
+    UI.message("[DEBUG test_ios] options[:skip_sk_tests] = #{options[:skip_sk_tests].inspect} (class: #{options[:skip_sk_tests].class})")
+    UI.message("[DEBUG test_ios] skip_sk_tests (after assignment) = #{skip_sk_tests.inspect} (class: #{skip_sk_tests.class})")
+    UI.message("[DEBUG test_ios] generate_snapshots = #{generate_snapshots.inspect}")
+
     if generate_snapshots
       if skip_sk_tests
         test_plan = "CI-RevenueCat-Snapshots"
@@ -699,6 +705,8 @@ platform :ios do
     else
       test_plan = "CI-AllTests"
     end
+
+    UI.message("[DEBUG test_ios] selected test_plan = #{test_plan}")
 
     scan(
       step_name: "scan - iPhone",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -688,12 +688,6 @@ platform :ios do
     # See https://developer.apple.com/forums/thread/724068 and `FB12223404`.
     skip_sk_tests = options[:skip_sk_tests]
 
-    # TEMP DEBUG: verify CircleCI pipeline parameter interpolation into skip_sk_tests.
-    UI.message("[DEBUG test_ios] options = #{options.inspect}")
-    UI.message("[DEBUG test_ios] options[:skip_sk_tests] = #{options[:skip_sk_tests].inspect} (class: #{options[:skip_sk_tests].class})")
-    UI.message("[DEBUG test_ios] skip_sk_tests (after assignment) = #{skip_sk_tests.inspect} (class: #{skip_sk_tests.class})")
-    UI.message("[DEBUG test_ios] generate_snapshots = #{generate_snapshots.inspect}")
-
     if generate_snapshots
       if skip_sk_tests
         test_plan = "CI-RevenueCat-Snapshots"
@@ -705,8 +699,6 @@ platform :ios do
     else
       test_plan = "CI-AllTests"
     end
-
-    UI.message("[DEBUG test_ios] selected test_plan = #{test_plan}")
 
     scan(
       step_name: "scan - iPhone",


### PR DESCRIPTION
## Summary

The `run-test-ios-15-and-14` CircleCI job has been observed to sometimes run indefinitely in an infinite loop during `generate_snapshots` pipelines, consuming the full 5h job timeout. The first test from a `StoreKitConfigTestCase`-derived class stalls inside `setUp` (before any test body starts), hits the test plan's 180s `maximumTestExecutionTimeAllowance`, and xcodebuild's built-in runner-crash recovery then retries the same tests and stalls again — indefinitely. Root cause of the underlying stall is not confirmed.

This PR passes `skip_sk_tests:<< pipeline.parameters.generate_snapshots >>` to `fastlane test_ios` in the iOS 15 step, so StoreKit tests are skipped only during snapshot-generation pipelines. Normal CI runs are unchanged.

Skipping StoreKit tests on iOS 15 costs no snapshot coverage: the only snapshot-producing test in the StoreKit test target is `DebugViewSwiftUITests`, which is `@available(iOS 16.0, *)` and is already recorded by the iOS 16+ jobs.

## Verification

Tested on this branch with two temporary debug commits (since reverted):

- Triggered a non-snapshot pipeline: `skip_sk_tests` resolved to `false` (`FalseClass`), selected `CI-AllTests` — unchanged from today's behavior.
- Triggered a snapshot-generation pipeline: `skip_sk_tests` resolved to `true` (`TrueClass`), selected `CI-RevenueCat-Snapshots` — routes around the hanging tests.

Confirmed that CircleCI interpolates the boolean pipeline parameter as `"true"` / `"false"` on the command line and that Fastlane's CLI parser coerces them to real Ruby booleans.

## Test plan

- [ ] Normal CI run on this PR — `run-test-ios-15-and-14` runs `CI-AllTests` as before.
- [ ] Manually trigger a `generate_snapshots` pipeline — `run-test-ios-15-and-14` completes within reasonable time and selects `CI-RevenueCat-Snapshots`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that tweaks which iOS 15 tests run during snapshot pipelines; no production code or runtime behavior is affected.
> 
> **Overview**
> Prevents the `run-test-ios-15-and-14` CircleCI job from hanging during snapshot-generation pipelines by **conditionally skipping StoreKit tests on iOS 15**.
> 
> The iOS 15 test step now passes `skip_sk_tests:<< pipeline.parameters.generate_snapshots >>` to `fastlane test_ios`, leaving normal CI runs unchanged while routing snapshot runs to the non-StoreKit snapshot test plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cf61418ca57cdf82e00e9f15d78f555916da834. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->