### PR TITLE
Expose Logger to internal consumers

### DIFF
--- a/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
+++ b/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
@@ -43,9 +43,11 @@ protocol LoggerType {
 }
 
 /// Contains a message that can be output by ``os.Logger``.
-protocol LogMessage: CustomStringConvertible {
+@_spi(Internal) public protocol LogMessage: CustomStringConvertible {
 
+    /// Human-readable text that will be logged.
     var description: String { get }
+    /// Logging category used by the underlying logger backend.
     var category: String { get }
 
 }

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -36,8 +36,8 @@ internal typealias InternalLogHandler = (_ level: LogLevel,
 
 // This is a `struct` instead of `enum` so that
 // we can use `Logger()` as a `LoggerType`.
-// swiftlint:disable:next convenience_type
-struct Logger {
+// swiftlint:disable:next convenience_type missing_docs
+@_spi(Internal) public struct Logger {
 
     static var logLevel: LogLevel = Self.defaultLogLevel
     static var internalLogHandler: InternalLogHandler = Self.defaultLogHandler
@@ -83,7 +83,7 @@ extension Logger {
 /// let logger: LoggerType
 /// logger.info("...")
 /// ```
-extension Logger: LoggerType {
+@_spi(Internal) extension Logger: LoggerType {
 
     func verbose(_ message: LogMessage,
                  fileName: String? = #fileID,

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -36,8 +36,11 @@ internal typealias InternalLogHandler = (_ level: LogLevel,
 
 // This is a `struct` instead of `enum` so that
 // we can use `Logger()` as a `LoggerType`.
-// swiftlint:disable:next convenience_type missing_docs
+// swiftlint:disable:next missing_docs
 @_spi(Internal) public struct Logger {
+
+    /// Creates an SPI-visible logger instance for internal module injection.
+    @_spi(Internal) public init() {}
 
     static var logLevel: LogLevel = Self.defaultLogLevel
     static var internalLogHandler: InternalLogHandler = Self.defaultLogHandler

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -36,11 +36,8 @@ internal typealias InternalLogHandler = (_ level: LogLevel,
 
 // This is a `struct` instead of `enum` so that
 // we can use `Logger()` as a `LoggerType`.
-// swiftlint:disable:next missing_docs
+// swiftlint:disable:next convenience_type missing_docs
 @_spi(Internal) public struct Logger {
-
-    /// Creates an SPI-visible logger instance for internal module injection.
-    @_spi(Internal) public init() {}
 
     static var logLevel: LogLevel = Self.defaultLogLevel
     static var internalLogHandler: InternalLogHandler = Self.defaultLogHandler
@@ -86,45 +83,40 @@ extension Logger {
 /// let logger: LoggerType
 /// logger.info("...")
 /// ```
-@_spi(Internal) extension Logger: LoggerType {
+extension Logger: LoggerType {
 
-    /// Logs a verbose message.
-    public func verbose(_ message: LogMessage,
-                        fileName: String? = #fileID,
-                        functionName: String? = #function,
-                        line: UInt = #line) {
+    func verbose(_ message: LogMessage,
+                 fileName: String? = #fileID,
+                 functionName: String? = #function,
+                 line: UInt = #line) {
         Self.verbose(message, fileName: fileName, functionName: functionName, line: line)
     }
 
-    /// Logs a debug message.
-    public func debug(_ message: LogMessage,
-                      fileName: String? = #fileID,
-                      functionName: String? = #function,
-                      line: UInt = #line) {
+    func debug(_ message: LogMessage,
+               fileName: String? = #fileID,
+               functionName: String? = #function,
+               line: UInt = #line) {
         Self.debug(message, fileName: fileName, functionName: functionName, line: line)
     }
 
-    /// Logs an info message.
-    public func info(_ message: LogMessage,
-                     fileName: String? = #fileID,
-                     functionName: String? = #function,
-                     line: UInt = #line) {
+    func info(_ message: LogMessage,
+              fileName: String? = #fileID,
+              functionName: String? = #function,
+              line: UInt = #line) {
         Self.info(message, fileName: fileName, functionName: functionName, line: line)
     }
 
-    /// Logs a warning message.
-    public func warn(_ message: LogMessage,
-                     fileName: String? = #fileID,
-                     functionName: String? = #function,
-                     line: UInt = #line) {
+    func warn(_ message: LogMessage,
+              fileName: String? = #fileID,
+              functionName: String? = #function,
+              line: UInt = #line) {
         Self.warn(message, fileName: fileName, functionName: functionName, line: line)
     }
 
-    /// Logs an error message.
-    public func error(_ message: LogMessage,
-                      fileName: String = #fileID,
-                      functionName: String = #function,
-                      line: UInt = #line) {
+    func error(_ message: LogMessage,
+               fileName: String = #fileID,
+               functionName: String = #function,
+               line: UInt = #line) {
         Self.error(message, fileName: fileName, functionName: functionName, line: line)
     }
 
@@ -134,34 +126,38 @@ extension Logger {
 
 extension Logger {
 
-    static func verbose(_ message: LogMessage,
-                        fileName: String? = #fileID,
-                        functionName: String? = #function,
-                        line: UInt = #line) {
+    /// Logs a verbose-level message through the shared logger pipeline.
+    @_spi(Internal) public static func verbose(_ message: LogMessage,
+                                               fileName: String? = #fileID,
+                                               functionName: String? = #function,
+                                               line: UInt = #line) {
         Self.log(level: .verbose, intent: .verbose, message: message,
                  fileName: fileName, functionName: functionName, line: line)
     }
 
-    static func debug(_ message: LogMessage,
-                      fileName: String? = #fileID,
-                      functionName: String? = #function,
-                      line: UInt = #line) {
+    /// Logs a debug-level message through the shared logger pipeline.
+    @_spi(Internal) public static func debug(_ message: LogMessage,
+                                             fileName: String? = #fileID,
+                                             functionName: String? = #function,
+                                             line: UInt = #line) {
         Self.log(level: .debug, intent: .info, message: message,
                  fileName: fileName, functionName: functionName, line: line)
     }
 
-    static func info(_ message: LogMessage,
-                     fileName: String? = #fileID,
-                     functionName: String? = #function,
-                     line: UInt = #line) {
+    /// Logs an info-level message through the shared logger pipeline.
+    @_spi(Internal) public static func info(_ message: LogMessage,
+                                            fileName: String? = #fileID,
+                                            functionName: String? = #function,
+                                            line: UInt = #line) {
         Self.log(level: .info, intent: .info, message: message,
                  fileName: fileName, functionName: functionName, line: line)
     }
 
-    static func warn(_ message: LogMessage,
-                     fileName: String? = #fileID,
-                     functionName: String? = #function,
-                     line: UInt = #line) {
+    /// Logs a warning-level message through the shared logger pipeline.
+    @_spi(Internal) public static func warn(_ message: LogMessage,
+                                            fileName: String? = #fileID,
+                                            functionName: String? = #function,
+                                            line: UInt = #line) {
         Self.log(level: .warn, intent: .warning, message: message,
                  fileName: fileName, functionName: functionName, line: line)
     }
@@ -178,10 +174,11 @@ extension Logger {
         )
     }
 
-    static func error(_ message: LogMessage,
-                      fileName: String = #fileID,
-                      functionName: String = #function,
-                      line: UInt = #line) {
+    /// Logs an error-level message through the shared logger pipeline.
+    @_spi(Internal) public static func error(_ message: LogMessage,
+                                             fileName: String = #fileID,
+                                             functionName: String = #function,
+                                             line: UInt = #line) {
         Self.log(level: .error, intent: .rcError, message: message,
                  fileName: fileName, functionName: functionName, line: line)
     }

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -85,38 +85,43 @@ extension Logger {
 /// ```
 @_spi(Internal) extension Logger: LoggerType {
 
-    func verbose(_ message: LogMessage,
-                 fileName: String? = #fileID,
-                 functionName: String? = #function,
-                 line: UInt = #line) {
+    /// Logs a verbose message.
+    public func verbose(_ message: LogMessage,
+                        fileName: String? = #fileID,
+                        functionName: String? = #function,
+                        line: UInt = #line) {
         Self.verbose(message, fileName: fileName, functionName: functionName, line: line)
     }
 
-    func debug(_ message: LogMessage,
-               fileName: String? = #fileID,
-               functionName: String? = #function,
-               line: UInt = #line) {
+    /// Logs a debug message.
+    public func debug(_ message: LogMessage,
+                      fileName: String? = #fileID,
+                      functionName: String? = #function,
+                      line: UInt = #line) {
         Self.debug(message, fileName: fileName, functionName: functionName, line: line)
     }
 
-    func info(_ message: LogMessage,
-              fileName: String? = #fileID,
-              functionName: String? = #function,
-              line: UInt = #line) {
+    /// Logs an info message.
+    public func info(_ message: LogMessage,
+                     fileName: String? = #fileID,
+                     functionName: String? = #function,
+                     line: UInt = #line) {
         Self.info(message, fileName: fileName, functionName: functionName, line: line)
     }
 
-    func warn(_ message: LogMessage,
-              fileName: String? = #fileID,
-              functionName: String? = #function,
-              line: UInt = #line) {
+    /// Logs a warning message.
+    public func warn(_ message: LogMessage,
+                     fileName: String? = #fileID,
+                     functionName: String? = #function,
+                     line: UInt = #line) {
         Self.warn(message, fileName: fileName, functionName: functionName, line: line)
     }
 
-    func error(_ message: LogMessage,
-               fileName: String = #fileID,
-               functionName: String = #function,
-               line: UInt = #line) {
+    /// Logs an error message.
+    public func error(_ message: LogMessage,
+                      fileName: String = #fileID,
+                      functionName: String = #function,
+                      line: UInt = #line) {
         Self.error(message, fileName: fileName, functionName: functionName, line: line)
     }
 

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -15,9 +15,9 @@ import Nimble
 import XCTest
 
 #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-@testable import RevenueCat_CustomEntitlementComputation
+@_spi(Internal) @testable import RevenueCat_CustomEntitlementComputation
 #else
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 #endif
 
 final class TestPurchaseDelegate: NSObject, PurchasesDelegate, Sendable {

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -18,9 +18,9 @@ import UniformTypeIdentifiers
 import XCTest
 
 #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-@testable import RevenueCat_CustomEntitlementComputation
+@_spi(Internal) @testable import RevenueCat_CustomEntitlementComputation
 #else
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 #endif
 
 @MainActor

--- a/Tests/BackendIntegrationTests/Helpers/ExternalPurchasesManager.swift
+++ b/Tests/BackendIntegrationTests/Helpers/ExternalPurchasesManager.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Nacho Soto on 7/27/23.
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import StoreKit
 
 /// Used for simulating purchases made from outside the SDK.

--- a/Tests/BackendIntegrationTests/Helpers/TestMessage.swift
+++ b/Tests/BackendIntegrationTests/Helpers/TestMessage.swift
@@ -15,9 +15,9 @@ import Foundation
 import Nimble
 
 #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-@testable import RevenueCat_CustomEntitlementComputation
+@_spi(Internal) @testable import RevenueCat_CustomEntitlementComputation
 #else
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 #endif
 
 import StoreKit

--- a/Tests/BackendIntegrationTests/MainThreadMonitor.swift
+++ b/Tests/BackendIntegrationTests/MainThreadMonitor.swift
@@ -12,7 +12,7 @@
 //  Created by Nacho Soto on 5/1/23.
 
 import Foundation
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import XCTest
 
 final class MainThreadMonitor {

--- a/Tests/StoreKitUnitTests/LoggerTests.swift
+++ b/Tests/StoreKitUnitTests/LoggerTests.swift
@@ -14,7 +14,7 @@
 import Nimble
 import XCTest
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 // Note: this is in `StoreKitUnitTests` because it modifies the global `Logger.logLevel`
 // which means it would interfere with other tests if ran concurrently.

--- a/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 import Nimble
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import StoreKitTest
 import XCTest
 

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -12,7 +12,7 @@
 //  Created by Nacho Soto on 1/24/22.
 
 import Nimble
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import StoreKit
 import StoreKitTest
 import XCTest

--- a/Tests/UnitTests/LocalReceiptParsing/ReceiptParserTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/ReceiptParserTests.swift
@@ -1,7 +1,7 @@
 import Nimble
 import XCTest
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 class ReceiptParserTests: TestCase {
 

--- a/Tests/UnitTests/Mocks/MockProductsManager.swift
+++ b/Tests/UnitTests/Mocks/MockProductsManager.swift
@@ -4,7 +4,7 @@
 //
 
 import Foundation
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import StoreKit
 
 class MockProductsManager: ProductsManager {

--- a/Tests/UnitTests/Mocks/MockReceiptParser.swift
+++ b/Tests/UnitTests/Mocks/MockReceiptParser.swift
@@ -4,7 +4,7 @@
 //
 
 import Foundation
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 import XCTest
 

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -10,7 +10,7 @@ import Foundation
 import Nimble
 import XCTest
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 class EmptyCustomerInfoTests: TestCase {
 

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -12,9 +12,9 @@
 //  Created by Nacho Soto on 8/19/22.
 
 #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-@testable import RevenueCat_CustomEntitlementComputation
+@_spi(Internal) @testable import RevenueCat_CustomEntitlementComputation
 #else
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 #endif
 
 import Foundation


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Reuse Logger behavior in Adapter SDKs when using `@_spi(Internal)`.

### Description
- mark `Logger` as `@_spi(Internal) public`
- expose `InternalLogHandler` as `@_spi(Internal) public` typealias
- expose logger state/handlers (`logLevel`, `internalLogHandler`, `defaultLogHandler`, `verbose`, `frameworkDescription`, `verboseLogsEnabled`) through SPI
- keep public API surface unchanged for non-SPI consumers

Tested with:
- `swift build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to visibility annotations for logging types/methods (via `@_spi(Internal)`) plus test import adjustments, with no changes to logging behavior or public API for non-SPI consumers.
> 
> **Overview**
> Makes the logging API reusable by internal/SPI consumers by exposing `Logger` (and its static `verbose`/`debug`/`info`/`warn`/`error` entry points) and the `LogMessage` protocol via `@_spi(Internal)`.
> 
> Updates unit and integration tests to import `RevenueCat` under the same SPI so they can access these newly SPI-exposed logging symbols.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6fe860a623caa94d2571397df47383ee69244f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->