### PR TITLE
Extend tuist-generate-workspace with include_test_dependencies param

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -506,15 +506,17 @@ commands:
         type: string
         default: ""
         description: "Optional query to pass to Tuist when generating workspace."
+      include_test_dependencies:
+        type: boolean
+        default: false
+        description: "Whether to include test/dev dependencies when generating the workspace."
     steps:
       - revenuecat/install-tuist
       - run:
           name: Generate Tuist workspace
           command: |
             export PATH="$HOME/.local/share/mise/shims:$PATH"
-            # Skip external test/dev dependencies to speed up tuist install.
-            # No CI job currently needs them (tests run via SPM, not Tuist).
-            export TUIST_INCLUDE_TEST_DEPENDENCIES=false
+            export TUIST_INCLUDE_TEST_DEPENDENCIES=<< parameters.include_test_dependencies >>
             if [ -n "<< parameters.query >>" ]; then
               tuist install && tuist generate << parameters.query >> --no-open
             else
@@ -1884,13 +1886,9 @@ jobs:
       - run:
           name: Fetch paywall-preview-resources
           command: bundle exec fastlane ios fetch_paywall_preview_resources
-      - revenuecat/install-tuist
-      - run:
-          name: Generate Tuist workspace
-          command: |
-            export PATH="$HOME/.local/share/mise/shims:$PATH"
-            export TUIST_INCLUDE_TEST_DEPENDENCIES=true
-            tuist install && tuist generate --no-open
+      - tuist-generate-workspace:
+          query: "PaywallScreenshotTests"
+          include_test_dependencies: true
       - run:
           name: Clone paywall-rendering-validation repository
           command: git clone git@github.com:RevenueCat/paywall-rendering-validation.git ../Tests/paywall-rendering-validation


### PR DESCRIPTION
Followup to #6744.

Extends `tuist-generate-workspace` with an `include_test_dependencies` boolean param (default: `false`) and replaces the inline duplicate steps in the screenshot job with a call to the shared command, passing `query: "PaywallScreenshotTests"` to only generate what that job needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI refactor that only changes how the Tuist workspace generation step is parameterized and reused; main potential impact is unintended CI behavior if the env var value is interpreted differently by Tuist.
> 
> **Overview**
> Updates the shared CircleCI `tuist-generate-workspace` command to accept an `include_test_dependencies` boolean and wires it to `TUIST_INCLUDE_TEST_DEPENDENCIES` instead of hardcoding test/dev dependencies off.
> 
> Refactors the paywall screenshot recording job to call `tuist-generate-workspace` with `query: "PaywallScreenshotTests"` and `include_test_dependencies: true`, removing duplicated inline Tuist install/generate steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3aa82961907063e6ba49d0cf24988b16425f039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->