### PR TITLE
fix(RevenueCatUI): legacy paywall `component_name` parity with Android

### DIFF
--- a/RevenueCatUI/Data/Constants.swift
+++ b/RevenueCatUI/Data/Constants.swift
@@ -110,6 +110,8 @@ enum PaywallComponentInteraction {
     static let restoreButtonName = "restore_button"
     static let termsLinkName = "terms_link"
     static let privacyLinkName = "privacy_link"
+    static let tierSelectorName = "tier_selector"
+    static let purchaseButtonName = "purchase_button"
 
     enum ComponentValue: String {
         case toggleAllPlans = "toggle_all_plans"

--- a/RevenueCatUI/Templates/Template7View.swift
+++ b/RevenueCatUI/Templates/Template7View.swift
@@ -226,6 +226,7 @@ struct Template7View: TemplateViewType {
                                         tierName: self.tierNames[tier],
                                         tierId: tier.id
                                     ),
+                                    componentName: PaywallComponentInteraction.tierSelectorName,
                                     originPackage: originPackage,
                                     destinationPackage: destinationPackage
                                 )

--- a/RevenueCatUI/Views/DefaultPaywall/DefaultPaywallView.swift
+++ b/RevenueCatUI/Views/DefaultPaywall/DefaultPaywallView.swift
@@ -173,7 +173,7 @@ struct DefaultPaywallView: View {
                         if let selected {
                             let method = PaywallComponent.PurchaseButtonComponent.Method.inAppCheckout
                             self.componentInteractionLogger(.paywallPurchaseButtonAction(
-                                componentName: nil,
+                                componentName: PaywallComponentInteraction.purchaseButtonName,
                                 componentValue: method.description,
                                 componentURL: nil,
                                 currentPackageIdentifier: selected.identifier,

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -93,6 +93,7 @@ struct PurchaseButton: View {
 
             let selectedContent = self.selectedPackage.content
             self.componentInteractionLogger(.paywallPurchaseButtonAction(
+                componentName: PaywallComponentInteraction.purchaseButtonName,
                 componentValue: PaywallComponent.PurchaseButtonComponent.Method.inAppCheckout.description,
                 currentPackageIdentifier: selectedContent.identifier,
                 currentProductIdentifier: selectedContent.storeProduct.productIdentifier


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Legacy (V1) paywall component interacted events on iOS were missing component_name for the main purchase CTA and Template 7 tier changes, while Android already sent purchase_button and tier_selector. This PR wires the same string constants at the equivalent iOS call sites so cross-platform analytics match.

### Description
- Extend `PaywallComponentInteraction` with `tier_selector` and `purchase_button` (mirroring Android’s `PaywallLegacyComponentInteraction`).
- **`PurchaseButton`**: include `component_name` on in-app checkout interaction (covers all V1 templates that use this view, including Watch).
- **`DefaultPaywallView`**: use `purchase_button` instead of `nil` for the fallback purchase path (parity with Android `InternalPaywall` + default UI).
- **`Template7View`**: pass `tier_selector` into `paywallTierSelection`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: analytics-only changes that add `component_name` strings to existing interaction events without altering purchase or UI flows.
> 
> **Overview**
> Aligns legacy (V1) paywall interaction analytics with Android by introducing `tier_selector` and `purchase_button` component-name constants.
> 
> Ensures `component_name` is emitted for Template 7 tier selection (`paywallTierSelection`) and for purchase CTA taps in both `PurchaseButton` and the `DefaultPaywallView` fallback purchase path (previously `nil`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c096243576ad60f5df62290b78afbf36fe7afc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->