### PR TITLE
Danger sticky comment

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -156,7 +156,7 @@ else
   if existing_comment
     github.api.update_comment(repo, existing_comment.id, body)
   else
-    github.api.create_comment(repo, pr_number, body)
+    github.api.add_comment(repo, pr_number, body)
   end
 
   fail("Purchases iOS checks failed — see the comment above for details.") unless all_failures.empty?

--- a/Dangerfile
+++ b/Dangerfile
@@ -7,13 +7,8 @@ EXCLUDED_SWIFT_PATH_PREFIXES = [
   'Tests/APITesters/'
 ].freeze
 
-# Check for submodules
-submodules = `git submodule status`.strip
-if !submodules.empty?
-  fail("This repository should not contain any submodules. When using Swift Package Manager, developers will get a resolution error because SPM cannot access private submodules.")
-end
+COMMENT_MARKER = "<!-- purchases-ios-danger -->"
 
-# Check for new Swift files that aren't added to RevenueCat.xcodeproj
 def normalize_path(path)
   Pathname(path).cleanpath.to_s.sub(%r{\A\./}, '')
 end
@@ -42,57 +37,55 @@ def project_swift_file_paths(project_file)
          .map { |path| normalize_path(path.cleanpath.relative_path_from(root).to_s) }
          .to_set
 rescue LoadError
-  warn("xcodeproj gem not available; skipping RevenueCat.xcodeproj sync check")
   nil
-rescue StandardError => e
-  warn("Unable to read #{project_file}: #{e.message}")
+rescue StandardError
   nil
 end
 
-def check_swift_files_in_project
+def xcodeproj_messages
+  failures = []
+  warnings = []
+
   project_file = 'RevenueCat.xcodeproj'
-  
+
   unless File.exist?(project_file)
-    warn("RevenueCat.xcodeproj not found")
-    return
+    warnings << "RevenueCat.xcodeproj not found"
+    return [failures, warnings]
   end
-  
+
   project_swift_files = project_swift_file_paths(project_file)
-  return if project_swift_files.nil?
-  
+  return [failures, warnings] if project_swift_files.nil?
+
   added_swift_files = git.added_files
     .select { |file| relevant_swift_file?(file) }
     .map { |file| normalize_path(file) }
-  
+
   deleted_swift_files = git.deleted_files
     .select { |file| relevant_swift_file?(file) }
     .map { |file| normalize_path(file) }
-  
+
   missing_files = added_swift_files.reject { |file| project_swift_files.include?(file) }
   lingering_references = deleted_swift_files.select { |file| project_swift_files.include?(file) }
 
-  return if missing_files.empty? && lingering_references.empty?
+  return [failures, warnings] if missing_files.empty? && lingering_references.empty?
 
   message = "**`RevenueCat.xcodeproj` is out of sync.**\n"
   unless missing_files.empty?
     message += "\nThe following Swift files were added but are missing from `RevenueCat.xcodeproj`:\n"
     missing_files.each { |file| message += "• `#{file}`\n" }
   end
-
   unless lingering_references.empty?
     message += "\nThe following Swift files were deleted but still referenced in `RevenueCat.xcodeproj`:\n"
     lingering_references.each { |file| message += "• `#{file}`\n" }
   end
-
   message += "\nTo fix: open `RevenueCat.xcodeproj` in Xcode, add/remove the files above in the appropriate target. "
   message += "Check where similar files in the same directory are assigned if you're unsure which target to use."
-  fail(message)
+
+  failures << message
+  [failures, warnings]
 end
 
-check_swift_files_in_project
-
-# Check for new public enums in Swift files
-def check_for_public_enums
+def public_enum_messages
   swift_files = (git.added_files + git.modified_files)
     .select { |file| file.start_with?('Sources/') || file.start_with?('RevenueCatUI/') }
     .select { |file| file.end_with?('.swift') }
@@ -115,13 +108,56 @@ def check_for_public_enums
     end
   end
 
-  return if files_with_public_enums.empty?
+  return [[], []] if files_with_public_enums.empty?
 
   message = "Public enums should not be added. Consider using a struct with static properties or an @objc enum instead.\n\n"
   message += "The following files contain new public enums:\n"
   files_with_public_enums.each { |file| message += "• #{file}\n" }
 
-  warn(message)
+  [[], [message]]
 end
 
-check_for_public_enums
+# Collect all issues
+all_failures = []
+all_warnings = []
+
+submodules = `git submodule status`.strip
+unless submodules.empty?
+  all_failures << "This repository should not contain any submodules. When using Swift Package Manager, developers will get a resolution error because SPM cannot access private submodules."
+end
+
+f, w = xcodeproj_messages
+all_failures.concat(f)
+all_warnings.concat(w)
+
+f, w = public_enum_messages
+all_failures.concat(f)
+all_warnings.concat(w)
+
+# Manage a single sticky comment — edit it on each run, delete it when all checks pass
+repo = github.pr_json["base"]["repo"]["full_name"]
+pr_number = github.pr_json["number"]
+
+existing_comment = github.api.issue_comments(repo, pr_number)
+                           .find { |c| c.body.include?(COMMENT_MARKER) }
+
+if all_failures.empty? && all_warnings.empty?
+  github.api.delete_comment(repo, existing_comment.id) if existing_comment
+else
+  sections = [COMMENT_MARKER]
+  unless all_failures.empty?
+    sections << "### :x: Failures\n\n" + all_failures.join("\n\n---\n\n")
+  end
+  unless all_warnings.empty?
+    sections << "### :warning: Warnings\n\n" + all_warnings.join("\n\n---\n\n")
+  end
+  body = sections.join("\n\n")
+
+  if existing_comment
+    github.api.update_comment(repo, existing_comment.id, body)
+  else
+    github.api.create_comment(repo, pr_number, body)
+  end
+
+  fail("Purchases iOS checks failed — see the comment above for details.") unless all_failures.empty?
+end

--- a/Sources/Misc/DangerTest.swift
+++ b/Sources/Misc/DangerTest.swift
@@ -1,6 +1,0 @@
-// This file exists solely to trigger the Danger public-enum check. Delete me.
-// swiftlint:disable missing_docs
-public enum DangerTestEnum {
-    case placeholder
-}
-// swiftlint:enable missing_docs

--- a/Sources/Misc/DangerTest.swift
+++ b/Sources/Misc/DangerTest.swift
@@ -1,0 +1,6 @@
+// This file exists solely to trigger the Danger public-enum check. Delete me.
+// swiftlint:disable missing_docs
+public enum DangerTestEnum {
+    case placeholder
+}
+// swiftlint:enable missing_docs


### PR DESCRIPTION
## Summary

- Updates the Dangerfile to manage a single sticky comment via `github.api` rather than relying on Danger's own comment creation, so the comment is edited in place on every run and deleted when all checks pass
- Adds `Sources/Misc/DangerTest.swift` with a `public enum` to trigger the Danger warning check

## What to verify

1. Danger runs and posts a comment (first run)
2. Push another commit → Danger **edits** the same comment, not a new one
3. Remove the `DangerTest.swift` file and push → Danger **deletes** the comment

> `DangerTest.swift` is intentionally throwaway — delete before merging.

#### 1st comment
<img width="990" height="469" alt="Screenshot 2026-05-06 at 18 19 03" src="https://github.com/user-attachments/assets/246bf462-c840-4cde-8f4f-2f11556a114b" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Danger to manage PR comments via `github.api` (create/update/delete) and alters how failures/warnings are surfaced, which could affect CI feedback and developer workflows if misconfigured.
> 
> **Overview**
> Updates the `Dangerfile` to aggregate all check results (submodule presence, `RevenueCat.xcodeproj` sync, and new public-enum detection) into **one sticky PR comment** identified by `<!-- purchases-ios-danger -->`, editing it in place on each run and deleting it when there are no issues.
> 
> Refactors the existing checks to return `[failures, warnings]` instead of immediately `fail`/`warn`, and only fails the Danger run after posting the consolidated comment when failures are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bfe4d9851771a832a28088a676d2a58188ff435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->