### PR TITLE
Add WorkflowContext to surface full workflow state from PurchaseHandler

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		03F446262D2FE1510046129A /* MaskShapePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */; };
 		03F446552D303E350046129A /* PaddingPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446542D303E350046129A /* PaddingPropertyTests.swift */; };
 		03F446572D303FA10046129A /* CornerRadiusesPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F446562D303FA10046129A /* CornerRadiusesPropertyTests.swift */; };
+		150BEBF14F59182317CDA8DA /* WorkflowContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = F598F832810DB534092FBED3 /* WorkflowContext.swift */; };
 		161627FE2F50987800DEEDEB /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 161627FD2F50987800DEEDEB /* Media.xcassets */; };
 		16216FEF2EBB8641008ACFE9 /* ResumeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16216FEE2EBB8641008ACFE9 /* ResumeAction.swift */; };
 		162170152EBE50F0008ACFE9 /* LocaleComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162170142EBE50F0008ACFE9 /* LocaleComparisonTests.swift */; };
@@ -2955,6 +2956,7 @@
 		F584742F278D00C0001B1CE6 /* MockDNSChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDNSChecker.swift; sourceTree = "<group>"; };
 		F591492526B994B400D32E58 /* SKPaymentTransactionExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKPaymentTransactionExtensionsTests.swift; sourceTree = "<group>"; };
 		F591492726B9956C00D32E58 /* MockTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTransaction.swift; sourceTree = "<group>"; };
+		F598F832810DB534092FBED3 /* WorkflowContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowContext.swift; sourceTree = "<group>"; };
 		F5BE423F26962ACF00254A30 /* ReceiptRefreshPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptRefreshPolicy.swift; sourceTree = "<group>"; };
 		F5BE424126965F9F00254A30 /* ProductRequestData+Initialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductRequestData+Initialization.swift"; sourceTree = "<group>"; };
 		F5BE4244269676E200254A30 /* StoreKitRequestFetcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreKitRequestFetcherTests.swift; sourceTree = "<group>"; };
@@ -5578,6 +5580,7 @@
 				887A5FEE2C1D037000E1A461 /* PaywallPurchasesType.swift */,
 				887A5FEF2C1D037000E1A461 /* PurchaseHandler.swift */,
 				887A5FF02C1D037000E1A461 /* PurchaseHandler+TestData.swift */,
+				F598F832810DB534092FBED3 /* WorkflowContext.swift */,
 			);
 			path = Purchasing;
 			sourceTree = "<group>";
@@ -8254,6 +8257,7 @@
 				6561C746FE7043F5E5AC75C1 /* CarouselState.swift in Sources */,
 				961B6FC99052B19102AE5AEC /* WorkflowNavigator.swift in Sources */,
 				97B9F00926E0977B0DAAD7D7 /* EnvironmentValues+Workflow.swift in Sources */,
+				150BEBF14F59182317CDA8DA /* WorkflowContext.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -321,6 +321,7 @@
 		2DEAC2E626EFE470006914ED /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DEAC2E526EFE470006914ED /* Assets.xcassets */; };
 		2DFF6C56270CA28800ECAFAB /* MockRequestFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B517926D44FF000BD2BD7 /* MockRequestFetcher.swift */; };
 		3137AB923EF70929169EB301 /* VideoAutoplayHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077AC81FEBE38D1468AE8670 /* VideoAutoplayHandlerTests.swift */; };
+		32BA5990B3275FB1EB48F01F /* WorkflowContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA86A1D9F5AE92988B20230 /* WorkflowContextTests.swift */; };
 		35109DAB2BC6E436001030C8 /* BackendPostDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35109DAA2BC6E436001030C8 /* BackendPostDiagnosticsTests.swift */; };
 		35109DB92BC8143E001030C8 /* DiagnosticsEventsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35109DB82BC8143E001030C8 /* DiagnosticsEventsRequest.swift */; };
 		351B513D26D4491E00BD2BD7 /* MockDeviceCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B513C26D4491E00BD2BD7 /* MockDeviceCache.swift */; };
@@ -2609,6 +2610,7 @@
 		77AABEB72F0C23450018C1D3 /* PurchasesStoreMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesStoreMessagesTests.swift; sourceTree = "<group>"; };
 		77BA1AB02CCBAB80009BF0EA /* RootViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewModel.swift; sourceTree = "<group>"; };
 		77BA1AB22CCBB6EE009BF0EA /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		7AA86A1D9F5AE92988B20230 /* WorkflowContextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowContextTests.swift; sourceTree = "<group>"; };
 		80CDB7B52E69C35100D7DB9E /* CustomerCenterStylingUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterStylingUtilities.swift; sourceTree = "<group>"; };
 		80E80EF026970DC3008F245A /* ReceiptFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
 		830003FE2E26161D00143F9F /* PlatformFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformFont.swift; sourceTree = "<group>"; };
@@ -5769,6 +5771,7 @@
 				166BA7A12F84028600BB46C9 /* PaywallEventTrackerTests.swift */,
 				16E146B42E99FF640089B609 /* MockStoreTransaction.swift */,
 				887A61372C1D168B00E1A461 /* PurchaseHandlerTests.swift */,
+				7AA86A1D9F5AE92988B20230 /* WorkflowContextTests.swift */,
 			);
 			path = Purchasing;
 			sourceTree = "<group>";
@@ -8343,6 +8346,7 @@
 				3137AB923EF70929169EB301 /* VideoAutoplayHandlerTests.swift in Sources */,
 				ED85C2AB8EAB82D346A12569 /* CarouselStateTests.swift in Sources */,
 				BBCED5B1D64CBEB6CDC2CDA7 /* WorkflowNavigatorTests.swift in Sources */,
+				32BA5990B3275FB1EB48F01F /* WorkflowContextTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -936,7 +936,7 @@ private extension CustomerInfo {
 }
 
 #if !os(tvOS)
-extension ProcessInfo {
+private extension ProcessInfo {
 
     var workflowsEndpointEnabled: Bool {
         arguments.contains("-EnableWorkflowsEndpoint")

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -329,6 +329,20 @@ extension PurchaseHandler {
         identifier: String,
         presentedOfferingContext: PresentedOfferingContext?
     ) async throws -> Offering {
+        return try await resolveWorkflowContext(
+            identifier: identifier,
+            presentedOfferingContext: presentedOfferingContext
+        ).offering
+    }
+
+    func resolveWorkflowContext(
+        identifier: String,
+        presentedOfferingContext: PresentedOfferingContext?
+    ) async throws -> (context: WorkflowContext, offering: Offering) {
+        guard ProcessInfo.processInfo.workflowsEndpointEnabled else {
+            throw PaywallError.offeringNotFound(identifier: identifier)
+        }
+
         async let fetchResultTask = self.purchases.workflow(forOfferingIdentifier: identifier)
         async let allOfferingsTask = self.purchases.offerings()
 
@@ -351,13 +365,23 @@ extension PurchaseHandler {
             uiConfig: workflow.uiConfig
         )
 
-        let offering = baseOffering.withPaywallComponents(paywallComponents)
+        let initialOffering = baseOffering.withPaywallComponents(paywallComponents)
 
+        let offering: Offering
         if let presentedOfferingContext {
-            return offering.withPresentedOfferingContext(presentedOfferingContext)
+            offering = initialOffering.withPresentedOfferingContext(presentedOfferingContext)
+        } else {
+            offering = initialOffering
         }
 
-        return offering
+        let context = WorkflowContext(
+            workflow: workflow,
+            allOfferings: allOfferings,
+            initialOffering: offering,
+            presentedOfferingContext: presentedOfferingContext
+        )
+
+        return (context, offering)
     }
     #endif
 
@@ -912,7 +936,7 @@ private extension CustomerInfo {
 }
 
 #if !os(tvOS)
-private extension ProcessInfo {
+extension ProcessInfo {
 
     var workflowsEndpointEnabled: Bool {
         arguments.contains("-EnableWorkflowsEndpoint")

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -1,0 +1,25 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WorkflowContext.swift
+
+@_spi(Internal) import RevenueCat
+
+#if !os(tvOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct WorkflowContext {
+    let workflow: PublishedWorkflow
+    let allOfferings: Offerings
+    let initialOffering: Offering
+    /// Preserved so every subsequent step's offering can carry the same placement/targeting metadata.
+    let presentedOfferingContext: PresentedOfferingContext?
+}
+
+#endif

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
@@ -1,0 +1,91 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WorkflowContextTests.swift
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if !os(tvOS) // For Paywalls V2
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class WorkflowContextTests: TestCase {
+
+    // MARK: - WorkflowContext
+
+    func testWorkflowContextStoresPresentedOfferingContext() throws {
+        let poc = PresentedOfferingContext(offeringIdentifier: "offering_a")
+        let context = WorkflowContext(
+            workflow: try Self.makeWorkflow(),
+            allOfferings: TestData.offerings,
+            initialOffering: TestData.offering,
+            presentedOfferingContext: poc
+        )
+
+        expect(context.presentedOfferingContext?.offeringIdentifier) == "offering_a"
+    }
+
+    func testWorkflowContextAllowsNilPresentedOfferingContext() throws {
+        let context = WorkflowContext(
+            workflow: try Self.makeWorkflow(),
+            allOfferings: TestData.offerings,
+            initialOffering: TestData.offering,
+            presentedOfferingContext: nil
+        )
+
+        expect(context.presentedOfferingContext).to(beNil())
+    }
+
+    // MARK: - resolveWorkflowContext
+
+    func testResolveWorkflowContextThrowsWhenFlagIsOff() async throws {
+        // In the unit test environment -EnableWorkflowsEndpoint is not a launch argument,
+        // so workflowsEndpointEnabled returns false and resolveWorkflowContext must throw.
+        let handler: PurchaseHandler = .mock()
+
+        await expect {
+            try await handler.resolveWorkflowContext(
+                identifier: "offering_a",
+                presentedOfferingContext: nil
+            )
+        }.to(throwError(PaywallError.offeringNotFound(identifier: "offering_a")))
+    }
+
+}
+
+// MARK: - Helpers
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension WorkflowContextTests {
+
+    static func makeWorkflow() throws -> PublishedWorkflow {
+        let json = """
+        {
+          "id": "wf_test",
+          "display_name": "Test",
+          "initial_step_id": "step_1",
+          "steps": {
+            "step_1": { "id": "step_1", "type": "screen" }
+          },
+          "screens": {},
+          "ui_config": {
+            "app": { "colors": {}, "fonts": {} },
+            "localizations": {}
+          }
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
@@ -22,11 +22,12 @@ final class WorkflowContextTests: TestCase {
     // MARK: - WorkflowContext
 
     func testWorkflowContextStoresPresentedOfferingContext() throws {
+        let offering = TestData.offeringWithIntroOffer
         let poc = PresentedOfferingContext(offeringIdentifier: "offering_a")
         let context = WorkflowContext(
             workflow: try Self.makeWorkflow(),
-            allOfferings: TestData.offerings,
-            initialOffering: TestData.offering,
+            allOfferings: Self.makeOfferings(offering),
+            initialOffering: offering,
             presentedOfferingContext: poc
         )
 
@@ -34,10 +35,11 @@ final class WorkflowContextTests: TestCase {
     }
 
     func testWorkflowContextAllowsNilPresentedOfferingContext() throws {
+        let offering = TestData.offeringWithIntroOffer
         let context = WorkflowContext(
             workflow: try Self.makeWorkflow(),
-            allOfferings: TestData.offerings,
-            initialOffering: TestData.offering,
+            allOfferings: Self.makeOfferings(offering),
+            initialOffering: offering,
             presentedOfferingContext: nil
         )
 
@@ -65,6 +67,26 @@ final class WorkflowContextTests: TestCase {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension WorkflowContextTests {
+
+    static func makeOfferings(_ offering: Offering) -> Offerings {
+        return Offerings(
+            offerings: [offering.identifier: offering],
+            currentOfferingID: nil,
+            placements: nil,
+            targeting: nil,
+            contents: .init(
+                response: .init(
+                    currentOfferingId: nil,
+                    offerings: [],
+                    placements: nil,
+                    targeting: nil,
+                    uiConfig: nil
+                ),
+                httpResponseOriginalSource: .mainServer
+            ),
+            loadedFromDiskCache: false
+        )
+    }
 
     static func makeWorkflow() throws -> PublishedWorkflow {
         let json = """


### PR DESCRIPTION
## Summary

- Adds `WorkflowContext` struct — bundles `PublishedWorkflow`, all `Offerings`, and the resolved initial `Offering` so a multi-step view can resolve any step on the fly
- `PurchaseHandler.resolveWorkflowContext(identifier:presentedOfferingContext:)` — new internal method that surfaces the full context; the existing `resolveWorkflowOfferingIdentifier` now delegates to it and discards the context, so the current `PaywallView` path is unchanged

Previously the workflow + all offerings were fetched but immediately discarded after resolving only the initial step. This PR preserves them for `WorkflowPaywallView` (PR 4b) to use when navigating to subsequent steps.

Independent of PR 3 — can be reviewed in parallel.
Next: PR 4b (WorkflowPaywallView core), which depends on both this and PR 3.

## Test plan

- [ ] `swift build` passes (verified locally)
- [ ] `resolveWorkflowOfferingIdentifier` behaviour is unchanged — it now delegates to `resolveWorkflowContext` and returns the same offering as before

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall offering resolution for the workflows endpoint path; behavior is intended to be unchanged but errors/metadata propagation could affect which offering is shown when workflows are enabled.
> 
> **Overview**
> Adds a new internal `WorkflowContext` value that bundles the fetched `PublishedWorkflow`, the full `Offerings` response, the resolved initial `Offering`, and the optional `PresentedOfferingContext` for reuse across multi-step workflow navigation.
> 
> Refactors `PurchaseHandler` so `resolveWorkflowOfferingIdentifier` delegates to a new `resolveWorkflowContext(identifier:presentedOfferingContext:)`, which returns both the resolved offering and the preserved workflow context, while keeping the existing paywall path returning the same `Offering`.
> 
> Updates the Xcode project to include the new source and adds `WorkflowContextTests` to validate `presentedOfferingContext` storage and that `resolveWorkflowContext` throws when the workflows flag is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2bea40d39461629c1438de9196d2101760b189e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->