### PR TITLE
Only run snapshot-bump workflow when `.version` changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,9 +61,6 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      # Compute pipeline parameters that are derived from the triggering
-      # commit and forward them to the continued pipeline (e.g. whether
-      # `.version` changed, used to gate the `snapshot-bump` workflow).
       - run:
           name: Generate continuation parameters
           command: node .circleci/generate-continuation-parameters.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,20 +62,11 @@ jobs:
     steps:
       - checkout
       # Compute pipeline parameters that are derived from the triggering
-      # commit and forward them to the continued pipeline. Currently this
-      # is just `version_file_changed`, used to gate the `snapshot-bump`
-      # workflow so it only runs on commits that actually modified `.version`.
+      # commit and forward them to the continued pipeline (e.g. whether
+      # `.version` changed, used to gate the `snapshot-bump` workflow).
       - run:
-          name: Compute continuation parameters
-          command: |
-            if git rev-parse --verify HEAD^ >/dev/null 2>&1 \
-              && git diff --name-only HEAD^ HEAD -- .version | grep -qx "\.version"; then
-              VERSION_FILE_CHANGED=true
-            else
-              VERSION_FILE_CHANGED=false
-            fi
-            echo "version_file_changed=$VERSION_FILE_CHANGED"
-            echo "{\"version_file_changed\": $VERSION_FILE_CHANGED}" > /tmp/continuation-parameters.json
+          name: Generate continuation parameters
+          command: node .circleci/generate-continuation-parameters.js
       - when:
           condition: << pipeline.parameters.requested_jobs >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,21 @@ jobs:
     resource_class: small
     steps:
       - checkout
+      # Compute pipeline parameters that are derived from the triggering
+      # commit and forward them to the continued pipeline. Currently this
+      # is just `version_file_changed`, used to gate the `snapshot-bump`
+      # workflow so it only runs on commits that actually modified `.version`.
+      - run:
+          name: Compute continuation parameters
+          command: |
+            if git rev-parse --verify HEAD^ >/dev/null 2>&1 \
+              && git diff --name-only HEAD^ HEAD -- .version | grep -qx "\.version"; then
+              VERSION_FILE_CHANGED=true
+            else
+              VERSION_FILE_CHANGED=false
+            fi
+            echo "version_file_changed=$VERSION_FILE_CHANGED"
+            echo "{\"version_file_changed\": $VERSION_FILE_CHANGED}" > /tmp/continuation-parameters.json
       - when:
           condition: << pipeline.parameters.requested_jobs >>
           steps:
@@ -71,11 +86,13 @@ jobs:
                 command: node .circleci/generate-requested-jobs-config.js
             - continuation/continue:
                 configuration_path: /tmp/requested-jobs-config.yml
+                parameters: /tmp/continuation-parameters.json
       - unless:
           condition: << pipeline.parameters.requested_jobs >>
           steps:
             - continuation/continue:
                 configuration_path: .circleci/default_config.yml
+                parameters: /tmp/continuation-parameters.json
 
 workflows:
   setup:

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -24,6 +24,15 @@ parameters:
   bump_with_fallback_pr_lookup:
     type: boolean
     default: false
+  # Forwarded by the setup pipeline (see .circleci/config.yml). True when the
+  # triggering commit actually modified the `.version` file. Used to gate the
+  # `snapshot-bump` workflow so we don't open duplicate "prepare next version"
+  # PRs from unrelated commits that land on `main` while a bump PR is in
+  # flight (the lane already no-ops on SNAPSHOT versions, but until the bump
+  # PR merges, every other commit on `main` would otherwise re-trigger it).
+  version_file_changed:
+    type: boolean
+    default: false
   requested_jobs:
     type: string
     default: ""
@@ -2413,6 +2422,10 @@ workflows:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - not:
             equal: [bump, << pipeline.parameters.action >>]
+        # Only run on commits that actually changed `.version` so we don't
+        # generate duplicate bump PRs from commits landing while a previous
+        # bump PR is in flight. See `version_file_changed` parameter above.
+        - equal: [true, << pipeline.parameters.version_file_changed >>]
     jobs:
       - prepare-next-version:
           <<: *only-main-branch

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -24,12 +24,6 @@ parameters:
   bump_with_fallback_pr_lookup:
     type: boolean
     default: false
-  # Forwarded by the setup pipeline (see .circleci/config.yml). True when the
-  # triggering commit actually modified the `.version` file. Used to gate the
-  # `snapshot-bump` workflow so we don't open duplicate "prepare next version"
-  # PRs from unrelated commits that land on `main` while a bump PR is in
-  # flight (the lane already no-ops on SNAPSHOT versions, but until the bump
-  # PR merges, every other commit on `main` would otherwise re-trigger it).
   version_file_changed:
     type: boolean
     default: false
@@ -2422,9 +2416,6 @@ workflows:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - not:
             equal: [bump, << pipeline.parameters.action >>]
-        # Only run on commits that actually changed `.version` so we don't
-        # generate duplicate bump PRs from commits landing while a previous
-        # bump PR is in flight. See `version_file_changed` parameter above.
         - equal: [true, << pipeline.parameters.version_file_changed >>]
     jobs:
       - prepare-next-version:

--- a/.circleci/generate-continuation-parameters.js
+++ b/.circleci/generate-continuation-parameters.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const { execSync } = require("child_process");
+
+const OUTPUT = "/tmp/continuation-parameters.json";
+
+// Runs a git command and returns its trimmed stdout, or null if the command fails.
+// stderr is discarded so callers don't need to redirect it themselves.
+function tryGit(args) {
+  try {
+    return execSync(`git ${args}`, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// True if the triggering commit modified `.version`. Used to gate the
+// `snapshot-bump` workflow so it only runs on commits that actually changed
+// the version (release commits and SNAPSHOT-bump merges) and not on every
+// unrelated commit landing on main.
+function versionFileChanged() {
+  if (tryGit("rev-parse --verify HEAD^") === null) {
+    return false;
+  }
+  const diff = tryGit("diff --name-only HEAD^ HEAD -- .version");
+  if (diff === null) {
+    return false;
+  }
+  return diff.split("\n").some((line) => line.trim() === ".version");
+}
+
+const parameters = {
+  version_file_changed: versionFileChanged(),
+};
+
+fs.writeFileSync(OUTPUT, `${JSON.stringify(parameters, null, 2)}\n`);
+
+for (const [key, value] of Object.entries(parameters)) {
+  console.log(`${key}=${value}`);
+}
+console.log(`Wrote ${OUTPUT}`);


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
The `snapshot-bump` workflow runs on every commit to `main`, and the underlying lane only de-duplicates against the live `bump/<version>` branch — not against already-merged bump PRs. So a commit that lands on `main` while a bump PR is in flight can race against the bump branch being deleted on merge and open a duplicate "prepare next version" PR (this is what produced [#6720](https://github.com/RevenueCat/purchases-ios/pull/6720), 20s after [#6719](https://github.com/RevenueCat/purchases-ios/pull/6719) merged).

### Description
- Restrict the `snapshot-bump` workflow to only run on commits that actually modify `.version`.
- The release commit (where the bump PR is created) and the bump merge commit (where the lane no-ops on the SNAPSHOT version) still trigger it; unrelated commits on `main` no longer can.
- Wired through the existing CircleCI dynamic config: the setup job computes a `version_file_changed` parameter from the triggering commit and forwards it to the workflow's `when` condition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that narrows when `snapshot-bump` runs; main risk is accidentally skipping the workflow if the git diff check fails in unusual pipeline contexts (e.g., shallow clones).
> 
> **Overview**
> **Stops `snapshot-bump` from running on every `main` commit** by adding a new `version_file_changed` pipeline parameter and requiring it to be `true` in the workflow’s `when` clause.
> 
> The CircleCI setup job now generates and forwards continuation parameters via a new `.circleci/generate-continuation-parameters.js` script, which detects whether the triggering commit modified `.version` and writes the result to `/tmp/continuation-parameters.json` for `continuation/continue`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83ff03eba82e1412db49b0bb90bb5e9483881edf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->