### PR TITLE
Document Tuist environment variables in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,24 @@ For environment setup, see **`Contributing/CONTRIBUTING.md`**. For code style, s
 
 The project uses **Tuist** for managing the Xcode workspace. See **`Contributing/DEVELOPMENT.md`** for full Tuist commands, environment variables, and troubleshooting.
 
+**Tuist environment variables** (prefix all with `TUIST_` when passing to `tuist generate`):
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `TUIST_RC_REMOTE=true` | Use remote instead of local RevenueCat dependency | local |
+| `TUIST_RC_XCODE_PROJECT=true` | Use Xcode project instead of Swift Package dependency | SPM |
+| `TUIST_INCLUDE_TEST_DEPENDENCIES=false` | Skip test/dev dependencies (Nimble, OHHTTPStubs, etc.) to speed up `tuist install` | `true` |
+| `TUIST_INCLUDE_XCFRAMEWORK_INSTALLATION_TESTS=true` | Include XCFrameworkInstallationTests project | `false` |
+| `TUIST_SK_CONFIG_PATH=/path/to/file.storekit` | Custom StoreKit config for PaywallsTester scheme | — |
+| `TUIST_RC_API_KEY=appl_xxxxx` | RevenueCat API key written to `Local.xcconfig` at generation time | — |
+| `TUIST_LAUNCH_ARGUMENTS="-Flag1 -Flag2"` | Space-separated launch arguments injected into PaywallsTester scheme run action (enabled by default) | — |
+| `TUIST_SWIFT_CONDITIONS="FLAG1 FLAG2"` | Space-separated Swift compilation conditions injected into all targets | — |
+
+Example combining multiple variables:
+```bash
+TUIST_RC_API_KEY=appl_xxxxx TUIST_LAUNCH_ARGUMENTS="-EnableWorkflowsEndpoint" tuist generate PaywallsTester
+```
+
 ### Target Specifications
 - **Minimum Deployment**: iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, visionOS 1.0
 - **Swift**: 5.9+


### PR DESCRIPTION
## Summary

- Adds a Tuist environment variables reference table to `AGENTS.md`
- Covers all env vars in `Tuist/ProjectDescriptionHelpers/Environment.swift`: `TUIST_RC_REMOTE`, `TUIST_RC_XCODE_PROJECT`, `TUIST_INCLUDE_TEST_DEPENDENCIES`, `TUIST_INCLUDE_XCFRAMEWORK_INSTALLATION_TESTS`, `TUIST_SK_CONFIG_PATH`, `TUIST_RC_API_KEY`, `TUIST_LAUNCH_ARGUMENTS`, `TUIST_SWIFT_CONDITIONS`
- Includes a combined usage example

Follows up on feedback from https://github.com/RevenueCat/purchases-ios/pull/6664#discussion_r3123380266.

## Test plan

- [ ] Review the rendered table in `AGENTS.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change with no impact on build or runtime behavior.
> 
> **Overview**
> Adds a **Tuist environment variables** section to `AGENTS.md`, including a table documenting supported `TUIST_*` flags (dependency mode, test dependency inclusion, XCFramework tests, StoreKit config, API key injection, launch arguments, and Swift compilation conditions) and a combined usage example for `tuist generate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3755832ee76c45cc670ba27ddcc37b49f215553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->