### PR TITLE
Add support for intro offer eligibility override in non-cec mode

### DIFF
--- a/Sources/Purchasing/Purchases/PurchaseParams.swift
+++ b/Sources/Purchasing/Purchases/PurchaseParams.swift
@@ -33,6 +33,7 @@ import Foundation
     let product: StoreProduct?
     let promotionalOffer: PromotionalOffer?
     let quantity: Int?
+    let introductoryOfferEligibilityJWS: String?
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
@@ -43,7 +44,6 @@ import Foundation
 
     #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
-    let introductoryOfferEligibilityJWS: String?
     let promotionalOfferOptions: StoreKit2PromotionalOfferPurchaseOptions?
 
     #endif
@@ -53,6 +53,7 @@ import Foundation
         self.product = builder.product
         self.package = builder.package
         self.quantity = builder.quantity
+        self.introductoryOfferEligibilityJWS = builder.introductoryOfferEligibilityJWS
 
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
@@ -62,7 +63,6 @@ import Foundation
         #endif
 
         #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-        self.introductoryOfferEligibilityJWS = builder.introductoryOfferEligibilityJWS
         self.promotionalOfferOptions = builder.promotionalOfferOptions
         #endif
     }
@@ -73,6 +73,7 @@ import Foundation
         private(set) var package: Package?
         private(set) var product: StoreProduct?
         private(set) var quantity: Int?
+        private(set) var introductoryOfferEligibilityJWS: String?
 
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
@@ -83,7 +84,6 @@ import Foundation
 
         #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
-        private(set) var introductoryOfferEligibilityJWS: String?
         private(set) var promotionalOfferOptions: StoreKit2PromotionalOfferPurchaseOptions?
 
         #endif
@@ -159,8 +159,6 @@ import Foundation
 
         #endif
 
-        #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-
         // swiftlint:disable line_length
         /**
          * Sets an introductoryOfferEligibility JWS to be included with the purchase. StoreKit 2 only.
@@ -176,6 +174,8 @@ import Foundation
             self.introductoryOfferEligibilityJWS = introductoryOfferEligibilityJWS
             return self
         }
+
+        #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
         // swiftlint:disable line_length
         /**

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -443,14 +443,14 @@ final class PurchasesOrchestrator {
 
         #endif
 
+        let introductoryOfferEligibilityJWS = params.introductoryOfferEligibilityJWS
+
         #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
-        let introductoryOfferEligibilityJWS = params.introductoryOfferEligibilityJWS
         let promotionalOfferOptions = params.promotionalOfferOptions
 
         #else
 
-        let introductoryOfferEligibilityJWS: String? = nil
         let promotionalOfferOptions: StoreKit2PromotionalOfferPurchaseOptions? = nil
 
         #endif

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
@@ -147,6 +147,10 @@ NSURL *url;
     #if ENABLE_TRANSACTION_METADATA
     packageParamBuilder = [packageParamBuilder withMetadata:@{@"foo": @"bar"}];
     #endif
+
+    if (@available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)) {
+        packageParamBuilder = [packageParamBuilder withIntroductoryOfferEligibilityJWS:@"abc123"];
+    }
     RCPurchaseParams *packageParams = [packageParamBuilder build];
 
 
@@ -154,6 +158,10 @@ NSURL *url;
     #if ENABLE_TRANSACTION_METADATA
     productParamBuilder = [packageParamBuilder withMetadata:@{@"foo": @"bar"}];
     #endif
+
+    if (@available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)) {
+        productParamBuilder = [productParamBuilder withIntroductoryOfferEligibilityJWS:@"abc123"];
+    }
     RCPurchaseParams *productParams = [productParamBuilder build];
 
     // Win-back offers

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
@@ -180,6 +180,10 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     packageParamsBuilder = packageParamsBuilder.with(metadata: ["foo":"bar"])
     #endif
 
+    if #available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *) {
+        packageParamsBuilder = packageParamsBuilder.with(introductoryOfferEligibilityJWS: "abc123")
+    }
+
     if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
         packageParamsBuilder = packageParamsBuilder.with(winBackOffer: winBackOffer)
     }
@@ -192,6 +196,10 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     #if ENABLE_TRANSACTION_METADATA
     productParamsBuilder = productParamsBuilder.with(metadata: ["foo":"bar"])
     #endif
+
+    if #available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *) {
+        productParamsBuilder = productParamsBuilder.with(introductoryOfferEligibilityJWS: "abc123")
+    }
 
     if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
         productParamsBuilder = packageParamsBuilder.with(winBackOffer: winBackOffer)

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -2313,6 +2313,8 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -2313,10 +2313,10 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
-    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
-    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams
     @objc deinit
   }

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -2313,6 +2313,8 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -2313,10 +2313,10 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
-    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
-    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams
     @objc deinit
   }

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -2274,6 +2274,8 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -2274,10 +2274,10 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
-    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
-    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams
     @objc deinit
   }

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -2274,6 +2274,8 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -2274,10 +2274,10 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
-    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
-    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams
     @objc deinit
   }

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -2274,6 +2274,8 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -2274,10 +2274,10 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
-    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
-    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams
     @objc deinit
   }

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -2313,6 +2313,8 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -2313,10 +2313,10 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
-    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
-    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams
     @objc deinit
   }

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -2313,6 +2313,8 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -2313,10 +2313,10 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
-    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
-    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams
     @objc deinit
   }

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -2275,10 +2275,10 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
-    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
-    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams
     @objc deinit
   }

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -2275,6 +2275,8 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -2275,10 +2275,10 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
-    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
-    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams
     @objc deinit
   }

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -2275,6 +2275,8 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public init(product: RevenueCat.StoreProduct)
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
+    @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)
+    @objc public func with(introductoryOfferEligibilityJWS: Swift.String) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @objc public func build() -> RevenueCat.PurchaseParams


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the purchase parameter plumbing for StoreKit 2 purchases; mistakes could change purchase behavior or option sets on supported OS versions. Scope is small and mostly gated by availability/compiler checks.
> 
> **Overview**
> Adds support for passing a developer-provided `introductoryOfferEligibilityJWS` through `PurchaseParams` in *non* `ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION` builds, instead of being limited to CEC-only compilation.
> 
> Updates `PurchasesOrchestrator.purchase(params:)` to always forward this JWS into the SK2 purchase path, and refreshes Swift/ObjC API surface + API tester coverage to exercise the new builder method under appropriate availability checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2053f1442bccfc705abce31fcbcc7c177d60fccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->