### PR TITLE
Fix: Enforce vertical bounds in RootView

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
@@ -47,6 +47,12 @@ struct RootView: View {
         self.defaultPackage = defaultPackage
     }
 
+    // enforce filling the height of the screen to ensure headers and footers
+    // appear where they should for all stack dimensions
+    private var fillVerticalBounds: some View {
+        Color.clear.frame(width: 1)
+    }
+
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
             if let headerViewModel = viewModel.headerViewModel,
@@ -59,6 +65,8 @@ struct RootView: View {
             }
 
             ZStack(alignment: .top) {
+                fillVerticalBounds
+
                 StackComponentView(
                     viewModel: viewModel.stackViewModel,
                     isScrollableByDefault: true,


### PR DESCRIPTION

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

PWENG-2

Zlayer stacks with headers and footers did not lay out consistently

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

Add a transparent filler view to RootView so the ZStack expands vertically and headers/footers are positioned correctly. Introduces a private fillVerticalBounds property (Color.clear.frame(width: 1)) and inserts it into the ZStack before the StackComponentView to ensure consistent layout across stack dimensions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk layout-only change: adds an invisible sizing view so the root `ZStack` reliably fills available height, which may subtly affect view sizing but does not touch data, networking, or auth.
> 
> **Overview**
> Fixes inconsistent header/footer positioning in Paywalls V2 by forcing the `RootView` `ZStack` to expand to the full vertical bounds.
> 
> Adds a private `fillVerticalBounds` (a transparent `Color.clear` frame) and inserts it into the `ZStack` before the main `StackComponentView` so z-layer stacks lay out consistently across different stack dimensions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f2f8c8014c81d6de8f43a2ba0a3629fde4384b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->