### PR TITLE
Add workflowTrigger to ButtonComponent.Action

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -111,6 +111,8 @@ struct ButtonComponentView: View {
             navigateTo(destination: destination)
         case .navigateBack:
             onDismiss()
+        case .workflowTrigger:
+            break
         case .unknown:
             Logger.warning(
                 Strings.paywall_unknown_button_action_tracked_for_diagnostics(

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
@@ -26,6 +26,7 @@ class ButtonComponentViewModel {
         case navigateTo(destination: Destination)
         case sheet(RevenueCat.PaywallComponent.ButtonComponent.Sheet)
         case navigateBack
+        case workflowTrigger
         case unknown
     }
 
@@ -99,6 +100,8 @@ class ButtonComponentViewModel {
             }
         case .navigateBack:
             self.action = .navigateBack
+        case .workflowTrigger:
+            self.action = .workflowTrigger
         case .unknown:
             self.action = .unknown
         }
@@ -116,6 +119,7 @@ class ButtonComponentViewModel {
             } else {
                 return false
             }
+        case .workflowTrigger: return false
         case .unknown: return true
         default: return false
         }
@@ -128,6 +132,8 @@ class ButtonComponentViewModel {
         case .navigateTo:
             return false
         case .navigateBack:
+            return false
+        case .workflowTrigger:
             return false
         case .unknown:
             return false
@@ -147,6 +153,8 @@ extension ButtonComponentViewModel.Action {
             return "restore_purchases"
         case .navigateBack:
             return "navigate_back"
+        case .workflowTrigger:
+            return "workflow_trigger"
         case .unknown:
             return "unknown"
         case .sheet:
@@ -160,7 +168,7 @@ extension ButtonComponentViewModel.Action {
         switch self {
         case .navigateTo(let destination):
             return destination.paywallComponentInteractionURL
-        case .restorePurchases, .navigateBack, .unknown, .sheet:
+        case .restorePurchases, .navigateBack, .workflowTrigger, .unknown, .sheet:
             return nil
         }
     }

--- a/Sources/Paywalls/Components/PaywallButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallButtonComponent.swift
@@ -93,6 +93,7 @@ import Foundation
             case restorePurchases
             case navigateBack
             case navigateTo(destination: Destination)
+            case workflowTrigger
 
             case unknown
 
@@ -112,6 +113,8 @@ import Foundation
                 case .navigateTo(let destination):
                     try container.encode("navigate_to", forKey: .type)
                     try destination.encode(to: encoder)
+                case .workflowTrigger:
+                    try container.encode("workflow", forKey: .type)
                 case .unknown:
                     try container.encode("unknown", forKey: .type)
                 }
@@ -129,6 +132,8 @@ import Foundation
                 case "navigate_to":
                     let destination = try Destination(from: decoder)
                     self = .navigateTo(destination: destination)
+                case "workflow":
+                    self = .workflowTrigger
                 case "unknown":
                     self = .unknown
                 default:

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -120,7 +120,7 @@ extension PaywallComponentsData.PaywallComponentsConfig {
                     case .customerCenter, .offerCode, .privacyPolicy, .terms, .webPaywallLink, .url, .unknown:
                         break
                     }
-                case .restorePurchases, .navigateBack, .unknown:
+                case .restorePurchases, .navigateBack, .workflowTrigger, .unknown:
                     break
                 }
             case .package(let package):

--- a/Tests/UnitTests/Paywalls/Components/ButtonComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/ButtonComponentTests.swift
@@ -236,6 +236,31 @@ class ButtonComponentCodableTests: TestCase {
         XCTAssertEqual(decodedButton, buttonComponent)
     }
 
+    func testWorkflowTriggerDecoding() throws {
+        let jsonString = """
+        {
+            "type": "button",
+            "action": {
+                "type": "workflow"
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
+
+        let buttonComponent = PaywallComponent.ButtonComponent(
+            action: .workflowTrigger,
+            stack: .init(
+                components: [],
+                dimension: .vertical(.center, .start),
+                size: .init(width: .fill, height: .fill)
+            )
+        )
+
+        XCTAssertEqual(decodedButton, buttonComponent)
+    }
+
     func testDecodesNameIgnoresExtraIdInJSON() throws {
         let jsonString = """
         {

--- a/Tests/UnitTests/Paywalls/Components/ButtonComponentViewModelInteractionTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/ButtonComponentViewModelInteractionTests.swift
@@ -21,6 +21,13 @@ final class ButtonComponentViewModelInteractionTests: TestCase {
         expect(action.paywallComponentInteractionURL).to(beNil())
     }
 
+    func testWorkflowTriggerInteractionValue() {
+        let action: ButtonComponentViewModel.Action = .workflowTrigger
+
+        expect(action.paywallComponentInteractionValue) == "workflow_trigger"
+        expect(action.paywallComponentInteractionURL).to(beNil())
+    }
+
 }
 
 #endif


### PR DESCRIPTION
## Summary

Mirrors Android's rename of \`Action.Workflow\` → \`Action.WorkflowTrigger\` from [purchases-android#3380](https://github.com/RevenueCat/purchases-android/pull/3380).

This PR just introduces the type — the actual workflow navigation behavior lives in #6692. Without this, buttons with \`"type": "workflow"\` from the backend decode as \`.unknown\` and are hidden; with it they render and track correctly.

Changes:
- Adds \`case workflowTrigger\` to \`PaywallButtonComponent.Action\`, decoding from \`"type": "workflow"\`
- Adds \`case workflowTrigger\` to \`ButtonComponentViewModel.Action\` with \`hasUnknownAction = false\` (so the button renders) and analytics value \`"workflow_trigger"\`

## Triggered by

#6692

## Test plan

- [ ] Verify workflow buttons are no longer hidden when the backend sends \`"type": "workflow"\`
- [ ] Verify analytics track \`"workflow_trigger"\` (not \`"unknown"\`) for workflow button taps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new enum case and wiring for decoding/analytics, with no behavioral workflow navigation yet (action is currently a no-op).
> 
> **Overview**
> Backend paywall button actions now recognize `"type": "workflow"` by adding `case workflowTrigger` to `PaywallComponent.ButtonComponent.Action` (including `Codable` support) and mirroring it in `ButtonComponentViewModel.Action`.
> 
> UI handling is updated so workflow-trigger buttons are **not treated as unknown/hidden** and they report analytics as `workflow_trigger` (with no URL); cache warming and unit tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2229079e4f78d2a67dd03ea61a0f886beffcc4fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->