### PR TITLE
fix: preload localized images and video override fallbacks for Paywalls V2

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -501,6 +501,7 @@
 		4F6ABC782A81595900250E63 /* PaywallCacheWarming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6ABC772A81595900250E63 /* PaywallCacheWarming.swift */; };
 		4F6ABC7A2A81649800250E63 /* MockPaywallCacheWarming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6ABC792A81649800250E63 /* MockPaywallCacheWarming.swift */; };
 		4F6ABC7C2A81673F00250E63 /* PaywallCacheWarmingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6ABC7B2A81673F00250E63 /* PaywallCacheWarmingTests.swift */; };
+		6724DA196FC24044AFA5BEC1 /* PaywallV2ImageURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B15BE89A354BD28091FEEA /* PaywallV2ImageURLTests.swift */; };
 		4F6ABC7E2A81700900250E63 /* PaywallsStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6ABC7D2A81700900250E63 /* PaywallsStrings.swift */; };
 		4F6BED592A26A14400CD9322 /* DebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6BED582A26A14400CD9322 /* DebugView.swift */; };
 		4F6BEDD92A26B55C00CD9322 /* DebugViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6BEDD82A26B55C00CD9322 /* DebugViewModel.swift */; };
@@ -969,6 +970,7 @@
 		751BE2CF2EC64FE50011C4CB /* PostReceiptDataOperationFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 751BE2CE2EC64FE50011C4CB /* PostReceiptDataOperationFactoryTests.swift */; };
 		753C77232EAB828E00CA4F9C /* FallbackURLBackendIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753C77222EAB828E00CA4F9C /* FallbackURLBackendIntegrationTests.swift */; };
 		75425E0F2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75425E0E2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift */; };
+		FB2F3EC48678418D9FE2EF1C /* LocalizationDataDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6E847ADD244AFFB0EC748C /* LocalizationDataDecodingTests.swift */; };
 		7542E4E92DEDCC2A002CE340 /* PaywallFontManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7542E4E82DEDCC2A002CE340 /* PaywallFontManagerType.swift */; };
 		7559DF072E38B05F0050C5B4 /* WebProductToStoreProductConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7559DF062E38B05F0050C5B4 /* WebProductToStoreProductConversionTests.swift */; };
 		755B63E52E7438D500919833 /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755B63E42E7438D500919833 /* TestLogHandler.swift */; };
@@ -2158,6 +2160,7 @@
 		4F6ABC772A81595900250E63 /* PaywallCacheWarming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallCacheWarming.swift; sourceTree = "<group>"; };
 		4F6ABC792A81649800250E63 /* MockPaywallCacheWarming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPaywallCacheWarming.swift; sourceTree = "<group>"; };
 		4F6ABC7B2A81673F00250E63 /* PaywallCacheWarmingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallCacheWarmingTests.swift; sourceTree = "<group>"; };
+		40B15BE89A354BD28091FEEA /* PaywallV2ImageURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallV2ImageURLTests.swift; sourceTree = "<group>"; };
 		4F6ABC7D2A81700900250E63 /* PaywallsStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallsStrings.swift; sourceTree = "<group>"; };
 		4F6BED582A26A14400CD9322 /* DebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugView.swift; sourceTree = "<group>"; };
 		4F6BEDD82A26B55C00CD9322 /* DebugViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugViewModel.swift; sourceTree = "<group>"; };
@@ -2566,6 +2569,7 @@
 		751BE2CE2EC64FE50011C4CB /* PostReceiptDataOperationFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReceiptDataOperationFactoryTests.swift; sourceTree = "<group>"; };
 		753C77222EAB828E00CA4F9C /* FallbackURLBackendIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FallbackURLBackendIntegrationTests.swift; sourceTree = "<group>"; };
 		75425E0E2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentsDataTests.swift; sourceTree = "<group>"; };
+		BF6E847ADD244AFFB0EC748C /* LocalizationDataDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationDataDecodingTests.swift; sourceTree = "<group>"; };
 		7542E4E82DEDCC2A002CE340 /* PaywallFontManagerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallFontManagerType.swift; sourceTree = "<group>"; };
 		7559DF062E38B05F0050C5B4 /* WebProductToStoreProductConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebProductToStoreProductConversionTests.swift; sourceTree = "<group>"; };
 		755B63E42E7438D500919833 /* TestLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLogHandler.swift; sourceTree = "<group>"; };
@@ -4880,6 +4884,7 @@
 				2C8EC6AD2CCBD33800D6CCF8 /* Components */,
 				4FE6FEE62AA940E300780B45 /* Events */,
 				4F6ABC7B2A81673F00250E63 /* PaywallCacheWarmingTests.swift */,
+				40B15BE89A354BD28091FEEA /* PaywallV2ImageURLTests.swift */,
 				4F05876E2A5DE03F00E9A834 /* PaywallDataTests.swift */,
 				4F0C11552B742F2F00583501 /* PaywallDataMultiTierTests.swift */,
 				4FBBD4E32A620539001CBA21 /* PaywallColorTests.swift */,
@@ -5081,6 +5086,7 @@
 				574A2F3E282D75E300150D40 /* OfferingsDecodingTests.swift */,
 				03A98D312D2441B2009BCA61 /* PaywallDataDecodingTests.swift */,
 				75425E0E2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift */,
+				BF6E847ADD244AFFB0EC748C /* LocalizationDataDecodingTests.swift */,
 				E1C0A00ABEEF0001CCDD0001 /* PaywallComponentsConfigHeaderTests.swift */,
 				03A98D352D244321009BCA61 /* UIConfigDecodingTests.swift */,
 				574A2F4E282D7B9E00150D40 /* PostOfferDecodingTests.swift */,
@@ -7766,6 +7772,7 @@
 				35D8330A262FBA9A00E60AC5 /* MockUserDefaults.swift in Sources */,
 				E1C0A004BEEF0001CCDD0001 /* HeaderComponentTests.swift in Sources */,
 				75425E0F2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift in Sources */,
+				FB2F3EC48678418D9FE2EF1C /* LocalizationDataDecodingTests.swift in Sources */,
 				E1C0A005BEEF0001CCDD0001 /* PaywallComponentsConfigHeaderTests.swift in Sources */,
 				2DDF41DF24F6F527005BC22D /* MockProductsManager.swift in Sources */,
 				FD18BF492DF0D9C100140FD6 /* VirtualCurrencyManagerTests.swift in Sources */,
@@ -7777,6 +7784,7 @@
 				57D62F182D4A73F8000235DC /* CustomerCenterEventCreationDataDefault.swift in Sources */,
 				2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */,
 				4F6ABC7C2A81673F00250E63 /* PaywallCacheWarmingTests.swift in Sources */,
+				6724DA196FC24044AFA5BEC1 /* PaywallV2ImageURLTests.swift in Sources */,
 				FA6ABC7C2A81673F00353AF7 /* SystemFontRegistryTests.swift in Sources */,
 				751BE2CF2EC64FE50011C4CB /* PostReceiptDataOperationFactoryTests.swift in Sources */,
 				57D04BB827D947C6006DAC06 /* HTTPResponseTests.swift in Sources */,

--- a/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
@@ -59,7 +59,7 @@ import Foundation
     }
 
     public enum LocalizationData: Codable, Equatable, Sendable {
-        case string(String), image(PaywallComponent.ThemeImageUrls)
+        case string(String), image(PaywallComponent.ThemeImageUrls), video(PaywallComponent.ThemeVideoUrls)
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()
@@ -67,6 +67,8 @@ import Foundation
                 self = .string(stringValue)
             } else if let imageValue = try? container.decode(PaywallComponent.ThemeImageUrls.self) {
                 self = .image(imageValue)
+            } else if let videoValue = try? container.decode(PaywallComponent.ThemeVideoUrls.self) {
+                self = .video(videoValue)
             } else {
                 throw DecodingError.typeMismatch(
                     LocalizationData.self,
@@ -83,6 +85,8 @@ import Foundation
                 try container.encode(stringValue)
             case .image(let imageValue):
                 try container.encode(imageValue)
+            case .video(let videoValue):
+                try container.encode(videoValue)
             }
         }
     }

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -45,7 +45,7 @@ private func imageURLs(
     for (_, localeValues) in localizations {
         for (_, value) in localeValues {
             switch value {
-            case .string:
+            case .string, .video:
                 break
             case .image(let image):
                 imageUrls += image.imageUrls
@@ -352,7 +352,8 @@ private extension PaywallComponent.ThemeImageUrls {
 private extension PaywallComponent.VideoComponent {
 
     var imageUrls: [URL] {
-        fallbackSource?.imageUrls ?? []
+        (fallbackSource?.imageUrls ?? []) +
+        (overrides?.compactMap(\.properties.fallbackSource).flatMap(\.imageUrls) ?? [])
     }
 
     var lowResVideoUrls: [URLWithValidation] {

--- a/Tests/UnitTests/Networking/Responses/LocalizationDataDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/LocalizationDataDecodingTests.swift
@@ -1,0 +1,96 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  LocalizationDataDecodingTests.swift
+
+@_spi(Internal) @testable import RevenueCat
+import XCTest
+
+class LocalizationDataDecodingTests: TestCase {
+
+    func testDecodesString() throws {
+        let json = #""hello world""#
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let result = try JSONDecoder.default.decode(PaywallComponentsData.LocalizationData.self, from: data)
+        XCTAssertEqual(result, .string("hello world"))
+    }
+
+    func testDecodesImage() throws {
+        let json = """
+        {
+            "light": {
+                "original": "https://assets.revenuecat.com/img.png",
+                "heic": "https://assets.revenuecat.com/img.heic",
+                "heic_low_res": "https://assets.revenuecat.com/img_low.heic",
+                "width": 100,
+                "height": 200
+            }
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let result = try JSONDecoder.default.decode(PaywallComponentsData.LocalizationData.self, from: data)
+        guard case .image(let urls) = result else {
+            XCTFail("Expected .image, got \(result)")
+            return
+        }
+        XCTAssertEqual(urls.light.heicLowRes.absoluteString, "https://assets.revenuecat.com/img_low.heic")
+    }
+
+    func testDecodesVideo() throws {
+        let json = """
+        {
+            "light": {
+                "url": "https://assets.revenuecat.com/video.mp4",
+                "url_low_res": "https://assets.revenuecat.com/video_low.mp4",
+                "width": 1920,
+                "height": 1080
+            }
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let result = try JSONDecoder.default.decode(PaywallComponentsData.LocalizationData.self, from: data)
+        guard case .video(let urls) = result else {
+            XCTFail("Expected .video, got \(result)")
+            return
+        }
+        XCTAssertEqual(urls.light.url.absoluteString, "https://assets.revenuecat.com/video.mp4")
+        XCTAssertEqual(urls.light.urlLowRes?.absoluteString, "https://assets.revenuecat.com/video_low.mp4")
+        XCTAssertNil(urls.dark)
+    }
+
+    func testVideoDoesNotCrashLocalizationDictionaryDecode() throws {
+        let json = """
+        {
+            "en_US": {
+                "text_key": "Hello",
+                "video_key": {
+                    "light": {
+                        "url": "https://assets.revenuecat.com/video.mp4",
+                        "url_low_res": "https://assets.revenuecat.com/video_low.mp4",
+                        "width": 1920,
+                        "height": 1080
+                    }
+                }
+            }
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let result = try JSONDecoder.default.decode(
+            [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary].self,
+            from: data
+        )
+        let locale = try XCTUnwrap(result["en_US"])
+        XCTAssertEqual(locale["text_key"], .string("Hello"))
+        guard case .video(let urls) = locale["video_key"] else {
+            XCTFail("Expected .video for video_key, got \(String(describing: locale["video_key"]))")
+            return
+        }
+        XCTAssertEqual(urls.light.url.absoluteString, "https://assets.revenuecat.com/video.mp4")
+    }
+}

--- a/Tests/UnitTests/Paywalls/PaywallV2ImageURLTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallV2ImageURLTests.swift
@@ -1,0 +1,130 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallV2ImageURLTests.swift
+
+@_spi(Internal) @testable import RevenueCat
+import XCTest
+
+class PaywallV2ImageURLTests: TestCase {
+
+    // MARK: - Localized image preloading
+
+    func testLocalizedImagesAreIncludedInAllImageURLs() {
+        let lightURL = URL(string: "https://assets.revenuecat.com/localized_light.heic")!
+        let imageUrls = makeImageUrls(heicLowRes: lightURL)
+        let localizations: [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary] = [
+            "en_US": ["image_key": .image(.init(light: imageUrls))]
+        ]
+
+        let urls = makeData(localizations: localizations).allImageURLs
+        XCTAssertTrue(urls.contains(lightURL), "Localized image URL should be preloaded")
+    }
+
+    func testLocalizedVideoDoesNotCrashAndIsIgnoredForImagePreloading() {
+        let videoUrls = makeVideoUrls()
+        let localizations: [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary] = [
+            "en_US": ["video_key": .video(videoUrls)]
+        ]
+
+        let urls = makeData(localizations: localizations).allImageURLs
+        XCTAssertTrue(urls.isEmpty, "Localized video should not contribute image URLs")
+    }
+
+    // MARK: - VideoComponent override fallback preloading
+
+    func testVideoFallbackSourceIsPreloaded() {
+        let lightURL = URL(string: "https://assets.revenuecat.com/fallback_light.heic")!
+        let video = PaywallComponent.VideoComponent(
+            source: makeVideoUrls(),
+            fallbackSource: .init(light: makeImageUrls(heicLowRes: lightURL))
+        )
+
+        let urls = makeData(components: [.video(video)]).allImageURLs
+        XCTAssertTrue(urls.contains(lightURL), "Video fallback source should be preloaded")
+    }
+
+    func testVideoOverrideFallbackSourceIsPreloaded() {
+        let overrideURL = URL(string: "https://assets.revenuecat.com/override_fallback.heic")!
+        let override = PaywallComponent.ComponentOverride(
+            conditions: [.compact],
+            properties: PaywallComponent.PartialVideoComponent(
+                fallbackSource: .init(light: makeImageUrls(heicLowRes: overrideURL))
+            )
+        )
+        let video = PaywallComponent.VideoComponent(
+            source: makeVideoUrls(),
+            overrides: [override]
+        )
+
+        let urls = makeData(components: [.video(video)]).allImageURLs
+        XCTAssertTrue(urls.contains(overrideURL), "Video override fallback source should be preloaded")
+    }
+
+    func testVideoFallbackAndOverrideFallbackBothPreloaded() {
+        let baseURL = URL(string: "https://assets.revenuecat.com/base_fallback.heic")!
+        let overrideURL = URL(string: "https://assets.revenuecat.com/override_fallback.heic")!
+        let override = PaywallComponent.ComponentOverride(
+            conditions: [.compact],
+            properties: PaywallComponent.PartialVideoComponent(
+                fallbackSource: .init(light: makeImageUrls(heicLowRes: overrideURL))
+            )
+        )
+        let video = PaywallComponent.VideoComponent(
+            source: makeVideoUrls(),
+            fallbackSource: .init(light: makeImageUrls(heicLowRes: baseURL)),
+            overrides: [override]
+        )
+
+        let urls = makeData(components: [.video(video)]).allImageURLs
+        XCTAssertTrue(urls.contains(baseURL), "Base fallback should be preloaded")
+        XCTAssertTrue(urls.contains(overrideURL), "Override fallback should be preloaded")
+    }
+
+}
+
+// MARK: - Helpers
+
+private extension PaywallV2ImageURLTests {
+
+    func makeImageUrls(heicLowRes: URL) -> PaywallComponent.ImageUrls {
+        return .init(width: 100, height: 100, original: heicLowRes, heic: heicLowRes, heicLowRes: heicLowRes)
+    }
+
+    func makeVideoUrls() -> PaywallComponent.ThemeVideoUrls {
+        let videoUrls = PaywallComponent.VideoUrls(
+            width: 1920,
+            height: 1080,
+            url: URL(string: "https://assets.revenuecat.com/video.mp4")!,
+            checksum: nil,
+            urlLowRes: URL(string: "https://assets.revenuecat.com/video_low.mp4")!,
+            checksumLowRes: nil
+        )
+        return .init(light: videoUrls)
+    }
+
+    func makeData(
+        components: [PaywallComponent] = [],
+        localizations: [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary] = [:]
+    ) -> PaywallComponentsData {
+        return .init(
+            templateName: "test",
+            assetBaseURL: URL(string: "https://assets.revenuecat.com")!,
+            componentsConfig: .init(base: .init(
+                stack: .init(components: components),
+                stickyFooter: nil,
+                background: .color(.init(light: .hex("#ffffff")))
+            )),
+            componentsLocalizations: localizations,
+            revision: 1,
+            defaultLocaleIdentifier: "en_US"
+        )
+    }
+
+}


### PR DESCRIPTION
### Why

Port of [purchases-android#3449](https://github.com/RevenueCat/purchases-android/pull/3449).

Two preloading gaps in Paywalls V2:

1. **`LocalizationData` missing `.video` case** — if a localization key held a `ThemeVideoUrls` value, decoding the whole locale dictionary would throw a `typeMismatch` error and the locale would silently fall back to `[:]`. Now the `.video` case is decoded correctly (and skipped during image preloading, same as `.string`).

2. **`VideoComponent` override fallback images not preloaded** — `VideoComponent.imageUrls` only returned the base `fallbackSource` image. Override-level `fallbackSource` values (e.g. a different image for compact layout) were missed. Both are now collected.

Carousel page image preloading (also part of the Android PR) was already correct on iOS.

### Changes

- `PaywallComponentsData.LocalizationData`: add `case video(ThemeVideoUrls)` with decode/encode support
- `PaywallV2CacheWarming`: handle `.video` in the localization switch; extend `VideoComponent.imageUrls` to include override fallback URLs
- New test files:
  - `LocalizationDataDecodingTests` — string / image / video decoding + whole-dict regression
  - `PaywallV2ImageURLTests` — localized image, video fallback, video override fallback, and both together

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates paywall UI response decoding and cache-warming URL collection, which could affect Paywalls V2 rendering/preloading behavior if the new `.video` localization variant is mis-decoded. Changes are covered by new unit tests and are scoped to asset preloading paths.
> 
> **Overview**
> Fixes two Paywalls V2 preloading gaps by extending `PaywallComponentsData.LocalizationData` to support a `.video(ThemeVideoUrls)` variant (including encode/decode) and ensuring cache warming skips localized videos instead of failing decoding.
> 
> Also expands `VideoComponent` image preloading to include *override-level* `fallbackSource` images (in addition to the base fallback), and adds regression/unit tests for localization decoding and image URL collection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef447ed2147969ac059529c5ad00b1cd5348342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->