### PR TITLE
Fix fullscreen paywall overflow for fill-mode videos

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		16A7F4C12E563B89001F9FC8 /* PaywallTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A7F4BF2E563B89001F9FC8 /* PaywallTransition.swift */; };
 		16A7F4C32E563B91001F9FC8 /* PaywallAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A7F4C22E563B91001F9FC8 /* PaywallAnimation.swift */; };
 		16A7F4C62E564B97001F9FC8 /* TransitionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A7F4C52E564B97001F9FC8 /* TransitionModifier.swift */; };
+		16A9F7B72FAA22D0008E8A4D /* VideoComponentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A9F7B62FAA22D0008E8A4D /* VideoComponentViewTests.swift */; };
 		16BCA3662E4D9AE400B39E7F /* LargeItemCacheType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BCA3652E4D9AE400B39E7F /* LargeItemCacheType.swift */; };
 		16BCA3682E4D9B0C00B39E7F /* FileRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BCA3672E4D9B0C00B39E7F /* FileRepository.swift */; };
 		16BCA36A2E4D9B2C00B39E7F /* KeyedDeferredValueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BCA3692E4D9B2C00B39E7F /* KeyedDeferredValueStore.swift */; };
@@ -1707,6 +1708,7 @@
 		16A7F4BF2E563B89001F9FC8 /* PaywallTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallTransition.swift; sourceTree = "<group>"; };
 		16A7F4C22E563B91001F9FC8 /* PaywallAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallAnimation.swift; sourceTree = "<group>"; };
 		16A7F4C52E564B97001F9FC8 /* TransitionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionModifier.swift; sourceTree = "<group>"; };
+		16A9F7B62FAA22D0008E8A4D /* VideoComponentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoComponentViewTests.swift; sourceTree = "<group>"; };
 		16BCA3652E4D9AE400B39E7F /* LargeItemCacheType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeItemCacheType.swift; sourceTree = "<group>"; };
 		16BCA3672E4D9B0C00B39E7F /* FileRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileRepository.swift; sourceTree = "<group>"; };
 		16BCA3692E4D9B2C00B39E7F /* KeyedDeferredValueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyedDeferredValueStore.swift; sourceTree = "<group>"; };
@@ -3180,6 +3182,7 @@
 		030890822D2B77DD0069677B /* PaywallsV2 */ = {
 			isa = PBXGroup;
 			children = (
+				16A9F7B62FAA22D0008E8A4D /* VideoComponentViewTests.swift */,
 				FACD00012F61A1230073D2DE /* TextComponentLocalizationTests.swift */,
 				FACD00032F61A1230073D2DE /* ViewModelFactoryBadgeTests.swift */,
 				FB5A72012F65F5B9005C64A1 /* ViewModelFactoryTests.swift */,
@@ -8321,6 +8324,7 @@
 				887A63312C1D177800E1A461 /* AvailabilityChecks.swift in Sources */,
 				FD89DB872DB97D2E00A8C231 /* VirtualCurrencyBalancesScreenViewModelTests.swift in Sources */,
 				887A63322C1D177800E1A461 /* CurrentTestCaseTracker.swift in Sources */,
+				16A9F7B72FAA22D0008E8A4D /* VideoComponentViewTests.swift in Sources */,
 				887A63332C1D177800E1A461 /* DataExtensions.swift in Sources */,
 				57BB08682DD3D9EC007493E1 /* SubscriptionDetailViewModelTests.swift in Sources */,
 				83EE33262E1E20430011CF1C /* PaywallPreviewResourcesLoader.swift in Sources */,

--- a/RevenueCatUI/Modifiers/FitToAspectRatio.swift
+++ b/RevenueCatUI/Modifiers/FitToAspectRatio.swift
@@ -33,12 +33,14 @@ extension Image {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 extension View {
     func fitToAspectRatio(
+		maxWidth: CGFloat? = nil,
         aspectRatio: Double,
         contentMode: SwiftUI.ContentMode,
         containerContentMode: SwiftUI.ContentMode? = nil
     ) -> some View {
         modifier(
             FitToAspectRatio(
+				maxWidth: maxWidth,
                 aspectRatio: aspectRatio,
                 contentMode: contentMode,
                 containerContentMode: containerContentMode
@@ -50,6 +52,7 @@ extension View {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 private struct FitToAspectRatio: ViewModifier {
 
+	let maxWidth: CGFloat?
     let aspectRatio: Double
     let contentMode: SwiftUI.ContentMode
     let containerContentMode: SwiftUI.ContentMode?
@@ -61,6 +64,7 @@ private struct FitToAspectRatio: ViewModifier {
             .aspectRatio(
                 self.aspectRatio,
                 contentMode: self.containerContentMode ?? self.paywallsV1ContainerContentMode)
+			.frame(maxWidth: maxWidth)
             .overlay(
                 content.aspectRatio(nil, contentMode: self.contentMode)
             )

--- a/RevenueCatUI/Modifiers/FitToAspectRatio.swift
+++ b/RevenueCatUI/Modifiers/FitToAspectRatio.swift
@@ -33,14 +33,14 @@ extension Image {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 extension View {
     func fitToAspectRatio(
-		maxWidth: CGFloat? = nil,
+        maxWidth: CGFloat? = nil,
         aspectRatio: Double,
         contentMode: SwiftUI.ContentMode,
         containerContentMode: SwiftUI.ContentMode? = nil
     ) -> some View {
         modifier(
             FitToAspectRatio(
-				maxWidth: maxWidth,
+                maxWidth: maxWidth,
                 aspectRatio: aspectRatio,
                 contentMode: contentMode,
                 containerContentMode: containerContentMode
@@ -52,7 +52,7 @@ extension View {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 private struct FitToAspectRatio: ViewModifier {
 
-	let maxWidth: CGFloat?
+    let maxWidth: CGFloat?
     let aspectRatio: Double
     let contentMode: SwiftUI.ContentMode
     let containerContentMode: SwiftUI.ContentMode?
@@ -64,7 +64,7 @@ private struct FitToAspectRatio: ViewModifier {
             .aspectRatio(
                 self.aspectRatio,
                 contentMode: self.containerContentMode ?? self.paywallsV1ContainerContentMode)
-			.frame(maxWidth: maxWidth)
+            .frame(maxWidth: maxWidth)
             .overlay(
                 content.aspectRatio(nil, contentMode: self.contentMode)
             )

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
@@ -51,6 +51,14 @@ struct VideoComponentView: View {
     @State private var cachedURL: URL?
     @State var imageSource: PaywallComponent.ThemeImageUrls?
 
+    init(
+        viewModel: VideoComponentViewModel,
+        size: CGSize = .zero
+    ) {
+        self.viewModel = viewModel
+        self._size = .init(initialValue: size)
+    }
+
     /// Tracks whether this page is active or adjacent in a carousel.
     /// Updated via onChange to ensure SwiftUI detects the change.
     @State private var isPlayable: Bool = true
@@ -233,22 +241,23 @@ struct VideoComponentView: View {
         size: CGSize,
         with style: VideoComponentStyle
     ) -> some View {
-		let maxWidth = calculateMaxWidth(parentWidth: size.width, style: style)
+        let maxWidth = Self.calculateMaxWidth(parentWidth: size.width, style: style)
         return video
-			.frame(maxWidth: maxWidth)
+            .frame(maxWidth: maxWidth)
             .fitToAspectRatio(
-				maxWidth: maxWidth,
+                maxWidth: maxWidth,
                 aspectRatio: aspectRatio(style: style),
                 contentMode: .fill, // This must be set to fill for the modifier to work correctly
                 containerContentMode: style.contentMode // the container is what truly controls this
             )
     }
 
-    private func calculateMaxWidth(parentWidth: CGFloat, style: VideoComponentStyle) -> CGFloat {
+    static func calculateMaxWidth(parentWidth: CGFloat, style: VideoComponentStyle) -> CGFloat {
         let totalBorderWidth = (style.border?.width ?? 0) * 2
-        return parentWidth - totalBorderWidth
+        let maxWidth = parentWidth - totalBorderWidth
             - style.margin.leading - style.margin.trailing
             - style.padding.leading - style.padding.trailing
+        return max(0, maxWidth)
     }
 }
 

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
@@ -233,9 +233,11 @@ struct VideoComponentView: View {
         size: CGSize,
         with style: VideoComponentStyle
     ) -> some View {
-        video
-            .frame(maxWidth: calculateMaxWidth(parentWidth: size.width, style: style))
+		let maxWidth = calculateMaxWidth(parentWidth: size.width, style: style)
+        return video
+			.frame(maxWidth: maxWidth)
             .fitToAspectRatio(
+				maxWidth: maxWidth,
                 aspectRatio: aspectRatio(style: style),
                 contentMode: .fill, // This must be set to fill for the modifier to work correctly
                 containerContentMode: style.contentMode // the container is what truly controls this

--- a/Tests/RevenueCatUITests/PaywallsV2/VideoComponentViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VideoComponentViewTests.swift
@@ -1,0 +1,144 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  VideoComponentViewTests.swift
+//
+//  Created by RevenueCat.
+//
+
+@_spi(Internal) import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if os(iOS)
+import UIKit
+#endif
+
+#if !os(tvOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class VideoComponentViewTests: TestCase {
+
+#if os(iOS)
+    func testFillModeDoesNotExceedFullscreenWidth() throws {
+        let fullScreenSize = CGSize(width: 460, height: 950)
+        let view = try Self.makeVideoComponentView(size: fullScreenSize)
+        let controller = UIHostingController(rootView: view)
+
+        let fittingSize = controller.sizeThatFits(in: fullScreenSize)
+
+        XCTAssertLessThanOrEqual(fittingSize.width, fullScreenSize.width)
+    }
+#endif
+
+    func testCalculateMaxWidthClampsNegativeInitialFullscreenFillWidth() {
+        let style = Self.makeStyle(
+            size: .init(width: .fill, height: .fit),
+            fitMode: .fill,
+            padding: .init(top: 0, bottom: 0, leading: 20, trailing: 20),
+            margin: .init(top: 0, bottom: 0, leading: 20, trailing: 20)
+        )
+
+        // VideoComponentView.size starts at .zero. The first render must not pass a negative
+        // maxWidth into FitToAspectRatio, or fullscreen fill-mode paywalls can expand off screen.
+        let maxWidth = VideoComponentView.calculateMaxWidth(parentWidth: 0, style: style)
+
+        XCTAssertEqual(maxWidth, 0)
+    }
+
+    func testCalculateMaxWidthSubtractsHorizontalSpacingWhenPositive() {
+        let style = Self.makeStyle(
+            padding: .init(top: 0, bottom: 0, leading: 15, trailing: 10),
+            margin: .init(top: 0, bottom: 0, leading: 20, trailing: 5),
+            border: .init(color: .init(light: .hex("#000000")), width: 2)
+        )
+
+        let maxWidth = VideoComponentView.calculateMaxWidth(parentWidth: 200, style: style)
+
+        XCTAssertEqual(maxWidth, 146)
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension VideoComponentViewTests {
+
+#if os(iOS)
+    static func makeVideoComponentView(size: CGSize) throws -> some View {
+        let component = PaywallComponent.VideoComponent(
+            source: .init(
+                light: .init(
+                    width: 1080,
+                    height: 1920,
+                    url: URL(string: "https://assets.revenuecat.com/video.mp4")!,
+                    checksum: nil,
+                    urlLowRes: nil,
+                    checksumLowRes: nil
+                )
+            ),
+            size: .init(width: .fill, height: .fit),
+            fitMode: .fill
+        )
+        let viewModel = VideoComponentViewModel(
+            localizationProvider: .init(locale: Locale(identifier: "en_US"), localizedStrings: [:]),
+            uiConfigProvider: UIConfigProvider(uiConfig: PreviewUIConfig.make()),
+            component: component
+        )
+
+        return VideoComponentView(viewModel: viewModel, size: size)
+            .environmentObject(PackageContext(package: nil, variableContext: .init(packages: [])))
+            .environmentObject(
+                IntroOfferEligibilityContext(
+                    introEligibilityChecker: BaseSnapshotTest.eligibleChecker
+                )
+            )
+            .environmentObject(
+                PaywallPromoOfferCache(
+                    subscriptionHistoryTracker: SubscriptionHistoryTracker()
+                )
+            )
+            .environment(\.componentViewState, .default)
+            .environment(\.screenCondition, .compact)
+            .environment(\.safeAreaInsets, EdgeInsets())
+    }
+#endif
+
+    static func makeStyle(
+        size: PaywallComponent.Size = .init(width: .fill, height: .fit),
+        fitMode: PaywallComponent.FitMode = .fit,
+        padding: PaywallComponent.Padding? = nil,
+        margin: PaywallComponent.Padding? = nil,
+        border: PaywallComponent.Border? = nil
+    ) -> VideoComponentStyle {
+        VideoComponentStyle(
+            showControls: false,
+            autoPlay: true,
+            loop: true,
+            url: URL(string: "https://assets.revenuecat.com/video.mp4")!,
+            lowResUrl: nil,
+            size: size,
+            widthLight: 1920,
+            heightLight: 1080,
+            widthDark: nil,
+            heightDark: nil,
+            muteAudio: true,
+            fitMode: fitMode,
+            padding: padding,
+            margin: margin,
+            border: border,
+            uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+            colorScheme: .light
+        )
+    }
+
+}
+
+#endif


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Fill-mode video components could cause fullscreen paywalls to expand off screen. This happened because the video aspect-ratio layout could grow wider than the available container when presented fullscreen. 
Sheet presentation was unaffected.

Resolves: ONCALL-1688

### Description
- Constrain video component width after applying aspect-ratio layout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk layout change: constrains video sizing during aspect-ratio layout and adds targeted tests to prevent regression in fullscreen paywalls.
> 
> **Overview**
> Prevents fullscreen Paywalls V2 from expanding off-screen when rendering *fill-mode* video components by constraining the aspect-ratio container to a computed `maxWidth`.
> 
> `VideoComponentView` now computes a clamped (non-negative) max width based on padding/margins/borders and passes it through `FitToAspectRatio`, and new `VideoComponentViewTests` cover the fullscreen width constraint and max-width calculation edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebd2826b6fa92982d3a7c5602cfb49cb30689196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->