### PR TITLE
Auto-invalidate VC cache for verified rewards

### DIFF
--- a/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/README.md
+++ b/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/README.md
@@ -139,6 +139,7 @@ For reward verification flows, the sample explicitly calls `enableRewardVerifica
 - grant virtual currency when `verifiedReward.virtualCurrency` is present
 - handle the `noReward` verified case separately
 - use a safe fallback for unknown verified reward shapes
+- rely on adapter-managed cache invalidation for verified virtual currency rewards (then refetch balances when needed)
 
 > **Important:** Do not reassign wrapped delegates/handlers after calling `loadAndTrack`.
 > For full-screen ads, pass your `fullScreenContentDelegate` through `loadAndTrack`.

--- a/AdapterSDKs/RevenueCatAdMob/README.md
+++ b/AdapterSDKs/RevenueCatAdMob/README.md
@@ -204,6 +204,10 @@ rewardedAd?.present(
 )
 ```
 
+When `rewardVerificationResult` returns `.verified(.virtualCurrency(...))`, the adapter automatically calls
+`Purchases.shared.invalidateVirtualCurrenciesCache()` (if Purchases is configured) before delivering the callback.
+You only need to refetch balances (`getVirtualCurrencies` / `virtualCurrencies()`) when your UI needs fresh values.
+
 ### Rewarded interstitial ads
 
 **AdMob only** ([docs](https://developers.google.com/admob/ios/rewarded-interstitial)):
@@ -280,6 +284,9 @@ rewardedInterstitialAd?.present(
     }
 )
 ```
+
+As with rewarded ads, `.verified(.virtualCurrency(...))` automatically invalidates RevenueCat's virtual-currency cache
+before your result callback executes.
 
 ### Native ads
 

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Logging/Strings/RewardVerificationStrings.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Logging/Strings/RewardVerificationStrings.swift
@@ -13,6 +13,7 @@ import Foundation
 enum RewardVerificationStrings {
 
     case setup_purchases_not_configured
+    case side_effect_purchases_not_configured
     case setup_install(adType: String, transactionID: String)
     case setup_custom_reward_text_encoding_failed(error: Error)
 
@@ -39,6 +40,8 @@ extension RewardVerificationStrings: LogMessage {
         switch self {
         case .setup_purchases_not_configured:
             return "RevenueCat SDK is not configured. Cannot install reward verification on rewarded ad."
+        case .side_effect_purchases_not_configured:
+            return "RevenueCat SDK is not configured. Cannot invalidate virtual currencies cache."
         case let .setup_install(adType, transactionID):
             return "Reward verification install on ad type=\(adType) transactionID=\(transactionID)"
         case let .setup_custom_reward_text_encoding_failed(error):

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardVerification.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardVerification.swift
@@ -17,9 +17,8 @@ internal enum RewardVerification {
     enum SideEffects {
 
         /// Invalidates virtual-currency cache if the SDK is configured.
-        ///
-        /// This is test-injected in `RevenueCatAdMobTests` and should remain simple.
-        static var invalidateVirtualCurrenciesCache: () -> Void = {
+        @MainActor
+        static func invalidateVirtualCurrenciesCacheIfConfigured() {
             guard Purchases.isConfigured else { return }
             Purchases.shared.invalidateVirtualCurrenciesCache()
         }

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardVerification.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardVerification.swift
@@ -19,7 +19,10 @@ internal enum RewardVerification {
         /// Invalidates virtual-currency cache if the SDK is configured.
         @MainActor
         static func invalidateVirtualCurrenciesCacheIfConfigured() {
-            guard Purchases.isConfigured else { return }
+            guard Purchases.isConfigured else {
+                Logger.warn(RewardVerificationStrings.side_effect_purchases_not_configured)
+                return
+            }
             Purchases.shared.invalidateVirtualCurrenciesCache()
         }
     }

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardVerification.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardVerification.swift
@@ -7,9 +7,23 @@
 import Foundation
 
 #if os(iOS) && canImport(GoogleMobileAds)
+@_spi(Internal) import RevenueCat
 
 /// Namespace for the AdMob adapter's reward-verification (SSV) subsystem.
 @available(iOS 15.0, *)
-internal enum RewardVerification {}
+internal enum RewardVerification {
+
+    /// Shared side effects triggered by reward-verification outcomes.
+    enum SideEffects {
+
+        /// Invalidates virtual-currency cache if the SDK is configured.
+        ///
+        /// This is test-injected in `RevenueCatAdMobTests` and should remain simple.
+        static var invalidateVirtualCurrenciesCache: @MainActor () -> Void = {
+            guard Purchases.isConfigured else { return }
+            Purchases.shared.invalidateVirtualCurrenciesCache()
+        }
+    }
+}
 
 #endif

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardVerification.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardVerification.swift
@@ -19,7 +19,7 @@ internal enum RewardVerification {
         /// Invalidates virtual-currency cache if the SDK is configured.
         ///
         /// This is test-injected in `RevenueCatAdMobTests` and should remain simple.
-        static var invalidateVirtualCurrenciesCache: @MainActor () -> Void = {
+        static var invalidateVirtualCurrenciesCache: () -> Void = {
             guard Purchases.isConfigured else { return }
             Purchases.shared.invalidateVirtualCurrenciesCache()
         }

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
@@ -193,6 +193,9 @@ internal extension RewardVerification.CapableAd {
                 state: state,
                 poller: resolvedPoller,
                 outcomeHandler: { internalOutcome in
+                    if case .verified(.virtualCurrency) = internalOutcome {
+                        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache()
+                    }
                     rewardVerificationResult(RewardVerification.mapOutcome(internalOutcome))
                 }
             )
@@ -218,9 +221,6 @@ internal extension RewardVerification {
     static func mapOutcome(_ outcome: Outcome) -> RewardVerificationResult {
         switch outcome {
         case .verified(let reward):
-            if case .virtualCurrency = reward {
-                Self.SideEffects.invalidateVirtualCurrenciesCache()
-            }
             return .verified(self.mapVerifiedReward(reward))
         case .failed:
             return .failed

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
@@ -167,7 +167,7 @@ internal extension RewardVerification.CapableAd {
     func createUserDidEarnRewardHandler(
         rewardVerificationStarted: (@MainActor () -> Void)?,
         rewardVerificationResult: (@MainActor (RewardVerificationResult) -> Void)?,
-        poller: RewardVerification.Poller? = nil
+        poller: RewardVerification.Poller? = nil,
         invalidateVirtualCurrenciesCache: @escaping @MainActor () -> Void
             = RewardVerification.SideEffects.invalidateVirtualCurrenciesCacheIfConfigured
     ) -> (() -> Void) {

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
@@ -30,6 +30,8 @@ import GoogleMobileAds
     /// Callback timing:
     /// - `rewardVerificationStarted` runs when the AdMob SDK invokes the reward callback and verification begins.
     /// - `rewardVerificationResult` runs later with the final verification outcome.
+    ///   When verification returns `.verified(.virtualCurrency(...))`, this API automatically invalidates
+    ///   RevenueCat virtual currencies cache before delivering the callback.
     ///
     /// To override the placement used for RevenueCat analytics at show time, use
     /// ``present(from:placement:rewardVerificationStarted:rewardVerificationResult:)`` instead of this method.
@@ -60,6 +62,8 @@ import GoogleMobileAds
     /// Callback timing:
     /// - `rewardVerificationStarted` runs when the AdMob SDK invokes the reward callback and verification begins.
     /// - `rewardVerificationResult` runs later with the final verification outcome.
+    ///   When verification returns `.verified(.virtualCurrency(...))`, this API automatically invalidates
+    ///   RevenueCat virtual currencies cache before delivering the callback.
     @MainActor
     func present(
         from viewController: UIViewController,
@@ -99,6 +103,8 @@ import GoogleMobileAds
     /// Callback timing:
     /// - `rewardVerificationStarted` runs when the AdMob SDK invokes the reward callback and verification begins.
     /// - `rewardVerificationResult` runs later with the final verification outcome.
+    ///   When verification returns `.verified(.virtualCurrency(...))`, this API automatically invalidates
+    ///   RevenueCat virtual currencies cache before delivering the callback.
     ///
     /// To override the placement used for RevenueCat analytics at show time, use
     /// ``present(from:placement:rewardVerificationStarted:rewardVerificationResult:)`` instead of this method.
@@ -129,6 +135,8 @@ import GoogleMobileAds
     /// Callback timing:
     /// - `rewardVerificationStarted` runs when the AdMob SDK invokes the reward callback and verification begins.
     /// - `rewardVerificationResult` runs later with the final verification outcome.
+    ///   When verification returns `.verified(.virtualCurrency(...))`, this API automatically invalidates
+    ///   RevenueCat virtual currencies cache before delivering the callback.
     @MainActor
     func present(
         from viewController: UIViewController,
@@ -210,6 +218,9 @@ internal extension RewardVerification {
     static func mapOutcome(_ outcome: Outcome) -> RewardVerificationResult {
         switch outcome {
         case .verified(let reward):
+            if case .virtualCurrency = reward {
+                Self.SideEffects.invalidateVirtualCurrenciesCache()
+            }
             return .verified(self.mapVerifiedReward(reward))
         case .failed:
             return .failed

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
@@ -166,12 +166,14 @@ internal extension RewardVerification.CapableAd {
     @MainActor
     func createUserDidEarnRewardHandler(
         rewardVerificationStarted: (@MainActor () -> Void)?,
-        rewardVerificationResult: @escaping @MainActor (RewardVerificationResult) -> Void,
+        rewardVerificationResult: (@MainActor (RewardVerificationResult) -> Void)?,
         poller: RewardVerification.Poller? = nil
+        invalidateVirtualCurrenciesCache: @escaping @MainActor () -> Void
+            = RewardVerification.SideEffects.invalidateVirtualCurrenciesCacheIfConfigured
     ) -> (() -> Void) {
         let state = RewardVerification.Setup.verificationState(for: self)
 
-        if state == nil {
+        if rewardVerificationResult != nil, state == nil {
             Logger.warn(RewardVerificationStrings.result_callback_missing_verification_state)
             assert(
                 state != nil,
@@ -181,6 +183,10 @@ internal extension RewardVerification.CapableAd {
 
         return {
             rewardVerificationStarted?()
+
+            guard let rewardVerificationResult else {
+                return
+            }
 
             guard let state else {
                 rewardVerificationResult(.failed)
@@ -194,7 +200,7 @@ internal extension RewardVerification.CapableAd {
                 poller: resolvedPoller,
                 outcomeHandler: { internalOutcome in
                     if case .verified(.virtualCurrency) = internalOutcome {
-                        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache()
+                        invalidateVirtualCurrenciesCache()
                     }
                     rewardVerificationResult(RewardVerification.mapOutcome(internalOutcome))
                 }

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentMappingTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentMappingTests.swift
@@ -35,64 +35,32 @@ final class PresentMappingTests: AdapterTestCase {
 
     func testMapOutcomeVerified() {
         let reward = RevenueCat.VerifiedReward.virtualCurrency(VirtualCurrencyReward(code: "c", amount: 2))
-        var sideEffectCallCount = 0
-        let originalInvalidation = RewardVerification.SideEffects.invalidateVirtualCurrenciesCache
-        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
-            sideEffectCallCount += 1
-        }
-        defer { RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = originalInvalidation }
-
         let result = RewardVerification.mapOutcome(.verified(reward))
 
-        XCTAssertEqual(sideEffectCallCount, 1)
         XCTAssertNotNil(result.verifiedReward)
         XCTAssertEqual(result.verifiedReward?.virtualCurrency?.code, "c")
         XCTAssertEqual(result.verifiedReward?.virtualCurrency?.amount, 2)
     }
 
     func testMapOutcomeFailed() {
-        var sideEffectCallCount = 0
-        let originalInvalidation = RewardVerification.SideEffects.invalidateVirtualCurrenciesCache
-        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
-            sideEffectCallCount += 1
-        }
-        defer { RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = originalInvalidation }
-
         let result = RewardVerification.mapOutcome(.failed)
 
         XCTAssertTrue(result.isFailed)
         XCTAssertNil(result.verifiedReward)
-        XCTAssertEqual(sideEffectCallCount, 0)
     }
 
-    func testMapOutcomeVerifiedNoRewardDoesNotInvalidateVirtualCurrenciesCache() {
-        var sideEffectCallCount = 0
-        let originalInvalidation = RewardVerification.SideEffects.invalidateVirtualCurrenciesCache
-        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
-            sideEffectCallCount += 1
-        }
-        defer { RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = originalInvalidation }
-
+    func testMapOutcomeVerifiedNoReward() {
         let result = RewardVerification.mapOutcome(.verified(.noReward))
 
         XCTAssertNotNil(result.verifiedReward)
         XCTAssertEqual(result.verifiedReward, .noReward)
-        XCTAssertEqual(sideEffectCallCount, 0)
     }
 
-    func testMapOutcomeVerifiedUnsupportedRewardDoesNotInvalidateVirtualCurrenciesCache() {
-        var sideEffectCallCount = 0
-        let originalInvalidation = RewardVerification.SideEffects.invalidateVirtualCurrenciesCache
-        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
-            sideEffectCallCount += 1
-        }
-        defer { RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = originalInvalidation }
-
+    func testMapOutcomeVerifiedUnsupportedReward() {
         let result = RewardVerification.mapOutcome(.verified(.unsupportedReward))
 
         XCTAssertNotNil(result.verifiedReward)
         XCTAssertEqual(result.verifiedReward, .unsupportedReward)
-        XCTAssertEqual(sideEffectCallCount, 0)
     }
 }
 

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentMappingTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentMappingTests.swift
@@ -36,7 +36,6 @@ final class PresentMappingTests: AdapterTestCase {
     func testMapOutcomeVerified() {
         let reward = RevenueCat.VerifiedReward.virtualCurrency(VirtualCurrencyReward(code: "c", amount: 2))
         let result = RewardVerification.mapOutcome(.verified(reward))
-
         XCTAssertNotNil(result.verifiedReward)
         XCTAssertEqual(result.verifiedReward?.virtualCurrency?.code, "c")
         XCTAssertEqual(result.verifiedReward?.virtualCurrency?.amount, 2)
@@ -44,23 +43,8 @@ final class PresentMappingTests: AdapterTestCase {
 
     func testMapOutcomeFailed() {
         let result = RewardVerification.mapOutcome(.failed)
-
         XCTAssertTrue(result.isFailed)
         XCTAssertNil(result.verifiedReward)
-    }
-
-    func testMapOutcomeVerifiedNoReward() {
-        let result = RewardVerification.mapOutcome(.verified(.noReward))
-
-        XCTAssertNotNil(result.verifiedReward)
-        XCTAssertEqual(result.verifiedReward, .noReward)
-    }
-
-    func testMapOutcomeVerifiedUnsupportedReward() {
-        let result = RewardVerification.mapOutcome(.verified(.unsupportedReward))
-
-        XCTAssertNotNil(result.verifiedReward)
-        XCTAssertEqual(result.verifiedReward, .unsupportedReward)
     }
 }
 

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentMappingTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentMappingTests.swift
@@ -35,16 +35,64 @@ final class PresentMappingTests: AdapterTestCase {
 
     func testMapOutcomeVerified() {
         let reward = RevenueCat.VerifiedReward.virtualCurrency(VirtualCurrencyReward(code: "c", amount: 2))
+        var sideEffectCallCount = 0
+        let originalInvalidation = RewardVerification.SideEffects.invalidateVirtualCurrenciesCache
+        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
+            sideEffectCallCount += 1
+        }
+        defer { RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = originalInvalidation }
+
         let result = RewardVerification.mapOutcome(.verified(reward))
+
+        XCTAssertEqual(sideEffectCallCount, 1)
         XCTAssertNotNil(result.verifiedReward)
         XCTAssertEqual(result.verifiedReward?.virtualCurrency?.code, "c")
         XCTAssertEqual(result.verifiedReward?.virtualCurrency?.amount, 2)
     }
 
     func testMapOutcomeFailed() {
+        var sideEffectCallCount = 0
+        let originalInvalidation = RewardVerification.SideEffects.invalidateVirtualCurrenciesCache
+        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
+            sideEffectCallCount += 1
+        }
+        defer { RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = originalInvalidation }
+
         let result = RewardVerification.mapOutcome(.failed)
+
         XCTAssertTrue(result.isFailed)
         XCTAssertNil(result.verifiedReward)
+        XCTAssertEqual(sideEffectCallCount, 0)
+    }
+
+    func testMapOutcomeVerifiedNoRewardDoesNotInvalidateVirtualCurrenciesCache() {
+        var sideEffectCallCount = 0
+        let originalInvalidation = RewardVerification.SideEffects.invalidateVirtualCurrenciesCache
+        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
+            sideEffectCallCount += 1
+        }
+        defer { RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = originalInvalidation }
+
+        let result = RewardVerification.mapOutcome(.verified(.noReward))
+
+        XCTAssertNotNil(result.verifiedReward)
+        XCTAssertEqual(result.verifiedReward, .noReward)
+        XCTAssertEqual(sideEffectCallCount, 0)
+    }
+
+    func testMapOutcomeVerifiedUnsupportedRewardDoesNotInvalidateVirtualCurrenciesCache() {
+        var sideEffectCallCount = 0
+        let originalInvalidation = RewardVerification.SideEffects.invalidateVirtualCurrenciesCache
+        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
+            sideEffectCallCount += 1
+        }
+        defer { RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = originalInvalidation }
+
+        let result = RewardVerification.mapOutcome(.verified(.unsupportedReward))
+
+        XCTAssertNotNil(result.verifiedReward)
+        XCTAssertEqual(result.verifiedReward, .unsupportedReward)
+        XCTAssertEqual(sideEffectCallCount, 0)
     }
 }
 

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
@@ -13,6 +13,25 @@ final class PresentRewardVerificationTests: AdapterTestCase {
     private static let testAPIKey = "appl_test_present_public_api"
     private static let testAppUserID = "user_present_public_api"
 
+    override func tearDown() {
+        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
+            guard Purchases.isConfigured else { return }
+            Purchases.shared.invalidateVirtualCurrenciesCache()
+        }
+        super.tearDown()
+    }
+
+    func testPresentWithoutVerificationStateInvokesOnlyStartedWhenOutcomeNil() {
+        let fakeAd = FakeCapableAd()
+        var startedCount = 0
+        let handler = fakeAd.createUserDidEarnRewardHandler(
+            rewardVerificationStarted: { startedCount += 1 },
+            rewardVerificationResult: nil
+        )
+
+        handler()
+        XCTAssertEqual(startedCount, 1)
+    }
     func testPresentWithStateAndOutcomeDeliversVerifiedOutcome() throws {
         let fakeAd = FakeCapableAd()
         RewardVerification.Setup.install(on: fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
@@ -112,6 +131,131 @@ final class PresentRewardVerificationTests: AdapterTestCase {
                 rewardVerificationResult: { _ in }
             )
         }.to(throwAssertion())
+    }
+
+    func testPresentWithVerifiedVirtualCurrencyInvalidatesVirtualCurrenciesCache() {
+        let fakeAd = FakeCapableAd()
+        RewardVerification.Setup.install(on: fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
+
+        let reward = VirtualCurrencyReward(code: "coins", amount: 4)
+        let poller = RewardVerification.Poller(
+            statusPoller: StubStatusPoller(statuses: [.verified(.virtualCurrency(reward))]),
+            sleeper: RecordingSleeper(),
+            jitter: RewardVerification.Jitter { 0 },
+            maxAttempts: 5
+        )
+
+        var invalidationCallCount = 0
+        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
+            invalidationCallCount += 1
+        }
+
+        let expectation = self.expectation(description: "verification callback")
+        let handler = fakeAd.createUserDidEarnRewardHandler(
+            rewardVerificationStarted: nil,
+            rewardVerificationResult: { _ in
+                expectation.fulfill()
+            },
+            poller: poller
+        )
+
+        handler()
+        self.wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(invalidationCallCount, 1)
+    }
+
+    func testPresentWithNoRewardDoesNotInvalidateVirtualCurrenciesCache() {
+        let fakeAd = FakeCapableAd()
+        RewardVerification.Setup.install(on: fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
+
+        let poller = RewardVerification.Poller(
+            statusPoller: StubStatusPoller(statuses: [.verified(.noReward)]),
+            sleeper: RecordingSleeper(),
+            jitter: RewardVerification.Jitter { 0 },
+            maxAttempts: 5
+        )
+
+        var invalidationCallCount = 0
+        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
+            invalidationCallCount += 1
+        }
+
+        let expectation = self.expectation(description: "verification callback")
+        let handler = fakeAd.createUserDidEarnRewardHandler(
+            rewardVerificationStarted: nil,
+            rewardVerificationResult: { _ in
+                expectation.fulfill()
+            },
+            poller: poller
+        )
+
+        handler()
+        self.wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(invalidationCallCount, 0)
+    }
+
+    func testPresentWithUnsupportedRewardDoesNotInvalidateVirtualCurrenciesCache() {
+        let fakeAd = FakeCapableAd()
+        RewardVerification.Setup.install(on: fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
+
+        let poller = RewardVerification.Poller(
+            statusPoller: StubStatusPoller(statuses: [.verified(.unsupportedReward)]),
+            sleeper: RecordingSleeper(),
+            jitter: RewardVerification.Jitter { 0 },
+            maxAttempts: 5
+        )
+
+        var invalidationCallCount = 0
+        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
+            invalidationCallCount += 1
+        }
+
+        let expectation = self.expectation(description: "verification callback")
+        let handler = fakeAd.createUserDidEarnRewardHandler(
+            rewardVerificationStarted: nil,
+            rewardVerificationResult: { _ in
+                expectation.fulfill()
+            },
+            poller: poller
+        )
+
+        handler()
+        self.wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(invalidationCallCount, 0)
+    }
+
+    func testPresentWithFailedOutcomeDoesNotInvalidateVirtualCurrenciesCache() {
+        let fakeAd = FakeCapableAd()
+        RewardVerification.Setup.install(on: fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
+
+        let poller = RewardVerification.Poller(
+            statusPoller: StubStatusPoller(statuses: [.failed]),
+            sleeper: RecordingSleeper(),
+            jitter: RewardVerification.Jitter { 0 },
+            maxAttempts: 5
+        )
+
+        var invalidationCallCount = 0
+        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
+            invalidationCallCount += 1
+        }
+
+        let expectation = self.expectation(description: "verification callback")
+        let handler = fakeAd.createUserDidEarnRewardHandler(
+            rewardVerificationStarted: nil,
+            rewardVerificationResult: { _ in
+                expectation.fulfill()
+            },
+            poller: poller
+        )
+
+        handler()
+        self.wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(invalidationCallCount, 0)
     }
 }
 

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
@@ -13,15 +13,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
     private static let testAPIKey = "appl_test_present_public_api"
     private static let testAppUserID = "user_present_public_api"
 
-    override func tearDown() {
-        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
-            guard Purchases.isConfigured else { return }
-            Purchases.shared.invalidateVirtualCurrenciesCache()
-        }
-        super.tearDown()
-    }
-
-    func testPresentWithoutVerificationStateInvokesOnlyStartedWhenOutcomeNil() {
+    func testCreateUserDidEarnRewardHandlerWithoutVerificationStateInvokesOnlyStartedWhenOutcomeNil() {
         let fakeAd = FakeCapableAd()
         var startedCount = 0
         let handler = fakeAd.createUserDidEarnRewardHandler(
@@ -32,7 +24,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
         handler()
         XCTAssertEqual(startedCount, 1)
     }
-    func testPresentWithStateAndOutcomeDeliversVerifiedOutcome() throws {
+    func testCreateUserDidEarnRewardHandlerWithStateDeliversVerifiedOutcome() throws {
         let fakeAd = FakeCapableAd()
         RewardVerification.Setup.install(on: fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
 
@@ -64,7 +56,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
         XCTAssertEqual(result.verifiedReward?.virtualCurrency?.amount, 4)
     }
 
-    func testPresentWithStateAndOutcomeDeliversFailedWhenPollerFails() throws {
+    func testCreateUserDidEarnRewardHandlerWithStateDeliversFailedWhenPollerFails() throws {
         let fakeAd = FakeCapableAd()
         RewardVerification.Setup.install(on: fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
 
@@ -93,7 +85,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
         XCTAssertTrue(result.isFailed)
     }
 
-    func testPresentWithStateInvokesStartedBeforeResult() {
+    func testCreateUserDidEarnRewardHandlerWithStateInvokesStartedBeforeResult() {
         let fakeAd = FakeCapableAd()
         RewardVerification.Setup.install(on: fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
 
@@ -133,7 +125,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
         }.to(throwAssertion())
     }
 
-    func testPresentWithVerifiedVirtualCurrencyInvalidatesVirtualCurrenciesCache() {
+    func testCreateUserDidEarnRewardHandlerWithVerifiedVirtualCurrencyInvalidatesVirtualCurrenciesCache() {
         let fakeAd = FakeCapableAd()
         RewardVerification.Setup.install(on: fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
 
@@ -146,7 +138,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
         )
 
         var invalidationCallCount = 0
-        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
+        let invalidateVirtualCurrenciesCache = {
             invalidationCallCount += 1
         }
 
@@ -156,7 +148,8 @@ final class PresentRewardVerificationTests: AdapterTestCase {
             rewardVerificationResult: { _ in
                 expectation.fulfill()
             },
-            poller: poller
+            poller: poller,
+            invalidateVirtualCurrenciesCache: invalidateVirtualCurrenciesCache
         )
 
         handler()
@@ -165,7 +158,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
         XCTAssertEqual(invalidationCallCount, 1)
     }
 
-    func testPresentWithNoRewardDoesNotInvalidateVirtualCurrenciesCache() {
+    func testCreateUserDidEarnRewardHandlerWithNoRewardDoesNotInvalidateVirtualCurrenciesCache() {
         let fakeAd = FakeCapableAd()
         RewardVerification.Setup.install(on: fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
 
@@ -177,7 +170,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
         )
 
         var invalidationCallCount = 0
-        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
+        let invalidateVirtualCurrenciesCache = {
             invalidationCallCount += 1
         }
 
@@ -187,7 +180,8 @@ final class PresentRewardVerificationTests: AdapterTestCase {
             rewardVerificationResult: { _ in
                 expectation.fulfill()
             },
-            poller: poller
+            poller: poller,
+            invalidateVirtualCurrenciesCache: invalidateVirtualCurrenciesCache
         )
 
         handler()
@@ -196,7 +190,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
         XCTAssertEqual(invalidationCallCount, 0)
     }
 
-    func testPresentWithUnsupportedRewardDoesNotInvalidateVirtualCurrenciesCache() {
+    func testCreateUserDidEarnRewardHandlerWithUnsupportedRewardDoesNotInvalidateVirtualCurrenciesCache() {
         let fakeAd = FakeCapableAd()
         RewardVerification.Setup.install(on: fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
 
@@ -208,7 +202,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
         )
 
         var invalidationCallCount = 0
-        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
+        let invalidateVirtualCurrenciesCache = {
             invalidationCallCount += 1
         }
 
@@ -218,7 +212,8 @@ final class PresentRewardVerificationTests: AdapterTestCase {
             rewardVerificationResult: { _ in
                 expectation.fulfill()
             },
-            poller: poller
+            poller: poller,
+            invalidateVirtualCurrenciesCache: invalidateVirtualCurrenciesCache
         )
 
         handler()
@@ -227,7 +222,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
         XCTAssertEqual(invalidationCallCount, 0)
     }
 
-    func testPresentWithFailedOutcomeDoesNotInvalidateVirtualCurrenciesCache() {
+    func testCreateUserDidEarnRewardHandlerWithFailedOutcomeDoesNotInvalidateVirtualCurrenciesCache() {
         let fakeAd = FakeCapableAd()
         RewardVerification.Setup.install(on: fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
 
@@ -239,7 +234,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
         )
 
         var invalidationCallCount = 0
-        RewardVerification.SideEffects.invalidateVirtualCurrenciesCache = {
+        let invalidateVirtualCurrenciesCache = {
             invalidationCallCount += 1
         }
 
@@ -249,7 +244,8 @@ final class PresentRewardVerificationTests: AdapterTestCase {
             rewardVerificationResult: { _ in
                 expectation.fulfill()
             },
-            poller: poller
+            poller: poller,
+            invalidateVirtualCurrenciesCache: invalidateVirtualCurrenciesCache
         )
 
         handler()


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
When reward verification returns a verified virtual-currency payload in the AdMob adapter, integrators currently need to remember to manually invalidate RevenueCat virtual currencies cache before fetching an updated balance. This is easy to miss and leads to stale balance reads.

### Description
- Automatically invalidate virtual currencies cache when reward verification yields `.verified(.virtualCurrency(...))`.
- Keep behavior scoped: do not invalidate for `.verified(.noReward)`, `.verified(.unsupportedReward)`, or `.failed`.
- Keep `mapOutcome` side-effect free and perform invalidation in the main-actor callback dispatch path before delivering `rewardVerificationResult`.
- Add callback-path tests in `PresentRewardVerificationTests` to verify invalidation behavior for each outcome type.
- Keep mapping tests in `PresentMappingTests` focused on pure mapping behavior.
- Update adapter docs and sample README to clarify cache invalidation is automatic for verified virtual-currency rewards, while balance refetching remains app-driven.

### Testing
- `swiftlint lint AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardVerification.swift AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentMappingTests.swift AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift`
- `xcodebuild test -scheme "RevenueCatAdMob" -destination "platform=iOS Simulator,OS=18.4,name=iPhone 16"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new automatic side effect (invalidating RevenueCat virtual-currency cache) on the reward-verification success path, which can affect integrators’ balance-refresh behavior and requires Purchases configuration checks.
> 
> **Overview**
> Automatically invalidates RevenueCat’s virtual-currency cache when reward verification completes with `.verified(.virtualCurrency(...))`, doing the side effect on the main-actor callback path before invoking `rewardVerificationResult` (and warning if `Purchases` isn’t configured).
> 
> Updates the reward-verification handler API to support optional result callbacks and injectible invalidation for testing, and expands unit coverage to assert invalidation happens *only* for verified virtual-currency outcomes.
> 
> Documentation in the adapter README and integration sample is updated to clarify that cache invalidation is adapter-managed and apps only need to refetch balances when they need fresh UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ac5565a54499741353de12293cb3c9ecdcee46d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->