### PR TITLE
[DO NOT MERGE] Re-run make-admob-release on-demand for 5.70.0

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -2054,7 +2054,16 @@ jobs:
       - install-rubydocker-dependencies
       - run:
           name: Create GitHub release for purchases-ios-admob
-          command: bundle exec fastlane admob_github_release version:"${CIRCLE_TAG}"
+          # Temporary workaround for the 5.70.0 admob re-release on the
+          # `ad-mob-release/5.70.0` branch:
+          #   * version is hardcoded because this branch run has no CIRCLE_TAG.
+          #   * CIRCLE_BRANCH=main is forced inline so the lane's GitHub PR
+          #     search uses `base:main` instead of `base:ad-mob-release/5.70.0`,
+          #     working around the upstream multi-result bug fixed in
+          #     https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/133.
+          # Revert this back to `bundle exec fastlane admob_github_release version:"${CIRCLE_TAG}"`
+          # before merging this branch.
+          command: CIRCLE_BRANCH=main bundle exec fastlane admob_github_release version:"5.70.0"
 
   bump-sdk-in-rc-mobile-app:
     docker:

--- a/.circleci/generate-requested-jobs-config.js
+++ b/.circleci/generate-requested-jobs-config.js
@@ -9,7 +9,9 @@ const OUTPUT = "/tmp/requested-jobs-config.yml";
 // Allowlist of jobs that can be triggered on-demand, mapped to the CircleCI contexts
 // each job needs. Contexts must match what the job is declared with in default_config.yml,
 // so the on-demand run has access to the same secrets as the regular run.
-// Release/deployment jobs are intentionally excluded.
+// Release/deployment jobs are intentionally excluded — `make-admob-release` is a
+// temporary exception added on `ad-mob-release/5.70.0` to re-run the failed admob
+// GitHub-release step from the 5.70.0 release pipeline. Drop it again before merging.
 const JOBS = {
   "api-tests": ["slack-secrets"],
   "backend-integration-tests-SK1": ["slack-secrets"],
@@ -28,6 +30,7 @@ const JOBS = {
   "installation-tests-carthage": ["slack-secrets"],
   "integration-tests-all": ["slack-secrets"],
   "lint": [],
+  "make-admob-release": [],
   "pod-lib-lint": ["slack-secrets"],
   "revenuecat-admob-tests": ["slack-secrets"],
   "run-all-maestro-e2e-tests": ["e2e-tests", "slack-secrets"],


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

The `make-admob-release` step in the `5.70.0` release pipeline failed, leaving the GitHub release on `purchases-ios-admob` uncreated. We need a way to re-run only that step from a branch while the upstream fix lands in [`fastlane-plugin-revenuecat_internal#133`](https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/133).

This PR is opened **for future reference only** — `[DO NOT MERGE]`.

### Description

- Allows triggering only `make-admob-release` on this branch.
- Hardcodes the `5.70.0` version and routes the changelog generator to the right base branch so the lane behaves correctly when re-run from a non-tag context.
- Both edits are scoped to this branch and are **not intended for `main`** — the proper fix lives upstream.