### PR TITLE
Fix: Auto Scaling Font Setting Serialization

### DIFF
--- a/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
@@ -130,7 +130,7 @@ import Foundation
         case _revision = "revision"
         case zeroDecimalPlaceCountries
         case exitOffers
-        case automaticallyScaleFontSize = "automatically_scale_font_size"
+        case automaticallyScaleFontSize
     }
 
     public init(id: String? = nil,


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

We have a JSON serializer that converts snake case to camel case. I forgot about that and set an explicit snake case coding key… The serializer isn't modifying our coding keys, but the JSON keys itself.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->


Remove that snake case coding key.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line Codable `CodingKeys` change that only affects JSON key mapping for `automaticallyScaleFontSize` serialization/deserialization.
> 
> **Overview**
> Fixes `PaywallComponentsData` JSON serialization for the auto font-scaling setting by removing the explicit snake_case `CodingKeys` mapping for `automaticallyScaleFontSize`, allowing the existing key-conversion logic to handle it correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e613e8d7b3c954f06f2911b6450668dfe9a6b7bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->