### PR TITLE
[Billing Plans]: Update CircleCI jobs to Xcode 26.5 RC 1

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -104,7 +104,7 @@ aliases:
         ignore: /.*/
       branches:
         only: main
-  swiftinterface-xcode-version: &swiftinterface-xcode-version "26.5"
+  swiftinterface-xcode-version: &swiftinterface-xcode-version "26.3"
 commands:
   slack-notify-on-fail:
     steps:

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -749,7 +749,7 @@ jobs:
           command: bundle exec fastlane test_revenuecatui
           no_output_timeout: 15m
           environment:
-            DEVICE: iPhone 17,OS=26.4
+            DEVICE: iPhone 16,OS=18.5
       - compress_result_bundle:
           directory: fastlane/test_output
           bundle_name: revenuecatui

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -544,9 +544,6 @@ commands:
     parameters:
       test_plan:
         type: string
-      scan_device:
-        type: string
-        default: "iPhone 16 (18.5)"
     steps:
       - checkout
       - install-dependencies
@@ -556,7 +553,7 @@ commands:
           command: bundle exec fastlane backend_integration_tests test_plan:"<< parameters.test_plan >>"
           no_output_timeout: 5m
           environment:
-            SCAN_DEVICE: << parameters.scan_device >>
+            SCAN_DEVICE: iPhone 16 (18.5)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: BackendIntegrationTests

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -49,7 +49,7 @@ executors:
     parameters:
       xcode_version:
         type: string
-        default: "26.5"
+        default: "16.4"
     macos:
       # circleci-lint: disable=unknown-xcode-version
       xcode: << parameters.xcode_version >>
@@ -63,7 +63,7 @@ executors:
     parameters:
       xcode_version:
         type: string
-        default: "26.5"
+        default: "16.4"
     macos:
       # circleci-lint: disable=unknown-xcode-version
       xcode: << parameters.xcode_version >>
@@ -544,6 +544,9 @@ commands:
     parameters:
       test_plan:
         type: string
+      scan_device:
+        type: string
+        default: "iPhone 16 (18.5)"
     steps:
       - checkout
       - install-dependencies
@@ -553,7 +556,7 @@ commands:
           command: bundle exec fastlane backend_integration_tests test_plan:"<< parameters.test_plan >>"
           no_output_timeout: 5m
           environment:
-            SCAN_DEVICE: iPhone 17 (26.4)
+            SCAN_DEVICE: << parameters.scan_device >>
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: BackendIntegrationTests
@@ -613,7 +616,7 @@ jobs:
   revenuecat-admob-tests:
     executor:
       name: macos-executor
-      xcode_version: "26.5"
+      xcode_version: "26.3"
     steps:
       - checkout
       - install-dependencies:
@@ -628,7 +631,7 @@ jobs:
           command: bundle exec fastlane test_revenuecat_admob
           no_output_timeout: 10m
           environment:
-            DEVICE: iPhone 17,OS=26.4
+            DEVICE: iPhone 17,OS=26.2
       - compress_result_bundle:
           directory: fastlane/test_output
           bundle_name: revenuecat_admob
@@ -806,7 +809,7 @@ jobs:
   record-and-upload-paywalls-v1-snapshots:
     executor:
       name: macos-executor
-      xcode_version: "26.5"
+      xcode_version: "26.3"
 
     steps:
       - checkout
@@ -818,7 +821,7 @@ jobs:
           command: bundle exec fastlane record_and_upload_v1_snapshots
           no_output_timeout: 15m
           environment:
-            DEVICE: iPhone 17,OS=26.4
+            DEVICE: iPhone 17,OS=26.2
       - store_test_results:
           path: fastlane/test_output/v1-snapshots/tests.xml
       - store_artifacts:
@@ -881,7 +884,7 @@ jobs:
           no_output_timeout: 15m
           environment:
             PLATFORM: watchOS Simulator
-            DEVICE: Apple Watch Series 11 (42mm),OS=26.4
+            DEVICE: Apple Watch Series 10 (46mm),OS=11.5
             BUILD_SDK: watchsimulator
       - create-snapshot-pr-if-needed:
           condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
@@ -1238,7 +1241,7 @@ jobs:
           no_output_timeout: 5m
           environment:
             SCAN_PLATFORM: watchOS Simulator
-            SCAN_DEVICE: Apple Watch Series 11 (42mm) (26.4)
+            SCAN_DEVICE: Apple Watch Series 10 (46mm) (11.5)
             BUILD_SDK: watchsimulator
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/watchos
@@ -1277,9 +1280,11 @@ jobs:
   backend-integration-tests-SK2:
     executor:
       name: macos-executor
+      xcode_version: "26.5"
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-SK2"
+          scan_device: "iPhone 17 (26.4)"
       - slack-notify-on-fail
 
   backend-integration-tests-other:
@@ -1309,12 +1314,12 @@ jobs:
   run-all-maestro-e2e-tests:
     executor:
       name: macos-executor
-      xcode_version: "26.5"
+      xcode_version: "26.3"
     steps:
       - macos/preboot-simulator:
-          version: "26.4"
+          version: "18.6"
           platform: "iOS"
-          device: "iPhone 17"
+          device: "iPhone 16 Pro"
       - checkout
       - install-dependencies
       - revenuecat/install-maestro
@@ -1778,7 +1783,7 @@ jobs:
   deploy-purchase-tester:
     executor:
       name: macos-executor
-      xcode_version: "26.5"
+      xcode_version: "26.3"
     parameters:
       dry_run:
         type: boolean
@@ -1797,7 +1802,7 @@ jobs:
   deploy-rct-tester:
     executor:
       name: macos-executor
-      xcode_version: "26.5"
+      xcode_version: "26.3"
     parameters:
       dry_run:
         type: boolean

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1280,11 +1280,9 @@ jobs:
   backend-integration-tests-SK2:
     executor:
       name: macos-executor
-      xcode_version: "26.5"
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-SK2"
-          scan_device: "iPhone 17 (26.4)"
       - slack-notify-on-fail
 
   backend-integration-tests-other:

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -881,7 +881,7 @@ jobs:
           no_output_timeout: 15m
           environment:
             PLATFORM: watchOS Simulator
-            DEVICE: Apple Watch Series 10 (46mm),OS=11.5
+            DEVICE: Apple Watch Series 11 (42mm),OS=26.4
             BUILD_SDK: watchsimulator
       - create-snapshot-pr-if-needed:
           condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
@@ -1012,7 +1012,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 17 (26.4)
+            SCAN_DEVICE: iPhone 16 (18.5)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: RevenueCat
@@ -1238,7 +1238,7 @@ jobs:
           no_output_timeout: 5m
           environment:
             SCAN_PLATFORM: watchOS Simulator
-            SCAN_DEVICE: Apple Watch Series 10 (46mm) (11.5)
+            SCAN_DEVICE: Apple Watch Series 11 (42mm) (26.4)
             BUILD_SDK: watchsimulator
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/watchos

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -553,7 +553,7 @@ commands:
           command: bundle exec fastlane backend_integration_tests test_plan:"<< parameters.test_plan >>"
           no_output_timeout: 5m
           environment:
-            SCAN_DEVICE: iPhone 16 (18.5)
+            SCAN_DEVICE: iPhone 17 (26.4)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: BackendIntegrationTests
@@ -628,7 +628,7 @@ jobs:
           command: bundle exec fastlane test_revenuecat_admob
           no_output_timeout: 10m
           environment:
-            DEVICE: iPhone 17,OS=26.5
+            DEVICE: iPhone 17,OS=26.4
       - compress_result_bundle:
           directory: fastlane/test_output
           bundle_name: revenuecat_admob
@@ -749,7 +749,7 @@ jobs:
           command: bundle exec fastlane test_revenuecatui
           no_output_timeout: 15m
           environment:
-            DEVICE: iPhone 16,OS=18.5
+            DEVICE: iPhone 17,OS=26.4
       - compress_result_bundle:
           directory: fastlane/test_output
           bundle_name: revenuecatui
@@ -818,7 +818,7 @@ jobs:
           command: bundle exec fastlane record_and_upload_v1_snapshots
           no_output_timeout: 15m
           environment:
-            DEVICE: iPhone 17,OS=26.5
+            DEVICE: iPhone 17,OS=26.4
       - store_test_results:
           path: fastlane/test_output/v1-snapshots/tests.xml
       - store_artifacts:
@@ -850,7 +850,7 @@ jobs:
           command: bundle exec fastlane test_revenuecatui
           no_output_timeout: 15m
           environment:
-            DEVICE: iPhone 17,OS=26.5
+            DEVICE: iPhone 17,OS=26.4
       - create-snapshot-pr-if-needed:
           condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
           job: "create_snapshot_pr"
@@ -970,7 +970,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 17 (26.5)
+            SCAN_DEVICE: iPhone 17 (26.4)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: RevenueCat
@@ -1012,7 +1012,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 16 (18.5)
+            SCAN_DEVICE: iPhone 17 (26.4)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: RevenueCat
@@ -1312,9 +1312,9 @@ jobs:
       xcode_version: "26.5"
     steps:
       - macos/preboot-simulator:
-          version: "18.6"
+          version: "26.4"
           platform: "iOS"
-          device: "iPhone 16 Pro"
+          device: "iPhone 17"
       - checkout
       - install-dependencies
       - revenuecat/install-maestro

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -985,6 +985,31 @@ jobs:
           destination: scan-test-output-ios-26
       - slack-notify-on-fail
 
+  build-ios-265:
+    executor:
+      name: macos-executor
+      xcode_version: "26.5"
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Build RevenueCat with Xcode 26.5
+          command: xcodebuild -workspace RevenueCat.xcworkspace -scheme RevenueCat -destination "generic/platform=iOS" -sdk iphoneos -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES build
+          no_output_timeout: 30m
+      - run:
+          name: Build RevenueCat_CustomEntitlementComputation with Xcode 26.5
+          command: xcodebuild -workspace RevenueCat.xcworkspace -scheme RevenueCat_CustomEntitlementComputation -destination "generic/platform=iOS" -sdk iphoneos -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES build
+          no_output_timeout: 30m
+      - run:
+          name: Build ReceiptParser with Xcode 26.5
+          command: xcodebuild -workspace RevenueCat.xcworkspace -scheme "ReceiptParser (RevenueCat Workspace)" -destination "generic/platform=iOS" -sdk iphoneos -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES build
+          no_output_timeout: 30m
+      - run:
+          name: Build RevenueCatUI with Xcode 26.5
+          command: xcodebuild -workspace RevenueCat.xcworkspace -scheme RevenueCatUI -destination "generic/platform=iOS" -sdk iphoneos -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES build
+          no_output_timeout: 30m
+      - slack-notify-on-fail
+
   run-test-ios-18-and-17:
     executor:
       name: macos-executor
@@ -2166,6 +2191,9 @@ workflows:
       - run-test-ios-26:
           context:
             - slack-secrets
+      - build-ios-265:
+          context:
+            - slack-secrets
       - pod-lib-lint:
           context:
             - slack-secrets
@@ -2331,6 +2359,7 @@ workflows:
             - check-api-changes-revenuecat
             - check-api-changes-revenuecatui
             - run-test-ios-26
+            - build-ios-265
             - pod-lib-lint
             - run-revenuecat-ui-ios-26
             - emerge_purchases_ui_snapshot_tests
@@ -2627,6 +2656,9 @@ workflows:
       - run-test-ios-26:
           context:
             - slack-secrets
+      - build-ios-265:
+          context:
+            - slack-secrets
       - pod-lib-lint:
           context:
             - slack-secrets
@@ -2647,6 +2679,7 @@ workflows:
             - run-all-maestro-e2e-tests
             - lint
             - run-test-ios-26
+            - build-ios-265
             - pod-lib-lint
             - run-revenuecat-ui-ios-26
             - emerge_purchases_ui_snapshot_tests

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -49,7 +49,7 @@ executors:
     parameters:
       xcode_version:
         type: string
-        default: "16.4"
+        default: "26.5"
     macos:
       # circleci-lint: disable=unknown-xcode-version
       xcode: << parameters.xcode_version >>
@@ -63,7 +63,7 @@ executors:
     parameters:
       xcode_version:
         type: string
-        default: "16.4"
+        default: "26.5"
     macos:
       # circleci-lint: disable=unknown-xcode-version
       xcode: << parameters.xcode_version >>
@@ -104,7 +104,7 @@ aliases:
         ignore: /.*/
       branches:
         only: main
-  swiftinterface-xcode-version: &swiftinterface-xcode-version "26.3"
+  swiftinterface-xcode-version: &swiftinterface-xcode-version "26.5"
 commands:
   slack-notify-on-fail:
     steps:
@@ -601,7 +601,6 @@ jobs:
   api-tests:
     executor:
       name: macos-executor
-      xcode_version: "16.4"
     steps:
       - checkout
       - install-dependencies
@@ -614,7 +613,7 @@ jobs:
   revenuecat-admob-tests:
     executor:
       name: macos-executor
-      xcode_version: "26.3"
+      xcode_version: "26.5"
     steps:
       - checkout
       - install-dependencies:
@@ -629,7 +628,7 @@ jobs:
           command: bundle exec fastlane test_revenuecat_admob
           no_output_timeout: 10m
           environment:
-            DEVICE: iPhone 17,OS=26.2
+            DEVICE: iPhone 17,OS=26.5
       - compress_result_bundle:
           directory: fastlane/test_output
           bundle_name: revenuecat_admob
@@ -807,7 +806,7 @@ jobs:
   record-and-upload-paywalls-v1-snapshots:
     executor:
       name: macos-executor
-      xcode_version: "26.3"
+      xcode_version: "26.5"
 
     steps:
       - checkout
@@ -819,7 +818,7 @@ jobs:
           command: bundle exec fastlane record_and_upload_v1_snapshots
           no_output_timeout: 15m
           environment:
-            DEVICE: iPhone 17,OS=26.2
+            DEVICE: iPhone 17,OS=26.5
       - store_test_results:
           path: fastlane/test_output/v1-snapshots/tests.xml
       - store_artifacts:
@@ -830,7 +829,7 @@ jobs:
   run-revenuecat-ui-ios-26:
     executor:
       name: macos-executor
-      xcode_version: "26.3"
+      xcode_version: "26.5"
 
     steps:
       - checkout
@@ -851,7 +850,7 @@ jobs:
           command: bundle exec fastlane test_revenuecatui
           no_output_timeout: 15m
           environment:
-            DEVICE: iPhone 17,OS=26.2
+            DEVICE: iPhone 17,OS=26.5
       - create-snapshot-pr-if-needed:
           condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
           job: "create_snapshot_pr"
@@ -947,7 +946,7 @@ jobs:
   run-test-ios-26:
     executor:
       name: macos-executor
-      xcode_version: "26.3"
+      xcode_version: "26.5"
 
     steps:
       - checkout
@@ -971,7 +970,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 17 (26.2)
+            SCAN_DEVICE: iPhone 17 (26.5)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: RevenueCat
@@ -1310,7 +1309,7 @@ jobs:
   run-all-maestro-e2e-tests:
     executor:
       name: macos-executor
-      xcode_version: "26.3"
+      xcode_version: "26.5"
     steps:
       - macos/preboot-simulator:
           version: "18.6"
@@ -1779,7 +1778,7 @@ jobs:
   deploy-purchase-tester:
     executor:
       name: macos-executor
-      xcode_version: "26.3"
+      xcode_version: "26.5"
     parameters:
       dry_run:
         type: boolean
@@ -1798,7 +1797,7 @@ jobs:
   deploy-rct-tester:
     executor:
       name: macos-executor
-      xcode_version: "26.3"
+      xcode_version: "26.5"
     parameters:
       dry_run:
         type: boolean
@@ -1876,7 +1875,6 @@ jobs:
     description: "Record new paywall template screenshots with Paparazzi and push them to the paywall-rendering-validation repository"
     executor:
       name: macos-executor
-      xcode_version: "16.4"
 
     steps:
       - checkout

--- a/.circleci/generate-requested-jobs-config.js
+++ b/.circleci/generate-requested-jobs-config.js
@@ -17,6 +17,7 @@ const JOBS = {
   "backend-integration-tests-custom-entitlements": ["slack-secrets"],
   "backend-integration-tests-offline": ["slack-secrets"],
   "backend-integration-tests-other": ["slack-secrets"],
+  "build-ios-265": ["slack-secrets"],
   "build-tv-watch-mac-and-visionos": ["slack-secrets"],
   "check-api-changes-revenuecat": ["slack-secrets-ios"],
   "check-api-changes-revenuecatui": ["slack-secrets-ios"],

--- a/Sources/Error Handling/SKError+Extensions.swift
+++ b/Sources/Error Handling/SKError+Extensions.swift
@@ -23,6 +23,11 @@ extension SKError: PurchasesErrorConvertible {
              .overlayTimeout,
              .overlayPresentedInBackgroundScene:
             return ErrorUtils.storeProblemError(error: self)
+        #if compiler(>=6.3.2)
+        // paymentMethodBindingConfigurationRequired introduced in Xcode 26.5
+        case .paymentMethodBindingConfigurationRequired:
+            return ErrorUtils.storeProblemError(error: self)
+        #endif
         case .clientInvalid,
              .paymentNotAllowed,
              .cloudServicePermissionDenied,
@@ -137,6 +142,11 @@ extension SKError.Code {
             return "unsupported_platform"
         case .overlayPresentedInBackgroundScene:
             return "overlay_presented_in_background_scene"
+        #if compiler(>=6.3.2)
+        // paymentMethodBindingConfigurationRequired introduced in Xcode 26.5
+        case .paymentMethodBindingConfigurationRequired:
+            return "payment_method_binding_configuration_required"
+        #endif
         @unknown default:
             return "unknown_store_kit_error"
         }

--- a/Sources/Error Handling/StoreKitError+Extensions.swift
+++ b/Sources/Error Handling/StoreKitError+Extensions.swift
@@ -103,6 +103,11 @@ extension Product.PurchaseError: PurchasesErrorConvertible {
                 .missingOfferParameters:
             return ErrorUtils.invalidPromotionalOfferError(error: self)
 
+        #if compiler(>=6.3.2)
+        case .paymentMethodBindingConfigurationRequired:
+            // paymentMethodBindingConfigurationRequired introduced in Xcode 26.5
+            return ErrorUtils.purchasesError(withStoreKitError: self)
+        #endif
         @unknown default:
             return ErrorUtils.unknownError(error: self)
         }
@@ -126,6 +131,11 @@ extension Product.PurchaseError: PurchasesErrorConvertible {
             return "invalid_offer_signature"
         case .missingOfferParameters:
             return "missing_offer_parameters"
+        #if compiler(>=6.3.2)
+        case .paymentMethodBindingConfigurationRequired:
+            // paymentMethodBindingConfigurationRequired introduced in Xcode 26.5
+            return "payment_method_binding_configuration_required"
+        #endif
         @unknown default:
             return "unknown_store_kit_error"
         }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -434,7 +434,7 @@ platform :ios do
   desc "Record V1 template snapshots and upload to Emerge"
   lane :record_and_upload_v1_snapshots do
     platform = ENV['PLATFORM'] || 'iOS Simulator'
-    destination = ENV['DEVICE'] || "iPhone 17,OS=26.2"
+    destination = ENV['DEVICE'] || "iPhone 17,OS=26.5"
     sdk = ENV['BUILD_SDK'] || 'iphonesimulator'
 
     begin

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -434,7 +434,7 @@ platform :ios do
   desc "Record V1 template snapshots and upload to Emerge"
   lane :record_and_upload_v1_snapshots do
     platform = ENV['PLATFORM'] || 'iOS Simulator'
-    destination = ENV['DEVICE'] || "iPhone 17,OS=26.4"
+    destination = ENV['DEVICE'] || "iPhone 17,OS=26.2"
     sdk = ENV['BUILD_SDK'] || 'iphonesimulator'
 
     begin
@@ -754,7 +754,7 @@ platform :ios do
 
     scan(
       step_name: "scan - watchOS",
-      device: ENV['SCAN_DEVICE'] || "Apple Watch Series 11 (42mm)",
+      device: ENV['SCAN_DEVICE'] || "Apple Watch Series 10 (46mm)",
       ensure_devices_found: true,
       scheme: "RevenueCat",
       prelaunch_simulator: true,
@@ -772,7 +772,7 @@ platform :ios do
   desc "Runs all RevenueCatAdMob tests (standalone SPM package under AdapterSDKs/RevenueCatAdMob)"
   lane :test_revenuecat_admob do
     platform = ENV['PLATFORM'] || 'iOS Simulator'
-    destination = ENV['DEVICE'] || "iPhone 17,OS=26.4"
+    destination = ENV['DEVICE'] || "iPhone 16,OS=18.5"
     sdk = ENV['BUILD_SDK'] || 'iphonesimulator'
 
     xcodebuild(
@@ -1755,7 +1755,7 @@ platform :ios do
     begin
       scan(
         project: "./Tests/v#{major}LoadShedderIntegration/v#{major}LoadShedderIntegration.xcodeproj",
-        device: ENV['SCAN_DEVICE'] || "iPhone 17 (26.4)",
+        device: ENV['SCAN_DEVICE'] || "iPhone 16 (18.5)",
         scheme: "v#{major}LoadShedderIntegration",
         ensure_devices_found: true,
         derived_data_path: "scan_derived_data",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -754,7 +754,7 @@ platform :ios do
 
     scan(
       step_name: "scan - watchOS",
-      device: ENV['SCAN_DEVICE'] || "Apple Watch Series 10 (46mm)",
+      device: ENV['SCAN_DEVICE'] || "Apple Watch Series 11 (42mm)",
       ensure_devices_found: true,
       scheme: "RevenueCat",
       prelaunch_simulator: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -434,7 +434,7 @@ platform :ios do
   desc "Record V1 template snapshots and upload to Emerge"
   lane :record_and_upload_v1_snapshots do
     platform = ENV['PLATFORM'] || 'iOS Simulator'
-    destination = ENV['DEVICE'] || "iPhone 17,OS=26.5"
+    destination = ENV['DEVICE'] || "iPhone 17,OS=26.4"
     sdk = ENV['BUILD_SDK'] || 'iphonesimulator'
 
     begin
@@ -772,7 +772,7 @@ platform :ios do
   desc "Runs all RevenueCatAdMob tests (standalone SPM package under AdapterSDKs/RevenueCatAdMob)"
   lane :test_revenuecat_admob do
     platform = ENV['PLATFORM'] || 'iOS Simulator'
-    destination = ENV['DEVICE'] || "iPhone 16,OS=18.5"
+    destination = ENV['DEVICE'] || "iPhone 17,OS=26.4"
     sdk = ENV['BUILD_SDK'] || 'iphonesimulator'
 
     xcodebuild(
@@ -1755,7 +1755,7 @@ platform :ios do
     begin
       scan(
         project: "./Tests/v#{major}LoadShedderIntegration/v#{major}LoadShedderIntegration.xcodeproj",
-        device: ENV['SCAN_DEVICE'] || "iPhone 16 (18.5)",
+        device: ENV['SCAN_DEVICE'] || "iPhone 17 (26.4)",
         scheme: "v#{major}LoadShedderIntegration",
         ensure_devices_found: true,
         derived_data_path: "scan_derived_data",


### PR DESCRIPTION
## Motivation
We're working on supporting monthly subscriptions with a 12-mo commitment. The StoreKit APIs required to use this API were introduced in the Xcode 26.5 betas, so to build/test code that uses these features, we need to upgrade our CI pipelines to use a variation of Xcode 26.5. This PR updates the CI pipelines to use Xcode 26.5. For now, CircleCI points this to Xcode 26.5 RC1, but when Xcode 26.5 is released for real, it should update to point towards the production release.

## Summary
- Switched the shared CircleCI macOS executor defaults to Xcode 26.5.
- Switched the modern CI jobs to use an iPhone 17 running iOS 26.4. (Billing plan APIs are available on iOS 26.4+, even though it requires Xcode 26.5+)
- Updated Xcode 26-era jobs and swiftinterface generation to use Xcode 26.5, including simulator destinations that were pinned to 26.2.
- Left the explicit older OS compatibility jobs on their existing Xcode versions.
- Introduce handling for `StoreKitError.paymentMethodBindingConfigurationRequired` so the `pod-lib-lint` will pass
