### PR TITLE
Update sdks-common-config orb with pinned mise install

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1,7 +1,7 @@
 orbs:
   macos: circleci/macos@2.5.1
   slack: circleci/slack@5.0.0
-  revenuecat: revenuecat/sdks-common-config@v3.19.0
+  revenuecat: revenuecat/sdks-common-config@3.19.0
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1,7 +1,7 @@
 orbs:
   macos: circleci/macos@2.5.1
   slack: circleci/slack@5.0.0
-  revenuecat: revenuecat/sdks-common-config@dev:b1093374e0453d495e6b5f249bb098de9b069f62
+  revenuecat: revenuecat/sdks-common-config@v3.19.0
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1,7 +1,7 @@
 orbs:
   macos: circleci/macos@2.5.1
   slack: circleci/slack@5.0.0
-  revenuecat: revenuecat/sdks-common-config@3.16.0
+  revenuecat: revenuecat/sdks-common-config@dev:b1093374e0453d495e6b5f249bb098de9b069f62
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 


### PR DESCRIPTION
Picks up the pinned mise install from RevenueCat/sdks-circleci-orb#53.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to CI configuration; the main impact is on pipeline behavior via updated orb scripts/steps.
> 
> **Overview**
> Updates the CircleCI `revenuecat/sdks-common-config` orb version in `.circleci/default_config.yml` from `3.16.0` to `3.19.0`, pulling in the latest shared CI configuration (including the pinned `mise` install referenced in the PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a4f1249f9054a95ce11e68aa6ff30f18b08560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->