### PR TITLE
[Billing Plans]: Introduce Xcode 26.5 build job + handle StoreKitError.paymentMethodBindingConfigurationRequired

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -986,6 +986,31 @@ jobs:
           destination: scan-test-output-ios-26
       - slack-notify-on-fail
 
+  build-ios-265:
+    executor:
+      name: macos-executor
+      xcode_version: "26.5"
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Build RevenueCat with Xcode 26.5
+          command: xcodebuild -workspace RevenueCat.xcworkspace -scheme RevenueCat -destination "generic/platform=iOS" -sdk iphoneos -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES build
+          no_output_timeout: 30m
+      - run:
+          name: Build RevenueCat_CustomEntitlementComputation with Xcode 26.5
+          command: xcodebuild -workspace RevenueCat.xcworkspace -scheme RevenueCat_CustomEntitlementComputation -destination "generic/platform=iOS" -sdk iphoneos -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES build
+          no_output_timeout: 30m
+      - run:
+          name: Build ReceiptParser with Xcode 26.5
+          command: xcodebuild -workspace RevenueCat.xcworkspace -scheme "ReceiptParser (RevenueCat Workspace)" -destination "generic/platform=iOS" -sdk iphoneos -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES build
+          no_output_timeout: 30m
+      - run:
+          name: Build RevenueCatUI with Xcode 26.5
+          command: xcodebuild -workspace RevenueCat.xcworkspace -scheme RevenueCatUI -destination "generic/platform=iOS" -sdk iphoneos -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES build
+          no_output_timeout: 30m
+      - slack-notify-on-fail
+
   run-test-ios-18-and-17:
     executor:
       name: macos-executor
@@ -2168,6 +2193,9 @@ workflows:
       - run-test-ios-26:
           context:
             - slack-secrets
+      - build-ios-265:
+          context:
+            - slack-secrets
       - pod-lib-lint:
           context:
             - slack-secrets
@@ -2333,6 +2361,7 @@ workflows:
             - check-api-changes-revenuecat
             - check-api-changes-revenuecatui
             - run-test-ios-26
+            - build-ios-265
             - pod-lib-lint
             - run-revenuecat-ui-ios-26
             - emerge_purchases_ui_snapshot_tests
@@ -2629,6 +2658,9 @@ workflows:
       - run-test-ios-26:
           context:
             - slack-secrets
+      - build-ios-265:
+          context:
+            - slack-secrets
       - pod-lib-lint:
           context:
             - slack-secrets
@@ -2649,6 +2681,7 @@ workflows:
             - run-all-maestro-e2e-tests
             - lint
             - run-test-ios-26
+            - build-ios-265
             - pod-lib-lint
             - run-revenuecat-ui-ios-26
             - emerge_purchases_ui_snapshot_tests

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -986,7 +986,7 @@ jobs:
           destination: scan-test-output-ios-26
       - slack-notify-on-fail
 
-  build-ios-265:
+  build-xcode-26.5:
     executor:
       name: macos-executor
       xcode_version: "26.5"
@@ -2193,7 +2193,7 @@ workflows:
       - run-test-ios-26:
           context:
             - slack-secrets
-      - build-ios-265:
+      - build-xcode-26.5:
           context:
             - slack-secrets
       - pod-lib-lint:
@@ -2361,7 +2361,7 @@ workflows:
             - check-api-changes-revenuecat
             - check-api-changes-revenuecatui
             - run-test-ios-26
-            - build-ios-265
+            - build-xcode-26.5
             - pod-lib-lint
             - run-revenuecat-ui-ios-26
             - emerge_purchases_ui_snapshot_tests
@@ -2658,7 +2658,7 @@ workflows:
       - run-test-ios-26:
           context:
             - slack-secrets
-      - build-ios-265:
+      - build-xcode-26.5:
           context:
             - slack-secrets
       - pod-lib-lint:
@@ -2681,7 +2681,7 @@ workflows:
             - run-all-maestro-e2e-tests
             - lint
             - run-test-ios-26
-            - build-ios-265
+            - build-xcode-26.5
             - pod-lib-lint
             - run-revenuecat-ui-ios-26
             - emerge_purchases_ui_snapshot_tests

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -986,7 +986,7 @@ jobs:
           destination: scan-test-output-ios-26
       - slack-notify-on-fail
 
-  build-xcode-26.5:
+  build-xcode-265:
     executor:
       name: macos-executor
       xcode_version: "26.5"
@@ -2193,7 +2193,7 @@ workflows:
       - run-test-ios-26:
           context:
             - slack-secrets
-      - build-xcode-26.5:
+      - build-xcode-265:
           context:
             - slack-secrets
       - pod-lib-lint:
@@ -2361,7 +2361,7 @@ workflows:
             - check-api-changes-revenuecat
             - check-api-changes-revenuecatui
             - run-test-ios-26
-            - build-xcode-26.5
+            - build-xcode-265
             - pod-lib-lint
             - run-revenuecat-ui-ios-26
             - emerge_purchases_ui_snapshot_tests
@@ -2658,7 +2658,7 @@ workflows:
       - run-test-ios-26:
           context:
             - slack-secrets
-      - build-xcode-26.5:
+      - build-xcode-265:
           context:
             - slack-secrets
       - pod-lib-lint:
@@ -2681,7 +2681,7 @@ workflows:
             - run-all-maestro-e2e-tests
             - lint
             - run-test-ios-26
-            - build-xcode-26.5
+            - build-xcode-265
             - pod-lib-lint
             - run-revenuecat-ui-ios-26
             - emerge_purchases_ui_snapshot_tests

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -986,6 +986,11 @@ jobs:
           destination: scan-test-output-ios-26
       - slack-notify-on-fail
 
+  # As of May 12, 2026, there is a StoreKit bug that is preventing us from running unit tests
+  # when building with Xcode 26.4+. When built with Xcode 26.4+, tests that fetch products
+  # with StoreKit with a SKConfig file fail to fetch products. Thus, a good chunk of our
+  # tests fail. While we can't run the tests, the least that we can do is ensure that the
+  # SDK builds on Xcode 26.5 with iOS 26.5, so this job does that.
   build-xcode-265:
     executor:
       name: macos-executor

--- a/.circleci/generate-requested-jobs-config.js
+++ b/.circleci/generate-requested-jobs-config.js
@@ -17,7 +17,7 @@ const JOBS = {
   "backend-integration-tests-custom-entitlements": ["slack-secrets"],
   "backend-integration-tests-offline": ["slack-secrets"],
   "backend-integration-tests-other": ["slack-secrets"],
-  "build-xcode-26.5": ["slack-secrets"],
+  "build-xcode-265": ["slack-secrets"],
   "build-tv-watch-mac-and-visionos": ["slack-secrets"],
   "check-api-changes-revenuecat": ["slack-secrets-ios"],
   "check-api-changes-revenuecatui": ["slack-secrets-ios"],

--- a/.circleci/generate-requested-jobs-config.js
+++ b/.circleci/generate-requested-jobs-config.js
@@ -17,6 +17,7 @@ const JOBS = {
   "backend-integration-tests-custom-entitlements": ["slack-secrets"],
   "backend-integration-tests-offline": ["slack-secrets"],
   "backend-integration-tests-other": ["slack-secrets"],
+  "build-ios-265": ["slack-secrets"],
   "build-tv-watch-mac-and-visionos": ["slack-secrets"],
   "check-api-changes-revenuecat": ["slack-secrets-ios"],
   "check-api-changes-revenuecatui": ["slack-secrets-ios"],

--- a/.circleci/generate-requested-jobs-config.js
+++ b/.circleci/generate-requested-jobs-config.js
@@ -17,7 +17,7 @@ const JOBS = {
   "backend-integration-tests-custom-entitlements": ["slack-secrets"],
   "backend-integration-tests-offline": ["slack-secrets"],
   "backend-integration-tests-other": ["slack-secrets"],
-  "build-ios-265": ["slack-secrets"],
+  "build-xcode-26.5": ["slack-secrets"],
   "build-tv-watch-mac-and-visionos": ["slack-secrets"],
   "check-api-changes-revenuecat": ["slack-secrets-ios"],
   "check-api-changes-revenuecatui": ["slack-secrets-ios"],

--- a/Sources/Error Handling/SKError+Extensions.swift
+++ b/Sources/Error Handling/SKError+Extensions.swift
@@ -23,6 +23,11 @@ extension SKError: PurchasesErrorConvertible {
              .overlayTimeout,
              .overlayPresentedInBackgroundScene:
             return ErrorUtils.storeProblemError(error: self)
+        #if compiler(>=6.3.2)
+        // paymentMethodBindingConfigurationRequired introduced in Xcode 26.5
+        case .paymentMethodBindingConfigurationRequired:
+            return ErrorUtils.storeProblemError(error: self)
+        #endif
         case .clientInvalid,
              .paymentNotAllowed,
              .cloudServicePermissionDenied,
@@ -137,6 +142,11 @@ extension SKError.Code {
             return "unsupported_platform"
         case .overlayPresentedInBackgroundScene:
             return "overlay_presented_in_background_scene"
+        #if compiler(>=6.3.2)
+        // paymentMethodBindingConfigurationRequired introduced in Xcode 26.5
+        case .paymentMethodBindingConfigurationRequired:
+            return "payment_method_binding_configuration_required"
+        #endif
         @unknown default:
             return "unknown_store_kit_error"
         }

--- a/Sources/Error Handling/StoreKitError+Extensions.swift
+++ b/Sources/Error Handling/StoreKitError+Extensions.swift
@@ -103,6 +103,11 @@ extension Product.PurchaseError: PurchasesErrorConvertible {
                 .missingOfferParameters:
             return ErrorUtils.invalidPromotionalOfferError(error: self)
 
+        #if compiler(>=6.3.2)
+        case .paymentMethodBindingConfigurationRequired:
+            // paymentMethodBindingConfigurationRequired introduced in Xcode 26.5
+            return ErrorUtils.purchasesError(withStoreKitError: self)
+        #endif
         @unknown default:
             return ErrorUtils.unknownError(error: self)
         }
@@ -126,6 +131,11 @@ extension Product.PurchaseError: PurchasesErrorConvertible {
             return "invalid_offer_signature"
         case .missingOfferParameters:
             return "missing_offer_parameters"
+        #if compiler(>=6.3.2)
+        case .paymentMethodBindingConfigurationRequired:
+            // paymentMethodBindingConfigurationRequired introduced in Xcode 26.5
+            return "payment_method_binding_configuration_required"
+        #endif
         @unknown default:
             return "unknown_store_kit_error"
         }

--- a/Sources/Error Handling/StoreKitError+Extensions.swift
+++ b/Sources/Error Handling/StoreKitError+Extensions.swift
@@ -106,7 +106,7 @@ extension Product.PurchaseError: PurchasesErrorConvertible {
         #if compiler(>=6.3.2)
         case .paymentMethodBindingConfigurationRequired:
             // paymentMethodBindingConfigurationRequired introduced in Xcode 26.5
-            return ErrorUtils.purchasesError(withStoreKitError: self)
+            return ErrorUtils.storeProblemError(error: self)
         #endif
         @unknown default:
             return ErrorUtils.unknownError(error: self)

--- a/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/EntitlementInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/EntitlementInfoAPI.swift
@@ -12,7 +12,7 @@
 //  Created by Madeline Beyl on 8/25/21.
 
 import Foundation
-import RevenueCat_CustomEntitlementComputation
+import RevenueCat_CustomEntitlementCasdfomputation
 
 var entitlementInfo: EntitlementInfo!
 func checkEntitlementInfoAPI() {

--- a/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/EntitlementInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/EntitlementInfoAPI.swift
@@ -12,7 +12,7 @@
 //  Created by Madeline Beyl on 8/25/21.
 
 import Foundation
-import RevenueCat_CustomEntitlementCasdfomputation
+import RevenueCat_CustomEntitlementComputation
 
 var entitlementInfo: EntitlementInfo!
 func checkEntitlementInfoAPI() {


### PR DESCRIPTION
### Motivation
Support for billing plans requires APIs that were shipped in Xcode 26.5. However, we can't run tests on Xcode/iOS 26.5 because of a StoreKit bug where fetching products doesn't work in tests on those versions.

The least we can do is build the SDK using those Xcode/iOS versions to confirm that the SDK compiles there :)

### Description
- Introduce a new build-ios-265 job that builds the SDK using Xcode 26.5
- Introduce handling for the new `StoreKitError.paymentMethodBindingConfigurationRequired`

### Note
It looks like the `installation-tests-all-but-carthage` job is failing in CI, but it's also failing in main right now, so it's unrelated to these changes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes CI gating by adding a new required job, which can block merges if the Xcode 26.5 environment is unstable; runtime behavior changes only for a newly introduced StoreKit error case and is compiler-gated.
> 
> **Overview**
> Adds a new CircleCI `build-xcode-265` job that **builds (but does not run tests)** with Xcode 26.5 across key schemes, and makes it part of the PR and release workflow gates (including on-demand job generation).
> 
> Updates StoreKit error handling to recognize the new `paymentMethodBindingConfigurationRequired` case (compiler-gated for Xcode 26.5+) and map it to a store-problem error plus a dedicated tracking string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0fdb3e013581d67b2c965d6638f6f60f9107423. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->