### PR TITLE
Add presented offering context to custom paywall events

### DIFF
--- a/Sources/Events/FeatureEvents/FeatureEvent.swift
+++ b/Sources/Events/FeatureEvents/FeatureEvent.swift
@@ -214,6 +214,18 @@ private extension CustomPaywallEvent {
             result["offering_id"] = offeringId
         }
 
+        if let placementIdentifier = self.data.placementIdentifier {
+            result["placement_identifier"] = placementIdentifier
+        }
+
+        if let targetingRevision = self.data.targetingRevision {
+            result["targeting_revision"] = targetingRevision
+        }
+
+        if let targetingRuleId = self.data.targetingRuleId {
+            result["targeting_rule_id"] = targetingRuleId
+        }
+
         return result
     }
 

--- a/Sources/Paywalls/Events/CustomPaywallEvent.swift
+++ b/Sources/Paywalls/Events/CustomPaywallEvent.swift
@@ -68,10 +68,22 @@ extension CustomPaywallEvent {
 
         var paywallId: String?
         var offeringId: String?
+        var placementIdentifier: String?
+        var targetingRevision: Int?
+        var targetingRuleId: String?
 
-        init(paywallId: String?, offeringId: String? = nil) {
+        init(
+            paywallId: String?,
+            offeringId: String? = nil,
+            placementIdentifier: String? = nil,
+            targetingRevision: Int? = nil,
+            targetingRuleId: String? = nil
+        ) {
             self.paywallId = paywallId
             self.offeringId = offeringId
+            self.placementIdentifier = placementIdentifier
+            self.targetingRevision = targetingRevision
+            self.targetingRuleId = targetingRuleId
         }
 
     }

--- a/Sources/Paywalls/Events/CustomPaywallEvent.swift
+++ b/Sources/Paywalls/Events/CustomPaywallEvent.swift
@@ -75,15 +75,13 @@ extension CustomPaywallEvent {
         init(
             paywallId: String?,
             offeringId: String? = nil,
-            placementIdentifier: String? = nil,
-            targetingRevision: Int? = nil,
-            targetingRuleId: String? = nil
+            presentedOfferingContext: PresentedOfferingContext? = nil
         ) {
             self.paywallId = paywallId
             self.offeringId = offeringId
-            self.placementIdentifier = placementIdentifier
-            self.targetingRevision = targetingRevision
-            self.targetingRuleId = targetingRuleId
+            self.placementIdentifier = presentedOfferingContext?.placementIdentifier
+            self.targetingRevision = presentedOfferingContext?.targetingContext?.revision
+            self.targetingRuleId = presentedOfferingContext?.targetingContext?.ruleId
         }
 
     }

--- a/Sources/Paywalls/Events/CustomPaywallImpressionParams.swift
+++ b/Sources/Paywalls/Events/CustomPaywallImpressionParams.swift
@@ -24,6 +24,24 @@ public final class CustomPaywallImpressionParams: NSObject, Sendable {
     /// If not provided, the SDK will use the current offering identifier from the cache.
     @objc public let offeringId: String?
 
+    /// The placement identifier this paywall was obtained from, if any.
+    @objc public let placementIdentifier: String?
+
+    private let targetingRevisionRawValue: Int?
+
+    /// The revision of the targeting rule used to obtain this paywall, if any.
+    @objc public var targetingRevision: NSNumber? {
+        return self.targetingRevisionRawValue.map(NSNumber.init(value:))
+    }
+
+    /// The revision of the targeting rule used to obtain this paywall, if any.
+    public var targetingRevisionValue: Int? {
+        return self.targetingRevisionRawValue
+    }
+
+    /// The id of the targeting rule used to obtain this paywall, if any.
+    @objc public let targetingRuleId: String?
+
     /// Creates parameters for a custom paywall impression.
     /// - Parameters:
     ///   - paywallId: An optional identifier for the custom paywall being shown.
@@ -32,12 +50,33 @@ public final class CustomPaywallImpressionParams: NSObject, Sendable {
     @objc public init(paywallId: String? = nil, offeringId: String?) {
         self.paywallId = paywallId
         self.offeringId = offeringId
+        self.placementIdentifier = nil
+        self.targetingRevisionRawValue = nil
+        self.targetingRuleId = nil
     }
 
     /// Creates parameters with only a paywall identifier.
     /// - Parameter paywallId: An optional identifier for the custom paywall being shown.
     @objc public convenience init(paywallId: String? = nil) {
         self.init(paywallId: paywallId, offeringId: nil)
+    }
+
+    /// Creates parameters for a custom paywall impression from the offering it was obtained from.
+    ///
+    /// This automatically populates the offering identifier and the placement and targeting
+    /// information from the offering's first available package's ``PresentedOfferingContext``.
+    ///
+    /// - Parameters:
+    ///   - paywallId: An optional identifier for the custom paywall being shown.
+    ///   - offering: The offering associated with the custom paywall.
+    @objc public init(paywallId: String? = nil, offering: Offering) {
+        self.paywallId = paywallId
+        self.offeringId = offering.identifier
+
+        let presentedOfferingContext = offering.availablePackages.first?.presentedOfferingContext
+        self.placementIdentifier = presentedOfferingContext?.placementIdentifier
+        self.targetingRevisionRawValue = presentedOfferingContext?.targetingContext?.revision
+        self.targetingRuleId = presentedOfferingContext?.targetingContext?.ruleId
     }
 
 }

--- a/Sources/Paywalls/Events/CustomPaywallImpressionParams.swift
+++ b/Sources/Paywalls/Events/CustomPaywallImpressionParams.swift
@@ -24,25 +24,17 @@ public final class CustomPaywallImpressionParams: NSObject, Sendable {
     /// If not provided, the SDK will use the current offering identifier from the cache.
     @objc public let offeringId: String?
 
-    /// The placement identifier this paywall was obtained from, if any.
-    @objc public let placementIdentifier: String?
+    /// The offering associated with the custom paywall.
+    ///
+    /// When provided, the SDK will derive the presented offering context (placement and targeting
+    /// information) from this offering. If neither `offering` nor `offeringId` is provided, the SDK
+    /// will use the current offering from the cache.
+    @objc public let offering: Offering?
 
-    private let targetingRevisionRawValue: Int?
-
-    /// The revision of the targeting rule used to obtain this paywall, if any.
-    @objc public var targetingRevision: NSNumber? {
-        return self.targetingRevisionRawValue.map(NSNumber.init(value:))
-    }
-
-    /// The revision of the targeting rule used to obtain this paywall, if any.
-    public var targetingRevisionValue: Int? {
-        return self.targetingRevisionRawValue
-    }
-
-    /// The id of the targeting rule used to obtain this paywall, if any.
-    @objc public let targetingRuleId: String?
-
-    /// Creates parameters for a custom paywall impression.
+    /// Creates parameters for a custom paywall impression with string identifiers.
+    ///
+    /// Use this initializer when the ``Offering`` object is not available at call time.
+    ///
     /// - Parameters:
     ///   - paywallId: An optional identifier for the custom paywall being shown.
     ///   - offeringId: An optional identifier for the offering associated with the custom paywall.
@@ -50,12 +42,14 @@ public final class CustomPaywallImpressionParams: NSObject, Sendable {
     @objc public init(paywallId: String? = nil, offeringId: String?) {
         self.paywallId = paywallId
         self.offeringId = offeringId
-        self.placementIdentifier = nil
-        self.targetingRevisionRawValue = nil
-        self.targetingRuleId = nil
+        self.offering = nil
     }
 
     /// Creates parameters with only a paywall identifier.
+    ///
+    /// The SDK will use the current offering from the cache to derive the offering identifier
+    /// and presented offering context.
+    ///
     /// - Parameter paywallId: An optional identifier for the custom paywall being shown.
     @objc public convenience init(paywallId: String? = nil) {
         self.init(paywallId: paywallId, offeringId: nil)
@@ -63,8 +57,10 @@ public final class CustomPaywallImpressionParams: NSObject, Sendable {
 
     /// Creates parameters for a custom paywall impression from the offering it was obtained from.
     ///
-    /// This automatically populates the offering identifier and the placement and targeting
-    /// information from the offering's first available package's ``PresentedOfferingContext``.
+    /// Use this initializer when presenting a paywall for an offering that is not the current
+    /// offering (for example, a placement-resolved offering). The SDK will derive both the offering
+    /// identifier and the presented offering context (placement and targeting information) from
+    /// the provided offering.
     ///
     /// - Parameters:
     ///   - paywallId: An optional identifier for the custom paywall being shown.
@@ -72,11 +68,7 @@ public final class CustomPaywallImpressionParams: NSObject, Sendable {
     @objc public init(paywallId: String? = nil, offering: Offering) {
         self.paywallId = paywallId
         self.offeringId = offering.identifier
-
-        let presentedOfferingContext = offering.availablePackages.first?.presentedOfferingContext
-        self.placementIdentifier = presentedOfferingContext?.placementIdentifier
-        self.targetingRevisionRawValue = presentedOfferingContext?.targetingContext?.revision
-        self.targetingRuleId = presentedOfferingContext?.targetingContext?.ruleId
+        self.offering = offering
     }
 
 }

--- a/Sources/Paywalls/Events/CustomPaywallImpressionParams.swift
+++ b/Sources/Paywalls/Events/CustomPaywallImpressionParams.swift
@@ -21,28 +21,21 @@ public final class CustomPaywallImpressionParams: NSObject, Sendable {
     @objc public let paywallId: String?
 
     /// An optional identifier for the offering associated with the custom paywall.
-    /// If not provided, the SDK will use the current offering identifier from the cache.
+    /// If neither this nor an ``Offering`` is provided, the SDK will use the current offering
+    /// identifier from the cache.
     @objc public let offeringId: String?
 
-    /// The offering associated with the custom paywall.
-    ///
-    /// When provided, the SDK will derive the presented offering context (placement and targeting
-    /// information) from this offering. If neither `offering` nor `offeringId` is provided, the SDK
-    /// will use the current offering from the cache.
-    @objc public let offering: Offering?
+    /// The presented offering context (placement and targeting information) derived from the
+    /// offering, if available.
+    @_spi(Internal) public let presentedOfferingContext: PresentedOfferingContext?
 
-    /// Creates parameters for a custom paywall impression with string identifiers.
-    ///
-    /// Use this initializer when the ``Offering`` object is not available at call time.
-    ///
-    /// - Parameters:
-    ///   - paywallId: An optional identifier for the custom paywall being shown.
-    ///   - offeringId: An optional identifier for the offering associated with the custom paywall.
-    ///     If `nil`, the SDK will use the current offering identifier from the cache.
-    @objc public init(paywallId: String? = nil, offeringId: String?) {
+    /// Designated initializer. Intended for use by hybrid SDKs that pass placement/targeting
+    /// context through purchases-hybrid-common rather than via an ``Offering`` object.
+    @_spi(Internal)
+    public init(paywallId: String? = nil, offeringId: String?, presentedOfferingContext: PresentedOfferingContext?) {
         self.paywallId = paywallId
         self.offeringId = offeringId
-        self.offering = nil
+        self.presentedOfferingContext = presentedOfferingContext
     }
 
     /// Creates parameters with only a paywall identifier.
@@ -52,7 +45,24 @@ public final class CustomPaywallImpressionParams: NSObject, Sendable {
     ///
     /// - Parameter paywallId: An optional identifier for the custom paywall being shown.
     @objc public convenience init(paywallId: String? = nil) {
-        self.init(paywallId: paywallId, offeringId: nil)
+        self.init(paywallId: paywallId, offeringId: nil, presentedOfferingContext: nil)
+    }
+
+    /// Creates parameters for a custom paywall impression with a string offering identifier.
+    ///
+    /// - Parameters:
+    ///   - paywallId: An optional identifier for the custom paywall being shown.
+    ///   - offeringId: An optional identifier for the offering associated with the custom paywall.
+    ///     If `nil`, the SDK will use the current offering identifier from the cache.
+    ///
+    /// - Important: Prefer ``init(paywallId:offering:)`` when an ``Offering`` object is available.
+    ///   Passing only a string identifier prevents the SDK from automatically deriving placement
+    ///   and targeting context.
+    @available(*, deprecated,
+               message: "Pass an Offering object instead. Using an offering identifier string prevents the SDK from deriving placement and targeting context automatically.",
+               renamed: "init(paywallId:offering:)")
+    @objc public convenience init(paywallId: String? = nil, offeringId: String?) {
+        self.init(paywallId: paywallId, offeringId: offeringId, presentedOfferingContext: nil)
     }
 
     /// Creates parameters for a custom paywall impression from the offering it was obtained from.
@@ -65,10 +75,12 @@ public final class CustomPaywallImpressionParams: NSObject, Sendable {
     /// - Parameters:
     ///   - paywallId: An optional identifier for the custom paywall being shown.
     ///   - offering: The offering associated with the custom paywall.
-    @objc public init(paywallId: String? = nil, offering: Offering) {
-        self.paywallId = paywallId
-        self.offeringId = offering.identifier
-        self.offering = offering
+    @objc public convenience init(paywallId: String? = nil, offering: Offering) {
+        self.init(
+            paywallId: paywallId,
+            offeringId: offering.identifier,
+            presentedOfferingContext: offering.availablePackages.first?.presentedOfferingContext
+        )
     }
 
 }

--- a/Sources/Paywalls/Events/CustomPaywallImpressionParams.swift
+++ b/Sources/Paywalls/Events/CustomPaywallImpressionParams.swift
@@ -59,6 +59,7 @@ public final class CustomPaywallImpressionParams: NSObject, Sendable {
     ///   Passing only a string identifier prevents the SDK from automatically deriving placement
     ///   and targeting context.
     @available(*, deprecated,
+               // swiftlint:disable:next line_length
                message: "Pass an Offering object instead. Using an offering identifier string prevents the SDK from deriving placement and targeting context automatically.",
                renamed: "init(paywallId:offering:)")
     @objc public convenience init(paywallId: String? = nil, offeringId: String?) {

--- a/Sources/Paywalls/Events/Networking/EventsRequest+CustomPaywallImpression.swift
+++ b/Sources/Paywalls/Events/Networking/EventsRequest+CustomPaywallImpression.swift
@@ -28,6 +28,7 @@ extension FeatureEventsRequest {
         var timestamp: UInt64
         var paywallId: String?
         var offeringId: String?
+        var presentedOfferingContext: FeatureEventsRequest.PaywallEvent.PresentedOfferingContextData?
 
     }
 
@@ -53,7 +54,12 @@ extension FeatureEventsRequest.CustomPaywallEvent {
                 appSessionID: storedEvent.appSessionID?.uuidString,
                 timestamp: event.creationData.date.millisecondsSince1970,
                 paywallId: event.data.paywallId,
-                offeringId: event.data.offeringId
+                offeringId: event.data.offeringId,
+                presentedOfferingContext: FeatureEventsRequest.PaywallEvent.PresentedOfferingContextData(
+                    placementIdentifier: event.data.placementIdentifier,
+                    targetingRevision: event.data.targetingRevision,
+                    targetingRuleId: event.data.targetingRuleId
+                )
             )
         } catch {
             Logger.error(Strings.paywalls.event_cannot_deserialize(error))
@@ -80,6 +86,7 @@ extension FeatureEventsRequest.CustomPaywallEvent: Encodable {
         case timestamp
         case paywallId
         case offeringId
+        case presentedOfferingContext
 
     }
 
@@ -93,6 +100,7 @@ extension FeatureEventsRequest.CustomPaywallEvent: Encodable {
         try container.encode(timestamp, forKey: .timestamp)
         try container.encodeIfPresent(paywallId, forKey: .paywallId)
         try container.encodeIfPresent(offeringId, forKey: .offeringId)
+        try container.encodeIfPresent(presentedOfferingContext, forKey: .presentedOfferingContext)
     }
 
 }

--- a/Sources/Paywalls/Events/Networking/EventsRequest+CustomPaywallImpression.swift
+++ b/Sources/Paywalls/Events/Networking/EventsRequest+CustomPaywallImpression.swift
@@ -28,13 +28,37 @@ extension FeatureEventsRequest {
         var timestamp: UInt64
         var paywallId: String?
         var offeringId: String?
-        var presentedOfferingContext: FeatureEventsRequest.PaywallEvent.PresentedOfferingContextData?
+        var presentedOfferingContext: PresentedOfferingContextData?
 
     }
 
 }
 
 extension FeatureEventsRequest.CustomPaywallEvent {
+
+    struct PresentedOfferingContextData: Encodable {
+
+        var placementIdentifier: String?
+        var targetingRevision: Int?
+        var targetingRuleId: String?
+
+        /// Returns `nil` if all fields are `nil`.
+        init?(
+            placementIdentifier: String?,
+            targetingRevision: Int?,
+            targetingRuleId: String?
+        ) {
+            guard placementIdentifier != nil ||
+                    targetingRevision != nil ||
+                    targetingRuleId != nil else {
+                return nil
+            }
+            self.placementIdentifier = placementIdentifier
+            self.targetingRevision = targetingRevision
+            self.targetingRuleId = targetingRuleId
+        }
+
+    }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     init?(storedEvent: StoredFeatureEvent) {
@@ -55,7 +79,7 @@ extension FeatureEventsRequest.CustomPaywallEvent {
                 timestamp: event.creationData.date.millisecondsSince1970,
                 paywallId: event.data.paywallId,
                 offeringId: event.data.offeringId,
-                presentedOfferingContext: FeatureEventsRequest.PaywallEvent.PresentedOfferingContextData(
+                presentedOfferingContext: PresentedOfferingContextData(
                     placementIdentifier: event.data.placementIdentifier,
                     targetingRevision: event.data.targetingRevision,
                     targetingRuleId: event.data.targetingRuleId

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2247,7 +2247,13 @@ extension Purchases {
         Task {
             let event = CustomPaywallEvent.impression(
                 .init(),
-                .init(paywallId: params.paywallId, offeringId: offeringId)
+                .init(
+                    paywallId: params.paywallId,
+                    offeringId: offeringId,
+                    placementIdentifier: params.placementIdentifier,
+                    targetingRevision: params.targetingRevisionValue,
+                    targetingRuleId: params.targetingRuleId
+                )
             )
             await self.eventsManager?.track(featureEvent: event)
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2243,16 +2243,18 @@ extension Purchases {
     /// - Parameter params: Parameters for the custom paywall impression.
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     @objc public func trackCustomPaywallImpression(_ params: CustomPaywallImpressionParams) {
-        let offeringId = params.offeringId ?? self.offeringsManager.cachedOfferings?.current?.identifier
+        let resolvedOffering = params.offering
+            ?? (params.offeringId == nil ? self.offeringsManager.cachedOfferings?.current : nil)
+        let presentedOfferingContext = resolvedOffering?.availablePackages.first?.presentedOfferingContext
+        let offeringId = params.offeringId ?? resolvedOffering?.identifier
+
         Task {
             let event = CustomPaywallEvent.impression(
                 .init(),
                 .init(
                     paywallId: params.paywallId,
                     offeringId: offeringId,
-                    placementIdentifier: params.placementIdentifier,
-                    targetingRevision: params.targetingRevisionValue,
-                    targetingRuleId: params.targetingRuleId
+                    presentedOfferingContext: presentedOfferingContext
                 )
             )
             await self.eventsManager?.track(featureEvent: event)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2243,8 +2243,10 @@ extension Purchases {
     /// - Parameter params: Parameters for the custom paywall impression.
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     @objc public func trackCustomPaywallImpression(_ params: CustomPaywallImpressionParams) {
+        let cachedOfferings = self.offeringsManager.cachedOfferings
         let resolvedOffering = params.offering
-            ?? (params.offeringId == nil ? self.offeringsManager.cachedOfferings?.current : nil)
+            ?? params.offeringId.flatMap { cachedOfferings?[$0] }
+            ?? (params.offeringId == nil ? cachedOfferings?.current : nil)
         let presentedOfferingContext = resolvedOffering?.availablePackages.first?.presentedOfferingContext
         let offeringId = params.offeringId ?? resolvedOffering?.identifier
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -855,6 +855,9 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             self.handleCustomerInfoChanged(from: old, to: new)
         }
 
+        self.transactionMetadataSyncHelper.syncIfNeeded(
+            allowSharingAppStoreAccount: purchasesOrchestrator.allowSharingAppStoreAccount
+        )
     }
 
     deinit {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2288,16 +2288,18 @@ extension Purchases {
     /// - Parameter params: Parameters for the custom paywall impression.
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     @objc public func trackCustomPaywallImpression(_ params: CustomPaywallImpressionParams) {
-        let offeringId = params.offeringId ?? self.offeringsManager.cachedOfferings?.current?.identifier
+        let resolvedOffering = params.offering
+            ?? (params.offeringId == nil ? self.offeringsManager.cachedOfferings?.current : nil)
+        let presentedOfferingContext = resolvedOffering?.availablePackages.first?.presentedOfferingContext
+        let offeringId = params.offeringId ?? resolvedOffering?.identifier
+
         Task {
             let event = CustomPaywallEvent.impression(
                 .init(),
                 .init(
                     paywallId: params.paywallId,
                     offeringId: offeringId,
-                    placementIdentifier: params.placementIdentifier,
-                    targetingRevision: params.targetingRevisionValue,
-                    targetingRuleId: params.targetingRuleId
+                    presentedOfferingContext: presentedOfferingContext
                 )
             )
             await self.eventsManager?.track(featureEvent: event)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -855,9 +855,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             self.handleCustomerInfoChanged(from: old, to: new)
         }
 
-        self.transactionMetadataSyncHelper.syncIfNeeded(
-            allowSharingAppStoreAccount: purchasesOrchestrator.allowSharingAppStoreAccount
-        )
     }
 
     deinit {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2288,8 +2288,10 @@ extension Purchases {
     /// - Parameter params: Parameters for the custom paywall impression.
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     @objc public func trackCustomPaywallImpression(_ params: CustomPaywallImpressionParams) {
+        let cachedOfferings = self.offeringsManager.cachedOfferings
         let resolvedOffering = params.offering
-            ?? (params.offeringId == nil ? self.offeringsManager.cachedOfferings?.current : nil)
+            ?? params.offeringId.flatMap { cachedOfferings?[$0] }
+            ?? (params.offeringId == nil ? cachedOfferings?.current : nil)
         let presentedOfferingContext = resolvedOffering?.availablePackages.first?.presentedOfferingContext
         let offeringId = params.offeringId ?? resolvedOffering?.identifier
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2292,7 +2292,13 @@ extension Purchases {
         Task {
             let event = CustomPaywallEvent.impression(
                 .init(),
-                .init(paywallId: params.paywallId, offeringId: offeringId)
+                .init(
+                    paywallId: params.paywallId,
+                    offeringId: offeringId,
+                    placementIdentifier: params.placementIdentifier,
+                    targetingRevision: params.targetingRevisionValue,
+                    targetingRuleId: params.targetingRuleId
+                )
             )
             await self.eventsManager?.track(featureEvent: event)
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2289,9 +2289,12 @@ extension Purchases {
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     @objc public func trackCustomPaywallImpression(_ params: CustomPaywallImpressionParams) {
         let cachedOfferings = self.offeringsManager.cachedOfferings
-        let resolvedOffering = params.offering
-            ?? params.offeringId.flatMap { cachedOfferings?[$0] }
-            ?? (params.offeringId == nil ? cachedOfferings?.current : nil)
+        let resolvedOffering = params.offering ?? {
+            if let offeringId = params.offeringId {
+                return cachedOfferings?[offeringId]
+            }
+            return cachedOfferings?.current
+        }()
         let presentedOfferingContext = resolvedOffering?.availablePackages.first?.presentedOfferingContext
         let offeringId = params.offeringId ?? resolvedOffering?.identifier
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2289,22 +2289,29 @@ extension Purchases {
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     @objc public func trackCustomPaywallImpression(_ params: CustomPaywallImpressionParams) {
         let cachedOfferings = self.offeringsManager.cachedOfferings
-        let resolvedOffering = params.offering ?? {
-            if let offeringId = params.offeringId {
-                return cachedOfferings?[offeringId]
-            }
-            return cachedOfferings?.current
-        }()
-        let presentedOfferingContext = resolvedOffering?.availablePackages.first?.presentedOfferingContext
-        let offeringId = params.offeringId ?? resolvedOffering?.identifier
+        let resolvedOfferingId: String?
+        let resolvedPresentedOfferingContext: PresentedOfferingContext?
+
+        if let presentedOfferingContext = params.presentedOfferingContext {
+            resolvedOfferingId = params.offeringId
+            resolvedPresentedOfferingContext = presentedOfferingContext
+        } else if let offeringId = params.offeringId {
+            let resolvedOffering = cachedOfferings?[offeringId]
+            resolvedOfferingId = offeringId
+            resolvedPresentedOfferingContext = resolvedOffering?.availablePackages.first?.presentedOfferingContext
+        } else {
+            let resolvedOffering = cachedOfferings?.current
+            resolvedOfferingId = resolvedOffering?.identifier
+            resolvedPresentedOfferingContext = resolvedOffering?.availablePackages.first?.presentedOfferingContext
+        }
 
         Task {
             let event = CustomPaywallEvent.impression(
                 .init(),
                 .init(
                     paywallId: params.paywallId,
-                    offeringId: offeringId,
-                    presentedOfferingContext: presentedOfferingContext
+                    offeringId: resolvedOfferingId,
+                    presentedOfferingContext: resolvedPresentedOfferingContext
                 )
             )
             await self.eventsManager?.track(featureEvent: event)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2244,9 +2244,12 @@ extension Purchases {
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     @objc public func trackCustomPaywallImpression(_ params: CustomPaywallImpressionParams) {
         let cachedOfferings = self.offeringsManager.cachedOfferings
-        let resolvedOffering = params.offering
-            ?? params.offeringId.flatMap { cachedOfferings?[$0] }
-            ?? (params.offeringId == nil ? cachedOfferings?.current : nil)
+        let resolvedOffering = params.offering ?? {
+            if let offeringId = params.offeringId {
+                return cachedOfferings?[offeringId]
+            }
+            return cachedOfferings?.current
+        }()
         let presentedOfferingContext = resolvedOffering?.availablePackages.first?.presentedOfferingContext
         let offeringId = params.offeringId ?? resolvedOffering?.identifier
 

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCCustomPaywallImpressionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCCustomPaywallImpressionAPI.m
@@ -20,14 +20,26 @@
         RCCustomPaywallImpressionParams *paramsBothNil __unused = [[RCCustomPaywallImpressionParams alloc] initWithPaywallId:nil offeringId:nil];
         RCCustomPaywallImpressionParams *paramsIdNilOffering __unused = [[RCCustomPaywallImpressionParams alloc] initWithPaywallId:@"my-paywall" offeringId:nil];
 
+        RCOffering *offering = [[RCOffering alloc] initWithIdentifier:@"my-offering"
+                                                    serverDescription:@""
+                                                             metadata:@{}
+                                                    availablePackages:@[]
+                                                       webCheckoutUrl:nil];
+        RCCustomPaywallImpressionParams *paramsWithOfferingObject __unused = [[RCCustomPaywallImpressionParams alloc] initWithPaywallId:@"my-paywall" offering:offering];
+        RCCustomPaywallImpressionParams *paramsWithOfferingObjectNilPaywall __unused = [[RCCustomPaywallImpressionParams alloc] initWithPaywallId:nil offering:offering];
+
         // CustomPaywallImpressionParams properties
         NSString *paywallId __unused = paramsWithId.paywallId;
         NSString *offeringId __unused = paramsWithOffering.offeringId;
+        NSString *placementIdentifier __unused = paramsWithOfferingObject.placementIdentifier;
+        NSNumber *targetingRevision __unused = paramsWithOfferingObject.targetingRevision;
+        NSString *targetingRuleId __unused = paramsWithOfferingObject.targetingRuleId;
 
         // trackCustomPaywallImpression API
         RCPurchases *purchases = RCPurchases.sharedPurchases;
         [purchases trackCustomPaywallImpression:paramsDefault];
         [purchases trackCustomPaywallImpression:paramsWithId];
+        [purchases trackCustomPaywallImpression:paramsWithOfferingObject];
         [purchases trackCustomPaywallImpression];
     }
 }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCCustomPaywallImpressionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCCustomPaywallImpressionAPI.m
@@ -31,9 +31,7 @@
         // CustomPaywallImpressionParams properties
         NSString *paywallId __unused = paramsWithId.paywallId;
         NSString *offeringId __unused = paramsWithOffering.offeringId;
-        NSString *placementIdentifier __unused = paramsWithOfferingObject.placementIdentifier;
-        NSNumber *targetingRevision __unused = paramsWithOfferingObject.targetingRevision;
-        NSString *targetingRuleId __unused = paramsWithOfferingObject.targetingRuleId;
+        RCOffering *offeringObject __unused = paramsWithOfferingObject.offering;
 
         // trackCustomPaywallImpression API
         RCPurchases *purchases = RCPurchases.sharedPurchases;

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCCustomPaywallImpressionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCCustomPaywallImpressionAPI.m
@@ -15,11 +15,6 @@
         RCCustomPaywallImpressionParams *paramsDefault __unused = [[RCCustomPaywallImpressionParams alloc] initWithPaywallId:nil];
         RCCustomPaywallImpressionParams *paramsWithId __unused = [[RCCustomPaywallImpressionParams alloc] initWithPaywallId:@"my-paywall"];
         RCCustomPaywallImpressionParams *paramsWithNil __unused = [[RCCustomPaywallImpressionParams alloc] initWithPaywallId:nil];
-        RCCustomPaywallImpressionParams *paramsWithOffering __unused = [[RCCustomPaywallImpressionParams alloc] initWithPaywallId:@"my-paywall" offeringId:@"my-offering"];
-        RCCustomPaywallImpressionParams *paramsOfferingOnly __unused = [[RCCustomPaywallImpressionParams alloc] initWithPaywallId:nil offeringId:@"my-offering"];
-        RCCustomPaywallImpressionParams *paramsBothNil __unused = [[RCCustomPaywallImpressionParams alloc] initWithPaywallId:nil offeringId:nil];
-        RCCustomPaywallImpressionParams *paramsIdNilOffering __unused = [[RCCustomPaywallImpressionParams alloc] initWithPaywallId:@"my-paywall" offeringId:nil];
-
         RCOffering *offering = [[RCOffering alloc] initWithIdentifier:@"my-offering"
                                                     serverDescription:@""
                                                              metadata:@{}
@@ -30,8 +25,7 @@
 
         // CustomPaywallImpressionParams properties
         NSString *paywallId __unused = paramsWithId.paywallId;
-        NSString *offeringId __unused = paramsWithOffering.offeringId;
-        RCOffering *offeringObject __unused = paramsWithOfferingObject.offering;
+        NSString *offeringId __unused = paramsWithOfferingObject.offeringId;
 
         // trackCustomPaywallImpression API
         RCPurchases *purchases = RCPurchases.sharedPurchases;

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/CustomPaywallImpressionAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/CustomPaywallImpressionAPI.swift
@@ -31,14 +31,30 @@ func checkCustomPaywallImpressionAPI() {
             paywallId: "my-paywall",
             offeringId: nil
         )
+        let offering: Offering = Offering(
+            identifier: "my-offering",
+            serverDescription: "",
+            availablePackages: [],
+            webCheckoutUrl: nil
+        )
+        let paramsWithOfferingObject: CustomPaywallImpressionParams = CustomPaywallImpressionParams(
+            paywallId: "my-paywall",
+            offering: offering
+        )
+        let paramsOfferingObjectOnly: CustomPaywallImpressionParams = CustomPaywallImpressionParams(offering: offering)
 
         // CustomPaywallImpressionParams properties
         let paywallId: String? = paramsWithId.paywallId
         let offeringId: String? = paramsWithOffering.offeringId
+        let placementIdentifier: String? = paramsWithOfferingObject.placementIdentifier
+        let targetingRevision: NSNumber? = paramsWithOfferingObject.targetingRevision
+        let targetingRuleId: String? = paramsWithOfferingObject.targetingRuleId
 
         // trackCustomPaywallImpression API
         purchases.trackCustomPaywallImpression(paramsDefault)
         purchases.trackCustomPaywallImpression(paramsWithId)
+        purchases.trackCustomPaywallImpression(paramsWithOfferingObject)
+        purchases.trackCustomPaywallImpression(paramsOfferingObjectOnly)
         purchases.trackCustomPaywallImpression()
     }
 }

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/CustomPaywallImpressionAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/CustomPaywallImpressionAPI.swift
@@ -46,9 +46,7 @@ func checkCustomPaywallImpressionAPI() {
         // CustomPaywallImpressionParams properties
         let paywallId: String? = paramsWithId.paywallId
         let offeringId: String? = paramsWithOffering.offeringId
-        let placementIdentifier: String? = paramsWithOfferingObject.placementIdentifier
-        let targetingRevision: NSNumber? = paramsWithOfferingObject.targetingRevision
-        let targetingRuleId: String? = paramsWithOfferingObject.targetingRuleId
+        let offeringObject: Offering? = paramsWithOfferingObject.offering
 
         // trackCustomPaywallImpression API
         purchases.trackCustomPaywallImpression(paramsDefault)

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/CustomPaywallImpressionAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/CustomPaywallImpressionAPI.swift
@@ -21,16 +21,6 @@ func checkCustomPaywallImpressionAPI() {
         let paramsDefault: CustomPaywallImpressionParams = CustomPaywallImpressionParams()
         let paramsWithId: CustomPaywallImpressionParams = CustomPaywallImpressionParams(paywallId: "my-paywall")
         let paramsWithNil: CustomPaywallImpressionParams = CustomPaywallImpressionParams(paywallId: nil)
-        let paramsWithOffering: CustomPaywallImpressionParams = CustomPaywallImpressionParams(
-            paywallId: "my-paywall",
-            offeringId: "my-offering"
-        )
-        let paramsOfferingOnly: CustomPaywallImpressionParams = CustomPaywallImpressionParams(offeringId: "my-offering")
-        let paramsBothNil: CustomPaywallImpressionParams = CustomPaywallImpressionParams(paywallId: nil, offeringId: nil)
-        let paramsIdNilOffering: CustomPaywallImpressionParams = CustomPaywallImpressionParams(
-            paywallId: "my-paywall",
-            offeringId: nil
-        )
         let offering: Offering = Offering(
             identifier: "my-offering",
             serverDescription: "",
@@ -45,8 +35,7 @@ func checkCustomPaywallImpressionAPI() {
 
         // CustomPaywallImpressionParams properties
         let paywallId: String? = paramsWithId.paywallId
-        let offeringId: String? = paramsWithOffering.offeringId
-        let offeringObject: Offering? = paramsWithOfferingObject.offering
+        let offeringId: String? = paramsWithOfferingObject.offeringId
 
         // trackCustomPaywallImpression API
         purchases.trackCustomPaywallImpression(paramsDefault)

--- a/Tests/UnitTests/Events/EventsManagerTests.swift
+++ b/Tests/UnitTests/Events/EventsManagerTests.swift
@@ -439,6 +439,37 @@ class EventsManagerTests: TestCase {
         expect(map["paywall_id"]).to(beNil())
     }
 
+    func testCustomPaywallImpressionToMapIncludesPlacementAndTargeting() {
+        let creationData = CustomPaywallEvent.CreationData()
+        let data = CustomPaywallEvent.Data(
+            paywallId: "my_paywall",
+            offeringId: "my_offering",
+            presentedOfferingContext: .init(
+                offeringIdentifier: "my_offering",
+                placementIdentifier: "onboarding",
+                targetingContext: .init(revision: 7, ruleId: "rule_42")
+            )
+        )
+        let event = CustomPaywallEvent.impression(creationData, data)
+        let map = (event as FeatureEvent).toMap()
+
+        expect(map["offering_id"] as? String) == "my_offering"
+        expect(map["placement_identifier"] as? String) == "onboarding"
+        expect(map["targeting_revision"] as? Int) == 7
+        expect(map["targeting_rule_id"] as? String) == "rule_42"
+    }
+
+    func testCustomPaywallImpressionToMapOmitsPlacementAndTargetingWhenNil() {
+        let creationData = CustomPaywallEvent.CreationData()
+        let data = CustomPaywallEvent.Data(paywallId: "my_paywall")
+        let event = CustomPaywallEvent.impression(creationData, data)
+        let map = (event as FeatureEvent).toMap()
+
+        expect(map["placement_identifier"]).to(beNil())
+        expect(map["targeting_revision"]).to(beNil())
+        expect(map["targeting_rule_id"]).to(beNil())
+    }
+
     // MARK: - trackEvent (Custom Paywall Impression)
 
     func testTrackCustomPaywallImpressionEvent() async throws {

--- a/Tests/UnitTests/Paywalls/Events/CustomPaywallEventTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/CustomPaywallEventTests.swift
@@ -312,19 +312,14 @@ class CustomPaywallEventTests: TestCase {
         expect(params.offeringId).to(beNil())
     }
 
-    func testParamsDefaultPlacementAndTargetingFieldsAreNil() {
+    func testParamsDefaultOfferingIsNil() {
         let params = CustomPaywallImpressionParams()
-        expect(params.placementIdentifier).to(beNil())
-        expect(params.targetingRevision).to(beNil())
-        expect(params.targetingRevisionValue).to(beNil())
-        expect(params.targetingRuleId).to(beNil())
+        expect(params.offering).to(beNil())
     }
 
-    func testParamsWithOfferingIdInitDoesNotPopulatePlacementAndTargeting() {
+    func testParamsWithOfferingIdInitDoesNotStoreOffering() {
         let params = CustomPaywallImpressionParams(paywallId: "pw", offeringId: "my_offering")
-        expect(params.placementIdentifier).to(beNil())
-        expect(params.targetingRevision).to(beNil())
-        expect(params.targetingRuleId).to(beNil())
+        expect(params.offering).to(beNil())
     }
 
     // MARK: - Params: Offering-based init
@@ -336,48 +331,10 @@ class CustomPaywallEventTests: TestCase {
         expect(params.offeringId) == "my_offering"
     }
 
-    func testParamsWithOfferingPopulatesPlacementAndTargeting() {
-        let context = PresentedOfferingContext(
-            offeringIdentifier: "offering_1",
-            placementIdentifier: "home_banner",
-            targetingContext: .init(revision: 3, ruleId: "rule_abc123")
-        )
-        let offering = Self.makeOffering(identifier: "offering_1", presentedOfferingContext: context)
-
+    func testParamsWithOfferingStoresOffering() {
+        let offering = Self.makeOffering(identifier: "my_offering")
         let params = CustomPaywallImpressionParams(paywallId: "pw", offering: offering)
-
-        expect(params.placementIdentifier) == "home_banner"
-        expect(params.targetingRevision) == NSNumber(value: 3)
-        expect(params.targetingRevisionValue) == 3
-        expect(params.targetingRuleId) == "rule_abc123"
-    }
-
-    func testParamsWithOfferingNoPlacementOrTargeting() {
-        let context = PresentedOfferingContext(offeringIdentifier: "offering_1")
-        let offering = Self.makeOffering(identifier: "offering_1", presentedOfferingContext: context)
-
-        let params = CustomPaywallImpressionParams(paywallId: "pw", offering: offering)
-
-        expect(params.placementIdentifier).to(beNil())
-        expect(params.targetingRevision).to(beNil())
-        expect(params.targetingRevisionValue).to(beNil())
-        expect(params.targetingRuleId).to(beNil())
-    }
-
-    func testParamsWithOfferingThatHasNoPackages() {
-        let offering = Offering(
-            identifier: "offering_1",
-            serverDescription: "",
-            availablePackages: [],
-            webCheckoutUrl: nil
-        )
-
-        let params = CustomPaywallImpressionParams(paywallId: "pw", offering: offering)
-
-        expect(params.offeringId) == "offering_1"
-        expect(params.placementIdentifier).to(beNil())
-        expect(params.targetingRevision).to(beNil())
-        expect(params.targetingRuleId).to(beNil())
+        expect(params.offering) === offering
     }
 
     func testParamsWithOfferingDefaultPaywallIdIsNil() {
@@ -385,6 +342,7 @@ class CustomPaywallEventTests: TestCase {
         let params = CustomPaywallImpressionParams(offering: offering)
         expect(params.paywallId).to(beNil())
         expect(params.offeringId) == "offering_1"
+        expect(params.offering) === offering
     }
 
     // MARK: - Data: Codable round-trip
@@ -393,9 +351,11 @@ class CustomPaywallEventTests: TestCase {
         let data = CustomPaywallEvent.Data(
             paywallId: "pw",
             offeringId: "off",
-            placementIdentifier: "home_banner",
-            targetingRevision: 3,
-            targetingRuleId: "rule_abc123"
+            presentedOfferingContext: PresentedOfferingContext(
+                offeringIdentifier: "off",
+                placementIdentifier: "home_banner",
+                targetingContext: .init(revision: 3, ruleId: "rule_abc123")
+            )
         )
 
         let encoded = try JSONEncoder.default.encode(data)
@@ -437,9 +397,11 @@ class CustomPaywallEventTests: TestCase {
             .init(
                 paywallId: "pw",
                 offeringId: "off",
-                placementIdentifier: "home_banner",
-                targetingRevision: 3,
-                targetingRuleId: "rule_abc123"
+                presentedOfferingContext: PresentedOfferingContext(
+                    offeringIdentifier: "off",
+                    placementIdentifier: "home_banner",
+                    targetingContext: .init(revision: 3, ruleId: "rule_abc123")
+                )
             )
         )
         let storedEvent = try XCTUnwrap(
@@ -468,9 +430,11 @@ class CustomPaywallEventTests: TestCase {
             .init(
                 paywallId: "pw",
                 offeringId: "off",
-                placementIdentifier: "home_banner",
-                targetingRevision: nil,
-                targetingRuleId: nil
+                presentedOfferingContext: PresentedOfferingContext(
+                    offeringIdentifier: "off",
+                    placementIdentifier: "home_banner",
+                    targetingContext: nil
+                )
             )
         )
         let storedEvent = try XCTUnwrap(

--- a/Tests/UnitTests/Paywalls/Events/CustomPaywallEventTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/CustomPaywallEventTests.swift
@@ -312,6 +312,211 @@ class CustomPaywallEventTests: TestCase {
         expect(params.offeringId).to(beNil())
     }
 
+    func testParamsDefaultPlacementAndTargetingFieldsAreNil() {
+        let params = CustomPaywallImpressionParams()
+        expect(params.placementIdentifier).to(beNil())
+        expect(params.targetingRevision).to(beNil())
+        expect(params.targetingRevisionValue).to(beNil())
+        expect(params.targetingRuleId).to(beNil())
+    }
+
+    func testParamsWithOfferingIdInitDoesNotPopulatePlacementAndTargeting() {
+        let params = CustomPaywallImpressionParams(paywallId: "pw", offeringId: "my_offering")
+        expect(params.placementIdentifier).to(beNil())
+        expect(params.targetingRevision).to(beNil())
+        expect(params.targetingRuleId).to(beNil())
+    }
+
+    // MARK: - Params: Offering-based init
+
+    func testParamsWithOfferingPopulatesOfferingId() {
+        let offering = Self.makeOffering(identifier: "my_offering")
+        let params = CustomPaywallImpressionParams(paywallId: "pw", offering: offering)
+        expect(params.paywallId) == "pw"
+        expect(params.offeringId) == "my_offering"
+    }
+
+    func testParamsWithOfferingPopulatesPlacementAndTargeting() {
+        let context = PresentedOfferingContext(
+            offeringIdentifier: "offering_1",
+            placementIdentifier: "home_banner",
+            targetingContext: .init(revision: 3, ruleId: "rule_abc123")
+        )
+        let offering = Self.makeOffering(identifier: "offering_1", presentedOfferingContext: context)
+
+        let params = CustomPaywallImpressionParams(paywallId: "pw", offering: offering)
+
+        expect(params.placementIdentifier) == "home_banner"
+        expect(params.targetingRevision) == NSNumber(value: 3)
+        expect(params.targetingRevisionValue) == 3
+        expect(params.targetingRuleId) == "rule_abc123"
+    }
+
+    func testParamsWithOfferingNoPlacementOrTargeting() {
+        let context = PresentedOfferingContext(offeringIdentifier: "offering_1")
+        let offering = Self.makeOffering(identifier: "offering_1", presentedOfferingContext: context)
+
+        let params = CustomPaywallImpressionParams(paywallId: "pw", offering: offering)
+
+        expect(params.placementIdentifier).to(beNil())
+        expect(params.targetingRevision).to(beNil())
+        expect(params.targetingRevisionValue).to(beNil())
+        expect(params.targetingRuleId).to(beNil())
+    }
+
+    func testParamsWithOfferingThatHasNoPackages() {
+        let offering = Offering(
+            identifier: "offering_1",
+            serverDescription: "",
+            availablePackages: [],
+            webCheckoutUrl: nil
+        )
+
+        let params = CustomPaywallImpressionParams(paywallId: "pw", offering: offering)
+
+        expect(params.offeringId) == "offering_1"
+        expect(params.placementIdentifier).to(beNil())
+        expect(params.targetingRevision).to(beNil())
+        expect(params.targetingRuleId).to(beNil())
+    }
+
+    func testParamsWithOfferingDefaultPaywallIdIsNil() {
+        let offering = Self.makeOffering(identifier: "offering_1")
+        let params = CustomPaywallImpressionParams(offering: offering)
+        expect(params.paywallId).to(beNil())
+        expect(params.offeringId) == "offering_1"
+    }
+
+    // MARK: - Data: Codable round-trip
+
+    func testDataCodableRoundTripPreservesPlacementAndTargeting() throws {
+        let data = CustomPaywallEvent.Data(
+            paywallId: "pw",
+            offeringId: "off",
+            placementIdentifier: "home_banner",
+            targetingRevision: 3,
+            targetingRuleId: "rule_abc123"
+        )
+
+        let encoded = try JSONEncoder.default.encode(data)
+        let decoded = try JSONDecoder.default.decode(CustomPaywallEvent.Data.self, from: encoded)
+
+        expect(decoded.paywallId) == "pw"
+        expect(decoded.offeringId) == "off"
+        expect(decoded.placementIdentifier) == "home_banner"
+        expect(decoded.targetingRevision) == 3
+        expect(decoded.targetingRuleId) == "rule_abc123"
+    }
+
+    func testDataDecodesLegacyJSONWithoutPlacementOrTargeting() throws {
+        // Mirrors the JSON format produced by an older SDK version that didn't have these fields.
+        let legacyJSON = """
+        {
+            "paywall_id": "pw",
+            "offering_id": "off"
+        }
+        """
+
+        let data = try JSONDecoder.default.decode(
+            CustomPaywallEvent.Data.self,
+            from: try XCTUnwrap(legacyJSON.data(using: .utf8))
+        )
+
+        expect(data.paywallId) == "pw"
+        expect(data.offeringId) == "off"
+        expect(data.placementIdentifier).to(beNil())
+        expect(data.targetingRevision).to(beNil())
+        expect(data.targetingRuleId).to(beNil())
+    }
+
+    // MARK: - Wire encoding: presented_offering_context
+
+    func testRequestEncodingIncludesPresentedOfferingContextWhenAllFieldsSet() throws {
+        let event = CustomPaywallEvent.impression(
+            Self.creationData,
+            .init(
+                paywallId: "pw",
+                offeringId: "off",
+                placementIdentifier: "home_banner",
+                targetingRevision: 3,
+                targetingRuleId: "rule_abc123"
+            )
+        )
+        let storedEvent = try XCTUnwrap(
+            StoredFeatureEvent(
+                event: event,
+                userID: Self.userID,
+                feature: .customPaywalls,
+                appSessionID: nil,
+                eventDiscriminator: nil
+            )
+        )
+
+        let requestEvent = try XCTUnwrap(FeatureEventsRequest.CustomPaywallEvent(storedEvent: storedEvent))
+        let encoded = try JSONEncoder.default.encode(requestEvent)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let context = try XCTUnwrap(json["presented_offering_context"] as? [String: Any])
+
+        expect(context["placement_identifier"] as? String) == "home_banner"
+        expect(context["targeting_revision"] as? Int) == 3
+        expect(context["targeting_rule_id"] as? String) == "rule_abc123"
+    }
+
+    func testRequestEncodingIncludesPresentedOfferingContextWithPlacementOnly() throws {
+        let event = CustomPaywallEvent.impression(
+            Self.creationData,
+            .init(
+                paywallId: "pw",
+                offeringId: "off",
+                placementIdentifier: "home_banner",
+                targetingRevision: nil,
+                targetingRuleId: nil
+            )
+        )
+        let storedEvent = try XCTUnwrap(
+            StoredFeatureEvent(
+                event: event,
+                userID: Self.userID,
+                feature: .customPaywalls,
+                appSessionID: nil,
+                eventDiscriminator: nil
+            )
+        )
+
+        let requestEvent = try XCTUnwrap(FeatureEventsRequest.CustomPaywallEvent(storedEvent: storedEvent))
+        let encoded = try JSONEncoder.default.encode(requestEvent)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let context = try XCTUnwrap(json["presented_offering_context"] as? [String: Any])
+
+        expect(context["placement_identifier"] as? String) == "home_banner"
+        expect(context["targeting_revision"]).to(beNil())
+        expect(context["targeting_rule_id"]).to(beNil())
+    }
+
+    func testRequestEncodingOmitsPresentedOfferingContextWhenAllFieldsNil() throws {
+        let event = CustomPaywallEvent.impression(
+            Self.creationData,
+            .init(paywallId: "pw", offeringId: "off")
+        )
+        let storedEvent = try XCTUnwrap(
+            StoredFeatureEvent(
+                event: event,
+                userID: Self.userID,
+                feature: .customPaywalls,
+                appSessionID: nil,
+                eventDiscriminator: nil
+            )
+        )
+
+        let requestEvent = try XCTUnwrap(FeatureEventsRequest.CustomPaywallEvent(storedEvent: storedEvent))
+        expect(requestEvent.presentedOfferingContext).to(beNil())
+
+        let encoded = try JSONEncoder.default.encode(requestEvent)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+        expect(json["presented_offering_context"]).to(beNil())
+    }
+
     // MARK: - Helpers
 
     private static let userID = "test-user"
@@ -321,5 +526,25 @@ class CustomPaywallEventTests: TestCase {
         id: .init(uuidString: "72164C05-2BDC-4807-8918-A4105F727DEB")!,
         date: .init(timeIntervalSince1970: 1694029328)
     )
+
+    private static func makeOffering(
+        identifier: String,
+        presentedOfferingContext: PresentedOfferingContext? = nil
+    ) -> Offering {
+        let context = presentedOfferingContext ?? PresentedOfferingContext(offeringIdentifier: identifier)
+        let package = Package(
+            identifier: "$rc_monthly",
+            packageType: .monthly,
+            storeProduct: StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "monthly_product")),
+            presentedOfferingContext: context,
+            webCheckoutUrl: nil
+        )
+        return Offering(
+            identifier: identifier,
+            serverDescription: "",
+            availablePackages: [package],
+            webCheckoutUrl: nil
+        )
+    }
 
 }

--- a/Tests/UnitTests/Paywalls/Events/CustomPaywallEventTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/CustomPaywallEventTests.swift
@@ -312,16 +312,6 @@ class CustomPaywallEventTests: TestCase {
         expect(params.offeringId).to(beNil())
     }
 
-    func testParamsDefaultOfferingIsNil() {
-        let params = CustomPaywallImpressionParams()
-        expect(params.offering).to(beNil())
-    }
-
-    func testParamsWithOfferingIdInitDoesNotStoreOffering() {
-        let params = CustomPaywallImpressionParams(paywallId: "pw", offeringId: "my_offering")
-        expect(params.offering).to(beNil())
-    }
-
     // MARK: - Params: Offering-based init
 
     func testParamsWithOfferingPopulatesOfferingId() {
@@ -331,18 +321,11 @@ class CustomPaywallEventTests: TestCase {
         expect(params.offeringId) == "my_offering"
     }
 
-    func testParamsWithOfferingStoresOffering() {
-        let offering = Self.makeOffering(identifier: "my_offering")
-        let params = CustomPaywallImpressionParams(paywallId: "pw", offering: offering)
-        expect(params.offering) === offering
-    }
-
     func testParamsWithOfferingDefaultPaywallIdIsNil() {
         let offering = Self.makeOffering(identifier: "offering_1")
         let params = CustomPaywallImpressionParams(offering: offering)
         expect(params.paywallId).to(beNil())
         expect(params.offeringId) == "offering_1"
-        expect(params.offering) === offering
     }
 
     // MARK: - Data: Codable round-trip

--- a/Tests/UnitTests/Paywalls/Events/PurchasesCustomPaywallEventsTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PurchasesCustomPaywallEventsTests.swift
@@ -183,23 +183,53 @@ class PurchasesCustomPaywallEventsTests: BasePurchasesTests {
         expect(data.targetingRuleId) == "rule_abc123"
     }
 
-    func testTrackCustomPaywallImpressionDoesNotInferContextWhenOfferingIdStringPassed() async throws {
-        let context = PresentedOfferingContext(
+    func testTrackCustomPaywallImpressionDerivesContextFromCachedOfferingMatchingPassedId() async throws {
+        let currentContext = PresentedOfferingContext(
             offeringIdentifier: "current_offering",
-            placementIdentifier: "home_banner",
-            targetingContext: .init(revision: 3, ruleId: "rule_abc123")
+            placementIdentifier: "current_placement",
+            targetingContext: .init(revision: 1, ruleId: "current_rule")
         )
-        self.setupMockOfferingsWithCurrentOffering(
-            identifier: "current_offering",
-            presentedOfferingContext: context
+        let otherContext = PresentedOfferingContext(
+            offeringIdentifier: "other_offering",
+            placementIdentifier: "other_placement",
+            targetingContext: .init(revision: 5, ruleId: "other_rule")
+        )
+        self.setupMockOfferings(
+            offerings: [
+                ("current_offering", currentContext),
+                ("other_offering", otherContext)
+            ],
+            currentOfferingID: "current_offering"
         )
 
-        let params = CustomPaywallImpressionParams(paywallId: "pw", offeringId: "explicit_offering")
+        let params = CustomPaywallImpressionParams(paywallId: "pw", offeringId: "other_offering")
         self.purchases.trackCustomPaywallImpression(params)
 
         let data = try await self.firstTrackedCustomPaywallEventData()
 
-        expect(data.offeringId) == "explicit_offering"
+        expect(data.offeringId) == "other_offering"
+        expect(data.placementIdentifier) == "other_placement"
+        expect(data.targetingRevision) == 5
+        expect(data.targetingRuleId) == "other_rule"
+    }
+
+    func testTrackCustomPaywallImpressionLeavesContextNilWhenPassedIdNotInCache() async throws {
+        let currentContext = PresentedOfferingContext(
+            offeringIdentifier: "current_offering",
+            placementIdentifier: "current_placement",
+            targetingContext: .init(revision: 1, ruleId: "current_rule")
+        )
+        self.setupMockOfferingsWithCurrentOffering(
+            identifier: "current_offering",
+            presentedOfferingContext: currentContext
+        )
+
+        let params = CustomPaywallImpressionParams(paywallId: "pw", offeringId: "unknown_offering")
+        self.purchases.trackCustomPaywallImpression(params)
+
+        let data = try await self.firstTrackedCustomPaywallEventData()
+
+        expect(data.offeringId) == "unknown_offering"
         expect(data.placementIdentifier).to(beNil())
         expect(data.targetingRevision).to(beNil())
         expect(data.targetingRuleId).to(beNil())
@@ -270,23 +300,36 @@ class PurchasesCustomPaywallEventsTests: BasePurchasesTests {
         identifier: String,
         presentedOfferingContext: PresentedOfferingContext? = nil
     ) {
-        let offering: Offering
-        if let presentedOfferingContext = presentedOfferingContext {
-            offering = Self.makeOffering(
-                identifier: identifier,
-                presentedOfferingContext: presentedOfferingContext
-            )
-        } else {
-            offering = Offering(
-                identifier: identifier,
-                serverDescription: "Test offering",
-                availablePackages: [],
-                webCheckoutUrl: nil
-            )
-        }
+        self.setupMockOfferings(
+            offerings: [(identifier, presentedOfferingContext)],
+            currentOfferingID: identifier
+        )
+    }
+
+    private func setupMockOfferings(
+        offerings: [(identifier: String, presentedOfferingContext: PresentedOfferingContext?)],
+        currentOfferingID: String
+    ) {
+        let offeringsByID: [String: Offering] = Dictionary(uniqueKeysWithValues: offerings.map { entry in
+            let offering: Offering = {
+                if let context = entry.presentedOfferingContext {
+                    return Self.makeOffering(
+                        identifier: entry.identifier,
+                        presentedOfferingContext: context
+                    )
+                }
+                return Offering(
+                    identifier: entry.identifier,
+                    serverDescription: "Test offering",
+                    availablePackages: [],
+                    webCheckoutUrl: nil
+                )
+            }()
+            return (entry.identifier, offering)
+        })
         let offerings = Offerings(
-            offerings: [identifier: offering],
-            currentOfferingID: identifier,
+            offerings: offeringsByID,
+            currentOfferingID: currentOfferingID,
             placements: nil,
             targeting: nil,
             contents: .mockContents,

--- a/Tests/UnitTests/Paywalls/Events/PurchasesCustomPaywallEventsTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PurchasesCustomPaywallEventsTests.swift
@@ -160,15 +160,130 @@ class PurchasesCustomPaywallEventsTests: BasePurchasesTests {
         expect(Set(trackedPaywallIds)) == Set(paywallIds)
     }
 
+    // MARK: - Presented offering context resolution
+
+    func testTrackCustomPaywallImpressionDerivesContextFromCachedCurrentOffering() async throws {
+        let context = PresentedOfferingContext(
+            offeringIdentifier: "current_offering",
+            placementIdentifier: "home_banner",
+            targetingContext: .init(revision: 3, ruleId: "rule_abc123")
+        )
+        self.setupMockOfferingsWithCurrentOffering(
+            identifier: "current_offering",
+            presentedOfferingContext: context
+        )
+
+        self.purchases.trackCustomPaywallImpression(CustomPaywallImpressionParams(paywallId: "pw"))
+
+        let data = try await self.firstTrackedCustomPaywallEventData()
+
+        expect(data.offeringId) == "current_offering"
+        expect(data.placementIdentifier) == "home_banner"
+        expect(data.targetingRevision) == 3
+        expect(data.targetingRuleId) == "rule_abc123"
+    }
+
+    func testTrackCustomPaywallImpressionDoesNotInferContextWhenOfferingIdStringPassed() async throws {
+        let context = PresentedOfferingContext(
+            offeringIdentifier: "current_offering",
+            placementIdentifier: "home_banner",
+            targetingContext: .init(revision: 3, ruleId: "rule_abc123")
+        )
+        self.setupMockOfferingsWithCurrentOffering(
+            identifier: "current_offering",
+            presentedOfferingContext: context
+        )
+
+        let params = CustomPaywallImpressionParams(paywallId: "pw", offeringId: "explicit_offering")
+        self.purchases.trackCustomPaywallImpression(params)
+
+        let data = try await self.firstTrackedCustomPaywallEventData()
+
+        expect(data.offeringId) == "explicit_offering"
+        expect(data.placementIdentifier).to(beNil())
+        expect(data.targetingRevision).to(beNil())
+        expect(data.targetingRuleId).to(beNil())
+    }
+
+    func testTrackCustomPaywallImpressionUsesPassedOfferingContext() async throws {
+        let cachedContext = PresentedOfferingContext(
+            offeringIdentifier: "current_offering",
+            placementIdentifier: "cached_placement",
+            targetingContext: .init(revision: 1, ruleId: "cached_rule")
+        )
+        self.setupMockOfferingsWithCurrentOffering(
+            identifier: "current_offering",
+            presentedOfferingContext: cachedContext
+        )
+
+        let passedContext = PresentedOfferingContext(
+            offeringIdentifier: "passed_offering",
+            placementIdentifier: "passed_placement",
+            targetingContext: .init(revision: 7, ruleId: "passed_rule")
+        )
+        let passedOffering = Self.makeOffering(
+            identifier: "passed_offering",
+            presentedOfferingContext: passedContext
+        )
+
+        self.purchases.trackCustomPaywallImpression(
+            CustomPaywallImpressionParams(paywallId: "pw", offering: passedOffering)
+        )
+
+        let data = try await self.firstTrackedCustomPaywallEventData()
+
+        expect(data.offeringId) == "passed_offering"
+        expect(data.placementIdentifier) == "passed_placement"
+        expect(data.targetingRevision) == 7
+        expect(data.targetingRuleId) == "passed_rule"
+    }
+
+    func testTrackCustomPaywallImpressionLeavesContextNilWhenCachedOfferingHasNoContext() async throws {
+        self.setupMockOfferingsWithCurrentOffering(identifier: "current_offering")
+
+        self.purchases.trackCustomPaywallImpression(CustomPaywallImpressionParams(paywallId: "pw"))
+
+        let data = try await self.firstTrackedCustomPaywallEventData()
+
+        expect(data.offeringId) == "current_offering"
+        expect(data.placementIdentifier).to(beNil())
+        expect(data.targetingRevision).to(beNil())
+        expect(data.targetingRuleId).to(beNil())
+    }
+
     // MARK: - Helpers
 
-    private func setupMockOfferingsWithCurrentOffering(identifier: String) {
-        let offering = Offering(
-            identifier: identifier,
-            serverDescription: "Test offering",
-            availablePackages: [],
-            webCheckoutUrl: nil
-        )
+    private func firstTrackedCustomPaywallEventData() async throws -> CustomPaywallEvent.Data {
+        let manager = try self.mockEventsManager
+        await expect { await manager.trackedEvents }.toEventually(haveCount(1))
+
+        let trackedEvents = await manager.trackedEvents
+        guard case let .impression(_, data) = trackedEvents.first as? CustomPaywallEvent else {
+            throw NSError(domain: "PurchasesCustomPaywallEventsTests", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Expected CustomPaywallEvent.impression"
+            ])
+        }
+        return data
+    }
+
+    private func setupMockOfferingsWithCurrentOffering(
+        identifier: String,
+        presentedOfferingContext: PresentedOfferingContext? = nil
+    ) {
+        let offering: Offering
+        if let presentedOfferingContext = presentedOfferingContext {
+            offering = Self.makeOffering(
+                identifier: identifier,
+                presentedOfferingContext: presentedOfferingContext
+            )
+        } else {
+            offering = Offering(
+                identifier: identifier,
+                serverDescription: "Test offering",
+                availablePackages: [],
+                webCheckoutUrl: nil
+            )
+        }
         let offerings = Offerings(
             offerings: [identifier: offering],
             currentOfferingID: identifier,
@@ -178,6 +293,25 @@ class PurchasesCustomPaywallEventsTests: BasePurchasesTests {
             loadedFromDiskCache: false
         )
         self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(offerings)
+    }
+
+    private static func makeOffering(
+        identifier: String,
+        presentedOfferingContext: PresentedOfferingContext
+    ) -> Offering {
+        let package = Package(
+            identifier: "$rc_monthly",
+            packageType: .monthly,
+            storeProduct: StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "monthly_product")),
+            presentedOfferingContext: presentedOfferingContext,
+            webCheckoutUrl: nil
+        )
+        return Offering(
+            identifier: identifier,
+            serverDescription: "",
+            availablePackages: [package],
+            webCheckoutUrl: nil
+        )
     }
 
 }

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -1193,11 +1193,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -1209,11 +1209,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -1209,15 +1209,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
-  @objc final public let offering: RevenueCat.Offering?
-  #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
-  #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
+  @available(*, deprecated, renamed: "init(paywallId:offering:)", message: "Pass an Offering object instead. Using an offering identifier string prevents the SDK from deriving placement and targeting context automatically.")
+  @objc convenience public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc convenience public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -1193,11 +1193,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -1209,11 +1209,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -1209,15 +1209,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
-  @objc final public let offering: RevenueCat.Offering?
-  #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
-  #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
+  @available(*, deprecated, renamed: "init(paywallId:offering:)", message: "Pass an Offering object instead. Using an offering identifier string prevents the SDK from deriving placement and targeting context automatically.")
+  @objc convenience public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc convenience public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -1156,11 +1156,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -1172,11 +1172,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -1172,15 +1172,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
-  @objc final public let offering: RevenueCat.Offering?
-  #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
-  #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
+  @available(*, deprecated, renamed: "init(paywallId:offering:)", message: "Pass an Offering object instead. Using an offering identifier string prevents the SDK from deriving placement and targeting context automatically.")
+  @objc convenience public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc convenience public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -1154,11 +1154,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -1170,15 +1170,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
-  @objc final public let offering: RevenueCat.Offering?
-  #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
-  #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
+  @available(*, deprecated, renamed: "init(paywallId:offering:)", message: "Pass an Offering object instead. Using an offering identifier string prevents the SDK from deriving placement and targeting context automatically.")
+  @objc convenience public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc convenience public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -1170,11 +1170,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -1154,11 +1154,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -1170,15 +1170,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
-  @objc final public let offering: RevenueCat.Offering?
-  #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
-  #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
+  @available(*, deprecated, renamed: "init(paywallId:offering:)", message: "Pass an Offering object instead. Using an offering identifier string prevents the SDK from deriving placement and targeting context automatically.")
+  @objc convenience public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc convenience public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -1170,11 +1170,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -1193,11 +1193,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -1209,11 +1209,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -1209,15 +1209,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
-  @objc final public let offering: RevenueCat.Offering?
-  #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
-  #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
+  @available(*, deprecated, renamed: "init(paywallId:offering:)", message: "Pass an Offering object instead. Using an offering identifier string prevents the SDK from deriving placement and targeting context automatically.")
+  @objc convenience public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc convenience public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -1193,11 +1193,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -1209,11 +1209,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -1209,15 +1209,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
-  @objc final public let offering: RevenueCat.Offering?
-  #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
-  #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
+  @available(*, deprecated, renamed: "init(paywallId:offering:)", message: "Pass an Offering object instead. Using an offering identifier string prevents the SDK from deriving placement and targeting context automatically.")
+  @objc convenience public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc convenience public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -1155,11 +1155,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -1171,11 +1171,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -1171,15 +1171,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
-  @objc final public let offering: RevenueCat.Offering?
-  #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
-  #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
+  @available(*, deprecated, renamed: "init(paywallId:offering:)", message: "Pass an Offering object instead. Using an offering identifier string prevents the SDK from deriving placement and targeting context automatically.")
+  @objc convenience public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc convenience public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -1155,11 +1155,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -1171,11 +1171,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
+  @objc final public let offering: RevenueCat.Offering?
   #if compiler(>=5.3) && $NonescapableTypes
   @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -1171,15 +1171,15 @@ extension RevenueCat.CacheFetchPolicy : Swift.Sendable {
 @objc(RCCustomPaywallImpressionParams) final public class CustomPaywallImpressionParams : ObjectiveC.NSObject, Swift.Sendable {
   @objc final public let paywallId: Swift.String?
   @objc final public let offeringId: Swift.String?
-  @objc final public let offering: RevenueCat.Offering?
-  #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
-  #endif
   #if compiler(>=5.3) && $NonescapableTypes
   @objc convenience public init(paywallId: Swift.String? = nil)
   #endif
   #if compiler(>=5.3) && $NonescapableTypes
-  @objc public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
+  @available(*, deprecated, renamed: "init(paywallId:offering:)", message: "Pass an Offering object instead. Using an offering identifier string prevents the SDK from deriving placement and targeting context automatically.")
+  @objc convenience public init(paywallId: Swift.String? = nil, offeringId: Swift.String?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  @objc convenience public init(paywallId: Swift.String? = nil, offering: RevenueCat.Offering)
   #endif
   @objc deinit
 }


### PR DESCRIPTION
### Description

Adds \`placementIdentifier\`, \`targetingRevision\`, and \`targetingRuleId\` to the custom paywall impression event.

Mirrors #6476, which added the same fields for the internal paywall events. Android parity: https://github.com/RevenueCat/purchases-android/pull/3424.

### What's new

- \`CustomPaywallImpressionParams\` gains an \`Offering\`-based initializer. Passing an \`Offering\` lets the SDK derive both the offering identifier and the presented offering context (placement and targeting) from the offering's first available package.
- The \`offeringId\`-only initializer is now deprecated in favour of passing an \`Offering\` object, matching Android.
- \`CustomPaywallImpressionParams\` exposes a \`@_spi(Internal) presentedOfferingContext\` property (equivalent to Android's \`@InternalRevenueCatAPI\` constructor) so hybrid SDKs can pass pre-resolved context through purchases-hybrid-common without requiring an \`Offering\` object.
- \`Purchases.trackCustomPaywallImpression(_:)\` resolves offering context using the following fallback chain, mirroring Android:
  | Developer passes | \`offering_id\` sent | context sent |
  | --- | --- | --- |
  | Nothing (or only \`paywallId\`) | from \`cachedOfferings.current\` | from current offering |
  | Deprecated \`offeringId\` matching cache | passed string | from cached match |
  | Deprecated \`offeringId\` not in cache | passed string | nil |
  | \`Offering\` object | from offering | derived from offering |
  | Internal \`presentedOfferingContext\` (hybrid SDK) | passed \`offeringId\` | passed context |
- \`CustomPaywallEvent.Data\` carries flat \`placementIdentifier\` / \`targetingRevision\` / \`targetingRuleId\` fields, mirroring the existing internal \`PaywallEvent.Data\` shape.
- The wire payload nests these under \`presented_offering_context\`. The custom paywall event has its own \`FeatureEventsRequest.CustomPaywallEvent.PresentedOfferingContextData\` rather than reusing the internal paywall event's struct, so each event owns its own.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API deprecation and new analytics fields affect integrators and backend payloads, but behavior is backward compatible for legacy stored events and is covered by broad unit tests.
> 
> **Overview**
> Custom paywall impression analytics now carry **placement and targeting** (placement identifier, targeting revision, rule id), aligned with internal paywall events and Android.
> 
> **Public API:** `CustomPaywallImpressionParams` adds `init(paywallId:offering:)` so the SDK can read `PresentedOfferingContext` from the offering’s first package. The `offeringId` string initializer is **deprecated** in favor of passing an `Offering`. An `@_spi(Internal)` path lets hybrid SDKs supply pre-resolved context without an `Offering`.
> 
> **Runtime:** `Purchases.trackCustomPaywallImpression` resolves offering id and context from explicit SPI context, a cached offering for a passed id, or the current cached offering (context nil if the id isn’t in cache).
> 
> **Events & wire:** `CustomPaywallEvent.Data` stores the new fields; hybrid `toMap()` and backend JSON include them (nested `presented_offering_context` on upload, omitted when empty). Stored events without those keys still decode.
> 
> API surface snapshots and unit/API tests cover encoding, resolution, and legacy payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c89d357dc931045884485d39e71552cbd3e5feb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —> 