### PR TITLE
Remove redundant isVerified from AdMob reward verification result

### DIFF
--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardVerificationResult.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardVerificationResult.swift
@@ -36,11 +36,6 @@ import Foundation
         return reward
     }
 
-    /// Whether this result is ``verified(_:)``.
-    public var isVerified: Bool {
-        self.verifiedReward != nil
-    }
-
     /// Whether this result is ``failed``.
     public var isFailed: Bool {
         if case .failed = self.storage { return true }

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentMappingTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentMappingTests.swift
@@ -36,7 +36,7 @@ final class PresentMappingTests: AdapterTestCase {
     func testMapOutcomeVerified() {
         let reward = RevenueCat.VerifiedReward.virtualCurrency(VirtualCurrencyReward(code: "c", amount: 2))
         let result = RewardVerification.mapOutcome(.verified(reward))
-        XCTAssertTrue(result.isVerified)
+        XCTAssertNotNil(result.verifiedReward)
         XCTAssertEqual(result.verifiedReward?.virtualCurrency?.code, "c")
         XCTAssertEqual(result.verifiedReward?.virtualCurrency?.amount, 2)
     }

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
@@ -52,7 +52,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
         self.wait(for: [expectation], timeout: 2.0)
 
         let result = try XCTUnwrap(receivedResult)
-        XCTAssertTrue(result.isVerified)
+        XCTAssertNotNil(result.verifiedReward)
         XCTAssertEqual(result.verifiedReward?.virtualCurrency?.code, "coins")
         XCTAssertEqual(result.verifiedReward?.virtualCurrency?.amount, 4)
     }

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RewardVerificationResultTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RewardVerificationResultTests.swift
@@ -9,7 +9,6 @@ final class RewardVerificationResultTests: AdapterTestCase {
     func testVerifiedProjectionsAndEquality() {
         let result = RewardVerificationResult.verified(.noReward)
 
-        XCTAssertTrue(result.isVerified)
         XCTAssertFalse(result.isFailed)
         XCTAssertEqual(result.verifiedReward, .noReward)
         XCTAssertEqual(result, .verified(.noReward))
@@ -19,7 +18,6 @@ final class RewardVerificationResultTests: AdapterTestCase {
         let result = RewardVerificationResult.failed
 
         XCTAssertTrue(result.isFailed)
-        XCTAssertFalse(result.isVerified)
         XCTAssertNil(result.verifiedReward)
         XCTAssertEqual(result, .failed)
     }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
`RewardVerificationResult.isVerified` duplicates the information already represented by `verifiedReward`. Keeping both introduces redundant API surface and can lead to ambiguous usage.

### Description
- Removes `RewardVerificationResult.isVerified` from the experimental `RevenueCatAdMob` API.
- Keeps verification success/failure projection through existing properties:
  - success: `verifiedReward != nil`
  - failure: `isFailed == true` (and `verifiedReward == nil`)
- Updates adapter unit tests to assert `verifiedReward` directly instead of `isVerified`.
- Verified by running: `swift test --filter RevenueCatAdMobTests` in `AdapterSDKs/RevenueCatAdMob`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a redundant experimental projection property and updates unit tests to check `verifiedReward` directly, with no behavioral changes to verification logic.
> 
> **Overview**
> Removes the experimental `RewardVerificationResult.isVerified` property, relying on `verifiedReward != nil` to represent successful verification.
> 
> Updates the AdMob adapter unit tests to stop referencing `isVerified` and instead assert `verifiedReward` presence/contents for verified outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2010b21c00ec19864957756a112c47d938efbf34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->