### PR TITLE
Add opt-in RTL layout for RevenueCatUI

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -10,6 +10,7 @@
 
 ## RevenueCatUI SDK
 ### 🐞 Bugfixes
+* `RevenueCatUI` Paywalls and Customer Center can now opt in to deriving layout direction from `overridePreferredUILocale` by passing `honorLayoutDirection: true`. Paywalls V2 can also use the dashboard `layout_direction` setting to match locale or force RTL/LTR.
 * Defer paywall dismissal after purchase callbacks (#6621) via Jacob Rakidzich (@JZDesign)
 ### Paywallsv2
 #### 🐞 Bugfixes

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1050,6 +1050,7 @@
 		887A606B2C1D037000E1A461 /* TrialOrIntroEligibilityChecker+TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A5FCC2C1D037000E1A461 /* TrialOrIntroEligibilityChecker+TestData.swift */; };
 		887A606C2C1D037000E1A461 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A5FCE2C1D037000E1A461 /* Constants.swift */; };
 		887A606D2C1D037000E1A461 /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A5FCF2C1D037000E1A461 /* Localization.swift */; };
+		B71000022F985A0000D1A001 /* Locale+LayoutDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71000012F985A0000D1A001 /* Locale+LayoutDirection.swift */; };
 		887A606E2C1D037000E1A461 /* LocalizedAlertError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A5FD02C1D037000E1A461 /* LocalizedAlertError.swift */; };
 		887A606F2C1D037000E1A461 /* PaywallData+Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A5FD12C1D037000E1A461 /* PaywallData+Validation.swift */; };
 		887A60702C1D037000E1A461 /* PaywallTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A5FD22C1D037000E1A461 /* PaywallTemplate.swift */; };
@@ -1149,6 +1150,7 @@
 		887A60CF2C1D037000E1A461 /* View+PresentPaywallFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A60632C1D037000E1A461 /* View+PresentPaywallFooter.swift */; };
 		887A60D02C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A60642C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift */; };
 		887A632B2C1D177800E1A461 /* LocalizedAlertErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A61282C1D168B00E1A461 /* LocalizedAlertErrorTests.swift */; };
+		B71000042F985A0000D1A001 /* LocaleLayoutDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71000032F985A0000D1A001 /* LocaleLayoutDirectionTests.swift */; };
 		887A632C2C1D177800E1A461 /* PackageVariablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A61292C1D168B00E1A461 /* PackageVariablesTests.swift */; };
 		887A632D2C1D177800E1A461 /* PaywallDataValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A612A2C1D168B00E1A461 /* PaywallDataValidationTests.swift */; };
 		887A632E2C1D177800E1A461 /* TemplateViewConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A612B2C1D168B00E1A461 /* TemplateViewConfigurationTests.swift */; };
@@ -2712,6 +2714,7 @@
 		887A60402C1D037000E1A461 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		887A60422C1D037000E1A461 /* hi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hi; path = hi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		887A60442C1D037000E1A461 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B71000012F985A0000D1A001 /* Locale+LayoutDirection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Locale+LayoutDirection.swift"; sourceTree = "<group>"; };
 		887A60472C1D037000E1A461 /* WatchTemplateView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchTemplateView.swift; sourceTree = "<group>"; };
 		887A60492C1D037000E1A461 /* Template1View.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Template1View.swift; sourceTree = "<group>"; };
 		887A604A2C1D037000E1A461 /* Template2View.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Template2View.swift; sourceTree = "<group>"; };
@@ -2739,6 +2742,7 @@
 		887A60632C1D037000E1A461 /* View+PresentPaywallFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+PresentPaywallFooter.swift"; sourceTree = "<group>"; };
 		887A60642C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+PurchaseRestoreCompleted.swift"; sourceTree = "<group>"; };
 		887A61282C1D168B00E1A461 /* LocalizedAlertErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalizedAlertErrorTests.swift; sourceTree = "<group>"; };
+		B71000032F985A0000D1A001 /* LocaleLayoutDirectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocaleLayoutDirectionTests.swift; sourceTree = "<group>"; };
 		887A61292C1D168B00E1A461 /* PackageVariablesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PackageVariablesTests.swift; sourceTree = "<group>"; };
 		887A612A2C1D168B00E1A461 /* PaywallDataValidationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallDataValidationTests.swift; sourceTree = "<group>"; };
 		887A612B2C1D168B00E1A461 /* TemplateViewConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TemplateViewConfigurationTests.swift; sourceTree = "<group>"; };
@@ -5529,6 +5533,7 @@
 				887A5FCD2C1D037000E1A461 /* IntroEligibility */,
 				887A5FCE2C1D037000E1A461 /* Constants.swift */,
 				887A5FCF2C1D037000E1A461 /* Localization.swift */,
+				B71000012F985A0000D1A001 /* Locale+LayoutDirection.swift */,
 				887A5FD02C1D037000E1A461 /* LocalizedAlertError.swift */,
 				887A5FD12C1D037000E1A461 /* PaywallData+Validation.swift */,
 				887A5FD22C1D037000E1A461 /* PaywallTemplate.swift */,
@@ -5752,6 +5757,7 @@
 			children = (
 				887A61272C1D168B00E1A461 /* __Snapshots__ */,
 				887A61282C1D168B00E1A461 /* LocalizedAlertErrorTests.swift */,
+				B71000032F985A0000D1A001 /* LocaleLayoutDirectionTests.swift */,
 				887A61292C1D168B00E1A461 /* PackageVariablesTests.swift */,
 				887A612A2C1D168B00E1A461 /* PaywallDataValidationTests.swift */,
 				887A612B2C1D168B00E1A461 /* TemplateViewConfigurationTests.swift */,
@@ -8288,6 +8294,7 @@
 				1699BD602EEFBF74002001FB /* AppIconDetailProvider.swift in Sources */,
 				887A60762C1D037000E1A461 /* TemplateViewConfiguration+Extensions.swift in Sources */,
 				16216FEF2EBB8641008ACFE9 /* ResumeAction.swift in Sources */,
+				B71000022F985A0000D1A001 /* Locale+LayoutDirection.swift in Sources */,
 				887A607A2C1D037000E1A461 /* Variables.swift in Sources */,
 				C074AAE036B449898E1FEF58 /* CustomPaywallVariables.swift in Sources */,
 				7DFF88B0441F83F94C8E855F /* VideoAutoplayHandler.swift in Sources */,
@@ -8306,6 +8313,7 @@
 				8834AFA52C2B9375005A72FE /* PresentIfNeededTests.swift in Sources */,
 				35617C762D5A3BC500612B7A /* FeedbackSurveyViewModelTests.swift in Sources */,
 				887A632B2C1D177800E1A461 /* LocalizedAlertErrorTests.swift in Sources */,
+				B71000042F985A0000D1A001 /* LocaleLayoutDirectionTests.swift in Sources */,
 				887A632C2C1D177800E1A461 /* PackageVariablesTests.swift in Sources */,
 				887A632D2C1D177800E1A461 /* PaywallDataValidationTests.swift in Sources */,
 				57BFCD0B2EEB0E56009E5844 /* TabsPackageInheritanceTests.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
+++ b/RevenueCatUI/CustomerCenter/Abstractions/CustomerCenterPurchasesType.swift
@@ -28,6 +28,8 @@ import SwiftUI
     var appUserID: String { get }
     var isConfigured: Bool { get }
     var storeFrontCountryCode: String? { get }
+    var preferredLocaleOverride: String? { get }
+    var preferredLocaleOverrideHonorsLayoutDirection: Bool { get }
 
     @Sendable
     func customerInfo() async throws -> CustomerInfo

--- a/RevenueCatUI/CustomerCenter/Data/CustomerCenterPurchases.swift
+++ b/RevenueCatUI/CustomerCenter/Data/CustomerCenterPurchases.swift
@@ -36,6 +36,14 @@ final class CustomerCenterPurchases: CustomerCenterPurchasesType {
         return Purchases.shared.storeFrontCountryCode
     }
 
+    var preferredLocaleOverride: String? {
+        return Purchases.shared.preferredLocaleOverride
+    }
+
+    var preferredLocaleOverrideHonorsLayoutDirection: Bool {
+        return Purchases.shared.preferredLocaleOverrideHonorsLayoutDirection
+    }
+
     func customerInfo() async throws -> RevenueCat.CustomerInfo {
         try await Purchases.shared.customerInfo()
     }

--- a/RevenueCatUI/CustomerCenter/Mocks/MockCustomerCenterPurchases.swift
+++ b/RevenueCatUI/CustomerCenter/Mocks/MockCustomerCenterPurchases.swift
@@ -23,6 +23,8 @@ final class MockCustomerCenterPurchases: @unchecked Sendable, CustomerCenterPurc
     let appUserID: String = "$RC_MOCK_APP_USER_ID"
     let isConfigured: Bool = true
     let storeFrontCountryCode: String? = "ESP"
+    var preferredLocaleOverride: String?
+    var preferredLocaleOverrideHonorsLayoutDirection: Bool
 
     var customerInfo: CustomerInfo
     let customerInfoError: Error?
@@ -43,6 +45,8 @@ final class MockCustomerCenterPurchases: @unchecked Sendable, CustomerCenterPurc
                                              price: 2.99)],
         showManageSubscriptionsError: Error? = nil,
         beginRefundShouldFail: Bool = false,
+        preferredLocaleOverride: String? = nil,
+        preferredLocaleOverrideHonorsLayoutDirection: Bool = false,
         customerCenterConfigData: CustomerCenterConfigData = CustomerCenterConfigData.mock(
             lastPublishedAppVersion: "2.0.0"
         )
@@ -54,6 +58,8 @@ final class MockCustomerCenterPurchases: @unchecked Sendable, CustomerCenterPurc
         }))
         self.showManageSubscriptionsError = showManageSubscriptionsError
         self.beginRefundShouldFail = beginRefundShouldFail
+        self.preferredLocaleOverride = preferredLocaleOverride
+        self.preferredLocaleOverrideHonorsLayoutDirection = preferredLocaleOverrideHonorsLayoutDirection
         self.loadCustomerCenterResult = .success(customerCenterConfigData)
     }
 

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -78,6 +78,12 @@ import Foundation
     @Published
     var nonSubscriptionsSection: [PurchaseInformation] = []
 
+    @Published
+    private(set) var preferredLocaleOverride: Locale?
+
+    @Published
+    private(set) var preferredLocaleOverrideHonorsLayoutDirection: Bool
+
     private(set) var purchasesProvider: CustomerCenterPurchasesType
     private(set) var customerCenterStoreKitUtilities: CustomerCenterStoreKitUtilitiesType
 
@@ -135,6 +141,7 @@ import Foundation
 
     private var error: Error?
     private var impressionData: CustomerCenterEvent.Data?
+    private var cancellables: Set<AnyCancellable> = []
 
     init(
         actionWrapper: CustomerCenterActionWrapper,
@@ -150,6 +157,20 @@ import Foundation
         self.purchasesProvider = purchasesProvider
         self.customerCenterStoreKitUtilities = customerCenterStoreKitUtilities
         self.customerInfo = nil
+        self.preferredLocaleOverride = purchasesProvider.preferredLocaleOverride.map(Locale.init)
+        self.preferredLocaleOverrideHonorsLayoutDirection =
+            purchasesProvider.preferredLocaleOverrideHonorsLayoutDirection
+
+        NotificationCenter.default
+            .preferredUILocaleOverrideChangedPublisher()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.preferredLocaleOverride = self.purchasesProvider.preferredLocaleOverride.map(Locale.init)
+                self.preferredLocaleOverrideHonorsLayoutDirection =
+                    self.purchasesProvider.preferredLocaleOverrideHonorsLayoutDirection
+            }
+            .store(in: &cancellables)
     }
 
     convenience init(
@@ -233,7 +254,7 @@ import Foundation
             return
         }
 
-        let eventData = CustomerCenterEvent.Data(locale: .current,
+        let eventData = CustomerCenterEvent.Data(locale: self.preferredLocaleOverride ?? .current,
                                                  darkMode: darkMode,
                                                  isSandbox: purchasesProvider.isSandbox,
                                                  displayMode: displayMode)

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -158,18 +158,16 @@ import Foundation
         self.purchasesProvider = purchasesProvider
         self.customerCenterStoreKitUtilities = customerCenterStoreKitUtilities
         self.customerInfo = nil
-        self.preferredLocaleOverride = purchasesProvider.preferredLocaleOverride.map(Locale.init)
-        self.preferredLocaleOverrideHonorsLayoutDirection =
-            purchasesProvider.preferredLocaleOverrideHonorsLayoutDirection
+        self.preferredLocaleOverride = nil
+        self.preferredLocaleOverrideHonorsLayoutDirection = false
+        self.updatePreferredLocaleOverride()
 
         NotificationCenter.default
             .preferredUILocaleOverrideChangedPublisher()
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                self.preferredLocaleOverride = self.purchasesProvider.preferredLocaleOverride.map(Locale.init)
-                self.preferredLocaleOverrideHonorsLayoutDirection =
-                    self.purchasesProvider.preferredLocaleOverrideHonorsLayoutDirection
+                self.updatePreferredLocaleOverride()
             }
             .store(in: &cancellables)
     }
@@ -396,6 +394,18 @@ private extension CustomerCenterViewModel {
         }
 
         return configuration
+    }
+
+    private func updatePreferredLocaleOverride() {
+        guard self.purchasesProvider.isConfigured else {
+            self.preferredLocaleOverride = nil
+            self.preferredLocaleOverrideHonorsLayoutDirection = false
+            return
+        }
+
+        self.preferredLocaleOverride = self.purchasesProvider.preferredLocaleOverride.map(Locale.init)
+        self.preferredLocaleOverrideHonorsLayoutDirection =
+            self.purchasesProvider.preferredLocaleOverrideHonorsLayoutDirection
     }
 }
 

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -12,6 +12,7 @@
 //
 //  Created by Cesar de la Vega on 27/5/24.
 //
+// swiftlint:disable file_length
 
 import Combine
 import Foundation

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -119,6 +119,7 @@ public struct CustomerCenterView: View {
     // swiftlint:disable:next missing_docs
     public var body: some View {
         navigationContent
+            .rcApplyLayoutDirection(self.preferredLayoutDirection)
             .task {
                 await loadInformationIfNeeded()
             }
@@ -128,6 +129,22 @@ public struct CustomerCenterView: View {
 #endif
                 self.trackImpression()
             }
+    }
+
+}
+
+@available(iOS 15.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+private extension CustomerCenterView {
+
+    var preferredLayoutDirection: LayoutDirection? {
+        return PaywallLayoutDirectionResolver.resolve(
+            editorLayoutDirection: nil,
+            preferredLocale: self.viewModel.preferredLocaleOverride,
+            honorsPreferredLocaleLayoutDirection: self.viewModel.preferredLocaleOverrideHonorsLayoutDirection
+        )
     }
 
 }

--- a/RevenueCatUI/Data/Locale+LayoutDirection.swift
+++ b/RevenueCatUI/Data/Locale+LayoutDirection.swift
@@ -1,0 +1,83 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Locale+LayoutDirection.swift
+//
+
+import Foundation
+@_spi(Internal) import RevenueCat
+import SwiftUI
+
+extension Locale {
+
+    var rcLayoutDirection: LayoutDirection {
+        #if swift(>=5.9)
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, visionOS 1.0, *) {
+            return self.language.characterDirection.rcLayoutDirection
+        }
+        #endif
+
+        let languageIdentifier = self.languageCode ?? self.identifier
+        return Locale.characterDirection(forLanguage: languageIdentifier).rcLayoutDirection
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+enum PaywallLayoutDirectionResolver {
+
+    typealias EditorLayoutDirection = PaywallComponentsData.PaywallComponentsConfig.LayoutDirection
+
+    static func resolve(
+        editorLayoutDirection: EditorLayoutDirection?,
+        preferredLocale: Locale?,
+        honorsPreferredLocaleLayoutDirection: Bool
+    ) -> LayoutDirection? {
+        switch editorLayoutDirection {
+        case .rtl:
+            return .rightToLeft
+        case .ltr:
+            return .leftToRight
+        case .locale:
+            return (preferredLocale ?? .current).rcLayoutDirection
+        case .system, .none:
+            guard honorsPreferredLocaleLayoutDirection else {
+                return nil
+            }
+            return (preferredLocale ?? .current).rcLayoutDirection
+        }
+    }
+
+}
+
+extension View {
+
+    @ViewBuilder
+    func rcApplyLayoutDirection(_ layoutDirection: LayoutDirection?) -> some View {
+        if let layoutDirection {
+            self.environment(\.layoutDirection, layoutDirection)
+        } else {
+            self
+        }
+    }
+
+}
+
+private extension Locale.LanguageDirection {
+
+    var rcLayoutDirection: LayoutDirection {
+        switch self {
+        case .rightToLeft:
+            return .rightToLeft
+        default:
+            return .leftToRight
+        }
+    }
+
+}

--- a/RevenueCatUI/Data/Locale+LayoutDirection.swift
+++ b/RevenueCatUI/Data/Locale+LayoutDirection.swift
@@ -17,14 +17,17 @@ import SwiftUI
 extension Locale {
 
     var rcLayoutDirection: LayoutDirection {
+        #if swift(>=5.9) && os(visionOS)
+        return self.language.characterDirection.rcLayoutDirection
+        #else
         #if swift(>=5.9)
         if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, visionOS 1.0, *) {
             return self.language.characterDirection.rcLayoutDirection
         }
         #endif
 
-        let languageIdentifier = self.languageCode ?? self.identifier
-        return Locale.characterDirection(forLanguage: languageIdentifier).rcLayoutDirection
+        return Locale.characterDirection(forLanguage: self.identifier).rcLayoutDirection
+        #endif
     }
 
 }

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -210,6 +210,7 @@ public struct PaywallView: View {
     // swiftlint:disable:next missing_docs
     public var body: some View {
         self.content
+            .rcApplyLayoutDirection(self.preferredLayoutDirection)
             .displayError(self.$error) {
                 guard let onRequestedDismissal = self.onRequestedDismissal else {
                     self.dismiss()
@@ -220,6 +221,14 @@ public struct PaywallView: View {
             // If the parent view uses refreshable, it can be inherited by the paywall view
             // and pulling down in the paywall would execute the parent's refreshable action
             .refreshableDisabled()
+    }
+
+    private var preferredLayoutDirection: LayoutDirection? {
+        return PaywallLayoutDirectionResolver.resolve(
+            editorLayoutDirection: nil,
+            preferredLocale: self.purchaseHandler.preferredLocaleOverride,
+            honorsPreferredLocaleLayoutDirection: self.purchaseHandler.preferredLocaleOverrideHonorsLayoutDirection
+        )
     }
 
     @MainActor
@@ -302,6 +311,7 @@ public struct PaywallView: View {
         checker: TrialOrIntroEligibilityChecker,
         purchaseHandler: PurchaseHandler
     ) -> some View {
+        let preferredLocale = purchaseHandler.preferredLocaleOverride ?? .current
 
         if let paywallComponents = useDraftPaywall ? offering.draftPaywallComponents : offering.paywallComponents {
             // For V2 paywalls, prefer zeroDecimalPlaceCountries from paywallComponents
@@ -314,7 +324,7 @@ public struct PaywallView: View {
 
             // For fallback view or footer
             let paywall: PaywallData = .createDefault(with: offering.availablePackages,
-                                                      locale: purchaseHandler.preferredLocaleOverride ?? .current)
+                                                      locale: preferredLocale)
 
             switch self.mode {
             // Show the default/fallback paywall for Paywalls V2 footer views
@@ -330,8 +340,16 @@ public struct PaywallView: View {
                     displayCloseButton: self.displayCloseButton,
                     introEligibility: checker,
                     purchaseHandler: purchaseHandler,
-                    locale: purchaseHandler.preferredLocaleOverride ?? .current,
+                    locale: preferredLocale,
                     showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+                )
+                .rcApplyLayoutDirection(
+                    PaywallLayoutDirectionResolver.resolve(
+                        editorLayoutDirection: paywallComponents.data.componentsConfig.base.layoutDirection,
+                        preferredLocale: purchaseHandler.preferredLocaleOverride,
+                        honorsPreferredLocaleLayoutDirection:
+                            purchaseHandler.preferredLocaleOverrideHonorsLayoutDirection
+                    )
                 )
             #endif
             // Show the actually V2 paywall for full screen
@@ -367,7 +385,7 @@ public struct PaywallView: View {
             )
 
             let (paywall, displayedLocale, template, error) = offering.validatedPaywall(
-                locale: purchaseHandler.preferredLocaleOverride ?? .current
+                locale: preferredLocale
             )
 
             LoadedOfferingPaywallView(

--- a/RevenueCatUI/Purchasing/MockPurchases.swift
+++ b/RevenueCatUI/Purchasing/MockPurchases.swift
@@ -30,8 +30,9 @@ final class MockPurchases: PaywallPurchasesType, @unchecked Sendable {
     private let restoreBlock: RestoreBlock
     private let trackEventBlock: TrackEventBlock
     private let _purchasesAreCompletedBy: PurchasesAreCompletedBy
-    let preferredLocales: [String]
-    let preferredLocaleOverride: String?
+    var preferredLocales: [String]
+    var preferredLocaleOverride: String?
+    var preferredLocaleOverrideHonorsLayoutDirection: Bool
 
     var purchasesAreCompletedBy: PurchasesAreCompletedBy {
         get { return _purchasesAreCompletedBy }
@@ -62,6 +63,7 @@ final class MockPurchases: PaywallPurchasesType, @unchecked Sendable {
         purchasesAreCompletedBy: PurchasesAreCompletedBy = .revenueCat,
         preferredLocales: [String] = ["en_US"],
         preferredLocaleOverride: String? = nil,
+        preferredLocaleOverrideHonorsLayoutDirection: Bool = false,
         purchase: @escaping PurchaseBlock,
         restorePurchases: @escaping RestoreBlock,
         trackEvent: @escaping TrackEventBlock,
@@ -74,6 +76,7 @@ final class MockPurchases: PaywallPurchasesType, @unchecked Sendable {
         self._purchasesAreCompletedBy = purchasesAreCompletedBy
         self.preferredLocales = preferredLocales
         self.preferredLocaleOverride = preferredLocaleOverride
+        self.preferredLocaleOverrideHonorsLayoutDirection = preferredLocaleOverrideHonorsLayoutDirection
     }
 
     func customerInfo() async throws -> RevenueCat.CustomerInfo {
@@ -150,7 +153,8 @@ extension PaywallPurchasesType {
         let mapped = MockPurchases(
             purchasesAreCompletedBy: self.purchasesAreCompletedBy,
             preferredLocales: self.preferredLocales,
-            preferredLocaleOverride: self.preferredLocaleOverride
+            preferredLocaleOverride: self.preferredLocaleOverride,
+            preferredLocaleOverrideHonorsLayoutDirection: self.preferredLocaleOverrideHonorsLayoutDirection
         ) { package, promotionalOffer, paywallEvent in
             try await purchase({ pkg, offer, event in
                 try await self.purchase(package: pkg, promotionalOffer: offer, paywallEvent: event)
@@ -179,7 +183,8 @@ extension PaywallPurchasesType {
         let mapped = MockPurchases(
             purchasesAreCompletedBy: self.purchasesAreCompletedBy,
             preferredLocales: self.preferredLocales,
-            preferredLocaleOverride: self.preferredLocaleOverride
+            preferredLocaleOverride: self.preferredLocaleOverride,
+            preferredLocaleOverrideHonorsLayoutDirection: self.preferredLocaleOverrideHonorsLayoutDirection
         ) { package, promotionalOffer, paywallEvent in
             try await self.purchase(package: package, promotionalOffer: promotionalOffer, paywallEvent: paywallEvent)
         } restorePurchases: {

--- a/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
+++ b/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
@@ -26,6 +26,9 @@ protocol PaywallPurchasesType: Sendable {
     /// property is only useful for reading the override value.
     var preferredLocaleOverride: String? { get }
 
+    /// Whether RevenueCatUI should derive layout direction from the preferred locale override.
+    var preferredLocaleOverrideHonorsLayoutDirection: Bool { get }
+
     /// Returns a tracker of user's subscription history
     var subscriptionHistoryTracker: SubscriptionHistoryTracker { get }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
@@ -34,6 +34,7 @@ extension PurchaseHandler {
         performPurchase: PerformPurchase? = nil,
         performRestore: PerformRestore? = nil,
         preferredLocaleOverride: String? = nil,
+        preferredLocaleOverrideHonorsLayoutDirection: Bool = false,
         purchaseResultPublisher: AnyPublisher<PurchaseResultData, Never> = Just(
             (
                 transaction: nil,
@@ -46,7 +47,8 @@ extension PurchaseHandler {
     ) -> Self {
         let purchases = MockPurchases(
             purchasesAreCompletedBy: purchasesAreCompletedBy,
-            preferredLocaleOverride: preferredLocaleOverride
+            preferredLocaleOverride: preferredLocaleOverride,
+            preferredLocaleOverrideHonorsLayoutDirection: preferredLocaleOverrideHonorsLayoutDirection
         ) { _, _, _ in
                 return (
                     // No current way to create a mock transaction with RevenueCat's public methods.

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -54,9 +54,11 @@ final class PurchaseHandler: ObservableObject {
         return purchases.preferredLocales.map(Locale.init)
     }
 
-    var preferredLocaleOverride: Locale? {
-        return purchases.preferredLocaleOverride.map(Locale.init)
-    }
+    @Published
+    private(set) var preferredLocaleOverride: Locale?
+
+    @Published
+    private(set) var preferredLocaleOverrideHonorsLayoutDirection: Bool
 
     /// Whether a purchase is currently in progress
     @Published
@@ -149,12 +151,25 @@ final class PurchaseHandler: ObservableObject {
         self.paywallEventTracker = eventTracker
         self.performPurchase = performPurchase
         self.performRestore = performRestore
+        self.preferredLocaleOverride = purchases.preferredLocaleOverride.map(Locale.init)
+        self.preferredLocaleOverrideHonorsLayoutDirection = purchases.preferredLocaleOverrideHonorsLayoutDirection
 
         purchaseResultPublisher
             .removeDuplicates(by: PurchaseResultComparator.compare)
             .receive(on: RunLoop.main)
             .sink { [weak self] result in
                 self?.setResult(result)
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default
+            .preferredUILocaleOverrideChangedPublisher()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.preferredLocaleOverride = self.purchases.preferredLocaleOverride.map(Locale.init)
+                self.preferredLocaleOverrideHonorsLayoutDirection =
+                    self.purchases.preferredLocaleOverrideHonorsLayoutDirection
             }
             .store(in: &cancellables)
     }
@@ -778,6 +793,8 @@ private final class NotConfiguredPurchases: PaywallPurchasesType {
     var preferredLocales: [String] { Locale.preferredLanguages }
 
     var preferredLocaleOverride: String? { nil }
+
+    var preferredLocaleOverrideHonorsLayoutDirection: Bool { false }
 
     var subscriptionHistoryTracker: RevenueCat.SubscriptionHistoryTracker {
         SubscriptionHistoryTracker()

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -162,6 +162,14 @@ struct PaywallsV2View: View {
                 }
             }
         )
+        .rcApplyLayoutDirection(
+            PaywallLayoutDirectionResolver.resolve(
+                editorLayoutDirection: self.paywallComponentsData.componentsConfig.base.layoutDirection,
+                preferredLocale: self.purchaseHandler.preferredLocaleOverride,
+                honorsPreferredLocaleLayoutDirection:
+                    self.purchaseHandler.preferredLocaleOverrideHonorsLayoutDirection
+            )
+        )
     }
 
     private func loadedPaywallView(paywallState: PaywallState) -> some View {

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -27,6 +27,8 @@ struct LoadingPaywallView: View {
     var displayCloseButton: Bool
 
     var shimmer: Bool = true
+    var locale: Locale = .current
+    var honorLayoutDirection: Bool = false
 
     var body: some View {
         LoadedOfferingPaywallView(
@@ -46,8 +48,15 @@ struct LoadingPaywallView: View {
             displayCloseButton: self.displayCloseButton,
             introEligibility: Self.introEligibility,
             purchaseHandler: Self.purchaseHandler,
-            locale: Locale.current,
+            locale: self.locale,
             showZeroDecimalPlacePrices: true
+        )
+        .rcApplyLayoutDirection(
+            PaywallLayoutDirectionResolver.resolve(
+                editorLayoutDirection: nil,
+                preferredLocale: self.locale,
+                honorsPreferredLocaleLayoutDirection: self.honorLayoutDirection
+            )
         )
         .allowsHitTesting(false)
         .redacted(reason: .placeholder)
@@ -160,6 +169,8 @@ private final class LoadingPaywallPurchases: PaywallPurchasesType {
     var preferredLocales: [String] { Locale.preferredLanguages }
 
     var preferredLocaleOverride: String? { nil }
+
+    var preferredLocaleOverrideHonorsLayoutDirection: Bool { false }
 
     var purchasesAreCompletedBy: PurchasesAreCompletedBy {
         get { return .myApp }

--- a/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
@@ -29,7 +29,7 @@ import Foundation
     public struct PaywallComponentsConfig: Codable, Equatable, Sendable {
 
         // swiftlint:disable:next nesting
-        public enum LayoutDirection: String, Codable, Equatable, Sendable {
+        @_spi(Internal) public enum LayoutDirection: String, Codable, Equatable, Sendable {
 
             case system
             case locale

--- a/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
@@ -29,10 +29,30 @@ import Foundation
     public struct PaywallComponentsConfig: Codable, Equatable, Sendable {
 
         public enum LayoutDirection: String, Codable, Equatable, Sendable {
+
             case system
             case locale
             case rtl
             case ltr
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let rawValue = try container.decode(String.self)
+
+                guard let value = Self(rawValue: rawValue) else {
+                    Logger.warn(Strings.codable.unexpectedValueError(type: Self.self, value: rawValue))
+                    self = .system
+                    return
+                }
+
+                self = value
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                try container.encode(self.rawValue)
+            }
+
         }
 
         public var stack: PaywallComponent.StackComponent

--- a/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
@@ -28,32 +28,44 @@ import Foundation
 
     public struct PaywallComponentsConfig: Codable, Equatable, Sendable {
 
+        public enum LayoutDirection: String, Codable, Equatable, Sendable {
+            case system
+            case locale
+            case rtl
+            case ltr
+        }
+
         public var stack: PaywallComponent.StackComponent
         @_spi(Internal) public let header: PaywallComponent.HeaderComponent?
         public let stickyFooter: PaywallComponent.StickyFooterComponent?
         public var background: PaywallComponent.Background
+        @_spi(Internal) public let layoutDirection: LayoutDirection?
 
         public init(
             stack: PaywallComponent.StackComponent,
             stickyFooter: PaywallComponent.StickyFooterComponent?,
-            background: PaywallComponent.Background
+            background: PaywallComponent.Background,
+            layoutDirection: LayoutDirection? = nil
         ) {
             self.header = nil
             self.stack = stack
             self.stickyFooter = stickyFooter
             self.background = background
+            self.layoutDirection = layoutDirection
         }
 
         @_spi(Internal) public init(
             stack: PaywallComponent.StackComponent,
             header: PaywallComponent.HeaderComponent?,
             stickyFooter: PaywallComponent.StickyFooterComponent?,
-            background: PaywallComponent.Background
+            background: PaywallComponent.Background,
+            layoutDirection: LayoutDirection? = nil
         ) {
             self.stack = stack
             self.header = header
             self.stickyFooter = stickyFooter
             self.background = background
+            self.layoutDirection = layoutDirection
         }
 
     }

--- a/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
@@ -28,6 +28,7 @@ import Foundation
 
     public struct PaywallComponentsConfig: Codable, Equatable, Sendable {
 
+        // swiftlint:disable:next nesting
         public enum LayoutDirection: String, Codable, Equatable, Sendable {
 
             case system

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -54,6 +54,7 @@ import Foundation
     let responseVerificationMode: Signing.ResponseVerificationMode
     let showStoreMessagesAutomatically: Bool
     let preferredLocale: String?
+    let preferredLocaleHonorsLayoutDirection: Bool
     let automaticDeviceIdentifierCollectionEnabled: Bool
     internal let diagnosticsEnabled: Bool
 
@@ -71,6 +72,7 @@ import Foundation
         self.showStoreMessagesAutomatically = builder.showStoreMessagesAutomatically
         self.diagnosticsEnabled = builder.diagnosticsEnabled
         self.preferredLocale = builder.preferredLocale
+        self.preferredLocaleHonorsLayoutDirection = builder.preferredLocaleHonorsLayoutDirection
         self.automaticDeviceIdentifierCollectionEnabled = builder.automaticDeviceIdentifierCollectionEnabled
     }
 
@@ -120,6 +122,7 @@ import Foundation
         ///
         /// This locale is included in all requests made by `HTTPClient`.
         private(set) var preferredLocale: String?
+        private(set) var preferredLocaleHonorsLayoutDirection: Bool = false
         private(set) var automaticDeviceIdentifierCollectionEnabled: Bool = true
 
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
@@ -349,7 +352,19 @@ import Foundation
         ///
         /// Defaults to `nil`, which means using the default user locale for RevenueCatUI components.
         public func with(preferredUILocaleOverride: String?) -> Builder {
+            return self.with(preferredUILocaleOverride: preferredUILocaleOverride, honorLayoutDirection: false)
+        }
+
+        /// Overrides the preferred locale for RevenueCatUI components.
+        ///
+        /// - Parameters:
+        ///   - preferredUILocaleOverride: A locale string in the format "language_region" (e.g., "en_US").
+        ///   - honorLayoutDirection: Whether RevenueCatUI should also derive layout direction from the locale.
+        ///
+        /// Defaults to `false`, which preserves existing layout behavior.
+        public func with(preferredUILocaleOverride: String?, honorLayoutDirection: Bool) -> Builder {
             self.preferredLocale = preferredUILocaleOverride
+            self.preferredLocaleHonorsLayoutDirection = honorLayoutDirection
             return self
         }
     }

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -352,7 +352,10 @@ import Foundation
         ///
         /// Defaults to `nil`, which means using the default user locale for RevenueCatUI components.
         public func with(preferredUILocaleOverride: String?) -> Builder {
-            return self.with(preferredUILocaleOverride: preferredUILocaleOverride, honorLayoutDirection: false)
+            return self.with(
+                preferredUILocaleOverride: preferredUILocaleOverride,
+                honorLayoutDirection: self.preferredLocaleHonorsLayoutDirection
+            )
         }
 
         /// Overrides the preferred locale for RevenueCatUI components.

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1634,7 +1634,7 @@ extension Purchases {
     /// - Important: This method only takes effect after `Purchases` has been configured.
     @objc(overridePreferredUILocale:)
     public func overridePreferredUILocale(_ locale: String?) {
-        self.overridePreferredUILocale(locale, honorLayoutDirection: false)
+        self.overridePreferredUILocale(locale, honorLayoutDirection: self.preferredLocaleHonorsLayoutDirection)
     }
 
     /// Overrides the preferred locale for RevenueCatUI components.

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -307,6 +307,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let requestFetcher: StoreKitRequestFetcher
     private let paymentQueueWrapper: EitherPaymentQueueWrapper
     fileprivate let systemInfo: SystemInfo
+    private var preferredLocaleHonorsLayoutDirection: Bool
     private let storeMessagesHelper: StoreMessagesHelperType?
     private var customerInfoObservationDisposable: (() -> Void)?
     private let healthManager: SDKHealthManager
@@ -333,6 +334,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                      showStoreMessagesAutomatically: Bool,
                      diagnosticsEnabled: Bool = false,
                      preferredLocale: String?,
+                     preferredLocaleHonorsLayoutDirection: Bool = false,
                      automaticDeviceIdentifierCollectionEnabled: Bool = true
     ) {
         if userDefaults != nil {
@@ -708,7 +710,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   diagnosticsTracker: diagnosticsTracker,
                   virtualCurrencyManager: virtualCurrencyManager,
                   healthManager: healthManager,
-                  transactionMetadataSyncHelper: transactionMetadataSyncHelper
+                  transactionMetadataSyncHelper: transactionMetadataSyncHelper,
+                  preferredLocaleHonorsLayoutDirection: preferredLocaleHonorsLayoutDirection
         )
     }
 
@@ -741,7 +744,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          diagnosticsTracker: DiagnosticsTrackerType?,
          virtualCurrencyManager: VirtualCurrencyManagerType,
          healthManager: SDKHealthManager,
-         transactionMetadataSyncHelper: TransactionMetadataSyncHelper
+         transactionMetadataSyncHelper: TransactionMetadataSyncHelper,
+         preferredLocaleHonorsLayoutDirection: Bool = false
     ) {
 
         if systemInfo.dangerousSettings.customEntitlementComputation {
@@ -793,6 +797,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.virtualCurrencyManager = virtualCurrencyManager
         self.healthManager = healthManager
         self.transactionMetadataSyncHelper = transactionMetadataSyncHelper
+        self.preferredLocaleHonorsLayoutDirection = preferredLocaleHonorsLayoutDirection
 
         super.init()
 
@@ -1627,12 +1632,38 @@ extension Purchases {
     ///
     /// Setting this will affect the display of RevenueCat UI components, such as the Paywalls.
     /// - Important: This method only takes effect after `Purchases` has been configured.
+    @objc(overridePreferredUILocale:)
     public func overridePreferredUILocale(_ locale: String?) {
-        guard locale != self.systemInfo.preferredLocaleOverride else {
+        self.overridePreferredUILocale(locale, honorLayoutDirection: false)
+    }
+
+    /// Overrides the preferred locale for RevenueCatUI components.
+    /// - Parameters:
+    ///   - locale: A locale string in the format "language_region" (e.g., "en_US").
+    ///   - honorLayoutDirection: Whether RevenueCatUI should also derive layout direction from the locale.
+    /// Use `nil` to remove the override and use the default user locale determined by the system.
+    ///
+    /// Setting this will affect the display of RevenueCat UI components, such as the Paywalls.
+    /// - Important: This method only takes effect after `Purchases` has been configured.
+    @objc(overridePreferredUILocale:honorLayoutDirection:)
+    public func overridePreferredUILocale(_ locale: String?, honorLayoutDirection: Bool) {
+        let localeChanged = locale != self.systemInfo.preferredLocaleOverride
+        let layoutDirectionChanged = honorLayoutDirection != self.preferredLocaleHonorsLayoutDirection
+
+        guard localeChanged || layoutDirectionChanged else {
             return
         }
 
-        self.systemInfo.overridePreferredLocale(locale)
+        if localeChanged {
+            self.systemInfo.overridePreferredLocale(locale)
+        }
+
+        self.preferredLocaleHonorsLayoutDirection = honorLayoutDirection
+        NotificationCenter.default.post(name: .preferredUILocaleOverrideChanged, object: nil)
+
+        guard localeChanged else {
+            return
+        }
 
         if self.overridePreferredUILocaleRateLimiter.shouldProceed() {
             // Refetches new offerings with preferred locale
@@ -1692,6 +1723,7 @@ public extension Purchases {
                   showStoreMessagesAutomatically: configuration.showStoreMessagesAutomatically,
                   diagnosticsEnabled: configuration.diagnosticsEnabled,
                   preferredLocale: configuration.preferredLocale,
+                  preferredLocaleHonorsLayoutDirection: configuration.preferredLocaleHonorsLayoutDirection,
                   automaticDeviceIdentifierCollectionEnabled: configuration.automaticDeviceIdentifierCollectionEnabled
         )
     }
@@ -1960,6 +1992,7 @@ public extension Purchases {
         showStoreMessagesAutomatically: Bool,
         diagnosticsEnabled: Bool,
         preferredLocale: String?,
+        preferredLocaleHonorsLayoutDirection: Bool = false,
         automaticDeviceIdentifierCollectionEnabled: Bool = true
     ) -> Purchases {
         return self.setDefaultInstance(
@@ -1977,6 +2010,7 @@ public extension Purchases {
                   showStoreMessagesAutomatically: showStoreMessagesAutomatically,
                   diagnosticsEnabled: diagnosticsEnabled,
                   preferredLocale: preferredLocale,
+                  preferredLocaleHonorsLayoutDirection: preferredLocaleHonorsLayoutDirection,
                   automaticDeviceIdentifierCollectionEnabled: automaticDeviceIdentifierCollectionEnabled)
         )
     }
@@ -2184,6 +2218,10 @@ extension Purchases {
     // swiftlint:disable missing_docs
     @_spi(Internal) public var preferredLocaleOverride: String? {
         return self.systemInfo.preferredLocaleOverride
+    }
+
+    @_spi(Internal) public var preferredLocaleOverrideHonorsLayoutDirection: Bool {
+        return self.preferredLocaleHonorsLayoutDirection
     }
 
     // swiftlint:disable missing_docs

--- a/Sources/Purchasing/Purchases/TransactionNotifications.swift
+++ b/Sources/Purchasing/Purchases/TransactionNotifications.swift
@@ -11,6 +11,9 @@ import Foundation
 extension NSNotification.Name {
     /// A notification that states a purchase has completed
     static let purchaseCompleted = Notification.Name("RevenueCat.PurchaseCompleted")
+
+    /// A notification that states the preferred RevenueCatUI locale override changed.
+    static let preferredUILocaleOverrideChanged = Notification.Name("RevenueCat.PreferredUILocaleOverrideChanged")
 }
 
 extension NotificationCenter {
@@ -23,6 +26,16 @@ extension NotificationCenter {
         self
             .publisher(for: .purchaseCompleted)
             .compactMap { $0.object as? PurchaseResultData }
+            .eraseToAnyPublisher()
+    }
+
+    /// A publisher that wraps the `preferredUILocaleOverrideChanged` notification.
+    ///
+    /// - Important: This is not intended for public consumption and should be used with care.
+    @_spi(Internal) public func preferredUILocaleOverrideChangedPublisher() -> AnyPublisher<Void, Never> {
+        self
+            .publisher(for: .preferredUILocaleOverrideChanged)
+            .map { _ in () }
             .eraseToAnyPublisher()
     }
 }

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/ConfigurationAPI.swift
@@ -24,6 +24,7 @@ func checkConfigurationAPI() {
         .with(entitlementVerificationMode: .informational)
         .with(automaticDeviceIdentifierCollectionEnabled: true)
         .with(preferredUILocaleOverride: "de_DE")
+        .with(preferredUILocaleOverride: "he", honorLayoutDirection: true)
         .with(preferredUILocaleOverride: nil)
 
 

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
@@ -440,6 +440,7 @@ private func checkConfigure() -> Purchases! {
 
 private func checkPreferredUILocaleAPIs(purchases: Purchases) {
     purchases.overridePreferredUILocale("de_DE")
+    purchases.overridePreferredUILocale("he", honorLayoutDirection: true)
     purchases.overridePreferredUILocale(nil)
 }
 

--- a/Tests/RevenueCatUITests/Data/LocaleLayoutDirectionTests.swift
+++ b/Tests/RevenueCatUITests/Data/LocaleLayoutDirectionTests.swift
@@ -1,0 +1,75 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  LocaleLayoutDirectionTests.swift
+//
+
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if !os(watchOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class LocaleLayoutDirectionTests: TestCase {
+
+    func testLeftToRightLocale() {
+        XCTAssertEqual(Locale(identifier: "en_US").rcLayoutDirection, .leftToRight)
+    }
+
+    func testHebrewLocaleIsRightToLeft() {
+        XCTAssertEqual(Locale(identifier: "he").rcLayoutDirection, .rightToLeft)
+    }
+
+    func testSaudiArabicLocaleIsRightToLeft() {
+        XCTAssertEqual(Locale(identifier: "ar_SA").rcLayoutDirection, .rightToLeft)
+    }
+
+    func testResolverDoesNotOverrideDirectionByDefault() {
+        XCTAssertNil(PaywallLayoutDirectionResolver.resolve(
+            editorLayoutDirection: nil,
+            preferredLocale: Locale(identifier: "he"),
+            honorsPreferredLocaleLayoutDirection: false
+        ))
+    }
+
+    func testResolverHonorsPreferredLocaleWhenOptedIn() {
+        XCTAssertEqual(PaywallLayoutDirectionResolver.resolve(
+            editorLayoutDirection: nil,
+            preferredLocale: Locale(identifier: "he"),
+            honorsPreferredLocaleLayoutDirection: true
+        ), .rightToLeft)
+    }
+
+    func testResolverUsesEditorLocaleSetting() {
+        XCTAssertEqual(PaywallLayoutDirectionResolver.resolve(
+            editorLayoutDirection: .locale,
+            preferredLocale: Locale(identifier: "ar_SA"),
+            honorsPreferredLocaleLayoutDirection: false
+        ), .rightToLeft)
+    }
+
+    func testResolverEditorForceDirectionOverridesSdkOptIn() {
+        XCTAssertEqual(PaywallLayoutDirectionResolver.resolve(
+            editorLayoutDirection: .ltr,
+            preferredLocale: Locale(identifier: "he"),
+            honorsPreferredLocaleLayoutDirection: true
+        ), .leftToRight)
+
+        XCTAssertEqual(PaywallLayoutDirectionResolver.resolve(
+            editorLayoutDirection: .rtl,
+            preferredLocale: Locale(identifier: "en_US"),
+            honorsPreferredLocaleLayoutDirection: false
+        ), .rightToLeft)
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -40,6 +40,83 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.restoreError).to(beNil())
     }
 
+    func testPreferredLocaleOverrideUpdatesWhenNotificationFires() throws {
+        let purchases = MockPurchases(preferredLocaleOverride: "en_US") { _, _, _ in
+            return (transaction: nil, customerInfo: TestData.customerInfo, userCancelled: false)
+        } restorePurchases: {
+            return TestData.customerInfo
+        } trackEvent: { event in
+            Logger.debug("Tracking event: \(event)")
+        } customerInfo: {
+            return TestData.customerInfo
+        }
+        let handler = PurchaseHandler(
+            purchases: purchases,
+            eventTracker: .init(purchases: purchases)
+        )
+
+        expect(handler.preferredLocaleOverride?.identifier) == "en_US"
+
+        let localeUpdated = self.expectation(description: "preferred locale override updated")
+        let cancellable = handler.$preferredLocaleOverride
+            .dropFirst()
+            .sink { locale in
+                if locale?.identifier == "he" {
+                    localeUpdated.fulfill()
+                }
+            }
+
+        purchases.preferredLocaleOverride = "he"
+        NotificationCenter.default.post(
+            name: Notification.Name("RevenueCat.PreferredUILocaleOverrideChanged"),
+            object: nil
+        )
+
+        wait(for: [localeUpdated], timeout: 1)
+        withExtendedLifetime(cancellable) {}
+        expect(handler.preferredLocaleOverride?.rcLayoutDirection) == .rightToLeft
+    }
+
+    func testPreferredLocaleLayoutDirectionFlagUpdatesWhenNotificationFires() throws {
+        let purchases = MockPurchases(
+            preferredLocaleOverride: "he",
+            preferredLocaleOverrideHonorsLayoutDirection: false
+        ) { _, _, _ in
+            return (transaction: nil, customerInfo: TestData.customerInfo, userCancelled: false)
+        } restorePurchases: {
+            return TestData.customerInfo
+        } trackEvent: { event in
+            Logger.debug("Tracking event: \(event)")
+        } customerInfo: {
+            return TestData.customerInfo
+        }
+        let handler = PurchaseHandler(
+            purchases: purchases,
+            eventTracker: .init(purchases: purchases)
+        )
+
+        expect(handler.preferredLocaleOverrideHonorsLayoutDirection) == false
+
+        let flagUpdated = self.expectation(description: "preferred locale layout direction flag updated")
+        let cancellable = handler.$preferredLocaleOverrideHonorsLayoutDirection
+            .dropFirst()
+            .sink { honorsLayoutDirection in
+                if honorsLayoutDirection {
+                    flagUpdated.fulfill()
+                }
+            }
+
+        purchases.preferredLocaleOverrideHonorsLayoutDirection = true
+        NotificationCenter.default.post(
+            name: Notification.Name("RevenueCat.PreferredUILocaleOverrideChanged"),
+            object: nil
+        )
+
+        wait(for: [flagUpdated], timeout: 1)
+        withExtendedLifetime(cancellable) {}
+        expect(handler.preferredLocaleOverrideHonorsLayoutDirection) == true
+    }
+
     func testPurchaseSetsCustomerInfo() async throws {
         let handler: PurchaseHandler = .mock()
 

--- a/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsWithPaywallComponents.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsWithPaywallComponents.json
@@ -19,6 +19,7 @@
                 "components_localizations": [],
                 "components_config": {
                     "base": {
+                        "layout_direction": "rtl",
                         "background": {
                             "type": "color",
                             "value": {

--- a/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
@@ -75,6 +75,30 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
         expect(draftComponents.componentsConfig.base.stack.components).to(haveCount(1))
     }
 
+    func testUnknownLayoutDirectionFallsBackToSystem() throws {
+        let data = try XCTUnwrap("""
+        {
+            "template_name": "componentsTEST",
+            "asset_base_url": "https://assets.revenuecat.com",
+            "components_config": {
+                "base": {
+                    "layout_direction": "future_value",
+                    "stack": { "type": "stack", "components": [] },
+                    "background": { "type": "color", "value": { "light": { "type": "hex", "value": "#ffffff" } } }
+                }
+            },
+            "components_localizations": {},
+            "default_locale": "en_US",
+            "revision": 1
+        }
+        """.data(using: .utf8))
+
+        let components = try JSONDecoder.default.decode(PaywallComponentsData.self, from: data)
+
+        expect(components.componentsConfig.base.layoutDirection) == .system
+        expect(components.errorInfo).to(beNil())
+    }
+
     func testDecodesPaywallComponentsWithOnlyDraftPaywallComponents() throws {
         let offering = try XCTUnwrap(self.response.offerings[safe: 2])
 

--- a/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
@@ -83,7 +83,22 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
             "components_config": {
                 "base": {
                     "layout_direction": "future_value",
-                    "stack": { "type": "stack", "components": [] },
+                    "stack": {
+                        "type": "stack",
+                        "components": [],
+                        "margin": {},
+                        "padding": {},
+                        "size": {
+                            "width": { "type": "fill" },
+                            "height": { "type": "fill" }
+                        },
+                        "dimension": {
+                            "type": "vertical",
+                            "alignment": "center",
+                            "distribution": "center"
+                        },
+                        "spacing": 16
+                    },
                     "background": { "type": "color", "value": { "light": { "type": "hex", "value": "#ffffff" } } }
                 }
             },

--- a/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
@@ -37,6 +37,7 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
         expect(components.id) == "pw_test_1"
         expect(components.templateName) == "componentsTEST"
         expect(components.revision) == 3
+        expect(components.componentsConfig.base.layoutDirection) == .rtl
         expect(components.componentsConfig.base.background) == .color(.init(light: .hex("#220000ff"), dark: nil))
         expect(components.componentsConfig.base.stickyFooter) == nil
         expect(components.componentsConfig.base.stack.spacing) == 16
@@ -57,6 +58,7 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
         let components = try XCTUnwrap(offering.paywallComponents)
         expect(components.templateName) == "componentsTEST"
         expect(components.revision) == 3
+        expect(components.componentsConfig.base.layoutDirection).to(beNil())
         expect(components.componentsConfig.base.background) == .color(.init(light: .hex("#220000ff"), dark: nil))
         expect(components.componentsConfig.base.stickyFooter) == nil
         expect(components.componentsConfig.base.stack.spacing) == 16

--- a/Tests/UnitTests/Purchasing/ConfigurationTests.swift
+++ b/Tests/UnitTests/Purchasing/ConfigurationTests.swift
@@ -88,6 +88,25 @@ class ConfigurationTests: TestCase {
         expect(configuration.diagnosticsEnabled) == true
     }
 
+    func testPreferredUILocaleOverrideDefaultsLayoutDirectionFlagToFalse() {
+        let configuration = Configuration.Builder(withAPIKey: "test")
+            .with(preferredUILocaleOverride: "he")
+            .build()
+
+        expect(configuration.preferredLocale) == "he"
+        expect(configuration.preferredLocaleHonorsLayoutDirection) == false
+    }
+
+    func testPreferredUILocaleOverrideWithLocaleOnlyPreservesLayoutDirectionFlag() {
+        let configuration = Configuration.Builder(withAPIKey: "test")
+            .with(preferredUILocaleOverride: "he", honorLayoutDirection: true)
+            .with(preferredUILocaleOverride: "ar_SA")
+            .build()
+
+        expect(configuration.preferredLocale) == "ar_SA"
+        expect(configuration.preferredLocaleHonorsLayoutDirection) == true
+    }
+
     func testStoreKitVersionUsesStoreKit1ByDefault() {
         let configuration = Configuration.Builder(withAPIKey: "test")
             .build()

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -216,10 +216,18 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
     func testOverridePreferredUILocaleDefaultsLayoutDirectionFlagToFalse() {
         self.setupPurchases()
 
-        self.purchases.overridePreferredUILocale("he", honorLayoutDirection: true)
         self.purchases.overridePreferredUILocale("he")
 
         expect(self.purchases.preferredLocaleOverrideHonorsLayoutDirection) == false
+    }
+
+    func testOverridePreferredUILocaleWithLocaleOnlyPreservesLayoutDirectionFlag() {
+        self.setupPurchases()
+
+        self.purchases.overridePreferredUILocale("he", honorLayoutDirection: true)
+        self.purchases.overridePreferredUILocale("ar_SA")
+
+        expect(self.purchases.preferredLocaleOverrideHonorsLayoutDirection) == true
     }
 
     func testOverridePreferredUILocaleDoesNotInvalidateOrFetchWhenRateLimited() {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -15,7 +15,7 @@ import Nimble
 import StoreKit
 import XCTest
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 class PurchasesGetOfferingsTests: BasePurchasesTests {
 
@@ -201,6 +201,25 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
 
         expect(self.mockOfferingsManager.invokedClearInMemoryOfferingsCache) == false
         expect(self.mockOfferingsManager.invokedOfferingsCount) == 0
+    }
+
+    func testOverridePreferredUILocaleUpdatesLayoutDirectionFlagWithoutRefetchingWhenLocaleUnchanged() {
+        self.setupPurchases()
+
+        self.purchases.overridePreferredUILocale(nil, honorLayoutDirection: true)
+
+        expect(self.purchases.preferredLocaleOverrideHonorsLayoutDirection) == true
+        expect(self.mockOfferingsManager.invokedClearInMemoryOfferingsCache) == false
+        expect(self.mockOfferingsManager.invokedOfferingsCount) == 0
+    }
+
+    func testOverridePreferredUILocaleDefaultsLayoutDirectionFlagToFalse() {
+        self.setupPurchases()
+
+        self.purchases.overridePreferredUILocale("he", honorLayoutDirection: true)
+        self.purchases.overridePreferredUILocale("he")
+
+        expect(self.purchases.preferredLocaleOverrideHonorsLayoutDirection) == false
     }
 
     func testOverridePreferredUILocaleDoesNotInvalidateOrFetchWhenRateLimited() {

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -1737,6 +1737,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
   }
@@ -2552,6 +2553,7 @@ extension RevenueCat.Purchases {
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
   final public func overridePreferredUILocale(_ locale: Swift.String?)
+  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -1737,6 +1737,8 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    #endif
+    #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
@@ -2552,8 +2554,10 @@ extension RevenueCat.Purchases {
 }
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
-  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
+  @objc(overridePreferredUILocale:) final public func overridePreferredUILocale(_ locale: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc(overridePreferredUILocale:honorLayoutDirection:) final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -1737,6 +1737,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
   }
@@ -2552,6 +2553,7 @@ extension RevenueCat.Purchases {
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
   final public func overridePreferredUILocale(_ locale: Swift.String?)
+  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -1737,6 +1737,8 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    #endif
+    #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
@@ -2552,8 +2554,10 @@ extension RevenueCat.Purchases {
 }
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
-  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
+  @objc(overridePreferredUILocale:) final public func overridePreferredUILocale(_ locale: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc(overridePreferredUILocale:honorLayoutDirection:) final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -1698,6 +1698,8 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    #endif
+    #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
@@ -2485,8 +2487,10 @@ extension RevenueCat.Purchases {
 }
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
-  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
+  @objc(overridePreferredUILocale:) final public func overridePreferredUILocale(_ locale: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc(overridePreferredUILocale:honorLayoutDirection:) final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -1698,6 +1698,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
   }
@@ -2485,6 +2486,7 @@ extension RevenueCat.Purchases {
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
   final public func overridePreferredUILocale(_ locale: Swift.String?)
+  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -1698,6 +1698,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
   }
@@ -2475,6 +2476,7 @@ extension RevenueCat.Purchases {
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
   final public func overridePreferredUILocale(_ locale: Swift.String?)
+  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -1698,6 +1698,8 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    #endif
+    #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
@@ -2475,8 +2477,10 @@ extension RevenueCat.Purchases {
 }
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
-  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
+  @objc(overridePreferredUILocale:) final public func overridePreferredUILocale(_ locale: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc(overridePreferredUILocale:honorLayoutDirection:) final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -1698,6 +1698,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
   }
@@ -2475,6 +2476,7 @@ extension RevenueCat.Purchases {
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
   final public func overridePreferredUILocale(_ locale: Swift.String?)
+  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -1698,6 +1698,8 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    #endif
+    #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
@@ -2475,8 +2477,10 @@ extension RevenueCat.Purchases {
 }
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
-  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
+  @objc(overridePreferredUILocale:) final public func overridePreferredUILocale(_ locale: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc(overridePreferredUILocale:honorLayoutDirection:) final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -1737,6 +1737,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
   }
@@ -2552,6 +2553,7 @@ extension RevenueCat.Purchases {
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
   final public func overridePreferredUILocale(_ locale: Swift.String?)
+  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -1737,6 +1737,8 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    #endif
+    #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
@@ -2552,8 +2554,10 @@ extension RevenueCat.Purchases {
 }
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
-  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
+  @objc(overridePreferredUILocale:) final public func overridePreferredUILocale(_ locale: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc(overridePreferredUILocale:honorLayoutDirection:) final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -1737,6 +1737,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
   }
@@ -2552,6 +2553,7 @@ extension RevenueCat.Purchases {
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
   final public func overridePreferredUILocale(_ locale: Swift.String?)
+  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -1737,6 +1737,8 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    #endif
+    #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
@@ -2552,8 +2554,10 @@ extension RevenueCat.Purchases {
 }
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
-  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
+  @objc(overridePreferredUILocale:) final public func overridePreferredUILocale(_ locale: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc(overridePreferredUILocale:honorLayoutDirection:) final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -1699,6 +1699,8 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    #endif
+    #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
@@ -2476,8 +2478,10 @@ extension RevenueCat.Purchases {
 }
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
-  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
+  @objc(overridePreferredUILocale:) final public func overridePreferredUILocale(_ locale: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc(overridePreferredUILocale:honorLayoutDirection:) final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -1699,6 +1699,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
   }
@@ -2476,6 +2477,7 @@ extension RevenueCat.Purchases {
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
   final public func overridePreferredUILocale(_ locale: Swift.String?)
+  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -1699,6 +1699,8 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    #endif
+    #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
@@ -2476,8 +2478,10 @@ extension RevenueCat.Purchases {
 }
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
-  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
+  @objc(overridePreferredUILocale:) final public func overridePreferredUILocale(_ locale: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc(overridePreferredUILocale:honorLayoutDirection:) final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -1699,6 +1699,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func build() -> RevenueCat.Configuration
     #if compiler(>=5.3) && $NonescapableTypes
     public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    public func with(preferredUILocaleOverride: Swift.String?, honorLayoutDirection: Swift.Bool) -> RevenueCat.Configuration.Builder
     #endif
     @objc deinit
   }
@@ -2476,6 +2477,7 @@ extension RevenueCat.Purchases {
 extension RevenueCat.Purchases {
   #if compiler(>=5.3) && $NonescapableTypes
   final public func overridePreferredUILocale(_ locale: Swift.String?)
+  final public func overridePreferredUILocale(_ locale: Swift.String?, honorLayoutDirection: Swift.Bool)
   #endif
 }
 extension RevenueCat.Purchases {


### PR DESCRIPTION
## Summary
- add false-by-default honorLayoutDirection support to preferred UI locale override/config APIs
- apply a shared layout direction resolver to Paywalls V1, Paywalls V2, LoadingPaywallView, and Customer Center
- parse V2 editor layout_direction values and let explicit editor values win over SDK opt-in
- add tests, API tester coverage, and changelog entry

## Tests
- swift test --filter "LocaleLayoutDirectionTests|PurchasesGetOfferingsTests/testOverridePreferredUILocale|PurchaseHandlerTests/testPreferredLocaleOverride"
- xcodebuild test -project RevenueCat.xcodeproj -scheme RevenueCat -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.0' -only-testing:UnitTests/PurchasesGetOfferingsTests
- rg hardcoded left/right layout audit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new configuration and runtime update paths that affect layout direction across paywalls and Customer Center; while default behavior is preserved, incorrect resolver/editor values could cause unexpected RTL/LTR rendering.
> 
> **Overview**
> **Adds opt-in layout-direction support for RevenueCatUI based on locale overrides.** `Configuration.Builder` and `Purchases.overridePreferredUILocale` now accept `honorLayoutDirection` (default `false`) and `Purchases` publishes `preferredUILocaleOverrideChanged` so UI can react to locale/layout-flag changes at runtime.
> 
> **Applies a shared resolver across UI surfaces.** Introduces `Locale.rcLayoutDirection` + `PaywallLayoutDirectionResolver` and uses it to set SwiftUI `layoutDirection` for Paywalls V1, Paywalls V2, `LoadingPaywallView`, and Customer Center; Paywalls V2 additionally decodes and honors dashboard `layout_direction` (with explicit RTL/LTR taking precedence, unknown values falling back to `.system`).
> 
> **Updates protocols/mocks and expands tests.** Extends `PaywallPurchasesType` and `CustomerCenterPurchasesType` with the new flag, updates mocks, adds unit tests for resolver behavior and notification-driven updates, and updates API tester coverage and fixtures, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e25b1198bc231cf75d0e33bdc0596585459f99df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->