### PR TITLE
Update sdks-common-config orb to v3.20.0

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1,7 +1,7 @@
 orbs:
   macos: circleci/macos@2.5.1
   slack: circleci/slack@5.0.0
-  revenuecat: revenuecat/sdks-common-config@3.16.0
+  revenuecat: revenuecat/sdks-common-config@3.20.0
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 


### PR DESCRIPTION
Bumps `revenuecat/sdks-common-config` from `3.16.0` to `3.20.0`.

This also pins the maestro install to a SHA256-verified GitHub release (replacing the previous unauthenticated `curl … | bash`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that updates a shared CircleCI orb version; main impact is potential differences in pipeline behavior if the orb introduces breaking changes.
> 
> **Overview**
> Updates CircleCI config to use `revenuecat/sdks-common-config` orb `3.20.0` (from `3.16.0`), picking up the latest shared CI logic from that orb.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31fa76a1aaa378fdec11fc60a62bfaa25e7ba4be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->