### PR TITLE
Skip SPM Release Build steps during snapshot-generation pipelines

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -688,10 +688,13 @@ jobs:
           install_xcbeautify: false
       - update-spm-installation-commit
       # === SPM RevenueCatUI Release Build (Xcode 15) ===
-      - run:
-          name: SPM RevenueCatUI Release Build (Xcode 15)
-          command: swift build -c release --target RevenueCatUI
-          no_output_timeout: 5m
+      - unless:
+          condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
+          steps:
+            - run:
+                name: SPM RevenueCatUI Release Build (Xcode 15)
+                command: swift build -c release --target RevenueCatUI
+                no_output_timeout: 5m
       # === RevenueCatUI iOS 16 tests ===
       - run:
           name: SPM RevenueCatUI Tests
@@ -725,10 +728,13 @@ jobs:
       - update-spm-installation-commit
 
       # === SPM RevenueCatUI Release Build (Xcode 16) ===
-      - run:
-          name: SPM RevenueCatUI Release Build (Xcode 16)
-          command: swift build -c release --target RevenueCatUI
-          no_output_timeout: 5m
+      - unless:
+          condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
+          steps:
+            - run:
+                name: SPM RevenueCatUI Release Build (Xcode 16)
+                command: swift build -c release --target RevenueCatUI
+                no_output_timeout: 5m
 
       # === RevenueCatUI iOS 18 tests ===
       - run:
@@ -825,10 +831,13 @@ jobs:
       - install-dependencies:
           install_xcbeautify: false
       - update-spm-installation-commit
-      - run:
-          name: SPM RevenueCatUI Release Build
-          command: swift build -c release --target RevenueCatUI
-          no_output_timeout: 5m
+      - unless:
+          condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
+          steps:
+            - run:
+                name: SPM RevenueCatUI Release Build
+                command: swift build -c release --target RevenueCatUI
+                no_output_timeout: 5m
       - run:
           name: SPM RevenueCatUI Tests
           command: bundle exec fastlane test_revenuecatui
@@ -940,10 +949,13 @@ jobs:
       - install-dependencies
 
       # === SPM Release Build (Xcode 26) ===
-      - run:
-          name: SPM Release Build (Xcode 26)
-          command: swift build -c release --target RevenueCat
-          no_output_timeout: 30m
+      - unless:
+          condition: << pipeline.parameters.generate_snapshots >>
+          steps:
+            - run:
+                name: SPM Release Build (Xcode 26)
+                command: swift build -c release --target RevenueCat
+                no_output_timeout: 30m
 
       # === iOS 26 tests ===
       - run:
@@ -979,10 +991,13 @@ jobs:
       - install-dependencies
 
       # === SPM Release Build (Xcode 16) ===
-      - run:
-          name: SPM Release Build (Xcode 16)
-          command: swift build -c release --target RevenueCat
-          no_output_timeout: 30m
+      - unless:
+          condition: << pipeline.parameters.generate_snapshots >>
+          steps:
+            - run:
+                name: SPM Release Build (Xcode 16)
+                command: swift build -c release --target RevenueCat
+                no_output_timeout: 30m
 
       # === iOS 18 tests ===
       - run:
@@ -1061,10 +1076,13 @@ jobs:
       - update-spm-installation-commit
 
       # === SPM Release Build (Xcode 15) ===
-      - run:
-          name: SPM Release Build (Xcode 15)
-          command: swift build -c release --target RevenueCat
-          no_output_timeout: 30m
+      - unless:
+          condition: << pipeline.parameters.generate_snapshots >>
+          steps:
+            - run:
+                name: SPM Release Build (Xcode 15)
+                command: swift build -c release --target RevenueCat
+                no_output_timeout: 30m
 
       # === iOS 16 tests ===
       - run:

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1105,8 +1105,6 @@ jobs:
       - update-spm-installation-commit
 
       # === SPM Release Build (Xcode 14) ===
-      # Skipped on snapshot-generation pipelines: no snapshots depend on the
-      # SPM release build, so we can save CI time.
       - unless:
           condition: << pipeline.parameters.generate_snapshots >>
           steps:

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1105,10 +1105,15 @@ jobs:
       - update-spm-installation-commit
 
       # === SPM Release Build (Xcode 14) ===
-      - run:
-          name: SPM Release Build (Xcode 14)
-          command: swift build -c release --target RevenueCat
-          no_output_timeout: 30m
+      # Skipped on snapshot-generation pipelines: no snapshots depend on the
+      # SPM release build, so we can save CI time.
+      - unless:
+          condition: << pipeline.parameters.generate_snapshots >>
+          steps:
+            - run:
+                name: SPM Release Build (Xcode 14)
+                command: swift build -c release --target RevenueCat
+                no_output_timeout: 30m
 
       # Start iOS 14.5 runtime download in the background so it can proceed
       # while iOS 15 tests run. Includes timeout detection and retry logic


### PR DESCRIPTION
## Summary

SPM release builds produce no snapshots, so running them during snapshot-generation pipelines is useless CI work. This PR wraps every SPM release build step that lives inside a job invoked by a snapshot-generation workflow in a step-level `unless` conditional keyed off the matching pipeline parameter.

Normal CI runs are unchanged — these steps only get skipped when a pipeline is explicitly triggered for snapshot generation.

## Steps affected

| Step | Parent job | Skip condition |
|------|------------|----------------|
| SPM RevenueCatUI Release Build (Xcode 15) | `spm-revenuecat-ui-ios-16` | `generate_revenuecatui_snapshots` |
| SPM RevenueCatUI Release Build (Xcode 16) | `run-revenuecat-ui-ios-18-and-17` | `generate_revenuecatui_snapshots` |
| SPM RevenueCatUI Release Build | `run-revenuecat-ui-ios-26` | `generate_revenuecatui_snapshots` |
| SPM Release Build (Xcode 26) | `run-test-ios-26` | `generate_snapshots` |
| SPM Release Build (Xcode 16) | `run-test-ios-18-and-17` | `generate_snapshots` |
| SPM Release Build (Xcode 15) | `run-test-ios-16` | `generate_snapshots` |
| SPM Release Build (Xcode 14) | `run-test-ios-15-and-14` | `generate_snapshots` |

## Steps intentionally left untouched

- `SPM RevenueCatAdMob Release Build` (in `revenuecat-admob-tests`)
- `SPM Receipt Parser` (in `spm-receipt-parser`)

These jobs are not invoked by either the `generate-snapshot` or `generate_revenuecatui_snapshots` workflows, so a conditional there would be dead code — they never run during a snapshot-generation pipeline in the first place.

## Test plan

- [ ] Normal CI run on this PR — every SPM release build step runs as today.
- [ ] Manually trigger a `generate_snapshots` pipeline — the four `generate_snapshots`-gated steps are skipped; snapshot PR creation is unaffected.
- [ ] Manually trigger a `generate_revenuecatui_snapshots` pipeline — the three `generate_revenuecatui_snapshots`-gated steps are skipped; RevenueCatUI snapshot PR creation is unaffected.