### PR TITLE
fix for CI - add missing JSON field

### DIFF
--- a/Tests/BackendIntegrationTests/__Snapshots__/FallbackURLBackendIntegrationTests/testCanGetOfferingsFromFallbackURL.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/FallbackURLBackendIntegrationTests/testCanGetOfferingsFromFallbackURL.1.json
@@ -32,6 +32,7 @@
       "paywall" : null,
       "paywall_components" : {
         "asset_base_url" : "https://assets.pawwalls.com",
+        "automatically_scale_font_size" : true,
         "components_config" : {
           "base" : {
             "background" : {

--- a/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferingsFromLoadShedder.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferingsFromLoadShedder.1.json
@@ -21,6 +21,7 @@
       "paywall" : null,
       "paywall_components" : {
         "asset_base_url" : "https://assets.pawwalls.com",
+        "automatically_scale_font_size" : true,
         "components_config" : {
           "base" : {
             "background" : {

--- a/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
@@ -32,6 +32,7 @@
       "paywall" : null,
       "paywall_components" : {
         "asset_base_url" : "https://assets.pawwalls.com",
+        "automatically_scale_font_size" : true,
         "components_config" : {
           "base" : {
             "background" : {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only snapshot JSON fixtures were updated to match a backend response shape, with no production code changes.
> 
> **Overview**
> Backend integration test snapshots for offerings were updated to expect a new `paywall_components.automatically_scale_font_size: true` field in the response (e.g., StoreKit, load shedder, and fallback URL scenarios). This aligns the tests with the current backend payload to unblock CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bee79df55d2b3c14e251e41d6c7e2512b5ed1174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->