### PR TITLE
Revert Customer Center hasActiveSubscription fix (accidentally merged in #6640)

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
@@ -38,7 +38,7 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
     }
 
     var hasActiveSubscription: Bool {
-        customerInfoViewModel.subscriptionsSection.contains(where: { !$0.isExpired })
+        !customerInfoViewModel.subscriptionsSection.isEmpty
     }
 
     func shouldShowCreateTicketButton(

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
@@ -90,49 +90,11 @@ final class SubscriptionDetailViewModelTests: TestCase {
         expect(viewModel.hasActiveSubscription).to(beTrue())
     }
 
-    func testHasActiveSubscription_withMultipleActiveSubscriptions() {
-        let mockPurchases = MockCustomerCenterPurchases()
-        let customerInfoViewModel = CustomerCenterViewModel(uiPreviewPurchaseProvider: mockPurchases)
-        customerInfoViewModel.subscriptionsSection = [
-            .mock(store: .appStore, isExpired: false),
-            .mock(store: .appStore, isExpired: false)
-        ]
-
-        let viewModel = SubscriptionDetailViewModel(
-            customerInfoViewModel: customerInfoViewModel,
-            screen: CustomerCenterConfigData.default.screens[.management]!,
-            showPurchaseHistory: false,
-            showVirtualCurrencies: false,
-            allowsMissingPurchaseAction: false,
-            purchaseInformation: .mock(store: .appStore, isExpired: false)
-        )
-
-        expect(viewModel.hasActiveSubscription).to(beTrue())
-    }
-
-    func testHasActiveSubscription_withExpiredSubscriptionInSection() {
-        // Regression: when subscriptionsSection contains an expired subscription
-        // (loaded via loadMostRecentExpiredTransaction), hasActiveSubscription must be false
-        // regardless of how many subscriptions are in the section.
-        let mockPurchases = MockCustomerCenterPurchases()
-        let customerInfoViewModel = CustomerCenterViewModel(uiPreviewPurchaseProvider: mockPurchases)
-        customerInfoViewModel.subscriptionsSection = [.mock(store: .appStore, isExpired: true)]
-
-        let viewModel = SubscriptionDetailViewModel(
-            customerInfoViewModel: customerInfoViewModel,
-            screen: CustomerCenterConfigData.default.screens[.management]!,
-            showPurchaseHistory: false,
-            showVirtualCurrencies: false,
-            allowsMissingPurchaseAction: false,
-            purchaseInformation: .mock(store: .appStore, isExpired: true)
-        )
-
-        expect(viewModel.hasActiveSubscription).to(beFalse())
-    }
-
     func testHasActiveSubscription_withoutActiveSubscriptions() {
         let mockPurchases = MockCustomerCenterPurchases()
         let customerInfoViewModel = CustomerCenterViewModel(uiPreviewPurchaseProvider: mockPurchases)
+
+        // No active subscriptions
         customerInfoViewModel.subscriptionsSection = []
 
         let viewModel = SubscriptionDetailViewModel(
@@ -141,7 +103,7 @@ final class SubscriptionDetailViewModelTests: TestCase {
             showPurchaseHistory: false,
             showVirtualCurrencies: false,
             allowsMissingPurchaseAction: false,
-            purchaseInformation: nil
+            purchaseInformation: .mock(store: .playStore, isExpired: false)
         )
 
         expect(viewModel.hasActiveSubscription).to(beFalse())
@@ -172,7 +134,7 @@ final class SubscriptionDetailViewModelTests: TestCase {
     func testShouldShowCreateTicketButton_customerTypeAll_withoutActiveSubscription() {
         let mockPurchases = MockCustomerCenterPurchases()
         let customerInfoViewModel = CustomerCenterViewModel(uiPreviewPurchaseProvider: mockPurchases)
-        customerInfoViewModel.subscriptionsSection = [.mock(store: .appStore, isExpired: true)]
+        customerInfoViewModel.subscriptionsSection = []
 
         let viewModel = SubscriptionDetailViewModel(
             customerInfoViewModel: customerInfoViewModel,
@@ -180,7 +142,7 @@ final class SubscriptionDetailViewModelTests: TestCase {
             showPurchaseHistory: false,
             showVirtualCurrencies: false,
             allowsMissingPurchaseAction: false,
-            purchaseInformation: .mock(store: .appStore, isExpired: true)
+            purchaseInformation: .mock(store: .playStore, isExpired: false)
         )
 
         let supportTickets = CustomerCenterConfigData.Support.SupportTickets(
@@ -216,7 +178,7 @@ final class SubscriptionDetailViewModelTests: TestCase {
     func testShouldShowCreateTicketButton_customerTypeActive_withoutActiveSubscription() {
         let mockPurchases = MockCustomerCenterPurchases()
         let customerInfoViewModel = CustomerCenterViewModel(uiPreviewPurchaseProvider: mockPurchases)
-        customerInfoViewModel.subscriptionsSection = [.mock(store: .appStore, isExpired: true)]
+        customerInfoViewModel.subscriptionsSection = []
 
         let viewModel = SubscriptionDetailViewModel(
             customerInfoViewModel: customerInfoViewModel,
@@ -224,7 +186,7 @@ final class SubscriptionDetailViewModelTests: TestCase {
             showPurchaseHistory: false,
             showVirtualCurrencies: false,
             allowsMissingPurchaseAction: false,
-            purchaseInformation: .mock(store: .appStore, isExpired: true)
+            purchaseInformation: .mock(store: .playStore, isExpired: false)
         )
 
         let supportTickets = CustomerCenterConfigData.Support.SupportTickets(
@@ -260,7 +222,7 @@ final class SubscriptionDetailViewModelTests: TestCase {
     func testShouldShowCreateTicketButton_customerTypeNotActive_withoutActiveSubscription() {
         let mockPurchases = MockCustomerCenterPurchases()
         let customerInfoViewModel = CustomerCenterViewModel(uiPreviewPurchaseProvider: mockPurchases)
-        customerInfoViewModel.subscriptionsSection = [.mock(store: .appStore, isExpired: true)]
+        customerInfoViewModel.subscriptionsSection = []
 
         let viewModel = SubscriptionDetailViewModel(
             customerInfoViewModel: customerInfoViewModel,
@@ -268,7 +230,7 @@ final class SubscriptionDetailViewModelTests: TestCase {
             showPurchaseHistory: false,
             showVirtualCurrencies: false,
             allowsMissingPurchaseAction: false,
-            purchaseInformation: .mock(store: .appStore, isExpired: true)
+            purchaseInformation: .mock(store: .playStore, isExpired: false)
         )
 
         let supportTickets = CustomerCenterConfigData.Support.SupportTickets(


### PR DESCRIPTION
## Summary

- Reverts the `SubscriptionDetailViewModel.hasActiveSubscription` fix and its associated tests that were accidentally squash-merged into #6640
- Restores `hasActiveSubscription` to the original `!customerInfoViewModel.subscriptionsSection.isEmpty` check
- Restores the original test setup in `SubscriptionDetailViewModelTests`

The changes from #6674 ended up squashed into #6640 and need to be reverted so they can land separately and deliberately.

## Test plan

- [ ] Existing `SubscriptionDetailViewModelTests` pass with the reverted logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk revert that only changes the boolean used to classify customers as active vs not active in the Customer Center and updates the corresponding unit tests; main risk is behavior change for users with only expired subscriptions in `subscriptionsSection`.
> 
> **Overview**
> Restores `SubscriptionDetailViewModel.hasActiveSubscription` to treat *any* non-empty `subscriptionsSection` as "active" (no longer checking `isExpired`).
> 
> Updates `SubscriptionDetailViewModelTests` to remove coverage for the reverted expired-subscription behavior and to set up "no active subscription" cases using an empty `subscriptionsSection` (adjusting related support-ticket visibility expectations accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0fff23ba7c1c598e6643c3795aa573475709b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->