### PR TITLE
Fix WorkflowTriggerAction.stepId to be optional (String?)

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowNavigator.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowNavigator.swift
@@ -41,7 +41,8 @@ final class WorkflowNavigator: ObservableObject {
               let actionId = trigger.actionId,
               let triggerAction = step.stepTriggerActions[actionId],
               triggerAction.type == "step",
-              let nextStep = workflow.steps[triggerAction.stepId] else {
+              let stepId = triggerAction.stepId,
+              let nextStep = workflow.steps[stepId] else {
             return nil
         }
 

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -28,7 +28,7 @@ import Foundation
 @_spi(Internal) public struct WorkflowTriggerAction {
 
     public let type: String
-    public let stepId: String
+    public let stepId: String?
 
 }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowNavigatorTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowNavigatorTests.swift
@@ -147,6 +147,25 @@ final class WorkflowNavigatorTests: TestCase {
         expect(navigator.currentStepId) == "step_1"
     }
 
+    func testTriggerActionWithConditionsTypeReturnsNil() throws {
+        // A "conditions" trigger action has no step_id. The navigator must not crash
+        // and must return nil (no navigation), leaving the current step unchanged.
+        let workflow = try Self.makeWorkflow(
+            steps: [
+                makeStepWithConditionsTriggerAction(id: "step_1", componentId: "btn_abc", actionId: "btn_abc"),
+                makeStep(id: "step_2")
+            ],
+            initialStepId: "step_1"
+        )
+        let navigator = WorkflowNavigator(workflow: workflow)
+
+        let result = navigator.triggerAction(componentId: "btn_abc")
+
+        expect(result).to(beNil())
+        expect(navigator.currentStepId) == "step_1"
+        expect(navigator.canNavigateBack) == false
+    }
+
     // MARK: - navigateBack
 
     func testNavigateBackFromInitialStepReturnsNil() throws {
@@ -288,6 +307,27 @@ private extension WorkflowNavigatorTests {
           "type": "screen",
           "triggers": \(triggersJSON),
           "trigger_actions": \(actionsJSON)
+        }
+        """
+        return StepDescriptor(id: id, json: json)
+    }
+
+    /// Creates a `StepDescriptor` where the trigger action has type "conditions" (no step_id field).
+    func makeStepWithConditionsTriggerAction(
+        id: String,
+        componentId: String,
+        actionId: String
+    ) -> StepDescriptor {
+        let json = """
+        {
+          "id": "\(id)",
+          "type": "screen",
+          "triggers": [
+            {"name":"Button","type":"on_press","action_id":"\(actionId)","component_id":"\(componentId)"}
+          ],
+          "trigger_actions": {
+            "\(actionId)": {"type":"conditions","conditions":{"if":[]}}
+          }
         }
         """
         return StepDescriptor(id: id, json: json)

--- a/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
+++ b/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
@@ -112,6 +112,51 @@ class WorkflowResponseTests: TestCase {
         expect(action.stepId) == "step_3"
     }
 
+    func testDecodeWorkflowTriggerActionConditionsTypeHasNilStepId() throws {
+        // Server can send trigger_actions with type "conditions" which have no step_id field.
+        // stepId must be optional so decoding doesn't fail for the entire workflow.
+        let json = """
+        { "type": "conditions", "conditions": { "if": [] } }
+        """.data(using: .utf8)!
+
+        let action = try JSONDecoder.default.decode(WorkflowTriggerAction.self, from: json)
+
+        expect(action.type) == "conditions"
+        expect(action.stepId).to(beNil())
+    }
+
+    func testDecodeWorkflowWithConditionsTriggerActionSucceeds() throws {
+        let json = """
+        {
+          "id": "wf_cond",
+          "display_name": "Cond",
+          "initial_step_id": "step_1",
+          "steps": {
+            "step_1": {
+              "id": "step_1",
+              "type": "screen",
+              "trigger_actions": {
+                "btn_1": { "type": "step", "step_id": "step_2" },
+                "btn_2": { "type": "conditions", "conditions": { "if": [] } }
+              }
+            }
+          },
+          "screens": {},
+          "ui_config": {
+            "app": { "colors": {}, "fonts": {} },
+            "localizations": {},
+            "variable_config": { "variable_compatibility_map": {}, "function_compatibility_map": {} }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let workflow = try JSONDecoder.default.decode(PublishedWorkflow.self, from: json)
+
+        expect(workflow.steps["step_1"]?.triggerActions["btn_1"]?.stepId) == "step_2"
+        expect(workflow.steps["step_1"]?.triggerActions["btn_2"]?.type) == "conditions"
+        expect(workflow.steps["step_1"]?.triggerActions["btn_2"]?.stepId).to(beNil())
+    }
+
     func testDecodeWorkflowTrigger() throws {
         let json = """
         {


### PR DESCRIPTION
## Motivation

`WorkflowTriggerAction.stepId` was declared as `String` (non-optional), but the server can return trigger actions with `type: "conditions"` that have **no `step_id` field at all**. When that happens, `Codable` throws a key-not-found error and the entire workflow fails to decode — silently breaking multipage paywall navigation.

Android already handles this correctly with `String? = null`:
- **Android**: [`WorkflowModels.kt` — `stepId: String? = null`](https://github.com/RevenueCat/purchases-android/pull/3300)

The server-side domain model (`khepri`) has two trigger action variants:
- `StepTriggerAction` → `{ type: "step", step_id: str }` — always has `step_id`
- `ConditionsTriggerAction` → `{ type: "conditions", conditions: {...} }` — **no `step_id`**

Both variants are passed through the SDK serializer as raw JSON, so clients must handle both.

## Changes

- `WorkflowsResponse.swift`: `stepId: String` → `stepId: String?`
- `WorkflowNavigator.swift`: add `let stepId = triggerAction.stepId` binding in the guard chain (navigator already checked `type == "step"`, but decoding would have already failed before reaching that guard)

## Tests

- `WorkflowResponseTests`: added two new cases:
  - `testDecodeWorkflowTriggerActionConditionsTypeHasNilStepId` — decoding a bare conditions action yields `stepId == nil`
  - `testDecodeWorkflowWithConditionsTriggerActionSucceeds` — a workflow with a mixed step/conditions step decodes without error
- `WorkflowNavigatorTests`: added `testTriggerActionWithConditionsTypeReturnsNil` — navigator returns nil and stays on current step when the resolved trigger action is a conditions type

## Related

- Android PR that introduced `String? = null`: https://github.com/RevenueCat/purchases-android/pull/3300
- iOS WorkflowNavigator PR: https://github.com/RevenueCat/purchases-ios/pull/6680

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow decoding and navigation logic used for multi-step paywalls; while the change is small and well-tested, it affects how server workflow JSON is interpreted and could impact navigation if assumptions about `step_id` change.
> 
> **Overview**
> Prevents workflow decoding failures when the backend returns trigger actions of type `"conditions"` (which omit `step_id`) by making `WorkflowTriggerAction.stepId` optional.
> 
> Updates `WorkflowNavigator.triggerAction` to safely unwrap `stepId` only for `type == "step"` before navigating, and adds unit/UI tests to ensure mixed step/conditions workflows decode successfully and that conditions actions do not navigate or modify the back stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cff3d36f21c0bbe6716ef87efd864527271a3a84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->