### PR TITLE
Fix workflow page transition layering

### DIFF
--- a/RevenueCatUI/Modifiers/EnvironmentValues+Workflow.swift
+++ b/RevenueCatUI/Modifiers/EnvironmentValues+Workflow.swift
@@ -14,8 +14,33 @@ import SwiftUI
 #if !os(tvOS)
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct WorkflowPageTransitionContext {
+
+    /// Current horizontal offset applied to the page by `WorkflowPaywallView`.
+    /// Header buttons use the inverse value so they stay visually fixed while page content slides.
+    let pageOffset: CGFloat
+    /// Opacity for buttons rendered inside workflow headers.
+    /// This crossfades outgoing and incoming header buttons during page transitions.
+    let headerButtonOpacity: CGFloat
+
+    static let identity = Self(pageOffset: 0, headerButtonOpacity: 1)
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct WorkflowTriggerActionKey: EnvironmentKey {
     static let defaultValue: ((String) -> Bool)? = nil
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct WorkflowPageTransitionContextKey: EnvironmentKey {
+    static let defaultValue = WorkflowPageTransitionContext.identity
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct IsWorkflowHeaderKey: EnvironmentKey {
+    /// Marks the header subtree so only header buttons consume workflow page transition context.
+    static let defaultValue = false
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -26,6 +51,16 @@ extension EnvironmentValues {
     var workflowTriggerAction: ((String) -> Bool)? {
         get { self[WorkflowTriggerActionKey.self] }
         set { self[WorkflowTriggerActionKey.self] = newValue }
+    }
+
+    var workflowPageTransitionContext: WorkflowPageTransitionContext {
+        get { self[WorkflowPageTransitionContextKey.self] }
+        set { self[WorkflowPageTransitionContextKey.self] = newValue }
+    }
+
+    var isWorkflowHeader: Bool {
+        get { self[IsWorkflowHeaderKey.self] }
+        set { self[IsWorkflowHeaderKey.self] = newValue }
     }
 }
 

--- a/RevenueCatUI/Modifiers/EnvironmentValues+Workflow.swift
+++ b/RevenueCatUI/Modifiers/EnvironmentValues+Workflow.swift
@@ -14,8 +14,28 @@ import SwiftUI
 #if !os(tvOS)
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct WorkflowPageTransitionContext {
+
+    let pageOffset: CGFloat
+    let headerButtonOpacity: CGFloat
+
+    static let identity = Self(pageOffset: 0, headerButtonOpacity: 1)
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct WorkflowTriggerActionKey: EnvironmentKey {
     static let defaultValue: ((String) -> Bool)? = nil
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct WorkflowPageTransitionContextKey: EnvironmentKey {
+    static let defaultValue = WorkflowPageTransitionContext.identity
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct IsWorkflowHeaderKey: EnvironmentKey {
+    static let defaultValue = false
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -26,6 +46,16 @@ extension EnvironmentValues {
     var workflowTriggerAction: ((String) -> Bool)? {
         get { self[WorkflowTriggerActionKey.self] }
         set { self[WorkflowTriggerActionKey.self] = newValue }
+    }
+
+    var workflowPageTransitionContext: WorkflowPageTransitionContext {
+        get { self[WorkflowPageTransitionContextKey.self] }
+        set { self[WorkflowPageTransitionContextKey.self] = newValue }
+    }
+
+    var isWorkflowHeader: Bool {
+        get { self[IsWorkflowHeaderKey.self] }
+        set { self[IsWorkflowHeaderKey.self] = newValue }
     }
 }
 

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -35,6 +35,8 @@ struct ButtonComponentView: View {
 
     @Environment(\.componentInteractionLogger) var componentInteractionLogger
     @Environment(\.workflowTriggerAction) private var workflowTriggerAction
+    @Environment(\.workflowPageTransitionContext) private var workflowPageTransitionContext
+    @Environment(\.isWorkflowHeader) private var isWorkflowHeader
 
     private let viewModel: ButtonComponentViewModel
     private let onDismiss: () -> Void
@@ -79,6 +81,8 @@ struct ButtonComponentView: View {
             .withTransition(viewModel.component.transition)
             .disabled(self.shouldBeDisabled)
             .opacity(self.shouldBeDisabled ? 0.35 : 1.0)
+            .offset(x: self.isWorkflowHeader ? -self.workflowPageTransitionContext.pageOffset : 0)
+            .opacity(self.isWorkflowHeader ? self.workflowPageTransitionContext.headerButtonOpacity : 1)
             #if canImport(SafariServices) && canImport(UIKit)
             .sheet(isPresented: .isNotNil(self.$inAppBrowserURL)) {
                 SafariView(url: self.inAppBrowserURL!)

--- a/RevenueCatUI/Templates/V2/Components/Header/HeaderComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Header/HeaderComponentView.swift
@@ -43,6 +43,7 @@ struct HeaderComponentView: View {
                 trailing: 0
             )
         )
+        .environment(\.isWorkflowHeader, true)
     }
 
 }

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -86,11 +86,24 @@ struct WorkflowPageTransitionState<Page> {
             return role == .current ? 0 : -1
         }
 
-        switch (self.direction, role) {
-        case (.forward, .current), (.back, .outgoing):
-            return 1
-        case (.forward, .outgoing), (.back, .current):
+        switch role {
+        case .current:
             return 0
+        case .outgoing:
+            return 1
+        }
+    }
+
+    func headerButtonOpacity(for role: PageRole) -> CGFloat {
+        guard self.isTransitioning else {
+            return role == .current ? 1 : 0
+        }
+
+        switch role {
+        case .current:
+            return self.progress
+        case .outgoing:
+            return 1 - self.progress
         }
     }
 
@@ -182,11 +195,20 @@ struct WorkflowPaywallView: View {
                 // the outgoing subtree when it changes role from current -> outgoing.
                 // Recreating that subtree at transition start caused visible flashing.
                 ForEach(self.displayedPages) { displayedPage in
+                    let pageOffset = self.transitionState.offset(
+                        for: displayedPage.role,
+                        width: proxy.size.width
+                    )
+
                     self.pageView(for: displayedPage.page)
-                        .offset(x: self.transitionState.offset(
-                            for: displayedPage.role,
-                            width: proxy.size.width
-                        ))
+                        .environment(
+                            \.workflowPageTransitionContext,
+                            .init(
+                                pageOffset: pageOffset,
+                                headerButtonOpacity: self.transitionState.headerButtonOpacity(for: displayedPage.role)
+                            )
+                        )
+                        .offset(x: pageOffset)
                         .zIndex(self.transitionState.zIndex(for: displayedPage.role))
                 }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -63,7 +63,7 @@ final class WorkflowPaywallViewTests: TestCase {
         expect(state.progress) == 1
     }
 
-    func testForwardTransitionMovesIncomingPageFromTheRight() {
+    func testForwardTransitionKeepsOutgoingPageOnTopWhileItSlidesLeft() {
         var state = WorkflowPageTransitionState(currentPage: "step_1")
 
         state.beginTransition(to: "step_2", direction: .forward)
@@ -73,13 +73,17 @@ final class WorkflowPaywallViewTests: TestCase {
         expect(state.progress) == 0
         expect(state.offset(for: .current, width: 320)) == 320
         expect(state.offset(for: .outgoing, width: 320)) == 0
-        expect(state.zIndex(for: .current)) == 1
-        expect(state.zIndex(for: .outgoing)) == 0
+        expect(state.zIndex(for: .current)) == 0
+        expect(state.zIndex(for: .outgoing)) == 1
+        expect(state.headerButtonOpacity(for: .current)) == 0
+        expect(state.headerButtonOpacity(for: .outgoing)) == 1
 
         state.advanceAnimation()
 
         expect(state.offset(for: .current, width: 320)) == 0
         expect(state.offset(for: .outgoing, width: 320)) == -320
+        expect(state.headerButtonOpacity(for: .current)) == 1
+        expect(state.headerButtonOpacity(for: .outgoing)) == 0
     }
 
     func testBackTransitionKeepsOutgoingPageOnTopWhileItSlidesRight() {
@@ -93,11 +97,15 @@ final class WorkflowPaywallViewTests: TestCase {
         expect(state.offset(for: .outgoing, width: 320)) == 0
         expect(state.zIndex(for: .current)) == 0
         expect(state.zIndex(for: .outgoing)) == 1
+        expect(state.headerButtonOpacity(for: .current)) == 0
+        expect(state.headerButtonOpacity(for: .outgoing)) == 1
 
         state.advanceAnimation()
 
         expect(state.offset(for: .current, width: 320)) == 0
         expect(state.offset(for: .outgoing, width: 320)) == 320
+        expect(state.headerButtonOpacity(for: .current)) == 1
+        expect(state.headerButtonOpacity(for: .outgoing)) == 0
     }
 
     func testCompletingTransitionDropsOutgoingPage() {


### PR DESCRIPTION
## Summary
- keep the outgoing workflow page above the incoming page during slide transitions to avoid visible blank backgrounds
- keep workflow header buttons visually stationary while crossfading them between pages
- cover the transition state behavior in WorkflowPaywallViewTests


https://github.com/user-attachments/assets/1bef24b4-a6c6-463d-9a3a-14c648529f50


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts core workflow paywall transition behavior (z-ordering, offsets, opacity) which can impact navigation UX and animation correctness across platforms, though changes are localized and covered by updated tests.
> 
> **Overview**
> Fixes workflow page slide transitions so the *outgoing* page remains on top during animations, preventing blank/flash artifacts.
> 
> Introduces a `WorkflowPageTransitionContext` propagated from `WorkflowPaywallView` via SwiftUI environment and marks header subtrees with `isWorkflowHeader` so header buttons can counter-offset (stay visually stationary) and crossfade (`headerButtonOpacity`) between steps.
> 
> Updates `WorkflowPaywallViewTests` to assert the new z-index ordering and header button opacity behavior for forward/back transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 594a8621b07fa2fafa2b391c3597ece0180cf50f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->