### PR TITLE
Use Tuist workspace for BackendIntegrationTests in CI

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -559,6 +559,8 @@ commands:
       - checkout
       - install-dependencies
       - update-spm-installation-commit
+      - tuist-generate-workspace:
+          include_test_dependencies: true
       - run:
           name: Run backend_integration Tests
           command: bundle exec fastlane backend_integration_tests test_plan:"<< parameters.test_plan >>"

--- a/BackendIntegrationTests/BackendIntegrationTests-All-CI.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-All-CI.xctestplan
@@ -27,8 +27,8 @@
     "maximumTestExecutionTimeAllowance" : 180,
     "maximumTestRepetitions" : 5,
     "targetForVariableExpansion" : {
-      "containerPath" : "container:RevenueCat.xcodeproj",
-      "identifier" : "2DE20B7E26409EB7004C597D",
+      "containerPath" : "container:RevenueCatTests.xcodeproj",
+      "identifier" : "1F16AE39220495C80A46E7A7",
       "name" : "BackendIntegrationTestsHostApp"
     },
     "testExecutionOrdering" : "random",
@@ -41,15 +41,15 @@
         "BaseLoadShedderStoreKitIntegrationTests"
       ],
       "target" : {
-        "containerPath" : "container:RevenueCat.xcodeproj",
-        "identifier" : "4B547C7901622A3858C2D9BC",
+        "containerPath" : "container:RevenueCatTests.xcodeproj",
+        "identifier" : "7CA426A0D9710B0C11153872",
         "name" : "BackendIntegrationTests"
       }
     },
     {
       "target" : {
-        "containerPath" : "container:RevenueCat.xcodeproj",
-        "identifier" : "3D0A4517786928BDA9E0DD0F",
+        "containerPath" : "container:RevenueCatTests.xcodeproj",
+        "identifier" : "1E4DD1A74419689AD33D88BD",
         "name" : "BackendCustomEntitlementsIntegrationTests"
       }
     }

--- a/BackendIntegrationTests/BackendIntegrationTests-All.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-All.xctestplan
@@ -25,8 +25,8 @@
       }
     ],
     "targetForVariableExpansion" : {
-      "containerPath" : "container:RevenueCat.xcodeproj",
-      "identifier" : "2DE20B7E26409EB7004C597D",
+      "containerPath" : "container:RevenueCatTests.xcodeproj",
+      "identifier" : "1F16AE39220495C80A46E7A7",
       "name" : "BackendIntegrationTestsHostApp"
     },
     "testExecutionOrdering" : "random"
@@ -34,15 +34,15 @@
   "testTargets" : [
     {
       "target" : {
-        "containerPath" : "container:RevenueCat.xcodeproj",
-        "identifier" : "2DE20B6B264087FB004C597D",
+        "containerPath" : "container:RevenueCatTests.xcodeproj",
+        "identifier" : "7CA426A0D9710B0C11153872",
         "name" : "BackendIntegrationTests"
       }
     },
     {
       "target" : {
-        "containerPath" : "container:RevenueCat.xcodeproj",
-        "identifier" : "4F6BEE042A27B02400CD9322",
+        "containerPath" : "container:RevenueCatTests.xcodeproj",
+        "identifier" : "1E4DD1A74419689AD33D88BD",
         "name" : "BackendCustomEntitlementsIntegrationTests"
       }
     }

--- a/BackendIntegrationTests/BackendIntegrationTests-CustomEntitlements.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-CustomEntitlements.xctestplan
@@ -27,8 +27,8 @@
     "maximumTestExecutionTimeAllowance" : 180,
     "maximumTestRepetitions" : 5,
     "targetForVariableExpansion" : {
-      "containerPath" : "container:RevenueCat.xcodeproj",
-      "identifier" : "4F6BEE042A27B02400CD9322",
+      "containerPath" : "container:RevenueCatTests.xcodeproj",
+      "identifier" : "1E4DD1A74419689AD33D88BD",
       "name" : "BackendCustomEntitlementsIntegrationTests"
     },
     "testExecutionOrdering" : "random",
@@ -38,8 +38,8 @@
   "testTargets" : [
     {
       "target" : {
-        "containerPath" : "container:RevenueCat.xcodeproj",
-        "identifier" : "4F6BEE042A27B02400CD9322",
+        "containerPath" : "container:RevenueCatTests.xcodeproj",
+        "identifier" : "1E4DD1A74419689AD33D88BD",
         "name" : "BackendCustomEntitlementsIntegrationTests"
       }
     }

--- a/BackendIntegrationTests/BackendIntegrationTests-LoadShedder.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-LoadShedder.xctestplan
@@ -27,8 +27,8 @@
     "maximumTestExecutionTimeAllowance" : 180,
     "maximumTestRepetitions" : 5,
     "targetForVariableExpansion" : {
-      "containerPath" : "container:RevenueCat.xcodeproj",
-      "identifier" : "2DE20B7E26409EB7004C597D",
+      "containerPath" : "container:RevenueCatTests.xcodeproj",
+      "identifier" : "1F16AE39220495C80A46E7A7",
       "name" : "BackendIntegrationTestsHostApp"
     },
     "testExecutionOrdering" : "random",
@@ -307,8 +307,8 @@
         "VirtualCurrencyStoreKit2IntegrationTests"
       ],
       "target" : {
-        "containerPath" : "container:RevenueCat.xcodeproj",
-        "identifier" : "4B547C7901622A3858C2D9BC",
+        "containerPath" : "container:RevenueCatTests.xcodeproj",
+        "identifier" : "7CA426A0D9710B0C11153872",
         "name" : "BackendIntegrationTests"
       }
     }

--- a/BackendIntegrationTests/BackendIntegrationTests-Offline.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-Offline.xctestplan
@@ -52,8 +52,8 @@
     "maximumTestExecutionTimeAllowance" : 180,
     "maximumTestRepetitions" : 5,
     "targetForVariableExpansion" : {
-      "containerPath" : "container:RevenueCat.xcodeproj",
-      "identifier" : "2DE20B6B264087FB004C597D",
+      "containerPath" : "container:RevenueCatTests.xcodeproj",
+      "identifier" : "7CA426A0D9710B0C11153872",
       "name" : "BackendIntegrationTests"
     },
     "testExecutionOrdering" : "random",
@@ -135,8 +135,8 @@
         "VirtualCurrencyStoreKit2IntegrationTests"
       ],
       "target" : {
-        "containerPath" : "container:RevenueCat.xcodeproj",
-        "identifier" : "2DE20B6B264087FB004C597D",
+        "containerPath" : "container:RevenueCatTests.xcodeproj",
+        "identifier" : "7CA426A0D9710B0C11153872",
         "name" : "BackendIntegrationTests"
       }
     }

--- a/BackendIntegrationTests/BackendIntegrationTests-Other.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-Other.xctestplan
@@ -52,8 +52,8 @@
     "maximumTestExecutionTimeAllowance" : 180,
     "maximumTestRepetitions" : 5,
     "targetForVariableExpansion" : {
-      "containerPath" : "container:RevenueCat.xcodeproj",
-      "identifier" : "2DE20B6B264087FB004C597D",
+      "containerPath" : "container:RevenueCatTests.xcodeproj",
+      "identifier" : "7CA426A0D9710B0C11153872",
       "name" : "BackendIntegrationTests"
     },
     "testExecutionOrdering" : "random",
@@ -135,8 +135,8 @@
         "VirtualCurrencyStoreKit2IntegrationTests"
       ],
       "target" : {
-        "containerPath" : "container:RevenueCat.xcodeproj",
-        "identifier" : "2DE20B6B264087FB004C597D",
+        "containerPath" : "container:RevenueCatTests.xcodeproj",
+        "identifier" : "7CA426A0D9710B0C11153872",
         "name" : "BackendIntegrationTests"
       }
     }

--- a/BackendIntegrationTests/BackendIntegrationTests-SK1.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-SK1.xctestplan
@@ -51,8 +51,8 @@
     "maximumTestExecutionTimeAllowance" : 180,
     "maximumTestRepetitions" : 5,
     "targetForVariableExpansion" : {
-      "containerPath" : "container:RevenueCat.xcodeproj",
-      "identifier" : "2DE20B7E26409EB7004C597D",
+      "containerPath" : "container:RevenueCatTests.xcodeproj",
+      "identifier" : "1F16AE39220495C80A46E7A7",
       "name" : "BackendIntegrationTestsHostApp"
     },
     "testExecutionOrdering" : "random",
@@ -115,8 +115,8 @@
         "TestCase"
       ],
       "target" : {
-        "containerPath" : "container:RevenueCat.xcodeproj",
-        "identifier" : "2DE20B6B264087FB004C597D",
+        "containerPath" : "container:RevenueCatTests.xcodeproj",
+        "identifier" : "7CA426A0D9710B0C11153872",
         "name" : "BackendIntegrationTests"
       }
     }

--- a/BackendIntegrationTests/BackendIntegrationTests-SK2.xctestplan
+++ b/BackendIntegrationTests/BackendIntegrationTests-SK2.xctestplan
@@ -52,8 +52,8 @@
     "maximumTestExecutionTimeAllowance" : 180,
     "maximumTestRepetitions" : 5,
     "targetForVariableExpansion" : {
-      "containerPath" : "container:RevenueCat.xcodeproj",
-      "identifier" : "2DE20B7E26409EB7004C597D",
+      "containerPath" : "container:RevenueCatTests.xcodeproj",
+      "identifier" : "1F16AE39220495C80A46E7A7",
       "name" : "BackendIntegrationTestsHostApp"
     },
     "testExecutionOrdering" : "random",
@@ -122,8 +122,8 @@
         "TestCase"
       ],
       "target" : {
-        "containerPath" : "container:RevenueCat.xcodeproj",
-        "identifier" : "2DE20B6B264087FB004C597D",
+        "containerPath" : "container:RevenueCatTests.xcodeproj",
+        "identifier" : "7CA426A0D9710B0C11153872",
         "name" : "BackendIntegrationTests"
       }
     }

--- a/Projects/RevenueCatTests/Project.swift
+++ b/Projects/RevenueCatTests/Project.swift
@@ -139,7 +139,18 @@ let project = Project(
                 "../../Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift",
                 "../../Tests/BackendIntegrationTests/MainThreadMonitor.swift",
                 "../../Tests/BackendIntegrationTests/Constants.swift",
-                "../../Tests/BackendIntegrationTests/Helpers/**/*.swift",
+                // Only the helpers that are CustomEntitlementComputation-aware (conditional import).
+                // The excluded helpers import `RevenueCat` directly and aren't used by these tests,
+                // so compiling them here would link against the wrong module.
+                .glob(
+                    "../../Tests/BackendIntegrationTests/Helpers/**/*.swift",
+                    excluding: [
+                        "../../Tests/BackendIntegrationTests/Helpers/SK1ProductFetcher.swift",
+                        "../../Tests/BackendIntegrationTests/Helpers/SK2ProductFetcher.swift",
+                        "../../Tests/BackendIntegrationTests/Helpers/ObserverModeManager.swift",
+                        "../../Tests/BackendIntegrationTests/Helpers/ExternalPurchasesManager.swift"
+                    ]
+                ),
                 "../../Tests/UnitTests/Misc/**/TestCase.swift",
                 "../../Tests/UnitTests/Mocks/MockSandboxEnvironmentDetector.swift",
                 "../../Tests/UnitTests/TestHelpers/**/TestLogHandler.swift",

--- a/Projects/RevenueCatTests/Project.swift
+++ b/Projects/RevenueCatTests/Project.swift
@@ -123,12 +123,6 @@ let project = Project(
             dependencies: [
              .storeKit
             ],
-            settings: .settings(
-                base: [
-                    "APPLICATION_EXTENSION_API_ONLY": "YES",
-                    "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION"
-                ]
-            ),
             metadata: .metadata(tags: ["RevenueCatTests"])
         ),
 

--- a/Projects/RevenueCatTests/Project.swift
+++ b/Projects/RevenueCatTests/Project.swift
@@ -102,7 +102,7 @@ let project = Project(
             additionalFiles: [
                 "../../Tests/StoreKitUnitTests/UnitTestsConfiguration.storekit"
             ],
-            metadata: .metadata(tags: ["RevenueCatTests"]),
+            metadata: .metadata(tags: ["RevenueCatTests"])
         ),
 
         // MARK: – BackendIntegrationTests Host App
@@ -129,7 +129,7 @@ let project = Project(
                     "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION"
                 ]
             ),
-            metadata: .metadata(tags: ["RevenueCatTests"]),
+            metadata: .metadata(tags: ["RevenueCatTests"])
         ),
 
         .target(
@@ -168,7 +168,7 @@ let project = Project(
                     "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION"
                 ]
             ),
-            metadata: .metadata(tags: ["RevenueCatTests"]),
+            metadata: .metadata(tags: ["RevenueCatTests"])
         ),
 
         .target(
@@ -262,7 +262,14 @@ let project = Project(
             shared: true,
             buildAction: .buildAction(targets: ["BackendIntegrationTests"]),
             testAction: .testPlans([
-                    .relativeToRoot("BackendIntegrationTests/BackendIntegrationTests-All-CI.xctestplan")
+                    .relativeToRoot("BackendIntegrationTests/BackendIntegrationTests-All-CI.xctestplan"),
+                    .relativeToRoot("BackendIntegrationTests/BackendIntegrationTests-All.xctestplan"),
+                    .relativeToRoot("BackendIntegrationTests/BackendIntegrationTests-SK1.xctestplan"),
+                    .relativeToRoot("BackendIntegrationTests/BackendIntegrationTests-SK2.xctestplan"),
+                    .relativeToRoot("BackendIntegrationTests/BackendIntegrationTests-Offline.xctestplan"),
+                    .relativeToRoot("BackendIntegrationTests/BackendIntegrationTests-Other.xctestplan"),
+                    .relativeToRoot("BackendIntegrationTests/BackendIntegrationTests-CustomEntitlements.xctestplan"),
+                    .relativeToRoot("BackendIntegrationTests/BackendIntegrationTests-LoadShedder.xctestplan")
                 ]
             ),
             runAction: .runAction(

--- a/Projects/RevenueCatTests/Project.swift
+++ b/Projects/RevenueCatTests/Project.swift
@@ -161,6 +161,9 @@ let project = Project(
                 "../../Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift",
                 "../../Tests/StoreKitUnitTests/TestHelpers/AvailabilityChecks.swift"
             ],
+            resources: [
+                "../../Tests/BackendIntegrationTests/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit"
+            ],
             dependencies: [
                 .revenueCatCustomEntitlementComputation,
                 .target(name: "BackendIntegrationTestsHostApp"),

--- a/Tests/BackendIntegrationTests/MainThreadMonitor.swift
+++ b/Tests/BackendIntegrationTests/MainThreadMonitor.swift
@@ -12,7 +12,11 @@
 //  Created by Nacho Soto on 5/1/23.
 
 import Foundation
+#if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+@_spi(Internal) @testable import RevenueCat_CustomEntitlementComputation
+#else
 @_spi(Internal) @testable import RevenueCat
+#endif
 import XCTest
 
 final class MainThreadMonitor {

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -12,7 +12,11 @@
 //  Created by Nacho Soto on 1/24/22.
 
 import Nimble
+#if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+@_spi(Internal) @testable import RevenueCat_CustomEntitlementComputation
+#else
 @_spi(Internal) @testable import RevenueCat
+#endif
 import StoreKit
 import StoreKitTest
 import XCTest

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1722,6 +1722,7 @@ platform :ios do
     success = false
     begin
       scan(
+        workspace: 'RevenueCat-Tuist.xcworkspace',
         scheme: "BackendIntegrationTests",
         ensure_devices_found: true,
         derived_data_path: "scan_derived_data",


### PR DESCRIPTION
## Summary
- Switches the `run-backend-tests` CI job to build from the Tuist-generated workspace (`RevenueCat-Tuist.xcworkspace`) instead of the legacy `RevenueCat.xcodeproj`
- Adds a `tuist-generate-workspace` step (with `include_test_dependencies: true`) to `run-backend-tests` before invoking fastlane
- Pins the `backend_integration_tests` Fastfile lane to the Tuist workspace explicitly via `workspace: 'RevenueCat-Tuist.xcworkspace'`
- Adds all 8 BackendIntegrationTests test plans to the Tuist scheme so xcodebuild's `-testPlan` flag can resolve each one (SK1, SK2, Offline, Other, CustomEntitlements, LoadShedder, All, All-CI)

Part of the longer-term goal of deleting `RevenueCat.xcodeproj` + `RevenueCat.xcworkspace`.

## Test plan
- [ ] CI `backend-integration-tests-SK1` through `backend-integration-tests-offline` jobs pass
- [ ] CI `backend-integration-tests-custom-entitlements` passes
- [ ] No regressions in other CI jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how backend integration tests are built and which SDK module the custom-entitlements target links; failures would show up as CI breakage rather than shipping SDK regressions, but purchase/backend coverage depends on these jobs.
> 
> **Overview**
> Moves **BackendIntegrationTests** CI onto the Tuist-generated **`RevenueCat-Tuist.xcworkspace`**: `run-backend-tests` now runs **`tuist-generate-workspace`** with **`include_test_dependencies: true`**, and the **`backend_integration_tests`** Fastlane lane passes **`workspace: 'RevenueCat-Tuist.xcworkspace'`** to `scan`.
> 
> All eight **`.xctestplan`** files now point at **`RevenueCatTests.xcodeproj`** and updated target identifiers instead of **`RevenueCat.xcodeproj`**. The Tuist **`BackendIntegrationTests`** scheme registers every test plan (All, All-CI, SK1, SK2, Offline, Other, CustomEntitlements, LoadShedder) so CI **`-testPlan`** selection still works.
> 
> **`Projects/RevenueCatTests/Project.swift`** trims host-app build settings, tightens **`BackendCustomEntitlementsIntegrationTests`** (excludes RevenueCat-only helpers, adds StoreKit config resource), and wires the full test-plan list on the scheme. **`MainThreadMonitor.swift`** and **`StoreKitTestHelpers.swift`** use conditional imports so they compile in both the standard and custom-entitlement test targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ea68c5bac3d874ddb167865faa5099356afa1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->