### PR TITLE
PaywallsTester: wire Workflows section in SamplePaywallsList

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -27,6 +27,9 @@ struct SamplePaywallsList: View {
     @State
     private var presentingCustomerCenterFullScreen: Bool = false
 
+    @State
+    private var workflowOfferingIdentifier: String = ""
+
     var body: some View {
         NavigationView {
             self.list
@@ -59,7 +62,7 @@ struct SamplePaywallsList: View {
                 fatalError()
 
             case .workflow:
-                fatalError()
+                EmptyView()
 
             #if !os(watchOS) && !os(macOS)
             case .footer, .condensedFooter:
@@ -111,6 +114,12 @@ struct SamplePaywallsList: View {
                 customerInfo: Self.loader.customerInfo,
                 displayCloseButton: Self.displayCloseButton,
                 introEligibility: Self.introEligibility
+            ))
+
+        case .workflowPaywall(let identifier):
+            PaywallView(configuration: .init(
+                content: .offeringIdentifier(identifier, presentedOfferingContext: nil),
+                purchaseHandler: .default()
             ))
         #endif
         #if canImport(UIKit) && os(iOS)
@@ -179,6 +188,20 @@ struct SamplePaywallsList: View {
                 } label: {
                     TemplateLabel(name: "Unrecognized paywall", icon: "exclamationmark.triangle")
                 }
+            }
+
+            Section("Workflows") {
+                TextField("Offering identifier", text: self.$workflowOfferingIdentifier)
+                    .autocorrectionDisabled()
+                    .autocapitalization(.none)
+
+                Button {
+                    self.display = .workflowPaywall(self.workflowOfferingIdentifier)
+                } label: {
+                    TemplateLabel(name: "Open workflow paywall",
+                                  icon: PaywallTesterViewMode.workflow.icon)
+                }
+                .disabled(self.workflowOfferingIdentifier.isEmpty)
             }
             #endif
 
@@ -342,6 +365,7 @@ private extension SamplePaywallsList {
         case missingPaywall
         case unrecognizedPaywall
         case componentPaywall(PaywallComponentsData)
+        case workflowPaywall(String)
         #endif
 
         @available(watchOS, unavailable)
@@ -378,6 +402,9 @@ extension SamplePaywallsList.Display: Identifiable {
 
         case .componentPaywall:
             return "component-paywall"
+
+        case .workflowPaywall(let identifier):
+            return "workflow-paywall-\(identifier)"
 
         #endif
         case .customerCenterSheet:

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -56,10 +56,10 @@ struct SamplePaywallsList: View {
                     introEligibility: Self.introEligibility
                 ))
             case .presentIfNeeded:
-                fatalError()
+                EmptyView()
 
             case .presentPaywall:
-                fatalError()
+                EmptyView()
 
             case .workflow:
                 EmptyView()
@@ -193,7 +193,7 @@ struct SamplePaywallsList: View {
             Section("Workflows") {
                 TextField("Offering identifier", text: self.$workflowOfferingIdentifier)
                     .autocorrectionDisabled()
-                    .autocapitalization(.none)
+                    .textInputAutocapitalization(.never)
 
                 Button {
                     self.display = .workflowPaywall(self.workflowOfferingIdentifier)


### PR DESCRIPTION
## Summary

- Replaces `fatalError()` with `EmptyView()` for the unreachable `.workflow` case inside the debug template switch (`isAvailableOnExamples` already prevents it from being triggered)
- Adds a **Workflows** section to `SamplePaywallsList` with an offering-identifier text field and an "Open workflow paywall" button
- The button routes through `PaywallView(configuration: .init(content: .offeringIdentifier(...)))`, so `WorkflowPaywallView` is rendered automatically when `-EnableWorkflowsEndpoint` is active

**Depends on:** #6703 (`facu/workflow-paywall-nav-ui`)

## Test plan

- [ ] Generate workspace: `TUIST_RC_API_KEY=appl_xxxxx TUIST_LAUNCH_ARGUMENTS="-EnableWorkflowsEndpoint" tuist generate PaywallsTester`
- [ ] Open **Examples** tab → scroll to **Workflows** section
- [ ] Enter a workflow offering identifier and tap **Open workflow paywall**
- [ ] Verify `WorkflowPaywallView` renders with nav bar, back/close buttons, and slide transitions
- [ ] Verify the workflow button is disabled when the text field is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to the PaywallsTester debug UI and replace `fatalError()` paths with `EmptyView()` to avoid crashes in unreachable states.
> 
> **Overview**
> Adds a **Workflows** section to `SamplePaywallsList` that lets testers enter an offering identifier and open a workflow paywall via `PaywallView(configuration: .init(content: .offeringIdentifier(...)))`.
> 
> Replaces `fatalError()` with `EmptyView()` for unsupported/unreachable `PaywallTesterViewMode` cases in the template switch, and adds a new `Display.workflowPaywall(String)` route/id to drive the new sheet presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 334d8c84dd865ce345f88cb371173cb5dcace89a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->