### PR TITLE
[Billing Plans]: Parse platform_product_plan_identifier in offerings response

### DIFF
--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -22,6 +22,7 @@ struct OfferingsResponse {
 
             let identifier: String
             let platformProductIdentifier: String
+            let platformProductPlanIdentifier: String?
             let webCheckoutUrl: URL?
 
         }

--- a/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
@@ -108,6 +108,7 @@ private extension OfferingsManagerStoreKitTests {
                       packages: [
                         .init(identifier: "$rc_monthly",
                               platformProductIdentifier: StoreKitConfigTestCase.productID,
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ],
                       webCheckoutUrl: nil)

--- a/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
@@ -71,6 +71,7 @@ extension OfferingsResponse {
                   packages: [
                     .init(identifier: "$rc_monthly",
                           platformProductIdentifier: "monthly_freetrial",
+                          platformProductPlanIdentifier: nil,
                           webCheckoutUrl: nil)
                   ], webCheckoutUrl: nil)
         ],

--- a/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsWithPlatformProductPlanIdentifier.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsWithPlatformProductPlanIdentifier.json
@@ -1,0 +1,17 @@
+{
+  "current_offering_id": "default",
+  "offerings": [
+    {
+      "identifier": "default",
+      "description": "standard set of packages",
+      "metadata": {},
+      "packages": [
+        {
+          "identifier": "$rc_monthly",
+          "platform_product_identifier": "com.revenuecat.monthly",
+          "platform_product_plan_identifier": "monthly"
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsWithoutPlatformProductPlanIdentifier.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsWithoutPlatformProductPlanIdentifier.json
@@ -1,0 +1,16 @@
+{
+  "current_offering_id": "default",
+  "offerings": [
+    {
+      "identifier": "default",
+      "description": "standard set of packages",
+      "metadata": {},
+      "packages": [
+        {
+          "identifier": "$rc_monthly",
+          "platform_product_identifier": "com.revenuecat.monthly"
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
@@ -43,9 +43,31 @@ final class OfferingsDecodingTests: BaseHTTPResponseTest {
 
         expect(package1.identifier) == PackageType.monthly.description
         expect(package1.platformProductIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro"
+        expect(package1.platformProductPlanIdentifier).to(beNil())
 
         expect(package2.identifier) == PackageType.annual.description
         expect(package2.platformProductIdentifier) == "com.revenuecat.yearly_10.99.2_week_intro"
+        expect(package2.platformProductPlanIdentifier).to(beNil())
+    }
+
+    func testDecodesPackageWithPlatformProductPlanIdentifier() throws {
+        let response: OfferingsResponse = try Self.decodeFixture("OfferingsWithPlatformProductPlanIdentifier")
+
+        let package = try XCTUnwrap(response.offerings.first?.packages.first)
+
+        expect(package.identifier) == PackageType.monthly.description
+        expect(package.platformProductIdentifier) == "com.revenuecat.monthly"
+        expect(package.platformProductPlanIdentifier) == "monthly"
+    }
+
+    func testDecodesPackageWithoutPlatformProductPlanIdentifier() throws {
+        let response: OfferingsResponse = try Self.decodeFixture("OfferingsWithoutPlatformProductPlanIdentifier")
+
+        let package = try XCTUnwrap(response.offerings.first?.packages.first)
+
+        expect(package.identifier) == PackageType.monthly.description
+        expect(package.platformProductIdentifier) == "com.revenuecat.monthly"
+        expect(package.platformProductPlanIdentifier).to(beNil())
     }
 
     func testDecodesSecondOffering() throws {

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -908,6 +908,7 @@ private extension OfferingsManagerTests {
                           packages: [
                             .init(identifier: "$rc_monthly",
                                   platformProductIdentifier: "monthly_freetrial",
+                                  platformProductPlanIdentifier: nil,
                                   webCheckoutUrl: nil)
                           ],
                           webCheckoutUrl: nil)
@@ -927,9 +928,11 @@ private extension OfferingsManagerTests {
                           packages: [
                             .init(identifier: "$rc_monthly",
                                   platformProductIdentifier: "monthly_freetrial",
+                                  platformProductPlanIdentifier: nil,
                                   webCheckoutUrl: nil),
                             .init(identifier: "$rc_yearly",
                                   platformProductIdentifier: "yearly_freetrial",
+                                  platformProductPlanIdentifier: nil,
                                   webCheckoutUrl: nil)
                           ],
                           webCheckoutUrl: nil)

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -21,6 +21,7 @@ class OfferingsTests: TestCase {
         let package = self.offeringsFactory.createPackage(
             with: .init(identifier: "$rc_monthly",
                         platformProductIdentifier: "com.myproduct.monthly",
+                        platformProductPlanIdentifier: nil,
                         webCheckoutUrl: nil),
             productsByID: [
                 "com.myproduct.annual": StoreProduct(sk1Product: SK1Product())
@@ -39,6 +40,7 @@ class OfferingsTests: TestCase {
             self.offeringsFactory.createPackage(
                 with: .init(identifier: packageIdentifier,
                             platformProductIdentifier: productIdentifier,
+                            platformProductPlanIdentifier: nil,
                             webCheckoutUrl: nil),
                 productsByID: [
                     productIdentifier: StoreProduct(sk1Product: product)
@@ -64,9 +66,11 @@ class OfferingsTests: TestCase {
                 packages: [
                     .init(identifier: "$rc_monthly",
                           platformProductIdentifier: "com.myproduct.monthly",
+                          platformProductPlanIdentifier: nil,
                           webCheckoutUrl: nil),
                     .init(identifier: "$rc_annual",
                           platformProductIdentifier: "com.myproduct.annual",
+                          platformProductPlanIdentifier: nil,
                           webCheckoutUrl: nil)
                 ],
                 webCheckoutUrl: nil),
@@ -94,12 +98,15 @@ class OfferingsTests: TestCase {
                     packages: [
                         .init(identifier: "$rc_monthly",
                               platformProductIdentifier: "com.myproduct.monthly",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil),
                         .init(identifier: "$rc_annual",
                               platformProductIdentifier: "com.myproduct.annual",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil),
                         .init(identifier: "$rc_six_month",
                               platformProductIdentifier: "com.myproduct.sixMonth",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                     ],
                     webCheckoutUrl: nil),
@@ -124,6 +131,7 @@ class OfferingsTests: TestCase {
                       packages: [
                         .init(identifier: "$rc_six_month",
                               platformProductIdentifier: "com.myproduct.sixMonth",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ],
                       webCheckoutUrl: nil),
@@ -132,6 +140,7 @@ class OfferingsTests: TestCase {
                       packages: [
                         .init(identifier: "$rc_monthly",
                               platformProductIdentifier: "com.myproduct.monthly",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ],
                       webCheckoutUrl: nil)
@@ -167,6 +176,7 @@ class OfferingsTests: TestCase {
                       packages: [
                         .init(identifier: "$rc_six_month",
                               platformProductIdentifier: "com.myproduct.annual",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ],
                       webCheckoutUrl: nil),
@@ -175,9 +185,11 @@ class OfferingsTests: TestCase {
                       packages: [
                         .init(identifier: "$rc_monthly",
                               platformProductIdentifier: "com.myproduct.monthly",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil),
                         .init(identifier: "custom_package",
                               platformProductIdentifier: "com.myproduct.custom",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ],
                       webCheckoutUrl: nil)
@@ -226,6 +238,7 @@ class OfferingsTests: TestCase {
                       packages: [
                         .init(identifier: "$rc_six_month",
                               platformProductIdentifier: "com.myproduct.annual",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ], webCheckoutUrl: nil),
                 .init(identifier: "offering_b",
@@ -233,9 +246,11 @@ class OfferingsTests: TestCase {
                       packages: [
                         .init(identifier: "$rc_monthly",
                               platformProductIdentifier: "com.myproduct.monthly",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil),
                         .init(identifier: "custom_package",
                               platformProductIdentifier: "com.myproduct.custom",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ], webCheckoutUrl: nil),
                 .init(identifier: "offering_c",
@@ -243,9 +258,11 @@ class OfferingsTests: TestCase {
                       packages: [
                         .init(identifier: "$rc_monthly",
                               platformProductIdentifier: "com.myproduct.monthly",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil),
                         .init(identifier: "custom_package",
                               platformProductIdentifier: "com.myproduct.custom",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ], webCheckoutUrl: nil)
             ],
@@ -318,6 +335,7 @@ class OfferingsTests: TestCase {
                       packages: [
                         .init(identifier: "$rc_six_month",
                               platformProductIdentifier: "com.myproduct.annual",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ],
                       webCheckoutUrl: nil),
@@ -326,9 +344,11 @@ class OfferingsTests: TestCase {
                       packages: [
                         .init(identifier: "$rc_monthly",
                               platformProductIdentifier: "com.myproduct.monthly",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil),
                         .init(identifier: "custom_package",
                               platformProductIdentifier: "com.myproduct.custom",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ],
                       webCheckoutUrl: nil)
@@ -375,6 +395,7 @@ class OfferingsTests: TestCase {
                       packages: [
                         .init(identifier: "$rc_six_month",
                               platformProductIdentifier: "com.myproduct.annual",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ], webCheckoutUrl: nil)
             ],
@@ -446,6 +467,7 @@ class OfferingsTests: TestCase {
                       packages: [
                         .init(identifier: "$rc_six_month",
                               platformProductIdentifier: "com.myproduct.annual",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ],
                       metadata: .init(
@@ -457,6 +479,7 @@ class OfferingsTests: TestCase {
                       packages: [
                         .init(identifier: "$rc_monthly",
                               platformProductIdentifier: "com.myproduct.monthly",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ],
                       webCheckoutUrl: nil)
@@ -611,6 +634,7 @@ class OfferingsTests: TestCase {
                       packages: [
                         .init(identifier: "$rc_six_month",
                               platformProductIdentifier: "com.myproduct.annual",
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ],
                       webCheckoutUrl: nil)
@@ -815,6 +839,7 @@ private extension OfferingsTests {
                       packages: [
                         .init(identifier: identifier,
                               platformProductIdentifier: productIdentifier,
+                              platformProductPlanIdentifier: nil,
                               webCheckoutUrl: nil)
                       ],
                       webCheckoutUrl: nil)


### PR DESCRIPTION
### Motivation
Preliminary work required for supporting billing plans in the iOS SDK.

### Description
Adds parsing support for `platform_product_plan_identifier` in `OfferingsResponse.Offering.Package`.

The new value is exposed internally as the optional `platformProductPlanIdentifier`, allowing offerings responses to carry a platform-specific product plan/base plan identifier when present while preserving `nil` behavior for responses that omit it.

No public API/behavior changes are introduced.

### Changes

- Added `platformProductPlanIdentifier: String?` to `OfferingsResponse.Offering.Package`
- Updated internal test fixtures and package construction call sites to account for the new optional field

### Testing
- Added explicit offerings decoding fixtures and tests for:
  - JSON with `platform_product_plan_identifier`
  - JSON without `platform_product_plan_identifier`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional decoded field to `OfferingsResponse.Offering.Package` and updates tests/fixtures; behavior is unchanged when the key is absent.
> 
> **Overview**
> Adds support for decoding `platform_product_plan_identifier` into a new optional `platformProductPlanIdentifier` on `OfferingsResponse.Offering.Package`.
> 
> Updates all affected test helpers to pass the new argument and adds fixtures + decoding tests covering both presence and absence of the new JSON field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b50b234aba7be1deec3355d04d6cc1a2a379ce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->