### PR TITLE
Update backend integration test snapshots (2026-04-23)

### DIFF
--- a/Tests/BackendIntegrationTests/__Snapshots__/FallbackURLBackendIntegrationTests/testCanGetOfferingsFromFallbackURL.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/FallbackURLBackendIntegrationTests/testCanGetOfferingsFromFallbackURL.1.json
@@ -105,6 +105,7 @@
                           "action" : {
                             "type" : "navigate_back"
                           },
+                          "id" : "68b5fP9Fpd",
                           "name" : "",
                           "stack" : {
                             "components" : [
@@ -1269,6 +1270,7 @@
                             "action" : {
                               "type" : "restore_purchases"
                             },
+                            "id" : "vLoUgvChkK",
                             "name" : "",
                             "stack" : {
                               "components" : [

--- a/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferingsFromLoadShedder.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferingsFromLoadShedder.1.json
@@ -128,6 +128,7 @@
                           "action" : {
                             "type" : "navigate_back"
                           },
+                          "id" : "68b5fP9Fpd",
                           "name" : "",
                           "stack" : {
                             "components" : [
@@ -1260,6 +1261,7 @@
                             "action" : {
                               "type" : "restore_purchases"
                             },
+                            "id" : "vLoUgvChkK",
                             "name" : "",
                             "stack" : {
                               "components" : [

--- a/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
@@ -105,6 +105,7 @@
                           "action" : {
                             "type" : "navigate_back"
                           },
+                          "id" : "68b5fP9Fpd",
                           "name" : "",
                           "stack" : {
                             "components" : [
@@ -1269,6 +1270,7 @@
                             "action" : {
                               "type" : "restore_purchases"
                             },
+                            "id" : "vLoUgvChkK",
                             "name" : "",
                             "stack" : {
                               "components" : [


### PR DESCRIPTION
Snapshot update branch for 2026-04-23. CI will push generated snapshots here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to backend integration test snapshot JSON outputs and don’t affect runtime code paths.
> 
> **Overview**
> Updates backend integration test snapshots for offerings/paywall component responses to include stable `id` fields on certain UI components (e.g., the `navigate_back` and `restore_purchases` buttons) across fallback URL, load shedder, and StoreKit scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1044e650acdc2a1367453ca6ecd4a2f5d11809c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->