### PR TITLE
[Billing Plans]: Dont support upFront compound product identifiers

### DIFF
--- a/Sources/Purchasing/StoreKit2/Products with Billing Plans/CompoundProductIdentifier.swift
+++ b/Sources/Purchasing/StoreKit2/Products with Billing Plans/CompoundProductIdentifier.swift
@@ -19,7 +19,7 @@ import StoreKit
 ///
 /// StoreKit only knows about the base ``productIdentifier``. RevenueCat can also receive an optional
 /// ``productPlanIdentifier`` from the backend to distinguish multiple SDK products backed by the same StoreKit
-/// product, such as monthly and up-front billing plans.
+/// product, such as monthly billing plans.
 ///
 /// SDK-facing compound product identifier strings use the format `{productIdentifier}` for products without specifying
 /// a particular billing plan, and `{productIdentifier}:{productPlanIdentifier}` for products with a given plan.
@@ -119,8 +119,6 @@ extension CompoundProductIdentifier {
         switch productPlanIdentifier {
         case "monthly":
             return StoreKit.Product.SubscriptionInfo.BillingPlanType.monthly
-        case "upFront":
-            return StoreKit.Product.SubscriptionInfo.BillingPlanType.upFront
         default:
             Logger.warn(
                 StoreKitStrings.sk2_unrecognized_billing_plan_identifer(billingPlanIdentifier: productPlanIdentifier)

--- a/Tests/UnitTests/Purchasing/StoreKitAbstractions/CompoundProductIdentifierTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitAbstractions/CompoundProductIdentifierTests.swift
@@ -292,7 +292,7 @@ extension CompoundProductIdentifierTests {
     }
 
     @available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *)
-    func testSK2BillingPlanTypeReturnsUpFrontForUpfrontProductPlanIdentifier() throws {
+    func testSK2BillingPlanTypeReturnsNilForUpfrontProductPlanIdentifier() throws {
         try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
 
         let identifier = try XCTUnwrap(CompoundProductIdentifier(
@@ -300,19 +300,7 @@ extension CompoundProductIdentifierTests {
             productPlanIdentifier: "upFront"
         ))
 
-        expect(identifier.sk2BillingPlanType) == StoreKit.Product.SubscriptionInfo.BillingPlanType.upFront
-    }
-
-    @available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *)
-    func testSK2BillingPlanTypeReturnsUpFront() throws {
-        try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
-
-        let identifier = try XCTUnwrap(CompoundProductIdentifier(
-            productIdentifier: "com.revenuecat.subscription",
-            productPlanIdentifier: "upFront"
-        ))
-
-        expect(identifier.sk2BillingPlanType) == StoreKit.Product.SubscriptionInfo.BillingPlanType.upFront
+        expect(identifier.sk2BillingPlanType).to(beNil())
     }
 
     @available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *)
@@ -340,18 +328,25 @@ extension CompoundProductIdentifierTests {
     }
 
     @available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *)
-    func testSK2BillingPlanTypeUsesProductPlanIdentifierFromStringInitializer() throws {
+    func testSK2BillingPlanTypeUsesSupportedProductPlanIdentifierFromStringInitializer() throws {
         try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
 
         let monthlyIdentifier = try XCTUnwrap(CompoundProductIdentifier(
             compoundProductIdentifier: "com.revenuecat.subscription:monthly"
         ))
+
+        expect(monthlyIdentifier.sk2BillingPlanType) == StoreKit.Product.SubscriptionInfo.BillingPlanType.monthly
+    }
+
+    @available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *)
+    func testSK2BillingPlanTypeReturnsNilForUpfrontProductPlanIdentifierFromStringInitializer() throws {
+        try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
+
         let upFrontIdentifier = try XCTUnwrap(CompoundProductIdentifier(
             compoundProductIdentifier: "com.revenuecat.subscription:upFront"
         ))
 
-        expect(monthlyIdentifier.sk2BillingPlanType) == StoreKit.Product.SubscriptionInfo.BillingPlanType.monthly
-        expect(upFrontIdentifier.sk2BillingPlanType) == StoreKit.Product.SubscriptionInfo.BillingPlanType.upFront
+        expect(upFrontIdentifier.sk2BillingPlanType).to(beNil())
     }
 }
 #endif


### PR DESCRIPTION
### Description
Don't support `:upFront` in product identifiers since the backend doesn't support them. This isn't a breaking change since nothing has been released yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes product identifier handling in `ProductsManager` and adds new public API (`BillingPlanType`, `InstallmentsInfo`) that affects how StoreKit2 products are returned when billing-plan suffixes are used; mistakes could cause products to be dropped or misidentified. Most behavior is gated behind Swift 6.3.2 / iOS 26.4 availability, reducing blast radius on older platforms.
> 
> **Overview**
> Adds first-class support for **StoreKit 2 billing-plan compound product identifiers** (e.g. `productId:monthly`) by parsing identifiers, de-duplicating StoreKit fetches to base product IDs, and optionally returning *billing-plan-specific* `SK2StoreProduct` variants while removing the base product when it wasn’t explicitly requested.
> 
> Introduces new public types `BillingPlanType` and `InstallmentsInfo`, and exposes `StoreProduct.installmentsInfo` (iOS 26.4+) populated via a new `InstallmentsInfoFactory` for eligible monthly billing plans; unsupported/invalid plan identifiers (including `:upFront`) are ignored with new StoreKit log warnings.
> 
> Updates unit tests, API testers, and the PurchaseTester app to cover/display compound identifiers, billing plan types, and installments info, plus adds helper availability checks and adjusts `SK2StoreProduct` hashing/equality to include the compound identifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56efb8ade6d2b3f48f31e41e39fdd3edd93c638c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->