### PR TITLE
Require rewardVerificationResult callback

### DIFF
--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
@@ -22,9 +22,9 @@ import GoogleMobileAds
         RewardVerification.Setup.install(on: self)
     }
 
-    /// Presents the ad with optional reward-verification callbacks.
+    /// Presents the ad with a required reward-verification result callback.
     ///
-    /// When `rewardVerificationResult` is non-`nil`, you must call ``enableRewardVerification()`` first
+    /// You must call ``enableRewardVerification()`` before presenting
     /// (checked with a debug assertion).
     ///
     /// Callback timing:
@@ -37,7 +37,7 @@ import GoogleMobileAds
     func present(
         from viewController: UIViewController,
         rewardVerificationStarted: (@MainActor () -> Void)? = nil,
-        rewardVerificationResult: (@MainActor (RewardVerificationResult) -> Void)? = nil
+        rewardVerificationResult: @escaping @MainActor (RewardVerificationResult) -> Void
     ) {
         let userDidEarnRewardHandler = self.createUserDidEarnRewardHandler(
             rewardVerificationStarted: rewardVerificationStarted,
@@ -49,11 +49,12 @@ import GoogleMobileAds
         )
     }
 
-    /// Presents the ad with optional reward-verification callbacks and an explicit placement for RevenueCat analytics.
+    /// Presents the ad with a required reward-verification result callback
+    /// and an explicit placement for RevenueCat analytics.
     ///
     /// The placement passed here takes precedence over any placement from
     /// ``loadAndTrack(withAdUnitID:request:placement:fullScreenContentDelegate:paidEventHandler:)``.
-    /// When `rewardVerificationResult` is non-`nil`, you must call ``enableRewardVerification()`` first
+    /// You must call ``enableRewardVerification()`` before presenting
     /// (checked with a debug assertion).
     ///
     /// Callback timing:
@@ -64,7 +65,7 @@ import GoogleMobileAds
         from viewController: UIViewController,
         placement: String?,
         rewardVerificationStarted: (@MainActor () -> Void)? = nil,
-        rewardVerificationResult: (@MainActor (RewardVerificationResult) -> Void)? = nil
+        rewardVerificationResult: @escaping @MainActor (RewardVerificationResult) -> Void
     ) {
         Tracking.setShowTimePlacement(placement, on: self)
         let userDidEarnRewardHandler = self.createUserDidEarnRewardHandler(
@@ -90,9 +91,9 @@ import GoogleMobileAds
         RewardVerification.Setup.install(on: self)
     }
 
-    /// Presents the ad with optional reward-verification callbacks.
+    /// Presents the ad with a required reward-verification result callback.
     ///
-    /// When `rewardVerificationResult` is non-`nil`, you must call ``enableRewardVerification()`` first
+    /// You must call ``enableRewardVerification()`` before presenting
     /// (checked with a debug assertion).
     ///
     /// Callback timing:
@@ -105,7 +106,7 @@ import GoogleMobileAds
     func present(
         from viewController: UIViewController,
         rewardVerificationStarted: (@MainActor () -> Void)? = nil,
-        rewardVerificationResult: (@MainActor (RewardVerificationResult) -> Void)? = nil
+        rewardVerificationResult: @escaping @MainActor (RewardVerificationResult) -> Void
     ) {
         let userDidEarnRewardHandler = self.createUserDidEarnRewardHandler(
             rewardVerificationStarted: rewardVerificationStarted,
@@ -117,11 +118,12 @@ import GoogleMobileAds
         )
     }
 
-    /// Presents the ad with optional reward-verification callbacks and an explicit placement for RevenueCat analytics.
+    /// Presents the ad with a required reward-verification result callback
+    /// and an explicit placement for RevenueCat analytics.
     ///
     /// The placement passed here takes precedence over any placement from
     /// ``loadAndTrack(withAdUnitID:request:placement:fullScreenContentDelegate:paidEventHandler:)``.
-    /// When `rewardVerificationResult` is non-`nil`, you must call ``enableRewardVerification()`` first
+    /// You must call ``enableRewardVerification()`` before presenting
     /// (checked with a debug assertion).
     ///
     /// Callback timing:
@@ -132,7 +134,7 @@ import GoogleMobileAds
         from viewController: UIViewController,
         placement: String?,
         rewardVerificationStarted: (@MainActor () -> Void)? = nil,
-        rewardVerificationResult: (@MainActor (RewardVerificationResult) -> Void)? = nil
+        rewardVerificationResult: @escaping @MainActor (RewardVerificationResult) -> Void
     ) {
         Tracking.setShowTimePlacement(placement, on: self)
         let userDidEarnRewardHandler = self.createUserDidEarnRewardHandler(
@@ -156,12 +158,12 @@ internal extension RewardVerification.CapableAd {
     @MainActor
     func createUserDidEarnRewardHandler(
         rewardVerificationStarted: (@MainActor () -> Void)?,
-        rewardVerificationResult: (@MainActor (RewardVerificationResult) -> Void)?,
+        rewardVerificationResult: @escaping @MainActor (RewardVerificationResult) -> Void,
         poller: RewardVerification.Poller? = nil
     ) -> (() -> Void) {
         let state = RewardVerification.Setup.verificationState(for: self)
 
-        if rewardVerificationResult != nil, state == nil {
+        if state == nil {
             Logger.warn(RewardVerificationStrings.result_callback_missing_verification_state)
             assert(
                 state != nil,
@@ -171,10 +173,6 @@ internal extension RewardVerification.CapableAd {
 
         return {
             rewardVerificationStarted?()
-
-            guard let rewardVerificationResult else {
-                return
-            }
 
             guard let state else {
                 rewardVerificationResult(.failed)

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/APISurfaceTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/APISurfaceTests.swift
@@ -166,7 +166,7 @@ final class APISurfaceTests: AdapterTestCase {
     func testPresentWithRewardVerificationEntryPointsRemainAvailableInSwift() {
         let rewardedPresent:
             (GoogleMobileAds.RewardedAd)
-            -> (UIViewController, (@MainActor () -> Void)?, (@MainActor (RewardVerificationResult) -> Void))
+            -> (UIViewController, (@MainActor () -> Void)?, (@escaping @MainActor (RewardVerificationResult) -> Void))
                 -> Void
             = GoogleMobileAds.RewardedAd.present(
                 from:rewardVerificationStarted:rewardVerificationResult:
@@ -177,13 +177,13 @@ final class APISurfaceTests: AdapterTestCase {
                 UIViewController,
                 String?,
                 (@MainActor () -> Void)?,
-                (@MainActor (RewardVerificationResult) -> Void)
+                (@escaping @MainActor (RewardVerificationResult) -> Void)
             ) -> Void = GoogleMobileAds.RewardedAd.present(
                 from:placement:rewardVerificationStarted:rewardVerificationResult:
             )
         let rewardedInterstitialPresent:
             (GoogleMobileAds.RewardedInterstitialAd)
-            -> (UIViewController, (@MainActor () -> Void)?, (@MainActor (RewardVerificationResult) -> Void))
+            -> (UIViewController, (@MainActor () -> Void)?, (@escaping @MainActor (RewardVerificationResult) -> Void))
                 -> Void
             = GoogleMobileAds.RewardedInterstitialAd.present(
                 from:rewardVerificationStarted:rewardVerificationResult:
@@ -194,7 +194,7 @@ final class APISurfaceTests: AdapterTestCase {
                 UIViewController,
                 String?,
                 (@MainActor () -> Void)?,
-                (@MainActor (RewardVerificationResult) -> Void)
+                (@escaping @MainActor (RewardVerificationResult) -> Void)
             ) -> Void = GoogleMobileAds.RewardedInterstitialAd.present(
                 from:placement:rewardVerificationStarted:rewardVerificationResult:
             )

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/APISurfaceTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/APISurfaceTests.swift
@@ -166,7 +166,7 @@ final class APISurfaceTests: AdapterTestCase {
     func testPresentWithRewardVerificationEntryPointsRemainAvailableInSwift() {
         let rewardedPresent:
             (GoogleMobileAds.RewardedAd)
-            -> (UIViewController, (@MainActor () -> Void)?, (@MainActor (RewardVerificationResult) -> Void)?)
+            -> (UIViewController, (@MainActor () -> Void)?, (@MainActor (RewardVerificationResult) -> Void))
                 -> Void
             = GoogleMobileAds.RewardedAd.present(
                 from:rewardVerificationStarted:rewardVerificationResult:
@@ -177,13 +177,13 @@ final class APISurfaceTests: AdapterTestCase {
                 UIViewController,
                 String?,
                 (@MainActor () -> Void)?,
-                (@MainActor (RewardVerificationResult) -> Void)?
+                (@MainActor (RewardVerificationResult) -> Void)
             ) -> Void = GoogleMobileAds.RewardedAd.present(
                 from:placement:rewardVerificationStarted:rewardVerificationResult:
             )
         let rewardedInterstitialPresent:
             (GoogleMobileAds.RewardedInterstitialAd)
-            -> (UIViewController, (@MainActor () -> Void)?, (@MainActor (RewardVerificationResult) -> Void)?)
+            -> (UIViewController, (@MainActor () -> Void)?, (@MainActor (RewardVerificationResult) -> Void))
                 -> Void
             = GoogleMobileAds.RewardedInterstitialAd.present(
                 from:rewardVerificationStarted:rewardVerificationResult:
@@ -194,7 +194,7 @@ final class APISurfaceTests: AdapterTestCase {
                 UIViewController,
                 String?,
                 (@MainActor () -> Void)?,
-                (@MainActor (RewardVerificationResult) -> Void)?
+                (@MainActor (RewardVerificationResult) -> Void)
             ) -> Void = GoogleMobileAds.RewardedInterstitialAd.present(
                 from:placement:rewardVerificationStarted:rewardVerificationResult:
             )

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
@@ -13,18 +13,6 @@ final class PresentRewardVerificationTests: AdapterTestCase {
     private static let testAPIKey = "appl_test_present_public_api"
     private static let testAppUserID = "user_present_public_api"
 
-    func testPresentWithoutVerificationStateInvokesOnlyStartedWhenOutcomeNil() {
-        let fakeAd = FakeCapableAd()
-        var startedCount = 0
-        let handler = fakeAd.createUserDidEarnRewardHandler(
-            rewardVerificationStarted: { startedCount += 1 },
-            rewardVerificationResult: nil
-        )
-
-        handler()
-        XCTAssertEqual(startedCount, 1)
-    }
-
     func testPresentWithStateAndOutcomeDeliversVerifiedOutcome() throws {
         let fakeAd = FakeCapableAd()
         RewardVerification.Setup.install(on: fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
This change tightens the AdMob reward-verification API contract so integrations handle the resolved verification outcome by default, not only verification start. It improves correctness, aligns with stricter cross-platform direction, and matches AdMob rewarded-ad semantics where presentation requires a reward handler (`OnUserEarnedRewardListener` on Android / `userDidEarnRewardHandler` on iOS).

### Description
## Why
- Enforce that reward-verification flows consume the final resolved outcome.
- Keep flexibility for callers who intentionally ignore results (`{ _ in }`).
- Align adapter API with underlying platform-level rewarded-ad contracts.

## What changed
- Breaking API update in `RewardedAds+RewardVerification`:
  - `rewardVerificationStarted` remains optional.
  - `rewardVerificationResult` is now required (non-optional, no default) for:
    - `GoogleMobileAds.RewardedAd.present(...)` (with and without `placement`)
    - `GoogleMobileAds.RewardedInterstitialAd.present(...)` (with and without `placement`)
- Internal handler update:
  - `createUserDidEarnRewardHandler(...)` now requires `rewardVerificationResult`.
  - Removed the optional callback guard path.
  - Kept missing-state behavior (`warn + assert` and `.failed`) and existing dispatch semantics.
- Tests:
  - Updated `APISurfaceTests` to reflect required callback signatures.
  - Removed nil callback usage from `PresentRewardVerificationTests`.
  - Preserved coverage for verified/failed outcomes, started-before-result ordering, and optional `rewardVerificationStarted`.

## Migration impact
Before:
```swift
rewardedAd?.present(from: viewController)
```

After:
```swift
rewardedAd?.present(
    from: viewController,
    rewardVerificationResult: { result in
        // handle verified/failed result, or intentionally ignore with { _ in }
    }
)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change to rewarded-ad `present` methods: callers must now provide a `rewardVerificationResult` handler, which could require downstream migration and affects runtime behavior if omitted previously.
> 
> **Overview**
> **Tightens the reward-verification API contract for AdMob rewarded ads** by making `rewardVerificationResult` a required, non-optional callback for `RewardedAd` and `RewardedInterstitialAd` `present(...)` (with and without `placement`).
> 
> Internally, `createUserDidEarnRewardHandler(...)` now always expects a result handler, removes the nil-guard path, and consistently reports `.failed` when reward verification state is missing (while still warning/asserting). Tests are updated to reflect the new required callback signatures and remove the “nil result callback” scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 966b96302319f09e11c5c908705aba19f81ca49f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

