### PR TITLE
Fix example app disable controls during reward verification

### DIFF
--- a/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/Support/Messages.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/Support/Messages.swift
@@ -38,7 +38,7 @@ struct Message: Equatable {
         static let readyWithoutVerification = Message(text: "🔓 Ready", severity: .info, isLoading: false)
         static let readyWithVerification = Message(text: "🔐 Ready", severity: .info, isLoading: false)
         static let waitingForReward = Message(text: "⏳ Waiting for reward...", severity: .info, isLoading: false)
-        static let verifyingReward = Message(text: "⏳ Verifying reward...", severity: .info, isLoading: false)
+        static let verifyingReward = Message(text: "⏳ Verifying reward...", severity: .info, isLoading: true)
         static let loadFailed = Message(text: "❌ Load failed", severity: .error, isLoading: false)
         static let dismissedBeforeReward = Message(
             text: "⚠️ Ad dismissed before reward was earned",


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
The previous PR merged before the final follow-up fix landed. This patch ensures reward verification is treated as an in-progress state so users cannot trigger state resets that drop verification results.

### Description
- Set `Message.Rewarded.verifyingReward` to `isLoading: true` in the AdMob integration sample.
- This keeps the reward verification toggle and Load button disabled while verification is in flight, matching how other loading states are handled.

Manual validation in sample app:
- Start a rewarded verification flow and reach the "Verifying reward..." state.
- Confirm Load and the verification toggle remain disabled until verification completes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single sample-app UI state flag change that only affects whether controls stay disabled during reward verification.
> 
> **Overview**
> Updates the AdMob integration sample’s `Message.Rewarded.verifyingReward` to set `isLoading: true`, so the "Verifying reward..." state is treated like other in-progress states.
> 
> This keeps the sample UI from re-enabling actions (e.g., Load/toggles) during reward verification, avoiding state resets that could drop verification results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa1e13cd9377c8aeb42b350fe009badcfa3389a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->