### PR TITLE
Fail PRs when Swift files are missing from RevenueCat.xcodeproj

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -86,7 +86,7 @@ def check_swift_files_in_project
 
   message += "\nTo fix: open `RevenueCat.xcodeproj` in Xcode, add/remove the files above in the appropriate target. "
   message += "Check where similar files in the same directory are assigned if you're unsure which target to use."
-  warn(message)
+  fail(message)
 end
 
 check_swift_files_in_project


### PR DESCRIPTION
### Motivation
The Dangerfile already detects Swift files that are added (or removed) on disk but not registered in the hand-maintained `RevenueCat.xcodeproj`. Until now this mismatch was reported only as a warning, so PRs could still merge in a state that breaks the xcframework build (see #6713 / #6694).

### Description
Promote the existing `warn` to `fail` in `check_swift_files_in_project` so the Danger check blocks merge until the project file is back in sync. No other behaviour changes — the same files are detected and the same remediation message is shown.

This obsoletes the heavier `xcframework-build-smoke` CI job approach in #6715 for this specific failure mode: Danger runs early, costs almost nothing, and pinpoints the exact missing files with a clear fix-up message.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tightens CI/Danger enforcement by turning an existing warning into a failure, with no product/runtime behavior changes.
> 
> **Overview**
> **Blocks merges when `RevenueCat.xcodeproj` is out of sync with Swift files on disk.**
> 
> Promotes the existing `check_swift_files_in_project` Danger check from `warn` to `fail`, so added Swift files missing from the project (or deleted files still referenced) now fail the PR instead of merely warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a99deb477369ba5fbb7b0169a4e6090313d74249. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->