### PR TITLE
Move deploy-purchase-tester after make-release

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -2379,15 +2379,16 @@ workflows:
           <<: *release-tags
       - docs-deploy:
           <<: *release-tags
-      - deploy-purchase-tester:
-          dry_run: false
-          <<: *release-tags
       - make-release:
           requires:
             - push-revenuecatui-pod
             - deploy-to-spm
             - docs-deploy
-            - deploy-purchase-tester
+          <<: *release-tags
+      - deploy-purchase-tester:
+          dry_run: false
+          requires:
+            - make-release
           <<: *release-tags
       - deploy-rct-tester:
           dry_run: false
@@ -2402,8 +2403,10 @@ workflows:
           repo_name: purchases-ios
           requires:
             - make-release
+            - deploy-purchase-tester
             - deploy-rct-tester
             - bump-sdk-in-rc-mobile-app
+            - make-admob-release
           <<: *release-tags
 
   snapshot-bump:


### PR DESCRIPTION
### Description

Reorganizes the `deploy-tag` CircleCI workflow so that `deploy-purchase-tester` runs **after** `make-release` (mirroring `deploy-rct-tester`), and updates `merge-release-pr` to additionally require `deploy-purchase-tester` and `make-admob-release`.

### Motivation

Previously, `deploy-purchase-tester` was listed as a required dependency of `make-release`. This meant that a failure in `deploy-purchase-tester` (which is **not** critical for cutting the release itself) would cause `make-release` to be cancelled — see this [recent run](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/37252/workflows/01ec47ce-4ae9-4dff-bb6d-fe0cdc622231) where a `deploy-purchase-tester` failure cancelled `make-release`.

### Changes

- `deploy-purchase-tester` now `requires: make-release` (instead of being a prerequisite of it).
- Removed `deploy-purchase-tester` from the `requires` list of `make-release`.
- `revenuecat/merge-release-pr` now also requires `deploy-purchase-tester` and `make-admob-release`, so the release PR is only merged once everything has been deployed.

### New dependency graph (deploy-tag workflow)

```
push-revenuecat-pod ──► push-revenuecatui-pod ─┐
deploy-to-spm ─────────┬───────────────────────┤
                       └► deploy-to-purchases-ios-admob ──► make-admob-release ────────┐
docs-deploy ───────────────────────────────────┤                                       │
                                               ▼                                       │
                                          make-release ──┬─► deploy-purchase-tester ───┐
                                                         ├─► deploy-rct-tester ────────┤
                                                         └─► bump-sdk-in-rc-mobile-app ┤
                                                                                       ▼
                                                                            revenuecat/merge-release-pr
```

### Testing

This is a CircleCI workflow-only change. The behavior will be exercised on the next release tag.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow reordering in CircleCI; main impact is release-tag job dependency/gating changes that could alter when merges/deploys occur if a job fails.
> 
> **Overview**
> Reorders the `deploy-tag` CircleCI workflow so `deploy-purchase-tester` runs *after* `make-release` instead of blocking it, preventing non-critical tester deployment failures from canceling the release job.
> 
> Updates `revenuecat/merge-release-pr` to additionally wait for `deploy-purchase-tester` and `make-admob-release`, so the release PR merges only after these deployments complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e8fd15eba0170f61f56249ed04b983f59b02d3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->