### PR TITLE
Parse exit_offers field on WorkflowScreen

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
@@ -26,7 +26,8 @@ enum WorkflowScreenMapper {
             componentsConfig: screen.componentsConfig,
             componentsLocalizations: screen.componentsLocalizations,
             revision: screen.revision,
-            defaultLocaleIdentifier: screen.defaultLocale
+            defaultLocaleIdentifier: screen.defaultLocale,
+            exitOffers: screen.exitOffers
         )
         return .init(uiConfig: uiConfig, data: data)
     }

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -82,6 +82,7 @@ import Foundation
     @DefaultDecodable.EmptyDictionary
     var config: [String: AnyDecodable]
     public let offeringIdentifier: String?
+    public let exitOffers: ExitOffers?
 
 }
 
@@ -157,6 +158,7 @@ extension WorkflowScreen: Codable, Equatable, Sendable {
         case defaultLocale
         case config
         case offeringIdentifier
+        case exitOffers
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
@@ -65,6 +65,24 @@ final class WorkflowScreenMapperTests: TestCase {
         expect(result.data.componentsLocalizations) == screen.componentsLocalizations
     }
 
+    func testPassesThroughExitOffers() throws {
+        let screen = try Self.makeScreen(exitOfferOfferingId: "exit_offering_a")
+        let uiConfig = try Self.makeUIConfig()
+
+        let result = WorkflowScreenMapper.toPaywallComponents(screen: screen, uiConfig: uiConfig)
+
+        expect(result.data.exitOffers?.dismiss?.offeringId) == "exit_offering_a"
+    }
+
+    func testExitOffersIsNilWhenAbsent() throws {
+        let screen = try Self.makeScreen()
+        let uiConfig = try Self.makeUIConfig()
+
+        let result = WorkflowScreenMapper.toPaywallComponents(screen: screen, uiConfig: uiConfig)
+
+        expect(result.data.exitOffers).to(beNil())
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -75,8 +93,15 @@ private extension WorkflowScreenMapperTests {
         templateName: String = "componentsTest",
         assetBaseURL: String = "https://assets.pawwalls.com",
         revision: Int = 3,
-        defaultLocale: String = "en_US"
+        defaultLocale: String = "en_US",
+        exitOfferOfferingId: String? = nil
     ) throws -> RevenueCat.WorkflowScreen {
+        var exitOffersJSON = ""
+        if let exitOfferOfferingId {
+            exitOffersJSON = """
+            , "exit_offers": { "dismiss": { "offering_id": "\(exitOfferOfferingId)" } }
+            """
+        }
         let json = """
         {
             "offering_identifier": "\(offeringIdentifier)",
@@ -110,7 +135,7 @@ private extension WorkflowScreenMapperTests {
                         }
                     }
                 }
-            }
+            }\(exitOffersJSON)
         }
         """
         let data = try XCTUnwrap(json.data(using: .utf8))

--- a/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
+++ b/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
@@ -225,6 +225,63 @@ class WorkflowResponseTests: TestCase {
         expect(screen.offeringIdentifier) == "default"
     }
 
+    func testDecodeWorkflowScreenWithExitOffers() throws {
+        let json = """
+        {
+          "template_name": "tmpl",
+          "asset_base_url": "https://assets.revenuecat.com",
+          "default_locale": "en_US",
+          "components_localizations": {},
+          "components_config": {
+            "base": {
+              "stack": {
+                "type": "stack", "components": [],
+                "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+                "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+                "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+                "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+              },
+              "background": { "type": "color", "value": { "light": { "type": "hex", "value": "#FFFFFF" } } }
+            }
+          },
+          "exit_offers": {
+            "dismiss": { "offering_id": "exit_offering_a" }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let screen = try JSONDecoder.default.decode(WorkflowScreen.self, from: json)
+
+        expect(screen.exitOffers?.dismiss?.offeringId) == "exit_offering_a"
+    }
+
+    func testDecodeWorkflowScreenExitOffersAbsentByDefault() throws {
+        let json = """
+        {
+          "template_name": "tmpl",
+          "asset_base_url": "https://assets.revenuecat.com",
+          "default_locale": "en_US",
+          "components_localizations": {},
+          "components_config": {
+            "base": {
+              "stack": {
+                "type": "stack", "components": [],
+                "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+                "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+                "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+                "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+              },
+              "background": { "type": "color", "value": { "light": { "type": "hex", "value": "#FFFFFF" } } }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let screen = try JSONDecoder.default.decode(WorkflowScreen.self, from: json)
+
+        expect(screen.exitOffers).to(beNil())
+    }
+
     func testDecodeWorkflowScreenOfferingFieldsAbsent() throws {
         let json = """
         {


### PR DESCRIPTION
## Summary

- Adds `exitOffers: ExitOffers?` to `WorkflowScreen` model, decoded from the `exit_offers` JSON key
- Passes it through `WorkflowScreenMapper` into `PaywallComponentsData`
- Adds decode tests in `WorkflowResponseTests` and mapper passthrough tests in `WorkflowScreenMapperTests`

Android equivalent: RevenueCat/purchases-android#3452

## Test plan

- [ ] New `testDecodeWorkflowScreenWithExitOffers` and `testDecodeWorkflowScreenExitOffersAbsentByDefault` tests in `WorkflowResponseTests` (Xcode/Tuist only)
- [ ] New `testPassesThroughExitOffers` and `testExitOffersIsNilWhenAbsent` tests in `WorkflowScreenMapperTests` (pass via `swift test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional decoded field and passes it through to existing paywall component data, with test coverage for presence/absence.
> 
> **Overview**
> Adds support for the `exit_offers` field on `WorkflowScreen` by decoding it into a new optional `exitOffers: ExitOffers?` property.
> 
> Updates `WorkflowScreenMapper` to pass `exitOffers` through into `PaywallComponentsData`, and adds unit/UI tests to verify decoding and mapper passthrough when present and `nil` when absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 097a886639ccda6b0f945091676a053c7b3a1f32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->