### PR TITLE
Add explicit directional step transitions to WorkflowPaywallView

### DIFF
--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -14,14 +14,123 @@ import SwiftUI
 
 #if !os(tvOS)
 
+struct WorkflowPageTransitionState<Page> {
+
+    enum Direction {
+        case forward
+        case back
+    }
+
+    enum PageRole {
+        case current
+        case outgoing
+    }
+
+    private(set) var currentPage: Page?
+    private(set) var outgoingPage: Page?
+    private(set) var direction: Direction = .forward
+    private(set) var progress: CGFloat = 1
+
+    var isTransitioning: Bool {
+        return self.outgoingPage != nil
+    }
+
+    init(currentPage: Page?) {
+        self.currentPage = currentPage
+    }
+
+    mutating func beginTransition(to incomingPage: Page?, direction: Direction) {
+        self.direction = direction
+
+        guard let currentPage = self.currentPage,
+              let incomingPage else {
+            self.currentPage = incomingPage
+            self.outgoingPage = nil
+            self.progress = 1
+            return
+        }
+
+        self.currentPage = incomingPage
+        self.outgoingPage = currentPage
+        self.progress = 0
+    }
+
+    mutating func advanceAnimation() {
+        guard self.isTransitioning else {
+            return
+        }
+
+        self.progress = 1
+    }
+
+    mutating func completeTransition() {
+        self.outgoingPage = nil
+        self.progress = 1
+    }
+
+    func offset(for role: PageRole, width: CGFloat) -> CGFloat {
+        guard self.isTransitioning else {
+            return 0
+        }
+
+        switch role {
+        case .current:
+            return self.direction.incomingOffset(width: width) * (1 - self.progress)
+        case .outgoing:
+            return self.direction.outgoingOffset(width: width) * self.progress
+        }
+    }
+
+    func zIndex(for role: PageRole) -> Double {
+        guard self.isTransitioning else {
+            return role == .current ? 0 : -1
+        }
+
+        switch (self.direction, role) {
+        case (.forward, .current), (.back, .outgoing):
+            return 1
+        case (.forward, .outgoing), (.back, .current):
+            return 0
+        }
+    }
+
+}
+
+private extension WorkflowPageTransitionState.Direction {
+
+    func incomingOffset(width: CGFloat) -> CGFloat {
+        switch self {
+        case .forward:
+            return width
+        case .back:
+            return -width
+        }
+    }
+
+    func outgoingOffset(width: CGFloat) -> CGFloat {
+        switch self {
+        case .forward:
+            return -width
+        case .back:
+            return width
+        }
+    }
+
+}
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct WorkflowPaywallView: View {
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
 
     enum DismissalAction: Equatable {
         case dismissWorkflow
         case navigateBack
+    }
+
+    private enum Constants {
+        static let transitionDuration: Double = 0.25
     }
 
     private let context: WorkflowContext
@@ -34,6 +143,8 @@ struct WorkflowPaywallView: View {
 
     @StateObject private var navigator: WorkflowNavigator
     @State private var hasLoggedInvalidState = false
+    @State private var transitionState: WorkflowPageTransitionState<RenderedPage>
+    @State private var activeTransitionID: UUID?
 
     init(
         context: WorkflowContext,
@@ -52,49 +163,105 @@ struct WorkflowPaywallView: View {
         self.promoOfferCache = promoOfferCache
         self.onDismiss = onDismiss
         self._navigator = .init(wrappedValue: WorkflowNavigator(workflow: context.workflow))
+        self._transitionState = .init(
+            wrappedValue: .init(
+                currentPage: Self.renderedPage(
+                    from: context,
+                    stepId: context.workflow.initialStepId,
+                    canNavigateBack: false,
+                    displayCloseButton: displayCloseButton
+                )
+            )
+        )
     }
 
     var body: some View {
-        if let stepContent = self.currentStepContent {
-            PaywallsV2View(
-                paywallComponents: stepContent.paywallComponents,
-                offering: stepContent.offering,
-                purchaseHandler: self.purchaseHandler,
-                introEligibilityChecker: self.introEligibilityChecker,
-                showZeroDecimalPlacePrices: self.showZeroDecimalPlacePrices,
-                displayCloseButton: self.shouldDisplayCloseButton,
-                onDismiss: self.handleDismiss,
-                failedToLoadFont: { fontConfig in
-                    if Purchases.isConfigured {
-                        Purchases.shared.failedToLoadFontWithConfig(fontConfig)
-                    }
-                },
-                colorScheme: self.colorScheme,
-                promoOfferCache: self.promoOfferCache
-            )
-            .id(navigator.currentStepId)
-            .environment(\.workflowTriggerAction, { componentId in
-                self.navigator.triggerAction(componentId: componentId) != nil
-            })
-        } else {
-            Color.clear
-                .frame(width: 0, height: 0)
-                .accessibilityHidden(true)
-                .onAppear {
-                    self.logInvalidWorkflowStateIfNeeded()
+        GeometryReader { proxy in
+            ZStack {
+                // Keep each rendered page keyed by its snapshot ID so SwiftUI preserves
+                // the outgoing subtree when it changes role from current -> outgoing.
+                // Recreating that subtree at transition start caused visible flashing.
+                ForEach(self.displayedPages) { displayedPage in
+                    self.pageView(for: displayedPage.page)
+                        .offset(x: self.transitionState.offset(
+                            for: displayedPage.role,
+                            width: proxy.size.width
+                        ))
+                        .zIndex(self.transitionState.zIndex(for: displayedPage.role))
                 }
+
+                if self.transitionState.currentPage == nil {
+                    Color.clear
+                        .frame(width: 0, height: 0)
+                        .accessibilityHidden(true)
+                        .onAppear {
+                            self.logInvalidWorkflowStateIfNeeded()
+                        }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .allowsHitTesting(!self.transitionState.isTransitioning)
+        .clipped()
+    }
+
+    // MARK: - Helpers
+
+    private var displayedPages: [DisplayedPage] {
+        return [
+            self.transitionState.outgoingPage.map { .init(role: .outgoing, page: $0) },
+            self.transitionState.currentPage.map { .init(role: .current, page: $0) }
+        ]
+        .compactMap { $0 }
+    }
+
+    private func pageView(for page: RenderedPage) -> some View {
+        PaywallsV2View(
+            paywallComponents: page.content.paywallComponents,
+            offering: page.content.offering,
+            purchaseHandler: self.purchaseHandler,
+            introEligibilityChecker: self.introEligibilityChecker,
+            showZeroDecimalPlacePrices: self.showZeroDecimalPlacePrices,
+            displayCloseButton: page.showCloseButton,
+            onDismiss: self.handleDismiss,
+            failedToLoadFont: { fontConfig in
+                if Purchases.isConfigured {
+                    Purchases.shared.failedToLoadFontWithConfig(fontConfig)
+                }
+            },
+            colorScheme: self.colorScheme,
+            promoOfferCache: self.promoOfferCache
+        )
+        .environment(\.workflowTriggerAction, { componentId in
+            return self.handleTriggeredNavigation(componentId: componentId)
+        })
     }
 
     private func handleDismiss() {
+        guard !self.transitionState.isTransitioning else {
+            return
+        }
+
         switch Self.dismissalAction(
             canNavigateBack: self.navigator.canNavigateBack,
             hasPurchasedInSession: self.purchaseHandler.hasPurchasedInSession
         ) {
         case .dismissWorkflow:
-            onDismiss()
+            self.onDismiss()
         case .navigateBack:
-            navigator.navigateBack()
+            guard let previousStep = self.navigator.navigateBack() else {
+                return
+            }
+
+            self.startTransition(
+                to: Self.renderedPage(
+                    from: self.context,
+                    stepId: previousStep.id,
+                    canNavigateBack: self.navigator.canNavigateBack,
+                    displayCloseButton: self.displayCloseButton
+                ),
+                direction: .back
+            )
         }
     }
 
@@ -112,24 +279,95 @@ struct WorkflowPaywallView: View {
         return .navigateBack
     }
 
-    private var shouldDisplayCloseButton: Bool {
-        return !self.navigator.canNavigateBack && self.displayCloseButton
+    private func handleTriggeredNavigation(componentId: String) -> Bool {
+        guard !self.transitionState.isTransitioning,
+              let nextStep = self.navigator.triggerAction(componentId: componentId) else {
+            return false
+        }
+
+        self.startTransition(
+            to: Self.renderedPage(
+                from: self.context,
+                stepId: nextStep.id,
+                canNavigateBack: self.navigator.canNavigateBack,
+                displayCloseButton: self.displayCloseButton
+            ),
+            direction: .forward
+        )
+
+        return true
     }
 
-    private var currentStepContent: CurrentStepContent? {
-        guard let step = self.navigator.currentStep,
+    private func startTransition(
+        to page: RenderedPage?,
+        direction: WorkflowPageTransitionState<RenderedPage>.Direction
+    ) {
+        self.transitionState.beginTransition(to: page, direction: direction)
+
+        guard self.transitionState.isTransitioning else {
+            self.activeTransitionID = nil
+            return
+        }
+
+        let transitionID = UUID()
+        self.activeTransitionID = transitionID
+
+        guard !self.reduceMotion else {
+            self.transitionState.advanceAnimation()
+            self.finishTransition(id: transitionID)
+            return
+        }
+
+        DispatchQueue.main.async {
+            guard self.activeTransitionID == transitionID else {
+                return
+            }
+
+            // Wait one run-loop turn so both pages render at their initial offsets
+            // before animating progress to the final positions.
+            withAnimation(.easeInOut(duration: Constants.transitionDuration)) {
+                self.transitionState.advanceAnimation()
+            }
+
+            // Schedule cleanup from here so the deadline is relative to when the
+            // animation actually starts, not when startTransition was called.
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.transitionDuration) {
+                self.finishTransition(id: transitionID)
+            }
+        }
+    }
+
+    private func finishTransition(id: UUID) {
+        guard self.activeTransitionID == id else {
+            return
+        }
+
+        self.transitionState.completeTransition()
+        self.activeTransitionID = nil
+    }
+
+    private static func renderedPage(
+        from context: WorkflowContext,
+        stepId: String,
+        canNavigateBack: Bool,
+        displayCloseButton: Bool
+    ) -> RenderedPage? {
+        guard let step = context.workflow.steps[stepId],
               let screenId = step.screenId,
-              let screen = self.context.workflow.screens[screenId],
-              let offering = self.context.offering(for: screen.offeringIdentifier) else {
+              let screen = context.workflow.screens[screenId],
+              let offering = context.offering(for: screen.offeringIdentifier) else {
             return nil
         }
 
         let paywallComponents = WorkflowScreenMapper.toPaywallComponents(
             screen: screen,
-            uiConfig: self.context.workflow.uiConfig
+            uiConfig: context.workflow.uiConfig
         )
 
-        return .init(paywallComponents: paywallComponents, offering: offering)
+        return .init(
+            content: .init(paywallComponents: paywallComponents, offering: offering),
+            showCloseButton: !canNavigateBack && displayCloseButton
+        )
     }
 
     private func logInvalidWorkflowStateIfNeeded() {
@@ -146,6 +384,21 @@ struct WorkflowPaywallView: View {
         )
     }
 
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct RenderedPage: Identifiable {
+    let id = UUID()
+    let content: CurrentStepContent
+    let showCloseButton: Bool
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct DisplayedPage: Identifiable {
+    let role: WorkflowPageTransitionState<RenderedPage>.PageRole
+    let page: RenderedPage
+
+    var id: UUID { self.page.id }
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -54,6 +54,76 @@ final class WorkflowPaywallViewTests: TestCase {
         expect(action) == .dismissWorkflow
     }
 
+    func testTransitionStateStartsWithoutOutgoingPage() {
+        let state = WorkflowPageTransitionState(currentPage: "step_1")
+
+        expect(state.currentPage) == "step_1"
+        expect(state.outgoingPage).to(beNil())
+        expect(state.isTransitioning) == false
+        expect(state.progress) == 1
+    }
+
+    func testForwardTransitionMovesIncomingPageFromTheRight() {
+        var state = WorkflowPageTransitionState(currentPage: "step_1")
+
+        state.beginTransition(to: "step_2", direction: .forward)
+
+        expect(state.currentPage) == "step_2"
+        expect(state.outgoingPage) == "step_1"
+        expect(state.progress) == 0
+        expect(state.offset(for: .current, width: 320)) == 320
+        expect(state.offset(for: .outgoing, width: 320)) == 0
+        expect(state.zIndex(for: .current)) == 1
+        expect(state.zIndex(for: .outgoing)) == 0
+
+        state.advanceAnimation()
+
+        expect(state.offset(for: .current, width: 320)) == 0
+        expect(state.offset(for: .outgoing, width: 320)) == -320
+    }
+
+    func testBackTransitionKeepsOutgoingPageOnTopWhileItSlidesRight() {
+        var state = WorkflowPageTransitionState(currentPage: "step_2")
+
+        state.beginTransition(to: "step_1", direction: .back)
+
+        expect(state.currentPage) == "step_1"
+        expect(state.outgoingPage) == "step_2"
+        expect(state.offset(for: .current, width: 320)) == -320
+        expect(state.offset(for: .outgoing, width: 320)) == 0
+        expect(state.zIndex(for: .current)) == 0
+        expect(state.zIndex(for: .outgoing)) == 1
+
+        state.advanceAnimation()
+
+        expect(state.offset(for: .current, width: 320)) == 0
+        expect(state.offset(for: .outgoing, width: 320)) == 320
+    }
+
+    func testCompletingTransitionDropsOutgoingPage() {
+        var state = WorkflowPageTransitionState(currentPage: "step_1")
+
+        state.beginTransition(to: "step_2", direction: .forward)
+        state.advanceAnimation()
+        state.completeTransition()
+
+        expect(state.currentPage) == "step_2"
+        expect(state.outgoingPage).to(beNil())
+        expect(state.isTransitioning) == false
+        expect(state.progress) == 1
+    }
+
+    func testInvalidTargetSkipsAnimationAndClearsTheCurrentPage() {
+        var state = WorkflowPageTransitionState(currentPage: "step_1")
+
+        state.beginTransition(to: nil, direction: .forward)
+
+        expect(state.currentPage).to(beNil())
+        expect(state.outgoingPage).to(beNil())
+        expect(state.isTransitioning) == false
+        expect(state.progress) == 1
+    }
+
 }
 
 #endif


### PR DESCRIPTION
## Summary

Builds on top of #6692 (`WorkflowPaywallView`) to add robust directional slide transitions when navigating between workflow steps, and cleans up a few rough edges from the initial implementation.

**What's in this PR:**
- Directional slide transitions between steps driven by explicit transition state rather than SwiftUI `.transition()`
- Workflow-aware back/dismiss behavior during step navigation, while keeping existing built-in close button support
- Guards against double-taps during transitions via `allowsHitTesting(false)`
- Respects `accessibilityReduceMotion` (instant swap, no animation)
- Keeps rendered pages keyed by stable snapshot IDs so SwiftUI preserves the outgoing subtree during transitions and avoids flashing
- Unit tests for the transition state machine

### Why not SwiftUI `.transition()`

SwiftUI captures a view's removal transition at insertion time. When navigating back after going forward, the outgoing view still has the forward removal transition baked in — it slides left instead of right. This breaks on every first change of direction.

The fix is `WorkflowPageTransitionState<Page>`, a small state machine that owns both the current and outgoing page simultaneously and drives the animation via explicit `.offset()` rather than `.transition()`. Direction and offsets are computed at render time from current state, so they're always correct regardless of navigation history.

### Why stable page identity matters

The outgoing page changes role from `current` to `outgoing` during a transition. Keeping each rendered page keyed by a stable snapshot ID lets SwiftUI preserve that subtree instead of recreating it in a different branch of the view tree, which avoids visible flashing at transition start.

### Why `DispatchQueue.main.async` to kick off the animation

When `beginTransition` is called, `progress` is set to `0` — both pages are at their starting offsets (outgoing centered, incoming off-screen). The animation then needs to drive `progress` to `1`.

If `advanceAnimation()` were called immediately in the same synchronous block, SwiftUI would batch both state changes (`progress = 0` then `progress = 1`) into a single render pass and skip straight to the final positions — no animation would play.

Deferring via `DispatchQueue.main.async` lets SwiftUI commit one frame with both pages at their initial offsets first. When the deferred block fires, `withAnimation` has a rendered starting state to animate from, so the slide plays correctly.

https://github.com/user-attachments/assets/1bc0ff5d-a892-4038-96f5-9c62c00c875d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall workflow navigation/rendering and introduces async animation timing, which could affect step changes or dismissal behavior if edge cases slip through; changes are localized and covered by new unit tests.
> 
> **Overview**
> Adds an explicit `WorkflowPageTransitionState` and refactors `WorkflowPaywallView` to render *current* and *outgoing* step pages simultaneously, driving **directional slide transitions** via computed `.offset`/`.zIndex` instead of SwiftUI `.transition()`.
> 
> Navigation/dismiss handling is updated to start forward/back transitions (including guarding against interactions mid-transition with `allowsHitTesting(false)`), respect `accessibilityReduceMotion` by swapping instantly, and keep stable page identity to avoid flashing; new tests validate the transition state machine’s offsets, z-order, and completion behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c14368246bab892c7b40f5ab58bb65ec72d3488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->