### PR TITLE
Decode reward payload in RewardVerification poll response

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1341,6 +1341,8 @@
 		DB1FC9512F9A1B23009A95EA /* WorkflowScreenMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1FC9502F9A1B23009A95EA /* WorkflowScreenMapper.swift */; };
 		DB1FC9582F9A1B63009A95EA /* PaywallViewConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1FC9572F9A1B63009A95EA /* PaywallViewConfigurationTests.swift */; };
 		DB1FC95A2F9A1B74009A95EA /* WorkflowScreenMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1FC9592F9A1B74009A95EA /* WorkflowScreenMapperTests.swift */; };
+		90A1B2C52F96927E00D32EDF /* VirtualCurrencyRewardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A1B2C42F96927E00D32EDF /* VirtualCurrencyRewardTests.swift */; };
+		90A1B2C72F96927E00D32EDF /* VerifiedRewardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A1B2C62F96927E00D32EDF /* VerifiedRewardTests.swift */; };
 		DB3395CA2F840A2B0079250C /* WorkflowsCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3395C92F840A2B0079250C /* WorkflowsCallback.swift */; };
 		DB3395D32F840A400079250C /* GetWorkflowOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3395D02F840A400079250C /* GetWorkflowOperation.swift */; };
 		DB3395D52F840A570079250C /* WorkflowsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3395D42F840A570079250C /* WorkflowsResponse.swift */; };
@@ -2920,6 +2922,8 @@
 		DB1FC9502F9A1B23009A95EA /* WorkflowScreenMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowScreenMapper.swift; sourceTree = "<group>"; };
 		DB1FC9572F9A1B63009A95EA /* PaywallViewConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewConfigurationTests.swift; sourceTree = "<group>"; };
 		DB1FC9592F9A1B74009A95EA /* WorkflowScreenMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowScreenMapperTests.swift; sourceTree = "<group>"; };
+		90A1B2C42F96927E00D32EDF /* VirtualCurrencyRewardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualCurrencyRewardTests.swift; sourceTree = "<group>"; };
+		90A1B2C62F96927E00D32EDF /* VerifiedRewardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedRewardTests.swift; sourceTree = "<group>"; };
 		DB3395C92F840A2B0079250C /* WorkflowsCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowsCallback.swift; sourceTree = "<group>"; };
 		DB3395D02F840A400079250C /* GetWorkflowOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetWorkflowOperation.swift; sourceTree = "<group>"; };
 		DB3395D42F840A570079250C /* WorkflowsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowsResponse.swift; sourceTree = "<group>"; };
@@ -6044,8 +6048,18 @@
 			isa = PBXGroup;
 			children = (
 				9094B43E2E96AA140094AD5F /* Events */,
+				90A1B2C82F96927E00D32EDF /* RewardVerification */,
 			);
 			path = Ads;
+			sourceTree = "<group>";
+		};
+		90A1B2C82F96927E00D32EDF /* RewardVerification */ = {
+			isa = PBXGroup;
+			children = (
+				90A1B2C42F96927E00D32EDF /* VirtualCurrencyRewardTests.swift */,
+				90A1B2C62F96927E00D32EDF /* VerifiedRewardTests.swift */,
+			);
+			path = RewardVerification;
 			sourceTree = "<group>";
 		};
 		B324DC482720C15300103EE9 /* Error Handling */ = {
@@ -7745,6 +7759,8 @@
 				FD18BF492DF0D9C100140FD6 /* VirtualCurrencyManagerTests.swift in Sources */,
 				351B514F26D44ACE00BD2BD7 /* PurchasesSubscriberAttributesTests.swift in Sources */,
 				D0DA209A2F23BBEC00BA3B77 /* AdEventTests.swift in Sources */,
+				90A1B2C52F96927E00D32EDF /* VirtualCurrencyRewardTests.swift in Sources */,
+				90A1B2C72F96927E00D32EDF /* VerifiedRewardTests.swift in Sources */,
 				57DBFA5D28AADA43002D18CA /* PurchasesLogInTests.swift in Sources */,
 				57D62F182D4A73F8000235DC /* CustomerCenterEventCreationDataDefault.swift in Sources */,
 				2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1204,6 +1204,9 @@
 		900D26FA2F96927E00D32EDF /* GetRewardVerificationStatusOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900D26F32F96927E00D32EDF /* GetRewardVerificationStatusOperation.swift */; };
 		900D26FB2F96927E00D32EDF /* AdsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900D26F72F96927E00D32EDF /* AdsAPI.swift */; };
 		900D26FC2F96927E00D32EDF /* RewardVerificationStatusCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900D26F12F96927E00D32EDF /* RewardVerificationStatusCallback.swift */; };
+		900D270A2F96A00000D32EDF /* VirtualCurrencyReward.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900D27092F96A00000D32EDF /* VirtualCurrencyReward.swift */; };
+		900D270C2F96A00000D32EDF /* VerifiedReward.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900D270B2F96A00000D32EDF /* VerifiedReward.swift */; };
+		900D270E2F96A00000D32EDF /* PurchasesRewardVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900D270D2F96A00000D32EDF /* PurchasesRewardVerificationTests.swift */; };
 		900D27032F96929800D32EDF /* MockAdsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900D27022F96929800D32EDF /* MockAdsAPI.swift */; };
 		900D27072F96943200D32EDF /* BackendGetRewardVerificationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900D27062F96943200D32EDF /* BackendGetRewardVerificationStatusTests.swift */; };
 		900D27082F96950000D32EDF /* MockAdsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900D27022F96929800D32EDF /* MockAdsAPI.swift */; };
@@ -2790,6 +2793,9 @@
 		900D26F72F96927E00D32EDF /* AdsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdsAPI.swift; sourceTree = "<group>"; };
 		900D27022F96929800D32EDF /* MockAdsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAdsAPI.swift; sourceTree = "<group>"; };
 		900D27062F96943200D32EDF /* BackendGetRewardVerificationStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetRewardVerificationStatusTests.swift; sourceTree = "<group>"; };
+		900D27092F96A00000D32EDF /* VirtualCurrencyReward.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualCurrencyReward.swift; sourceTree = "<group>"; };
+		900D270B2F96A00000D32EDF /* VerifiedReward.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedReward.swift; sourceTree = "<group>"; };
+		900D270D2F96A00000D32EDF /* PurchasesRewardVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesRewardVerificationTests.swift; sourceTree = "<group>"; };
 		901DE80D2EA0E096007EAA86 /* AdTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdTracker.swift; sourceTree = "<group>"; };
 		9025C53C2EA66E2500845BCE /* PostFeatureEventsOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostFeatureEventsOperation.swift; sourceTree = "<group>"; };
 		903A04332EB35929009B9CE4 /* EventsHTTPRequestPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsHTTPRequestPath.swift; sourceTree = "<group>"; };
@@ -5034,6 +5040,7 @@
 				FDAC7B5A2CD4085800DFC0D9 /* PurchasesWinBackOfferTests.swift */,
 				756AE8342D8816CD00BA2E39 /* PurchasesDiagnosticsTrackingTests.swift */,
 				FD43A7972E01F77300CBA838 /* PurchasesVirtualCurrenciesTests.swift */,
+				900D270D2F96A00000D32EDF /* PurchasesRewardVerificationTests.swift */,
 				77AABEB72F0C23450018C1D3 /* PurchasesStoreMessagesTests.swift */,
 				FD4E63412F34E0B60040BA46 /* PurchasesIsPurchaseAllowedByRestoreBehaviorTests.swift */,
 			);
@@ -5933,6 +5940,8 @@
 			children = (
 				900D26F42F96927E00D32EDF /* Networking */,
 				900D26F52F96927E00D32EDF /* RewardVerificationPollStatus.swift */,
+				900D270B2F96A00000D32EDF /* VerifiedReward.swift */,
+				900D27092F96A00000D32EDF /* VirtualCurrencyReward.swift */,
 			);
 			path = RewardVerification;
 			sourceTree = "<group>";
@@ -7091,6 +7100,8 @@
 				900D26FA2F96927E00D32EDF /* GetRewardVerificationStatusOperation.swift in Sources */,
 				900D26FB2F96927E00D32EDF /* AdsAPI.swift in Sources */,
 				900D26FC2F96927E00D32EDF /* RewardVerificationStatusCallback.swift in Sources */,
+				900D270A2F96A00000D32EDF /* VirtualCurrencyReward.swift in Sources */,
+				900D270C2F96A00000D32EDF /* VerifiedReward.swift in Sources */,
 				9A65E03B25918B0900DE00B0 /* CustomerInfoStrings.swift in Sources */,
 				5721360F28B4602C006C46BE /* Purchases+nonasync.swift in Sources */,
 				57DE806D28074976008D6C6F /* Storefront.swift in Sources */,
@@ -7553,6 +7564,7 @@
 				57E9CF11290B2ADC00EE12D1 /* CachingTrialOrIntroPriceEligibilityCheckerTests.swift in Sources */,
 				5757EDF82DEE092900AC4BE1 /* ClockTests.swift in Sources */,
 				57E415FF28469EAB00EA5460 /* PurchasesGetProductsTests.swift in Sources */,
+				900D270E2F96A00000D32EDF /* PurchasesRewardVerificationTests.swift in Sources */,
 				57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */,
 				351B514726D44A0D00BD2BD7 /* MockSystemInfo.swift in Sources */,
 				B300E4C226D439B700B22262 /* IntroEligibilityCalculatorTests.swift in Sources */,

--- a/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
+++ b/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
@@ -71,11 +71,16 @@ extension RewardVerificationStatusResponse: Decodable {
         from container: KeyedDecodingContainer<CodingKeys>
     ) -> VerifiedReward {
         guard container.contains(.reward),
-              let rewardContainer = try? container.nestedContainer(
-                keyedBy: RewardCodingKeys.self,
-                forKey: .reward
-              ) else {
+              (try? container.decodeNil(forKey: .reward)) != true else {
             return .noReward
+        }
+
+        guard let rewardContainer = try? container.nestedContainer(
+            keyedBy: RewardCodingKeys.self,
+            forKey: .reward
+        ) else {
+            Logger.warn(Strings.backendError.unexpected_reward_verification_reward_value)
+            return .unsupportedReward
         }
 
         let rewardType = (try? rewardContainer.decode(String.self, forKey: .type)) ?? ""

--- a/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
+++ b/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
@@ -16,16 +16,10 @@ import Foundation
 struct RewardVerificationStatusResponse: Equatable {
 
     let status: Status
-    let verifiedReward: VerifiedReward?
 
-    init(status: Status, verifiedReward: VerifiedReward? = nil) {
-        self.status = status
-        self.verifiedReward = verifiedReward
-    }
+    enum Status: Equatable {
 
-    enum Status: String, Codable, Equatable {
-
-        case verified
+        case verified(VerifiedReward)
         case pending
         case failed
         case unknown
@@ -53,17 +47,23 @@ extension RewardVerificationStatusResponse: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let rawStatus = try container.decode(String.self, forKey: .status)
-        if let known = Status(rawValue: rawStatus), known != .unknown {
-            self.status = known
-        } else {
-            Logger.warn(Strings.backendError.unknown_reward_verification_status(status: rawStatus))
-            self.status = .unknown
-        }
+        self.status = Self.decodeStatus(rawStatus, from: container)
+    }
 
-        if self.status == .verified {
-            self.verifiedReward = Self.decodeVerifiedReward(from: container)
-        } else {
-            self.verifiedReward = nil
+    private static func decodeStatus(
+        _ rawStatus: String,
+        from container: KeyedDecodingContainer<CodingKeys>
+    ) -> Status {
+        switch rawStatus {
+        case "verified":
+            return .verified(Self.decodeVerifiedReward(from: container))
+        case "pending":
+            return .pending
+        case "failed":
+            return .failed
+        default:
+            Logger.warn(Strings.backendError.unknown_reward_verification_status(status: rawStatus))
+            return .unknown
         }
     }
 

--- a/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
+++ b/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
@@ -13,15 +13,15 @@
 
 import Foundation
 
-/// Decoded body of
-/// `GET /v1/subscribers/{app_user_id}/ads/reward_verifications/{client_transaction_id}`.
-///
-/// The endpoint returns 200 with a `status` of `verified`, `pending`, or `failed`.
-/// Unrecognized future values decode to `.unknown` so the caller can choose how to
-/// handle them rather than failing decode.
 struct RewardVerificationStatusResponse: Equatable {
 
     let status: Status
+    let verifiedReward: VerifiedReward?
+
+    init(status: Status, verifiedReward: VerifiedReward? = nil) {
+        self.status = status
+        self.verifiedReward = verifiedReward
+    }
 
     enum Status: String, Codable, Equatable {
 
@@ -33,10 +33,21 @@ struct RewardVerificationStatusResponse: Equatable {
     }
 }
 
-extension RewardVerificationStatusResponse: Codable {
+extension RewardVerificationStatusResponse: Decodable {
 
     private enum CodingKeys: String, CodingKey {
         case status
+        case reward
+    }
+
+    private enum RewardCodingKeys: String, CodingKey {
+        case type
+        case code
+        case amount
+    }
+
+    private enum RewardType {
+        static let virtualCurrency = "virtual_currency"
     }
 
     init(from decoder: Decoder) throws {
@@ -47,6 +58,43 @@ extension RewardVerificationStatusResponse: Codable {
         } else {
             Logger.warn(Strings.backendError.unknown_reward_verification_status(status: rawStatus))
             self.status = .unknown
+        }
+
+        if self.status == .verified {
+            self.verifiedReward = Self.decodeVerifiedReward(from: container)
+        } else {
+            self.verifiedReward = nil
+        }
+    }
+
+    private static func decodeVerifiedReward(
+        from container: KeyedDecodingContainer<CodingKeys>
+    ) -> VerifiedReward {
+        guard container.contains(.reward),
+              let rewardContainer = try? container.nestedContainer(
+                keyedBy: RewardCodingKeys.self,
+                forKey: .reward
+              ) else {
+            return .noReward
+        }
+
+        let rewardType = (try? rewardContainer.decode(String.self, forKey: .type)) ?? ""
+
+        switch rewardType {
+        case RewardType.virtualCurrency:
+            guard let code = try? rewardContainer.decode(String.self, forKey: .code),
+                  let amount = try? rewardContainer.decode(Decimal.self, forKey: .amount) else {
+                Logger.warn(
+                    Strings.backendError.malformed_reward_verification_reward_payload(type: rewardType)
+                )
+                return .unsupportedReward
+            }
+            return .virtualCurrency(VirtualCurrencyReward(code: code, amount: amount))
+        default:
+            Logger.warn(
+                Strings.backendError.unsupported_reward_verification_reward_type(type: rewardType)
+            )
+            return .unsupportedReward
         }
     }
 }

--- a/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
+++ b/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
@@ -88,6 +88,7 @@ extension RewardVerificationStatusResponse: Decodable {
         switch rewardType {
         case RewardType.virtualCurrency:
             guard let code = try? rewardContainer.decode(String.self, forKey: .code),
+                  !code.isEmpty,
                   let amount = try? rewardContainer.decode(Int.self, forKey: .amount),
                   amount > 0 else {
                 Logger.warn(

--- a/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
+++ b/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
@@ -88,7 +88,7 @@ extension RewardVerificationStatusResponse: Decodable {
         switch rewardType {
         case RewardType.virtualCurrency:
             guard let code = try? rewardContainer.decode(String.self, forKey: .code),
-                  let amount = try? rewardContainer.decode(Decimal.self, forKey: .amount) else {
+                  let amount = try? rewardContainer.decode(Int.self, forKey: .amount) else {
                 Logger.warn(
                     Strings.backendError.malformed_reward_verification_reward_payload(type: rewardType)
                 )

--- a/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
+++ b/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
@@ -88,7 +88,8 @@ extension RewardVerificationStatusResponse: Decodable {
         switch rewardType {
         case RewardType.virtualCurrency:
             guard let code = try? rewardContainer.decode(String.self, forKey: .code),
-                  let amount = try? rewardContainer.decode(Int.self, forKey: .amount) else {
+                  let amount = try? rewardContainer.decode(Int.self, forKey: .amount),
+                  amount > 0 else {
                 Logger.warn(
                     Strings.backendError.malformed_reward_verification_reward_payload(type: rewardType)
                 )

--- a/Sources/Ads/RewardVerification/RewardVerificationPollStatus.swift
+++ b/Sources/Ads/RewardVerification/RewardVerificationPollStatus.swift
@@ -13,19 +13,16 @@
 
 import Foundation
 
-/// Result of a single ad reward verification status poll. Returned by
-/// `Purchases.pollRewardVerificationStatus(clientTransactionID:)` and consumed by
-/// RC-shipped ad adapters (e.g. `RevenueCatAdMob`).
-@_spi(Internal) public enum RewardVerificationPollStatus: Sendable {
-    /// The ad network's reward postback was received and verified by the backend.
-    case verified
+/// Result of a single ad reward verification status poll.
+@_spi(Internal) public enum RewardVerificationPollStatus: Sendable, Equatable {
 
-    /// The ad network's reward postback has not yet arrived (or is still being processed).
-    /// The caller is expected to keep polling until the status becomes terminal
-    /// or the caller's own retry budget is exhausted.
+    /// Verified by the backend, with the granted reward payload.
+    case verified(VerifiedReward)
+
+    /// Verification has not yet completed; the caller should keep polling.
     case pending
 
-    /// The ad network's reward postback was received but rejected by the backend.
+    /// The reward postback was rejected by the backend.
     case failed
 
     /// The backend returned an unrecognized status value.

--- a/Sources/Ads/RewardVerification/VerifiedReward.swift
+++ b/Sources/Ads/RewardVerification/VerifiedReward.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  VerifiedReward.swift
+//
+//  Created by Pol Miro on 23/04/2026.
+
+import Foundation
+
+/// Reward payload carried on a verified reward-verification outcome.
+@_spi(Internal) public enum VerifiedReward: Sendable, Equatable {
+
+    /// A virtual-currency reward.
+    case virtualCurrency(VirtualCurrencyReward)
+
+    /// Verified, but no reward was granted.
+    case noReward
+
+    /// Verified with a reward shape not modeled by this SDK version.
+    case unsupportedReward
+}

--- a/Sources/Ads/RewardVerification/VirtualCurrencyReward.swift
+++ b/Sources/Ads/RewardVerification/VirtualCurrencyReward.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  VirtualCurrencyReward.swift
+//
+//  Created by Pol Miro on 23/04/2026.
+
+import Foundation
+
+/// A virtual-currency reward granted by an ad network after a successful reward verification.
+@_spi(Internal) public struct VirtualCurrencyReward: Sendable, Equatable {
+
+    /// The reward type identifier (e.g. `"coins"`, `"gems"`).
+    public let code: String
+
+    /// The reward amount.
+    public let amount: Decimal
+
+    /// Creates a virtual-currency reward.
+    public init(code: String, amount: Decimal) {
+        self.code = code
+        self.amount = amount
+    }
+}

--- a/Sources/Ads/RewardVerification/VirtualCurrencyReward.swift
+++ b/Sources/Ads/RewardVerification/VirtualCurrencyReward.swift
@@ -20,10 +20,10 @@ import Foundation
     public let code: String
 
     /// The reward amount.
-    public let amount: Decimal
+    public let amount: Int
 
     /// Creates a virtual-currency reward.
-    public init(code: String, amount: Decimal) {
+    public init(code: String, amount: Int) {
         self.code = code
         self.amount = amount
     }

--- a/Sources/Logging/Strings/BackendErrorStrings.swift
+++ b/Sources/Logging/Strings/BackendErrorStrings.swift
@@ -25,6 +25,8 @@ enum BackendErrorStrings {
     // Posting offerIdForSigning failed due to a signature problem.
     case signature_error(signatureDataString: Any?)
     case unknown_reward_verification_status(status: String)
+    case unsupported_reward_verification_reward_type(type: String)
+    case malformed_reward_verification_reward_payload(type: String)
 
 }
 
@@ -44,6 +46,10 @@ extension BackendErrorStrings: LogMessage {
             return "Missing 'signatureData' or its structure changed:\n\(String(describing: signatureDataString))"
         case let .unknown_reward_verification_status(status):
             return "Received unknown reward verification status: \(status)"
+        case let .unsupported_reward_verification_reward_type(type):
+            return "Received unsupported reward verification reward type: \(type)"
+        case let .malformed_reward_verification_reward_payload(type):
+            return "Received malformed reward verification reward payload for type: \(type)"
         }
     }
 

--- a/Sources/Logging/Strings/BackendErrorStrings.swift
+++ b/Sources/Logging/Strings/BackendErrorStrings.swift
@@ -27,6 +27,7 @@ enum BackendErrorStrings {
     case unknown_reward_verification_status(status: String)
     case unsupported_reward_verification_reward_type(type: String)
     case malformed_reward_verification_reward_payload(type: String)
+    case unexpected_reward_verification_reward_value
 
 }
 
@@ -50,6 +51,8 @@ extension BackendErrorStrings: LogMessage {
             return "Received unsupported reward verification reward type: \(type)"
         case let .malformed_reward_verification_reward_payload(type):
             return "Received malformed reward verification reward payload for type: \(type)"
+        case .unexpected_reward_verification_reward_value:
+            return "Received unexpected reward verification reward value: expected a JSON object"
         }
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1605,7 +1605,7 @@ extension Purchases {
 
         switch response.status {
         case .verified:
-            return .verified
+            return .verified(response.verifiedReward ?? .noReward)
         case .pending:
             return .pending
         case .failed:

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1604,8 +1604,8 @@ extension Purchases {
         }
 
         switch response.status {
-        case .verified:
-            return .verified(response.verifiedReward ?? .noReward)
+        case let .verified(reward):
+            return .verified(reward)
         case .pending:
             return .pending
         case .failed:

--- a/Tests/UnitTests/Ads/RewardVerification/VerifiedRewardTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/VerifiedRewardTests.swift
@@ -44,20 +44,4 @@ final class VerifiedRewardTests: TestCase {
         expect(VerifiedReward.virtualCurrency(one)) != VerifiedReward.unsupportedReward
     }
 
-    func testSwitchExhaustivelyCoversAllCases() {
-        let values: [VerifiedReward] = [
-            .virtualCurrency(VirtualCurrencyReward(code: "coins", amount: 1)),
-            .noReward,
-            .unsupportedReward
-        ]
-        for value in values {
-            switch value {
-            case .virtualCurrency: continue
-            case .noReward: continue
-            case .unsupportedReward: continue
-            }
-        }
-        expect(values.count) == 3
-    }
-
 }

--- a/Tests/UnitTests/Ads/RewardVerification/VerifiedRewardTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/VerifiedRewardTests.swift
@@ -29,19 +29,4 @@ final class VerifiedRewardTests: TestCase {
         expect(captured) == reward
     }
 
-    func testNoRewardAndUnsupportedRewardAreDistinctCases() {
-        expect(VerifiedReward.noReward) != .unsupportedReward
-        expect(VerifiedReward.noReward) == .noReward
-        expect(VerifiedReward.unsupportedReward) == .unsupportedReward
-    }
-
-    func testEqualityRequiresMatchingAssociatedReward() {
-        let one = VirtualCurrencyReward(code: "coins", amount: 5)
-        let two = VirtualCurrencyReward(code: "coins", amount: 6)
-        expect(VerifiedReward.virtualCurrency(one)) == VerifiedReward.virtualCurrency(one)
-        expect(VerifiedReward.virtualCurrency(one)) != VerifiedReward.virtualCurrency(two)
-        expect(VerifiedReward.virtualCurrency(one)) != VerifiedReward.noReward
-        expect(VerifiedReward.virtualCurrency(one)) != VerifiedReward.unsupportedReward
-    }
-
 }

--- a/Tests/UnitTests/Ads/RewardVerification/VerifiedRewardTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/VerifiedRewardTests.swift
@@ -1,0 +1,63 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  VerifiedRewardTests.swift
+//
+//  Created by Pol Miro on 21/04/2026.
+
+import Foundation
+import Nimble
+import XCTest
+
+@_spi(Internal) @testable import RevenueCat
+
+final class VerifiedRewardTests: TestCase {
+
+    func testVirtualCurrencyCarriesAssociatedReward() {
+        let reward = VirtualCurrencyReward(code: "coins", amount: 5)
+        let value: VerifiedReward = .virtualCurrency(reward)
+
+        guard case .virtualCurrency(let captured) = value else {
+            return XCTFail("Expected .virtualCurrency, got \(value)")
+        }
+        expect(captured) == reward
+    }
+
+    func testNoRewardAndUnsupportedRewardAreDistinctCases() {
+        expect(VerifiedReward.noReward) != .unsupportedReward
+        expect(VerifiedReward.noReward) == .noReward
+        expect(VerifiedReward.unsupportedReward) == .unsupportedReward
+    }
+
+    func testEqualityRequiresMatchingAssociatedReward() {
+        let one = VirtualCurrencyReward(code: "coins", amount: 5)
+        let two = VirtualCurrencyReward(code: "coins", amount: 6)
+        expect(VerifiedReward.virtualCurrency(one)) == VerifiedReward.virtualCurrency(one)
+        expect(VerifiedReward.virtualCurrency(one)) != VerifiedReward.virtualCurrency(two)
+        expect(VerifiedReward.virtualCurrency(one)) != VerifiedReward.noReward
+        expect(VerifiedReward.virtualCurrency(one)) != VerifiedReward.unsupportedReward
+    }
+
+    func testSwitchExhaustivelyCoversAllCases() {
+        let values: [VerifiedReward] = [
+            .virtualCurrency(VirtualCurrencyReward(code: "coins", amount: 1)),
+            .noReward,
+            .unsupportedReward
+        ]
+        for value in values {
+            switch value {
+            case .virtualCurrency: continue
+            case .noReward: continue
+            case .unsupportedReward: continue
+            }
+        }
+        expect(values.count) == 3
+    }
+
+}

--- a/Tests/UnitTests/Ads/RewardVerification/VirtualCurrencyRewardTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/VirtualCurrencyRewardTests.swift
@@ -32,15 +32,4 @@ final class VirtualCurrencyRewardTests: TestCase {
         expect(lhs) != VirtualCurrencyReward(code: "coins", amount: 6)
     }
 
-    func testSupportsArbitraryDecimalPrecision() {
-        // Decimal preserves the full payload precision the backend may emit; sanity-check
-        // a fractional and a large-scale value to make sure we don't accidentally truncate
-        // to Int/Double in a future refactor.
-        let fractional = VirtualCurrencyReward(code: "coins", amount: Decimal(string: "0.123456789")!)
-        expect(fractional.amount) == Decimal(string: "0.123456789")!
-
-        let large = VirtualCurrencyReward(code: "coins", amount: Decimal(string: "9999999999999999")!)
-        expect(large.amount) == Decimal(string: "9999999999999999")!
-    }
-
 }

--- a/Tests/UnitTests/Ads/RewardVerification/VirtualCurrencyRewardTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/VirtualCurrencyRewardTests.swift
@@ -1,0 +1,46 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  VirtualCurrencyRewardTests.swift
+//
+//  Created by Pol Miro on 21/04/2026.
+
+import Foundation
+import Nimble
+import XCTest
+
+@_spi(Internal) @testable import RevenueCat
+
+final class VirtualCurrencyRewardTests: TestCase {
+
+    func testStoresCodeAndAmount() {
+        let reward = VirtualCurrencyReward(code: "coins", amount: 5)
+        expect(reward.code) == "coins"
+        expect(reward.amount) == 5
+    }
+
+    func testEqualityRequiresBothFieldsToMatch() {
+        let lhs = VirtualCurrencyReward(code: "coins", amount: 5)
+        expect(lhs) == VirtualCurrencyReward(code: "coins", amount: 5)
+        expect(lhs) != VirtualCurrencyReward(code: "gems", amount: 5)
+        expect(lhs) != VirtualCurrencyReward(code: "coins", amount: 6)
+    }
+
+    func testSupportsArbitraryDecimalPrecision() {
+        // Decimal preserves the full payload precision the backend may emit; sanity-check
+        // a fractional and a large-scale value to make sure we don't accidentally truncate
+        // to Int/Double in a future refactor.
+        let fractional = VirtualCurrencyReward(code: "coins", amount: Decimal(string: "0.123456789")!)
+        expect(fractional.amount) == Decimal(string: "0.123456789")!
+
+        let large = VirtualCurrencyReward(code: "coins", amount: Decimal(string: "9999999999999999")!)
+        expect(large.amount) == Decimal(string: "9999999999999999")!
+    }
+
+}

--- a/Tests/UnitTests/Networking/Backend/BackendGetRewardVerificationStatusTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRewardVerificationStatusTests.swift
@@ -68,9 +68,8 @@ final class BackendGetRewardVerificationStatusTests: BaseBackendTests {
         }
 
         let response = try XCTUnwrap(result?.value)
-        expect(response.status) == .verified
-        expect(response.verifiedReward)
-            == .virtualCurrency(VirtualCurrencyReward(code: "coins", amount: 10))
+        expect(response.status)
+            == .verified(.virtualCurrency(VirtualCurrencyReward(code: "coins", amount: 10)))
     }
 
     func testGetRewardVerificationStatusPending() throws {

--- a/Tests/UnitTests/Networking/Backend/BackendGetRewardVerificationStatusTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRewardVerificationStatusTests.swift
@@ -15,7 +15,7 @@ import Foundation
 import Nimble
 import XCTest
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 final class BackendGetRewardVerificationStatusTests: BaseBackendTests {
 
@@ -69,6 +69,8 @@ final class BackendGetRewardVerificationStatusTests: BaseBackendTests {
 
         let response = try XCTUnwrap(result?.value)
         expect(response.status) == .verified
+        expect(response.verifiedReward)
+            == .virtualCurrency(VirtualCurrencyReward(code: "coins", amount: 10))
     }
 
     func testGetRewardVerificationStatusPending() throws {
@@ -333,7 +335,14 @@ final class BackendGetRewardVerificationStatusTests: BaseBackendTests {
 
 private extension BackendGetRewardVerificationStatusTests {
 
-    static let verifiedResponse: [String: Any] = ["status": "verified"]
+    static let verifiedResponse: [String: Any] = [
+        "status": "verified",
+        "reward": [
+            "type": "virtual_currency",
+            "code": "coins",
+            "amount": 10
+        ]
+    ]
     static let pendingResponse: [String: Any] = ["status": "pending"]
     static let failedResponse: [String: Any] = ["status": "failed"]
 

--- a/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
@@ -109,6 +109,22 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
         expect(response.verifiedReward) == .noReward
     }
 
+    func testDecodesVerifiedWithNonObjectRewardAsUnsupportedReward() throws {
+        let json = #"{"status":"verified","reward":"not_an_object"}"#
+        let response = try RewardVerificationStatusResponse.create(with: Data(json.utf8))
+        expect(response.status) == .verified
+        expect(response.verifiedReward) == .unsupportedReward
+        expect(self.logger.messages.map(\.message)).to(
+            containElementSatisfying {
+                $0.contains(
+                    Strings.backendError
+                        .unexpected_reward_verification_reward_value
+                        .description
+                )
+            }
+        )
+    }
+
     func testDecodesVerifiedWithUnknownRewardTypeAsUnsupportedReward() throws {
         let unknownType = "physical_item"
         let response = try Self.decode([

--- a/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
@@ -15,10 +15,12 @@ import Foundation
 import Nimble
 import XCTest
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 // swiftlint:disable:next type_name
 final class RewardVerificationStatusResponseDecodingTests: TestCase {
+
+    // MARK: - Status decoding
 
     func testDecodesVerifiedStatus() throws {
         let response = try Self.decode(["status": "verified"])
@@ -40,9 +42,6 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
         let response = try Self.decode(["status": unrecognized])
         expect(response.status) == .unknown
 
-        // Guard the warning log: a future refactor that drops the warning would silently
-        // strip diagnostics for unmapped backend status values, so this is asserted here
-        // (mirroring `testGetRewardVerificationStatusUnknownStatusDecodesAsUnknown`).
         expect(self.logger.messages.map(\.message)).to(
             containElementSatisfying {
                 $0.contains(
@@ -67,6 +66,103 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
                 )
             }
         )
+    }
+
+    // MARK: - Reward payload decoding
+
+    func testDecodesVerifiedWithVirtualCurrencyReward() throws {
+        let response = try Self.decode([
+            "status": "verified",
+            "reward": [
+                "type": "virtual_currency",
+                "code": "coins",
+                "amount": 10
+            ]
+        ])
+        expect(response.status) == .verified
+        expect(response.verifiedReward) == .virtualCurrency(VirtualCurrencyReward(code: "coins", amount: 10))
+    }
+
+    func testDecodesVerifiedWithVirtualCurrencyRewardPreservesDecimalPrecision() throws {
+        let response = try Self.decode([
+            "status": "verified",
+            "reward": [
+                "type": "virtual_currency",
+                "code": "gems",
+                "amount": Decimal(string: "0.123456789")!
+            ]
+        ])
+        expect(response.verifiedReward)
+            == .virtualCurrency(VirtualCurrencyReward(code: "gems", amount: Decimal(string: "0.123456789")!))
+    }
+
+    func testDecodesVerifiedWithMissingRewardFieldAsNoReward() throws {
+        let response = try Self.decode(["status": "verified"])
+        expect(response.status) == .verified
+        expect(response.verifiedReward) == .noReward
+    }
+
+    func testDecodesVerifiedWithNullRewardAsNoReward() throws {
+        let json = #"{"status":"verified","reward":null}"#
+        let response = try RewardVerificationStatusResponse.create(with: Data(json.utf8))
+        expect(response.status) == .verified
+        expect(response.verifiedReward) == .noReward
+    }
+
+    func testDecodesVerifiedWithUnknownRewardTypeAsUnsupportedReward() throws {
+        let unknownType = "physical_item"
+        let response = try Self.decode([
+            "status": "verified",
+            "reward": [
+                "type": unknownType,
+                "sku": "tshirt"
+            ]
+        ])
+        expect(response.status) == .verified
+        expect(response.verifiedReward) == .unsupportedReward
+        expect(self.logger.messages.map(\.message)).to(
+            containElementSatisfying {
+                $0.contains(
+                    Strings.backendError
+                        .unsupported_reward_verification_reward_type(type: unknownType)
+                        .description
+                )
+            }
+        )
+    }
+
+    func testDecodesVerifiedWithMalformedVirtualCurrencyAsUnsupportedReward() throws {
+        let response = try Self.decode([
+            "status": "verified",
+            "reward": [
+                "type": "virtual_currency",
+                "code": "coins"
+            ]
+        ])
+        expect(response.status) == .verified
+        expect(response.verifiedReward) == .unsupportedReward
+        expect(self.logger.messages.map(\.message)).to(
+            containElementSatisfying {
+                $0.contains(
+                    Strings.backendError
+                        .malformed_reward_verification_reward_payload(type: "virtual_currency")
+                        .description
+                )
+            }
+        )
+    }
+
+    func testNonVerifiedStatusDoesNotCarryReward() throws {
+        let response = try Self.decode([
+            "status": "pending",
+            "reward": [
+                "type": "virtual_currency",
+                "code": "coins",
+                "amount": 10
+            ]
+        ])
+        expect(response.status) == .pending
+        expect(response.verifiedReward).to(beNil())
     }
 
     private static func decode(_ json: [String: Any]) throws -> RewardVerificationStatusResponse {

--- a/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
@@ -24,7 +24,7 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
 
     func testDecodesVerifiedStatus() throws {
         let response = try Self.decode(["status": "verified"])
-        expect(response.status) == .verified
+        expect(response.status) == .verified(.noReward)
     }
 
     func testDecodesPendingStatus() throws {
@@ -79,8 +79,7 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
                 "amount": 10
             ]
         ])
-        expect(response.status) == .verified
-        expect(response.verifiedReward) == .virtualCurrency(VirtualCurrencyReward(code: "coins", amount: 10))
+        expect(response.status) == .verified(.virtualCurrency(VirtualCurrencyReward(code: "coins", amount: 10)))
     }
 
     func testDecodesVerifiedWithVirtualCurrencyRewardWithFractionalAmountAsUnsupportedReward() throws {
@@ -94,8 +93,7 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
                 "amount": 0.5
             ]
         ])
-        expect(response.status) == .verified
-        expect(response.verifiedReward) == .unsupportedReward
+        expect(response.status) == .verified(.unsupportedReward)
         expect(self.logger.messages.map(\.message)).to(
             containElementSatisfying {
                 $0.contains(
@@ -109,22 +107,19 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
 
     func testDecodesVerifiedWithMissingRewardFieldAsNoReward() throws {
         let response = try Self.decode(["status": "verified"])
-        expect(response.status) == .verified
-        expect(response.verifiedReward) == .noReward
+        expect(response.status) == .verified(.noReward)
     }
 
     func testDecodesVerifiedWithNullRewardAsNoReward() throws {
         let json = #"{"status":"verified","reward":null}"#
         let response = try RewardVerificationStatusResponse.create(with: Data(json.utf8))
-        expect(response.status) == .verified
-        expect(response.verifiedReward) == .noReward
+        expect(response.status) == .verified(.noReward)
     }
 
     func testDecodesVerifiedWithNonObjectRewardAsUnsupportedReward() throws {
         let json = #"{"status":"verified","reward":"not_an_object"}"#
         let response = try RewardVerificationStatusResponse.create(with: Data(json.utf8))
-        expect(response.status) == .verified
-        expect(response.verifiedReward) == .unsupportedReward
+        expect(response.status) == .verified(.unsupportedReward)
         expect(self.logger.messages.map(\.message)).to(
             containElementSatisfying {
                 $0.contains(
@@ -145,8 +140,7 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
                 "sku": "tshirt"
             ]
         ])
-        expect(response.status) == .verified
-        expect(response.verifiedReward) == .unsupportedReward
+        expect(response.status) == .verified(.unsupportedReward)
         expect(self.logger.messages.map(\.message)).to(
             containElementSatisfying {
                 $0.contains(
@@ -166,8 +160,7 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
                 "code": "coins"
             ]
         ])
-        expect(response.status) == .verified
-        expect(response.verifiedReward) == .unsupportedReward
+        expect(response.status) == .verified(.unsupportedReward)
         expect(self.logger.messages.map(\.message)).to(
             containElementSatisfying {
                 $0.contains(
@@ -179,7 +172,7 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
         )
     }
 
-    func testNonVerifiedStatusDoesNotCarryReward() throws {
+    func testNonVerifiedStatusIgnoresRewardPayload() throws {
         let response = try Self.decode([
             "status": "pending",
             "reward": [
@@ -189,7 +182,6 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
             ]
         ])
         expect(response.status) == .pending
-        expect(response.verifiedReward).to(beNil())
     }
 
     private static func decode(_ json: [String: Any]) throws -> RewardVerificationStatusResponse {

--- a/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
@@ -83,17 +83,28 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
         expect(response.verifiedReward) == .virtualCurrency(VirtualCurrencyReward(code: "coins", amount: 10))
     }
 
-    func testDecodesVerifiedWithVirtualCurrencyRewardPreservesDecimalPrecision() throws {
+    func testDecodesVerifiedWithVirtualCurrencyRewardWithFractionalAmountAsUnsupportedReward() throws {
+        // The backend models the amount as an integer; a fractional value is malformed
+        // and should not be silently truncated.
         let response = try Self.decode([
             "status": "verified",
             "reward": [
                 "type": "virtual_currency",
                 "code": "gems",
-                "amount": Decimal(string: "0.123456789")!
+                "amount": 0.5
             ]
         ])
-        expect(response.verifiedReward)
-            == .virtualCurrency(VirtualCurrencyReward(code: "gems", amount: Decimal(string: "0.123456789")!))
+        expect(response.status) == .verified
+        expect(response.verifiedReward) == .unsupportedReward
+        expect(self.logger.messages.map(\.message)).to(
+            containElementSatisfying {
+                $0.contains(
+                    Strings.backendError
+                        .malformed_reward_verification_reward_payload(type: "virtual_currency")
+                        .description
+                )
+            }
+        )
     }
 
     func testDecodesVerifiedWithMissingRewardFieldAsNoReward() throws {

--- a/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
@@ -172,6 +172,27 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
         )
     }
 
+    func testDecodesVerifiedWithNonPositiveVirtualCurrencyAmountAsUnsupportedReward() throws {
+        let response = try Self.decode([
+            "status": "verified",
+            "reward": [
+                "type": "virtual_currency",
+                "code": "coins",
+                "amount": 0
+            ]
+        ])
+        expect(response.status) == .verified(.unsupportedReward)
+        expect(self.logger.messages.map(\.message)).to(
+            containElementSatisfying {
+                $0.contains(
+                    Strings.backendError
+                        .malformed_reward_verification_reward_payload(type: "virtual_currency")
+                        .description
+                )
+            }
+        )
+    }
+
     func testNonVerifiedStatusIgnoresRewardPayload() throws {
         let response = try Self.decode([
             "status": "pending",

--- a/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
@@ -193,6 +193,27 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
         )
     }
 
+    func testDecodesVerifiedWithEmptyVirtualCurrencyCodeAsUnsupportedReward() throws {
+        let response = try Self.decode([
+            "status": "verified",
+            "reward": [
+                "type": "virtual_currency",
+                "code": "",
+                "amount": 10
+            ]
+        ])
+        expect(response.status) == .verified(.unsupportedReward)
+        expect(self.logger.messages.map(\.message)).to(
+            containElementSatisfying {
+                $0.contains(
+                    Strings.backendError
+                        .malformed_reward_verification_reward_payload(type: "virtual_currency")
+                        .description
+                )
+            }
+        )
+    }
+
     func testNonVerifiedStatusIgnoresRewardPayload() throws {
         let response = try Self.decode([
             "status": "pending",

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -84,7 +84,9 @@ class BasePurchasesTests: TestCase {
                                           systemInfo: self.systemInfo,
                                           offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
-        self.backend = MockBackend(backendConfig: config, attributionFetcher: self.attributionFetcher)
+        self.backend = MockBackend(backendConfig: config,
+                                   attributionFetcher: self.attributionFetcher,
+                                   mockAdsAPI: MockAdsAPI())
         self.subscriberAttributesManager = MockSubscriberAttributesManager(
             backend: self.backend,
             deviceCache: self.deviceCache,
@@ -472,6 +474,34 @@ extension BasePurchasesTests {
 
         /// Tracks the order in which backend methods are called.
         var callOrder: [MockBackendOperation] = []
+
+        convenience init(backendConfig: BackendConfiguration,
+                         attributionFetcher: AttributionFetcher,
+                         mockAdsAPI: MockAdsAPI) {
+            let customer = CustomerAPI(backendConfig: backendConfig, attributionFetcher: attributionFetcher)
+            let identity = IdentityAPI(backendConfig: backendConfig)
+            let offerings = OfferingsAPI(backendConfig: backendConfig)
+            let webBilling = WebBillingAPI(backendConfig: backendConfig)
+            let offlineEntitlements = OfflineEntitlementsAPI(backendConfig: backendConfig)
+            let internalAPI = InternalAPI(backendConfig: backendConfig)
+            let customerCenterConfig = CustomerCenterConfigAPI(backendConfig: backendConfig)
+            let redeemWebPurchaseAPI = RedeemWebPurchaseAPI(backendConfig: backendConfig)
+            let virtualCurrenciesAPI = VirtualCurrenciesAPI(backendConfig: backendConfig)
+            let workflowsAPI = WorkflowsAPI(backendConfig: backendConfig)
+
+            self.init(backendConfig: backendConfig,
+                      customerAPI: customer,
+                      identityAPI: identity,
+                      offeringsAPI: offerings,
+                      webBillingAPI: webBilling,
+                      offlineEntitlements: offlineEntitlements,
+                      internalAPI: internalAPI,
+                      customerCenterConfig: customerCenterConfig,
+                      redeemWebPurchaseAPI: redeemWebPurchaseAPI,
+                      virtualCurrenciesAPI: virtualCurrenciesAPI,
+                      workflowsAPI: workflowsAPI,
+                      adsAPI: mockAdsAPI)
+        }
 
         var userID: String?
         var originalApplicationVersion: String?

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
@@ -44,12 +44,45 @@ final class PurchasesRewardVerificationTests: BasePurchasesTests {
         expect(try self.mockAdsAPI.invokedGetRewardVerificationStatusParameters?.clientTransactionID) == transactionID
     }
 
-    func testPollRewardVerificationStatusMapsVerifiedStatus() async throws {
-        try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(.init(status: .verified))
+    func testPollRewardVerificationStatusMapsVerifiedStatusWithVirtualCurrencyReward() async throws {
+        let reward = VirtualCurrencyReward(code: "coins", amount: 10)
+        try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
+            .init(status: .verified, verifiedReward: .virtualCurrency(reward))
+        )
 
         let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
 
-        expect(status) == .verified
+        expect(status) == .verified(.virtualCurrency(reward))
+    }
+
+    func testPollRewardVerificationStatusMapsVerifiedStatusWithNoReward() async throws {
+        try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
+            .init(status: .verified, verifiedReward: .noReward)
+        )
+
+        let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
+
+        expect(status) == .verified(.noReward)
+    }
+
+    func testPollRewardVerificationStatusMapsVerifiedStatusWithUnsupportedReward() async throws {
+        try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
+            .init(status: .verified, verifiedReward: .unsupportedReward)
+        )
+
+        let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
+
+        expect(status) == .verified(.unsupportedReward)
+    }
+
+    func testPollRewardVerificationStatusVerifiedWithoutRewardFallsBackToNoReward() async throws {
+        try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
+            .init(status: .verified, verifiedReward: nil)
+        )
+
+        let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
+
+        expect(status) == .verified(.noReward)
     }
 
     func testPollRewardVerificationStatusMapsPendingStatus() async throws {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
@@ -47,7 +47,7 @@ final class PurchasesRewardVerificationTests: BasePurchasesTests {
     func testPollRewardVerificationStatusMapsVerifiedStatusWithVirtualCurrencyReward() async throws {
         let reward = VirtualCurrencyReward(code: "coins", amount: 10)
         try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
-            .init(status: .verified, verifiedReward: .virtualCurrency(reward))
+            .init(status: .verified(.virtualCurrency(reward)))
         )
 
         let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
@@ -57,7 +57,7 @@ final class PurchasesRewardVerificationTests: BasePurchasesTests {
 
     func testPollRewardVerificationStatusMapsVerifiedStatusWithNoReward() async throws {
         try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
-            .init(status: .verified, verifiedReward: .noReward)
+            .init(status: .verified(.noReward))
         )
 
         let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
@@ -67,22 +67,12 @@ final class PurchasesRewardVerificationTests: BasePurchasesTests {
 
     func testPollRewardVerificationStatusMapsVerifiedStatusWithUnsupportedReward() async throws {
         try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
-            .init(status: .verified, verifiedReward: .unsupportedReward)
+            .init(status: .verified(.unsupportedReward))
         )
 
         let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
 
         expect(status) == .verified(.unsupportedReward)
-    }
-
-    func testPollRewardVerificationStatusVerifiedWithoutRewardFallsBackToNoReward() async throws {
-        try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
-            .init(status: .verified, verifiedReward: nil)
-        )
-
-        let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
-
-        expect(status) == .verified(.noReward)
     }
 
     func testPollRewardVerificationStatusMapsPendingStatus() async throws {


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
The internal `@_spi(Internal) Purchases.pollRewardVerificationStatus(clientTransactionID:)` SPI today only exposes whether verification passed (`.verified` / `.pending` / `.failed` / `.unknown`).

This PR adds reward-payload support to the response shape and surfaces it through the SPI.

### Description

#### Wire shape (typed nested)
Discussed with @peter-revenuecat to follow this typed nested approach.

```json
{ "status": "verified", "reward": { "type": "virtual_currency", "code": "coins", "amount": 10 } }
```

The explicit `type` discriminator makes it possible to distinguish future reward kinds (e.g. physical items) without having to disambiguate by-shape.

#### New types (internal SPI)
Both under `Sources/Ads/RewardVerification/`, both `@_spi(Internal) public`, `Sendable`, `Equatable`:

- `VirtualCurrencyReward { code: String, amount: Decimal }`
- `VerifiedReward { case virtualCurrency(VirtualCurrencyReward), .noReward, .unsupportedReward }`

Per the codebase rule against new public `@frozen` enums, these stay on the SPI surface only — they don't widen the stable public API.

#### Decoder (`RewardVerificationStatusResponse`)
Decode is **lenient on the reward**: never fails the overall decode just because the reward subtree is missing or malformed.

| Wire | `verifiedReward` |
|---|---|
| `status != "verified"` | `nil` |
| `status == "verified"`, `reward` absent or `null` | `.noReward` |
| `status == "verified"`, `reward` present but not a JSON object | `.unsupportedReward` + `Logger.warn` |
| `reward.type == "virtual_currency"` with valid `code` + `amount` | `.virtualCurrency(...)` |
| `reward.type == "virtual_currency"` with malformed fields | `.unsupportedReward` + `Logger.warn` |
| `reward.type` is anything else | `.unsupportedReward` + `Logger.warn` |

Unknown wire status values continue to map to `.unknown` with the existing `Logger.warn` (unchanged).

#### SPI mapping
`RewardVerificationPollStatus.verified` now carries a `VerifiedReward`. `Purchases.pollRewardVerificationStatus(clientTransactionID:)` returns `.verified(response.verifiedReward ?? .noReward)` (defensive fallback so a future decoder regression can't crash the SPI).

#### Tests
- `RewardVerificationStatusResponseDecodingTests` — added cases for verified+virtual-currency, decimal precision, missing/null reward, non-object reward, unknown reward type, malformed `virtual_currency`, and non-verified statuses ignoring stray reward payloads.
- `BackendGetRewardVerificationStatusTests` — extended `testGetRewardVerificationStatusVerified` to assert the reward payload reaches the callback.
- `PurchasesRewardVerificationTests` — end-to-end SPI mapping for all `VerifiedReward` cases plus the defensive fallback. (Also fixed: this test file was previously not registered in `RevenueCat.xcodeproj`, so it was silently never running. Registered it and added a `BasePurchasesTests.MockBackend` convenience init that injects a `MockAdsAPI` so `backend.adsAPI as? MockAdsAPI` resolves.)
- `VirtualCurrencyRewardTests` and `VerifiedRewardTests` — direct unit tests for the new types under `Tests/UnitTests/Ads/RewardVerification/` (field storage, equality, decimal precision; case construction, equality, exhaustive switch).

#### Verification
- `swift build` ✅
- `xcodebuild test -only-testing:UnitTests/{RewardVerificationStatusResponseDecodingTests,BackendGetRewardVerificationStatusTests,PurchasesRewardVerificationTests,VirtualCurrencyRewardTests,VerifiedRewardTests}` ✅
- `swiftlint` on changed files ✅
- `bundle exec fastlane run_api_tests` — pending (couldn't run locally; relying on CI)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the reward-verification response model and decoding logic to carry reward payloads through an internal SPI, which could affect ad-reward integrations if decoding/mapping is wrong. Impact is limited to `@_spi(Internal)` APIs and is covered by expanded unit tests for malformed/unknown payload handling.
> 
> **Overview**
> **Reward verification polling now returns reward details on success.** The internal SPI `RewardVerificationPollStatus.verified` now carries a `VerifiedReward`, and `Purchases.pollRewardVerificationStatus` maps backend responses through with that associated payload.
> 
> **Backend response decoding was expanded to parse the `reward` subtree leniently.** `RewardVerificationStatusResponse` now decodes `reward` only for `status == "verified"`, supports `virtual_currency` via new `VirtualCurrencyReward`, and downgrades missing/malformed/unsupported reward payloads to `.noReward` / `.unsupportedReward` while logging new backend warning strings.
> 
> **Tests and project wiring were updated.** Adds unit tests for the new reward types and decoding edge cases, updates backend and purchases reward-verification tests to assert reward propagation, and registers new test/source files in the Xcode project (including fixing `PurchasesRewardVerificationTests` being included in the test target).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bbdea2da2ddd8f9218a316a10d0d734a0840b34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->