### PR TITLE
Propagate default package across workflow steps

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2369,6 +2369,7 @@
 		57BF87582967880C00424254 /* MockCachingTrialOrIntroPriceEligibilityChecker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockCachingTrialOrIntroPriceEligibilityChecker.swift; sourceTree = "<group>"; };
 		57BFCD0A2EEB0E56009E5844 /* TabsPackageInheritanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsPackageInheritanceTests.swift; sourceTree = "<group>"; };
 		57BFCD0F2EEB1234009E5844 /* TabsPackageSelectionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsPackageSelectionResolverTests.swift; sourceTree = "<group>"; };
+		E7EAAD1DC166ABD68E484EAA /* RootViewSheetDismissalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewSheetDismissalTests.swift; sourceTree = "<group>"; };
 		57C0BB6829F840BD00827807 /* FrameworkDisambiguation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkDisambiguation.swift; sourceTree = "<group>"; };
 		57C2931428BFEF4F0054EDFC /* PurchasesError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesError.swift; sourceTree = "<group>"; };
 		57C381B62791E593009E3940 /* StoreKit2TransactionListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionListenerTests.swift; sourceTree = "<group>"; };
@@ -3053,6 +3054,7 @@
 				FD4253DD2F1DBD7E0073D2DE /* FileImageLoaderTests.swift */,
 				57BFCD0F2EEB1234009E5844 /* TabsPackageSelectionResolverTests.swift */,
 				57BFCD0A2EEB0E56009E5844 /* TabsPackageInheritanceTests.swift */,
+				E7EAAD1DC166ABD68E484EAA /* RootViewSheetDismissalTests.swift */,
 				03CCFCE12DE9638F0052B764 /* __PreviewResources__ */,
 				83EE33252E1E20360011CF1C /* PaywallPreviewResourcesLoader.swift */,
 				038EC8222DE7A8AC00786C42 /* TakeScreenshot.swift */,

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -100,14 +100,6 @@ struct WorkflowContext {
         return (offeringId: offeringId, triggeringStepId: stepId)
     }
 
-    /// Returns the package context that should be broadcast in the environment for `stepId`.
-    /// Prefers the step's own package context when available so that package-bearing steps
-    /// use their own configured defaults rather than the global workflow fallback.
-    /// Equivalent to `effectivePackageContext(for:preferring: nil)`.
-    func effectivePackageContext(for stepId: String) -> WorkflowPackageContext? {
-        return self.packageContext(for: stepId) ?? self.workflowPackageContext
-    }
-
     /// Returns the effective package context for `stepId`, preferring `preferredPackage` as the
     /// selection when that package is present in the step's available packages.
     ///

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -116,7 +116,8 @@ struct WorkflowContext {
     /// is absent from the step. As a last resort (workflow has no `singleStepFallbackId`), returns
     /// the step's own authored default from `isSelectedByDefault`.
     func effectivePackageContext(for stepId: String, preferring preferredPackage: Package?) -> WorkflowPackageContext? {
-        guard let base = self.effectivePackageContext(for: stepId) else {
+        let wfContext = self.workflowPackageContext
+        guard let base = self.packageContext(for: stepId) ?? wfContext else {
             return nil
         }
 
@@ -128,7 +129,7 @@ struct WorkflowContext {
             return .init(selectedPackage: preferredPackage, packages: base.packages)
         }
 
-        if let wfDefault = self.workflowPackageContext?.selectedPackage,
+        if let wfDefault = wfContext?.selectedPackage,
            base.packages.contains(where: { $0.identifier == wfDefault.identifier }) {
             return .init(selectedPackage: wfDefault, packages: base.packages)
         }

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -21,25 +21,39 @@ struct WorkflowContext {
     let initialOffering: Offering
     /// Preserved so every subsequent step's offering can carry the same placement/targeting metadata.
     let presentedOfferingContext: PresentedOfferingContext?
+    /// Package context from `singleStepFallbackId`, precomputed because it is stable for a workflow.
+    let workflowPackageContext: WorkflowPackageContext?
+
+    init(
+        workflow: PublishedWorkflow,
+        allOfferings: Offerings,
+        initialOffering: Offering,
+        presentedOfferingContext: PresentedOfferingContext?
+    ) {
+        self.workflow = workflow
+        self.allOfferings = allOfferings
+        self.initialOffering = initialOffering
+        self.presentedOfferingContext = presentedOfferingContext
+
+        let workflowPackageContext = Self.workflowPackageContext(
+            workflow: workflow,
+            allOfferings: allOfferings,
+            initialOffering: initialOffering,
+            presentedOfferingContext: presentedOfferingContext
+        )
+        if let singleWorkflowStepFallbackId = workflow.singleStepFallbackId, workflowPackageContext == nil {
+            Logger.warning(Strings.workflow_package_context_unresolvable(stepId: singleWorkflowStepFallbackId))
+        }
+        self.workflowPackageContext = workflowPackageContext
+    }
 
     func offering(for offeringIdentifier: String?) -> Offering? {
-        guard let offeringIdentifier else {
-            return self.initialOffering
-        }
-
-        if self.initialOffering.identifier == offeringIdentifier {
-            return self.initialOffering
-        }
-
-        guard let offering = self.allOfferings.all[offeringIdentifier] else {
-            return nil
-        }
-
-        guard let presentedOfferingContext else {
-            return offering
-        }
-
-        return offering.withPresentedOfferingContext(presentedOfferingContext)
+        return Self.offering(
+            for: offeringIdentifier,
+            allOfferings: self.allOfferings,
+            initialOffering: self.initialOffering,
+            presentedOfferingContext: self.presentedOfferingContext
+        )
     }
 
     /// The step ID from which the exit offer may be triggered.
@@ -84,20 +98,6 @@ struct WorkflowContext {
             return nil
         }
         return (offeringId: offeringId, triggeringStepId: stepId)
-    }
-
-    /// Resolves the package context from the workflow's `singleStepFallbackId` step so that
-    /// packageless early screens can still resolve price/period template variables.
-    var workflowPackageContext: WorkflowPackageContext? {
-        guard let singleWorkflowStepFallbackId = self.workflow.singleStepFallbackId else {
-            return nil
-        }
-
-        let context = self.packageContext(for: singleWorkflowStepFallbackId)
-        if context == nil {
-            Logger.warning(Strings.workflow_package_context_unresolvable(stepId: singleWorkflowStepFallbackId))
-        }
-        return context
     }
 
     /// Returns the package context that should be broadcast in the environment for `stepId`.
@@ -155,6 +155,35 @@ struct WorkflowContext {
         offering: Offering
     ) -> WorkflowPackageContext? {
         let base = screen.componentsConfig.base
+        return Self.workflowPackageContext(for: base, offering: offering)
+    }
+
+    private static func workflowPackageContext(
+        workflow: PublishedWorkflow,
+        allOfferings: Offerings,
+        initialOffering: Offering,
+        presentedOfferingContext: PresentedOfferingContext?
+    ) -> WorkflowPackageContext? {
+        guard let singleWorkflowStepFallbackId = workflow.singleStepFallbackId,
+              let step = workflow.steps[singleWorkflowStepFallbackId],
+              let screenId = step.screenId,
+              let screen = workflow.screens[screenId],
+              let offering = Self.offering(
+                  for: screen.offeringIdentifier,
+                  allOfferings: allOfferings,
+                  initialOffering: initialOffering,
+                  presentedOfferingContext: presentedOfferingContext
+              ) else {
+            return nil
+        }
+
+        return Self.workflowPackageContext(for: screen.componentsConfig.base, offering: offering)
+    }
+
+    private static func workflowPackageContext(
+        for base: PaywallComponentsData.PaywallComponentsConfig,
+        offering: Offering
+    ) -> WorkflowPackageContext? {
         let allComponents = base.stack.components
             + (base.stickyFooter?.stack.components ?? [])
         let packages = Self.collectPackages(in: allComponents, offering: offering)
@@ -168,6 +197,31 @@ struct WorkflowContext {
             selectedPackage: selectedPackage,
             packages: packages.map(\.package)
         )
+    }
+
+    private static func offering(
+        for offeringIdentifier: String?,
+        allOfferings: Offerings,
+        initialOffering: Offering,
+        presentedOfferingContext: PresentedOfferingContext?
+    ) -> Offering? {
+        guard let offeringIdentifier else {
+            return initialOffering
+        }
+
+        if initialOffering.identifier == offeringIdentifier {
+            return initialOffering
+        }
+
+        guard let offering = allOfferings.all[offeringIdentifier] else {
+            return nil
+        }
+
+        guard let presentedOfferingContext else {
+            return offering
+        }
+
+        return offering.withPresentedOfferingContext(presentedOfferingContext)
     }
 
     private static func collectPackages(

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -100,6 +100,13 @@ struct WorkflowContext {
         return context
     }
 
+    /// Returns the package context that should be broadcast in the environment for `stepId`.
+    /// Prefers the step's own package context when available so that package-bearing steps
+    /// use their own configured defaults rather than the global workflow fallback.
+    func effectivePackageContext(for stepId: String) -> WorkflowPackageContext? {
+        return self.packageContext(for: stepId) ?? self.workflowPackageContext
+    }
+
     /// Resolves the package context for any step by scanning its screen's components.
     /// Returns `nil` if the step, screen, or offering cannot be resolved, or if the step has no package components.
     func packageContext(for stepId: String) -> WorkflowPackageContext? {

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -107,6 +107,35 @@ struct WorkflowContext {
         return self.packageContext(for: stepId) ?? self.workflowPackageContext
     }
 
+    /// Returns the effective package context for `stepId`, preferring `preferredPackage` as the
+    /// selection when that package is present in the step's available packages.
+    ///
+    /// Used for forward navigation carry-forward: when the user selected a package on a prior step,
+    /// that selection should seed the next step when the package is available there.
+    /// Falls back to the workflow-global default (`workflowPackageContext`) if `preferredPackage`
+    /// is absent from the step. As a last resort (workflow has no `singleStepFallbackId`), returns
+    /// the step's own authored default from `isSelectedByDefault`.
+    func effectivePackageContext(for stepId: String, preferring preferredPackage: Package?) -> WorkflowPackageContext? {
+        guard let base = self.effectivePackageContext(for: stepId) else {
+            return nil
+        }
+
+        guard let preferredPackage else {
+            return base
+        }
+
+        if base.packages.contains(where: { $0.identifier == preferredPackage.identifier }) {
+            return .init(selectedPackage: preferredPackage, packages: base.packages)
+        }
+
+        if let wfDefault = self.workflowPackageContext?.selectedPackage,
+           base.packages.contains(where: { $0.identifier == wfDefault.identifier }) {
+            return .init(selectedPackage: wfDefault, packages: base.packages)
+        }
+
+        return base
+    }
+
     /// Resolves the package context for any step by scanning its screen's components.
     /// Returns `nil` if the step, screen, or offering cannot be resolved, or if the step has no package components.
     func packageContext(for stepId: String) -> WorkflowPackageContext? {

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -103,6 +103,7 @@ struct WorkflowContext {
     /// Returns the package context that should be broadcast in the environment for `stepId`.
     /// Prefers the step's own package context when available so that package-bearing steps
     /// use their own configured defaults rather than the global workflow fallback.
+    /// Equivalent to `effectivePackageContext(for:preferring: nil)`.
     func effectivePackageContext(for stepId: String) -> WorkflowPackageContext? {
         return self.packageContext(for: stepId) ?? self.workflowPackageContext
     }

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -93,11 +93,20 @@ struct WorkflowContext {
             return nil
         }
 
-        guard let step = self.workflow.steps[singleWorkflowStepFallbackId],
+        let context = self.packageContext(for: singleWorkflowStepFallbackId)
+        if context == nil {
+            Logger.warning(Strings.workflow_package_context_unresolvable(stepId: singleWorkflowStepFallbackId))
+        }
+        return context
+    }
+
+    /// Resolves the package context for any step by scanning its screen's components.
+    /// Returns `nil` if the step, screen, or offering cannot be resolved, or if the step has no package components.
+    func packageContext(for stepId: String) -> WorkflowPackageContext? {
+        guard let step = self.workflow.steps[stepId],
               let screenId = step.screenId,
               let screen = self.workflow.screens[screenId],
               let offering = self.offering(for: screen.offeringIdentifier) else {
-            Logger.warning(Strings.workflow_package_context_unresolvable(stepId: singleWorkflowStepFallbackId))
             return nil
         }
 

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -150,7 +150,7 @@ struct WorkflowContext {
         return self.workflowPackageContext(for: screen, offering: offering)
     }
 
-    func workflowPackageContext(
+    private func workflowPackageContext(
         for screen: WorkflowScreen,
         offering: Offering
     ) -> WorkflowPackageContext? {

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -147,6 +147,13 @@ struct WorkflowContext {
             return nil
         }
 
+        return self.workflowPackageContext(for: screen, offering: offering)
+    }
+
+    func workflowPackageContext(
+        for screen: WorkflowScreen,
+        offering: Offering
+    ) -> WorkflowPackageContext? {
         let base = screen.componentsConfig.base
         let allComponents = base.stack.components
             + (base.stickyFooter?.stack.components ?? [])

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -125,13 +125,13 @@ struct WorkflowContext {
             return base
         }
 
-        if base.packages.contains(where: { $0.identifier == preferredPackage.identifier }) {
-            return .init(selectedPackage: preferredPackage, packages: base.packages)
+        if let matched = base.packages.first(where: { $0.identifier == preferredPackage.identifier }) {
+            return .init(selectedPackage: matched, packages: base.packages)
         }
 
         if let wfDefault = wfContext?.selectedPackage,
-           base.packages.contains(where: { $0.identifier == wfDefault.identifier }) {
-            return .init(selectedPackage: wfDefault, packages: base.packages)
+           let matched = base.packages.first(where: { $0.identifier == wfDefault.identifier }) {
+            return .init(selectedPackage: matched, packages: base.packages)
         }
 
         return base

--- a/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
@@ -136,12 +136,12 @@ struct RootView: View {
             } else {
                 // Reset package selection when sheet is dismissed; snapshot sheet name before clear for analytics.
                 let selectionInSheetContext = self.packageContext.package
-                if self.workflowPackageContext != nil {
-                    self.packageContext.package = self.packageBeforeSheet ?? self.defaultPackage
-                    self.packageBeforeSheet = nil
-                } else {
-                    self.packageContext.package = self.defaultPackage
-                }
+                self.packageContext.package = Self.restoredPackageAfterSheetDismissal(
+                    workflowPackageContext: self.workflowPackageContext,
+                    packageBeforeSheet: self.packageBeforeSheet,
+                    defaultPackage: self.defaultPackage
+                )
+                self.packageBeforeSheet = nil
                 let resultingRootPackage = self.packageContext.package
                 let sheetName = self.packageSelectionSheetComponentName
                 self.packageSelectionSheetComponentName = nil
@@ -154,6 +154,22 @@ struct RootView: View {
                 )
             }
         }
+    }
+
+    /// Returns the package that should be selected after a selection sheet is dismissed.
+    ///
+    /// In a workflow context the view snapshots the pre-sheet selection on open; this restores
+    /// that snapshot so navigating into and out of the sheet is a no-op for the workflow step.
+    /// Outside a workflow the sheet always resets to the step default.
+    static func restoredPackageAfterSheetDismissal(
+        workflowPackageContext: WorkflowPackageContext?,
+        packageBeforeSheet: Package?,
+        defaultPackage: Package?
+    ) -> Package? {
+        if workflowPackageContext != nil {
+            return packageBeforeSheet ?? defaultPackage
+        }
+        return defaultPackage
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
@@ -38,7 +38,7 @@ struct RootView: View {
 
     @State private var sheetViewModel: SheetViewModel?
     @State private var packageSelectionSheetComponentName: String?
-    @State private var packageBeforeSheet: Package?
+    @State private var packageBeforeOpeningSheet: Package?
     @State private var overlaidHeaderHeight: CGFloat = 0
 
     internal init(
@@ -131,17 +131,17 @@ struct RootView: View {
             if let newValue {
                 self.packageSelectionSheetComponentName = newValue.sheet.name
                 if self.workflowPackageContext != nil {
-                    self.packageBeforeSheet = self.packageContext.package
+                    self.packageBeforeOpeningSheet = self.packageContext.package
                 }
             } else {
                 // Reset package selection when sheet is dismissed; snapshot sheet name before clear for analytics.
                 let selectionInSheetContext = self.packageContext.package
                 self.packageContext.package = Self.restoredPackageAfterSheetDismissal(
                     workflowPackageContext: self.workflowPackageContext,
-                    packageBeforeSheet: self.packageBeforeSheet,
+                    packageBeforeOpeningSheet: self.packageBeforeOpeningSheet,
                     defaultPackage: self.defaultPackage
                 )
-                self.packageBeforeSheet = nil
+                self.packageBeforeOpeningSheet = nil
                 let resultingRootPackage = self.packageContext.package
                 let sheetName = self.packageSelectionSheetComponentName
                 self.packageSelectionSheetComponentName = nil
@@ -163,11 +163,11 @@ struct RootView: View {
     /// Outside a workflow the sheet always resets to the step default.
     static func restoredPackageAfterSheetDismissal(
         workflowPackageContext: WorkflowPackageContext?,
-        packageBeforeSheet: Package?,
+        packageBeforeOpeningSheet: Package?,
         defaultPackage: Package?
     ) -> Package? {
         if workflowPackageContext != nil {
-            return packageBeforeSheet ?? defaultPackage
+            return packageBeforeOpeningSheet ?? defaultPackage
         }
         return defaultPackage
     }

--- a/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
@@ -38,6 +38,7 @@ struct RootView: View {
 
     @State private var sheetViewModel: SheetViewModel?
     @State private var packageSelectionSheetComponentName: String?
+    @State private var packageBeforeSheet: Package?
     @State private var overlaidHeaderHeight: CGFloat = 0
 
     internal init(
@@ -129,10 +130,18 @@ struct RootView: View {
         .onChangeOf(sheetViewModel) { newValue in
             if let newValue {
                 self.packageSelectionSheetComponentName = newValue.sheet.name
+                if self.workflowPackageContext != nil {
+                    self.packageBeforeSheet = self.packageContext.package
+                }
             } else {
                 // Reset package selection when sheet is dismissed; snapshot sheet name before clear for analytics.
                 let selectionInSheetContext = self.packageContext.package
-                self.packageContext.package = self.workflowPackageContext?.selectedPackage ?? self.defaultPackage
+                if self.workflowPackageContext != nil {
+                    self.packageContext.package = self.packageBeforeSheet ?? self.defaultPackage
+                    self.packageBeforeSheet = nil
+                } else {
+                    self.packageContext.package = self.defaultPackage
+                }
                 let resultingRootPackage = self.packageContext.package
                 let sheetName = self.packageSelectionSheetComponentName
                 self.packageSelectionSheetComponentName = nil

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
@@ -208,9 +208,14 @@ struct LoadedTabsComponentView: View {
         self._tierPackageContexts = .init(initialValue: Dictionary(
             uniqueKeysWithValues: viewModel.tabViewModels.map { key, tabViewModel -> (String, PackageContext) in
                 if !tabViewModel.packages.isEmpty {
-                    // Tab has its own packages - create context with tab's packages
+                    // Tab has its own packages - create context with tab's packages.
                     let packageContext = PackageContext(
-                        package: workflowDefaultPackage ?? tabViewModel.defaultSelectedPackage,
+                        package: Self.initialPackage(
+                            parentPackage: parentPackageContext.package,
+                            tabPackages: tabViewModel.packages,
+                            workflowDefaultPackage: workflowDefaultPackage,
+                            tabDefaultPackage: tabViewModel.defaultSelectedPackage
+                        ),
                         variableContext: .init(
                             packages: tabViewModel.packages,
                             showZeroDecimalPlacePrices: parentPackageContext.variableContext.showZeroDecimalPlacePrices
@@ -224,6 +229,25 @@ struct LoadedTabsComponentView: View {
                 }
             }
         ))
+    }
+
+    /// Determines the initial package selection for a tab that has its own packages.
+    ///
+    /// On a workflow step revisit `parentPackage` already holds the user's cached selection
+    /// (stored in `WorkflowPaywallView.stepPackageContexts`). Prefer it when it is present in
+    /// this tab's package list so that the tab's `onAppear` propagation back to the parent
+    /// is a no-op rather than silently restoring the authored default and destroying the choice.
+    static func initialPackage(
+        parentPackage: Package?,
+        tabPackages: [Package],
+        workflowDefaultPackage: Package?,
+        tabDefaultPackage: Package?
+    ) -> Package? {
+        if let cached = parentPackage,
+           tabPackages.contains(where: { $0.identifier == cached.identifier }) {
+            return cached
+        }
+        return workflowDefaultPackage ?? tabDefaultPackage
     }
 
     var body: some View {

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -67,6 +67,7 @@ struct PaywallsV2View: View {
     private let workflowDefaultPackage: Package?
     private let workflowPackages: [Package]?
     private let showZeroDecimalPlacePrices: Bool
+    private let selectedPackageContextOverride: PackageContext?
     /// This is a configuration value from PaywallsV1, but it's important to include here just in case the
     /// default paywall is shown. This is not used in the success path
     private let displayCloseButton: Bool
@@ -95,7 +96,8 @@ struct PaywallsV2View: View {
         failedToLoadFont: @escaping UIConfigProvider.FailedToLoadFont,
         colorScheme: ColorScheme,
         promoOfferCache: PaywallPromoOfferCache? = nil,
-        introEligibilityContext: IntroOfferEligibilityContext? = nil
+        introEligibilityContext: IntroOfferEligibilityContext? = nil,
+        selectedPackageContextOverride: PackageContext? = nil
     ) {
         let uiConfigProvider = UIConfigProvider(
             uiConfig: paywallComponents.uiConfig,
@@ -113,6 +115,7 @@ struct PaywallsV2View: View {
         self.displayCloseButton = displayCloseButton
         self.onDismiss = onDismiss
         self.closeWorkflowAction = closeWorkflowAction
+        self.selectedPackageContextOverride = selectedPackageContextOverride
         self._paywallPromoOfferCache = .init(wrappedValue: promoOfferCache ?? PaywallPromoOfferCache(
             subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
         ))
@@ -143,7 +146,9 @@ struct PaywallsV2View: View {
         )
 
         let selectedPackageContext: PackageContext
-        if case .success(let paywallState) = initialState {
+        if let override = selectedPackageContextOverride {
+            selectedPackageContext = override
+        } else if case .success(let paywallState) = initialState {
             selectedPackageContext = Self.makeSelectedPackageContext(
                 from: paywallState,
                 defaultPackage: Self.effectiveDefaultPackage(
@@ -186,7 +191,7 @@ struct PaywallsV2View: View {
 
     private func loadedPaywallView(paywallState: PaywallState) -> some View {
         let contentLocale = paywallState.rootViewModel.localizationProvider.locale
-        let defaultPackage = Self.effectiveDefaultPackage(
+        let defaultPackage = self.selectedPackageContextOverride?.package ?? Self.effectiveDefaultPackage(
             pageDefaultPackage: paywallState.viewModelFactory.packageValidator.defaultSelectedPackage,
             workflowDefaultPackage: self.workflowPackageContext?.selectedPackage ?? self.workflowDefaultPackage
         )

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -191,7 +191,7 @@ struct PaywallsV2View: View {
 
     private func loadedPaywallView(paywallState: PaywallState) -> some View {
         let contentLocale = paywallState.rootViewModel.localizationProvider.locale
-        let defaultPackage = self.selectedPackageContextOverride?.package ?? Self.effectiveDefaultPackage(
+        let defaultPackage = Self.effectiveDefaultPackage(
             pageDefaultPackage: paywallState.viewModelFactory.packageValidator.defaultSelectedPackage,
             workflowDefaultPackage: self.workflowPackageContext?.selectedPackage ?? self.workflowDefaultPackage
         )

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -67,7 +67,6 @@ struct PaywallsV2View: View {
     private let workflowDefaultPackage: Package?
     private let workflowPackages: [Package]?
     private let showZeroDecimalPlacePrices: Bool
-    private let selectedPackageContextOverride: PackageContext?
     /// This is a configuration value from PaywallsV1, but it's important to include here just in case the
     /// default paywall is shown. This is not used in the success path
     private let displayCloseButton: Bool
@@ -115,7 +114,6 @@ struct PaywallsV2View: View {
         self.displayCloseButton = displayCloseButton
         self.onDismiss = onDismiss
         self.closeWorkflowAction = closeWorkflowAction
-        self.selectedPackageContextOverride = selectedPackageContextOverride
         self._paywallPromoOfferCache = .init(wrappedValue: promoOfferCache ?? PaywallPromoOfferCache(
             subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
         ))

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowNavigator.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowNavigator.swift
@@ -15,6 +15,12 @@ import Combine
 #if !os(tvOS)
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct WorkflowBackNavigationDestination {
+    let step: WorkflowStep
+    let canNavigateBackAfterNavigation: Bool
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class WorkflowNavigator: ObservableObject {
 
     @Published private(set) var currentStepId: String
@@ -32,6 +38,18 @@ final class WorkflowNavigator: ObservableObject {
 
     var canNavigateBack: Bool {
         return !backStack.isEmpty
+    }
+
+    var backNavigationDestination: WorkflowBackNavigationDestination? {
+        guard let previousStepId = backStack.last,
+              let previousStep = workflow.steps[previousStepId] else {
+            return nil
+        }
+
+        return .init(
+            step: previousStep,
+            canNavigateBackAfterNavigation: backStack.count > 1
+        )
     }
 
     @discardableResult

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -180,13 +180,13 @@ struct WorkflowPaywallView: View {
         self.onDismiss = onDismiss
         self._navigator = .init(wrappedValue: WorkflowNavigator(workflow: context.workflow))
         let initialStepId = context.workflow.initialStepId
-        let initialPackageContext = Self.buildPackageContext(
+        let initialPackageInput = Self.buildPackageInput(
             stepId: initialStepId,
             context: context,
             preferredPackage: nil,
             showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
         )
-        self._stepPackageContexts = .init(wrappedValue: [initialStepId: initialPackageContext])
+        self._stepPackageContexts = .init(wrappedValue: [initialStepId: initialPackageInput.packageContext])
         self._transitionState = .init(
             wrappedValue: .init(
                 currentPage: Self.renderedPage(
@@ -194,13 +194,7 @@ struct WorkflowPaywallView: View {
                     stepId: initialStepId,
                     canNavigateBack: false,
                     displayCloseButton: displayCloseButton,
-                    packageInput: .init(
-                        packageContext: initialPackageContext,
-                        effectiveWorkflowPackageContext: context.effectivePackageContext(
-                            for: initialStepId,
-                            preferring: initialPackageContext.package
-                        )
-                    )
+                    packageInput: initialPackageInput
                 )
             )
         )
@@ -304,15 +298,17 @@ struct WorkflowPaywallView: View {
         case .dismissWorkflow:
             self.onDismiss()
         case .navigateBack:
-            guard let previousStep = self.navigator.navigateBack() else {
+            guard let destination = self.navigator.backNavigationDestination,
+                  let page = self.renderedPageForBackNavigation(
+                      stepId: destination.step.id,
+                      canNavigateBack: destination.canNavigateBackAfterNavigation
+                  ) else {
                 return
             }
 
+            self.navigator.navigateBack()
             self.startTransition(
-                to: self.renderedPageForBackNavigation(
-                    stepId: previousStep.id,
-                    canNavigateBack: self.navigator.canNavigateBack
-                ),
+                to: page,
                 direction: .back
             )
         }
@@ -432,27 +428,33 @@ struct WorkflowPaywallView: View {
         )
     }
 
-    static func buildPackageContext(
+    static func buildPackageInput(
         stepId: String,
         context: WorkflowContext,
         preferredPackage: Package?,
         showZeroDecimalPlacePrices: Bool
-    ) -> PackageContext {
+    ) -> RenderedPagePackageInput {
         let effective = context.effectivePackageContext(for: stepId, preferring: preferredPackage)
 
         guard let effective else {
-            return PackageContext(
-                package: nil,
-                variableContext: .init(packages: [], showZeroDecimalPlacePrices: showZeroDecimalPlacePrices)
+            return .init(
+                packageContext: .init(
+                    package: nil,
+                    variableContext: .init(packages: [], showZeroDecimalPlacePrices: showZeroDecimalPlacePrices)
+                ),
+                effectiveWorkflowPackageContext: nil
             )
         }
 
-        return PackageContext(
-            package: effective.selectedPackage,
-            variableContext: .init(
-                packages: effective.packages,
-                showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
-            )
+        return .init(
+            packageContext: .init(
+                package: effective.selectedPackage,
+                variableContext: .init(
+                    packages: effective.packages,
+                    showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+                )
+            ),
+            effectiveWorkflowPackageContext: effective
         )
     }
 
@@ -490,17 +492,23 @@ struct WorkflowPaywallView: View {
         canNavigateBack: Bool,
         carryForwardPackage: Package?
     ) -> RenderedPage? {
-        let packageContext: PackageContext
+        let packageInput: RenderedPagePackageInput
         if let cached = self.stepPackageContexts[stepId] {
-            packageContext = cached
+            packageInput = .init(
+                packageContext: cached,
+                effectiveWorkflowPackageContext: self.context.effectivePackageContext(
+                    for: stepId,
+                    preferring: cached.package
+                )
+            )
         } else {
-            packageContext = Self.buildPackageContext(
+            packageInput = Self.buildPackageInput(
                 stepId: stepId,
                 context: self.context,
                 preferredPackage: carryForwardPackage,
                 showZeroDecimalPlacePrices: self.showZeroDecimalPlacePrices
             )
-            self.stepPackageContexts[stepId] = packageContext
+            self.stepPackageContexts[stepId] = packageInput.packageContext
         }
 
         return Self.renderedPage(
@@ -508,13 +516,7 @@ struct WorkflowPaywallView: View {
             stepId: stepId,
             canNavigateBack: canNavigateBack,
             displayCloseButton: self.displayCloseButton,
-            packageInput: .init(
-                packageContext: packageContext,
-                effectiveWorkflowPackageContext: self.context.effectivePackageContext(
-                    for: stepId,
-                    preferring: packageContext.package
-                )
-            )
+            packageInput: packageInput
         )
     }
 
@@ -558,7 +560,7 @@ private struct CurrentStepContent {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private struct RenderedPagePackageInput {
+struct RenderedPagePackageInput {
     let packageContext: PackageContext
     let effectiveWorkflowPackageContext: WorkflowPackageContext?
 }

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -195,7 +195,8 @@ struct WorkflowPaywallView: View {
                     stepId: initialStepId,
                     canNavigateBack: false,
                     displayCloseButton: displayCloseButton,
-                    packageContext: initialPackageContext
+                    packageContext: initialPackageContext,
+                    effectiveWorkflowPackageContext: context.effectivePackageContext(for: initialStepId)
                 )
             )
         )
@@ -275,7 +276,7 @@ struct WorkflowPaywallView: View {
             promoOfferCache: self.promoOfferCache,
             selectedPackageContextOverride: page.packageContext
         )
-        .environment(\.workflowPackageContext, self.workflowPackageContext)
+        .environment(\.workflowPackageContext, page.effectiveWorkflowPackageContext)
         .environment(\.workflowTriggerAction, { componentId in
             return self.handleTriggeredNavigation(componentId: componentId)
         })
@@ -399,12 +400,14 @@ struct WorkflowPaywallView: View {
         self.activeTransitionID = nil
     }
 
+    // swiftlint:disable:next function_parameter_count
     private static func renderedPage(
         from context: WorkflowContext,
         stepId: String,
         canNavigateBack: Bool,
         displayCloseButton: Bool,
-        packageContext: PackageContext
+        packageContext: PackageContext,
+        effectiveWorkflowPackageContext: WorkflowPackageContext?
     ) -> RenderedPage? {
         guard let step = context.workflow.steps[stepId],
               let screenId = step.screenId,
@@ -421,7 +424,8 @@ struct WorkflowPaywallView: View {
         return .init(
             content: .init(paywallComponents: paywallComponents, offering: offering),
             showCloseButton: !canNavigateBack && displayCloseButton,
-            packageContext: packageContext
+            packageContext: packageContext,
+            effectiveWorkflowPackageContext: effectiveWorkflowPackageContext
         )
     }
 
@@ -431,17 +435,9 @@ struct WorkflowPaywallView: View {
         workflowPackageContext: WorkflowPackageContext?,
         showZeroDecimalPlacePrices: Bool
     ) -> PackageContext {
-        if let stepPackageContext = context.packageContext(for: stepId) {
-            return PackageContext(
-                package: stepPackageContext.selectedPackage,
-                variableContext: .init(
-                    packages: stepPackageContext.packages,
-                    showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
-                )
-            )
-        }
+        let effective = context.effectivePackageContext(for: stepId) ?? workflowPackageContext
 
-        guard let workflow = workflowPackageContext else {
+        guard let effective else {
             return PackageContext(
                 package: nil,
                 variableContext: .init(packages: [], showZeroDecimalPlacePrices: showZeroDecimalPlacePrices)
@@ -449,9 +445,9 @@ struct WorkflowPaywallView: View {
         }
 
         return PackageContext(
-            package: workflow.selectedPackage,
+            package: effective.selectedPackage,
             variableContext: .init(
-                packages: workflow.packages,
+                packages: effective.packages,
                 showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
             )
         )
@@ -479,7 +475,8 @@ struct WorkflowPaywallView: View {
             stepId: stepId,
             canNavigateBack: canNavigateBack,
             displayCloseButton: self.displayCloseButton,
-            packageContext: packageContext
+            packageContext: packageContext,
+            effectiveWorkflowPackageContext: self.context.effectivePackageContext(for: stepId)
         )
     }
 
@@ -505,6 +502,7 @@ private struct RenderedPage: Identifiable {
     let content: CurrentStepContent
     let showCloseButton: Bool
     let packageContext: PackageContext
+    let effectiveWorkflowPackageContext: WorkflowPackageContext?
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -177,8 +177,7 @@ struct WorkflowPaywallView: View {
         self.displayCloseButton = displayCloseButton
         self.promoOfferCache = promoOfferCache
         self.onDismiss = onDismiss
-        let wfPackageContext = context.workflowPackageContext
-        self.workflowPackageContext = wfPackageContext
+        self.workflowPackageContext = context.workflowPackageContext
         self._navigator = .init(wrappedValue: WorkflowNavigator(workflow: context.workflow))
         let initialStepId = context.workflow.initialStepId
         let initialPackageContext = Self.buildPackageContext(

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -158,6 +158,8 @@ struct WorkflowPaywallView: View {
     @State private var hasLoggedInvalidState = false
     @State private var transitionState: WorkflowPageTransitionState<RenderedPage>
     @State private var activeTransitionID: UUID?
+    /// PackageContext is intentionally cached by reference: PaywallsV2View mutates the same
+    /// instance, so user selections persist when revisiting a workflow step.
     @State private var stepPackageContexts: [String: PackageContext]
 
     init(

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -184,7 +184,7 @@ struct WorkflowPaywallView: View {
         let initialPackageContext = Self.buildPackageContext(
             stepId: initialStepId,
             context: context,
-            workflowPackageContext: wfPackageContext,
+            preferredPackage: nil,
             showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
         )
         self._stepPackageContexts = .init(wrappedValue: [initialStepId: initialPackageContext])
@@ -307,7 +307,8 @@ struct WorkflowPaywallView: View {
             self.startTransition(
                 to: self.renderedPageForStep(
                     stepId: previousStep.id,
-                    canNavigateBack: self.navigator.canNavigateBack
+                    canNavigateBack: self.navigator.canNavigateBack,
+                    carryForwardPackage: nil
                 ),
                 direction: .back
             )
@@ -344,7 +345,8 @@ struct WorkflowPaywallView: View {
         self.startTransition(
             to: self.renderedPageForStep(
                 stepId: nextStep.id,
-                canNavigateBack: self.navigator.canNavigateBack
+                canNavigateBack: self.navigator.canNavigateBack,
+                carryForwardPackage: self.transitionState.currentPage?.packageContext.package
             ),
             direction: .forward
         )
@@ -432,10 +434,10 @@ struct WorkflowPaywallView: View {
     private static func buildPackageContext(
         stepId: String,
         context: WorkflowContext,
-        workflowPackageContext: WorkflowPackageContext?,
+        preferredPackage: Package?,
         showZeroDecimalPlacePrices: Bool
     ) -> PackageContext {
-        let effective = context.effectivePackageContext(for: stepId)
+        let effective = context.effectivePackageContext(for: stepId, preferring: preferredPackage)
 
         guard let effective else {
             return PackageContext(
@@ -455,16 +457,21 @@ struct WorkflowPaywallView: View {
 
     private func renderedPageForStep(
         stepId: String,
-        canNavigateBack: Bool
+        canNavigateBack: Bool,
+        carryForwardPackage: Package?
     ) -> RenderedPage? {
         let packageContext: PackageContext
         if let cached = self.stepPackageContexts[stepId] {
             packageContext = cached
+            if carryForwardPackage != nil {
+                let resolved = self.context.effectivePackageContext(for: stepId, preferring: carryForwardPackage)
+                packageContext.package = resolved?.selectedPackage ?? packageContext.package
+            }
         } else {
             packageContext = Self.buildPackageContext(
                 stepId: stepId,
                 context: self.context,
-                workflowPackageContext: self.workflowPackageContext,
+                preferredPackage: carryForwardPackage,
                 showZeroDecimalPlacePrices: self.showZeroDecimalPlacePrices
             )
             self.stepPackageContexts[stepId] = packageContext

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -309,10 +309,9 @@ struct WorkflowPaywallView: View {
             }
 
             self.startTransition(
-                to: self.renderedPageForStep(
+                to: self.renderedPageForBackNavigation(
                     stepId: previousStep.id,
-                    canNavigateBack: self.navigator.canNavigateBack,
-                    carryForwardPackage: nil
+                    canNavigateBack: self.navigator.canNavigateBack
                 ),
                 direction: .back
             )
@@ -347,7 +346,7 @@ struct WorkflowPaywallView: View {
         }
 
         self.startTransition(
-            to: self.renderedPageForStep(
+            to: self.renderedPageForForwardNavigation(
                 stepId: nextStep.id,
                 canNavigateBack: self.navigator.canNavigateBack,
                 carryForwardPackage: self.transitionState.currentPage?.packageContext.package
@@ -457,7 +456,30 @@ struct WorkflowPaywallView: View {
         )
     }
 
-    private func renderedPageForStep(
+    private func renderedPageForBackNavigation(
+        stepId: String,
+        canNavigateBack: Bool
+    ) -> RenderedPage? {
+        guard let packageContext = self.stepPackageContexts[stepId] else {
+            preconditionFailure("back-navigation target should always be cached")
+        }
+
+        return Self.renderedPage(
+            from: self.context,
+            stepId: stepId,
+            canNavigateBack: canNavigateBack,
+            displayCloseButton: self.displayCloseButton,
+            packageInput: .init(
+                packageContext: packageContext,
+                effectiveWorkflowPackageContext: self.context.effectivePackageContext(
+                    for: stepId,
+                    preferring: packageContext.package
+                )
+            )
+        )
+    }
+
+    private func renderedPageForForwardNavigation(
         stepId: String,
         canNavigateBack: Bool,
         carryForwardPackage: Package?
@@ -466,12 +488,6 @@ struct WorkflowPaywallView: View {
         if let cached = self.stepPackageContexts[stepId] {
             packageContext = cached
         } else {
-            if canNavigateBack {
-                precondition(
-                    self.stepPackageContexts[stepId] != nil,
-                    "back-navigation target should always be cached"
-                )
-            }
             packageContext = Self.buildPackageContext(
                 stepId: stepId,
                 context: self.context,

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -159,6 +159,7 @@ struct WorkflowPaywallView: View {
     @State private var hasLoggedInvalidState = false
     @State private var transitionState: WorkflowPageTransitionState<RenderedPage>
     @State private var activeTransitionID: UUID?
+    @State private var stepPackageContexts: [String: PackageContext]
 
     init(
         context: WorkflowContext,
@@ -176,15 +177,25 @@ struct WorkflowPaywallView: View {
         self.displayCloseButton = displayCloseButton
         self.promoOfferCache = promoOfferCache
         self.onDismiss = onDismiss
-        self.workflowPackageContext = context.workflowPackageContext
+        let wfPackageContext = context.workflowPackageContext
+        self.workflowPackageContext = wfPackageContext
         self._navigator = .init(wrappedValue: WorkflowNavigator(workflow: context.workflow))
+        let initialStepId = context.workflow.initialStepId
+        let initialPackageContext = Self.buildPackageContext(
+            stepId: initialStepId,
+            context: context,
+            workflowPackageContext: wfPackageContext,
+            showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+        )
+        self._stepPackageContexts = .init(wrappedValue: [initialStepId: initialPackageContext])
         self._transitionState = .init(
             wrappedValue: .init(
                 currentPage: Self.renderedPage(
                     from: context,
-                    stepId: context.workflow.initialStepId,
+                    stepId: initialStepId,
                     canNavigateBack: false,
-                    displayCloseButton: displayCloseButton
+                    displayCloseButton: displayCloseButton,
+                    packageContext: initialPackageContext
                 )
             )
         )
@@ -261,7 +272,8 @@ struct WorkflowPaywallView: View {
             closeWorkflowAction: self.onDismiss,
             failedToLoadFont: self.failedToLoadFont,
             colorScheme: self.colorScheme,
-            promoOfferCache: self.promoOfferCache
+            promoOfferCache: self.promoOfferCache,
+            selectedPackageContextOverride: page.packageContext
         )
         .environment(\.workflowPackageContext, self.workflowPackageContext)
         .environment(\.workflowTriggerAction, { componentId in
@@ -292,11 +304,9 @@ struct WorkflowPaywallView: View {
             }
 
             self.startTransition(
-                to: Self.renderedPage(
-                    from: self.context,
+                to: self.renderedPageForStep(
                     stepId: previousStep.id,
-                    canNavigateBack: self.navigator.canNavigateBack,
-                    displayCloseButton: self.displayCloseButton
+                    canNavigateBack: self.navigator.canNavigateBack
                 ),
                 direction: .back
             )
@@ -331,11 +341,9 @@ struct WorkflowPaywallView: View {
         }
 
         self.startTransition(
-            to: Self.renderedPage(
-                from: self.context,
+            to: self.renderedPageForStep(
                 stepId: nextStep.id,
-                canNavigateBack: self.navigator.canNavigateBack,
-                displayCloseButton: self.displayCloseButton
+                canNavigateBack: self.navigator.canNavigateBack
             ),
             direction: .forward
         )
@@ -395,7 +403,8 @@ struct WorkflowPaywallView: View {
         from context: WorkflowContext,
         stepId: String,
         canNavigateBack: Bool,
-        displayCloseButton: Bool
+        displayCloseButton: Bool,
+        packageContext: PackageContext
     ) -> RenderedPage? {
         guard let step = context.workflow.steps[stepId],
               let screenId = step.screenId,
@@ -411,7 +420,66 @@ struct WorkflowPaywallView: View {
 
         return .init(
             content: .init(paywallComponents: paywallComponents, offering: offering),
-            showCloseButton: !canNavigateBack && displayCloseButton
+            showCloseButton: !canNavigateBack && displayCloseButton,
+            packageContext: packageContext
+        )
+    }
+
+    private static func buildPackageContext(
+        stepId: String,
+        context: WorkflowContext,
+        workflowPackageContext: WorkflowPackageContext?,
+        showZeroDecimalPlacePrices: Bool
+    ) -> PackageContext {
+        if let stepPackageContext = context.packageContext(for: stepId) {
+            return PackageContext(
+                package: stepPackageContext.selectedPackage,
+                variableContext: .init(
+                    packages: stepPackageContext.packages,
+                    showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+                )
+            )
+        }
+
+        guard let workflow = workflowPackageContext else {
+            return PackageContext(
+                package: nil,
+                variableContext: .init(packages: [], showZeroDecimalPlacePrices: showZeroDecimalPlacePrices)
+            )
+        }
+
+        return PackageContext(
+            package: workflow.selectedPackage,
+            variableContext: .init(
+                packages: workflow.packages,
+                showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+            )
+        )
+    }
+
+    private func renderedPageForStep(
+        stepId: String,
+        canNavigateBack: Bool
+    ) -> RenderedPage? {
+        let packageContext: PackageContext
+        if let cached = self.stepPackageContexts[stepId] {
+            packageContext = cached
+        } else {
+            packageContext = Self.buildPackageContext(
+                stepId: stepId,
+                context: self.context,
+                workflowPackageContext: self.workflowPackageContext,
+                showZeroDecimalPlacePrices: self.showZeroDecimalPlacePrices
+            )
+            self.stepPackageContexts[stepId] = packageContext
+        }
+
+        return Self.renderedPage(
+            from: self.context,
+            stepId: stepId,
+            canNavigateBack: canNavigateBack,
+            displayCloseButton: self.displayCloseButton,
+            packageContext: packageContext
         )
     }
 
@@ -436,6 +504,7 @@ private struct RenderedPage: Identifiable {
     let id = UUID()
     let content: CurrentStepContent
     let showCloseButton: Bool
+    let packageContext: PackageContext
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -435,7 +435,7 @@ struct WorkflowPaywallView: View {
         workflowPackageContext: WorkflowPackageContext?,
         showZeroDecimalPlacePrices: Bool
     ) -> PackageContext {
-        let effective = context.effectivePackageContext(for: stepId) ?? workflowPackageContext
+        let effective = context.effectivePackageContext(for: stepId)
 
         guard let effective else {
             return PackageContext(

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -153,7 +153,6 @@ struct WorkflowPaywallView: View {
     private let displayCloseButton: Bool
     private let promoOfferCache: PaywallPromoOfferCache?
     private let onDismiss: () -> Void
-    private let workflowPackageContext: WorkflowPackageContext?
 
     @StateObject private var navigator: WorkflowNavigator
     @State private var hasLoggedInvalidState = false
@@ -177,7 +176,6 @@ struct WorkflowPaywallView: View {
         self.displayCloseButton = displayCloseButton
         self.promoOfferCache = promoOfferCache
         self.onDismiss = onDismiss
-        self.workflowPackageContext = context.workflowPackageContext
         self._navigator = .init(wrappedValue: WorkflowNavigator(workflow: context.workflow))
         let initialStepId = context.workflow.initialStepId
         let initialPackageContext = Self.buildPackageContext(
@@ -195,7 +193,10 @@ struct WorkflowPaywallView: View {
                     canNavigateBack: false,
                     displayCloseButton: displayCloseButton,
                     packageContext: initialPackageContext,
-                    effectiveWorkflowPackageContext: context.effectivePackageContext(for: initialStepId)
+                    effectiveWorkflowPackageContext: context.effectivePackageContext(
+                        for: initialStepId,
+                        preferring: initialPackageContext.package
+                    )
                 )
             )
         )
@@ -265,8 +266,8 @@ struct WorkflowPaywallView: View {
             purchaseHandler: self.purchaseHandler,
             introEligibilityChecker: self.introEligibilityChecker,
             showZeroDecimalPlacePrices: self.showZeroDecimalPlacePrices,
-            workflowDefaultPackage: self.workflowPackageContext?.selectedPackage,
-            workflowPackages: self.workflowPackageContext?.packages,
+            workflowDefaultPackage: page.effectiveWorkflowPackageContext?.selectedPackage,
+            workflowPackages: page.effectiveWorkflowPackageContext?.packages,
             displayCloseButton: page.showCloseButton,
             onDismiss: self.handleDismiss,
             closeWorkflowAction: self.onDismiss,
@@ -478,7 +479,10 @@ struct WorkflowPaywallView: View {
             canNavigateBack: canNavigateBack,
             displayCloseButton: self.displayCloseButton,
             packageContext: packageContext,
-            effectiveWorkflowPackageContext: self.context.effectivePackageContext(for: stepId)
+            effectiveWorkflowPackageContext: self.context.effectivePackageContext(
+                for: stepId,
+                preferring: packageContext.package
+            )
         )
     }
 

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -463,10 +463,6 @@ struct WorkflowPaywallView: View {
         let packageContext: PackageContext
         if let cached = self.stepPackageContexts[stepId] {
             packageContext = cached
-            if carryForwardPackage != nil {
-                let resolved = self.context.effectivePackageContext(for: stepId, preferring: carryForwardPackage)
-                packageContext.package = resolved?.selectedPackage ?? packageContext.package
-            }
         } else {
             packageContext = Self.buildPackageContext(
                 stepId: stepId,

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -466,6 +466,12 @@ struct WorkflowPaywallView: View {
         if let cached = self.stepPackageContexts[stepId] {
             packageContext = cached
         } else {
+            if canNavigateBack {
+                precondition(
+                    self.stepPackageContexts[stepId] != nil,
+                    "back-navigation target should always be cached"
+                )
+            }
             packageContext = Self.buildPackageContext(
                 stepId: stepId,
                 context: self.context,

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -431,7 +431,7 @@ struct WorkflowPaywallView: View {
         )
     }
 
-    private static func buildPackageContext(
+    static func buildPackageContext(
         stepId: String,
         context: WorkflowContext,
         preferredPackage: Package?,

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -194,10 +194,12 @@ struct WorkflowPaywallView: View {
                     stepId: initialStepId,
                     canNavigateBack: false,
                     displayCloseButton: displayCloseButton,
-                    packageContext: initialPackageContext,
-                    effectiveWorkflowPackageContext: context.effectivePackageContext(
-                        for: initialStepId,
-                        preferring: initialPackageContext.package
+                    packageInput: .init(
+                        packageContext: initialPackageContext,
+                        effectiveWorkflowPackageContext: context.effectivePackageContext(
+                            for: initialStepId,
+                            preferring: initialPackageContext.package
+                        )
                     )
                 )
             )
@@ -404,14 +406,12 @@ struct WorkflowPaywallView: View {
         self.activeTransitionID = nil
     }
 
-    // swiftlint:disable:next function_parameter_count
     private static func renderedPage(
         from context: WorkflowContext,
         stepId: String,
         canNavigateBack: Bool,
         displayCloseButton: Bool,
-        packageContext: PackageContext,
-        effectiveWorkflowPackageContext: WorkflowPackageContext?
+        packageInput: RenderedPagePackageInput
     ) -> RenderedPage? {
         guard let step = context.workflow.steps[stepId],
               let screenId = step.screenId,
@@ -428,8 +428,8 @@ struct WorkflowPaywallView: View {
         return .init(
             content: .init(paywallComponents: paywallComponents, offering: offering),
             showCloseButton: !canNavigateBack && displayCloseButton,
-            packageContext: packageContext,
-            effectiveWorkflowPackageContext: effectiveWorkflowPackageContext
+            packageContext: packageInput.packageContext,
+            effectiveWorkflowPackageContext: packageInput.effectiveWorkflowPackageContext
         )
     }
 
@@ -480,10 +480,12 @@ struct WorkflowPaywallView: View {
             stepId: stepId,
             canNavigateBack: canNavigateBack,
             displayCloseButton: self.displayCloseButton,
-            packageContext: packageContext,
-            effectiveWorkflowPackageContext: self.context.effectivePackageContext(
-                for: stepId,
-                preferring: packageContext.package
+            packageInput: .init(
+                packageContext: packageContext,
+                effectiveWorkflowPackageContext: self.context.effectivePackageContext(
+                    for: stepId,
+                    preferring: packageContext.package
+                )
             )
         )
     }
@@ -525,6 +527,12 @@ private struct DisplayedPage: Identifiable {
 private struct CurrentStepContent {
     let paywallComponents: Offering.PaywallComponents
     let offering: Offering
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct RenderedPagePackageInput {
+    let packageContext: PackageContext
+    let effectiveWorkflowPackageContext: WorkflowPackageContext?
 }
 
 #endif

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -461,7 +461,13 @@ struct WorkflowPaywallView: View {
         canNavigateBack: Bool
     ) -> RenderedPage? {
         guard let packageContext = self.stepPackageContexts[stepId] else {
-            preconditionFailure("back-navigation target should always be cached")
+            Logger.error(
+                Strings.workflow_paywall_invalid_state(
+                    currentStepId: stepId,
+                    screenId: self.context.workflow.steps[stepId]?.screenId
+                )
+            )
+            return nil
         }
 
         return Self.renderedPage(

--- a/Tests/RevenueCatUITests/PaywallsV2/RootViewSheetDismissalTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/RootViewSheetDismissalTests.swift
@@ -1,0 +1,85 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RootViewSheetDismissalTests.swift
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if !os(tvOS) // For Paywalls V2
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class RootViewSheetDismissalTests: TestCase {
+
+    // MARK: - restoredPackageAfterSheetDismissal
+
+    /// In a workflow context, dismissing the sheet without selecting a new package must restore
+    /// the snapshot taken when the sheet opened — not fall back to the global workflow default.
+    func testWorkflowContextRestoresSnapshotOnDismissal() {
+        let snapshot = TestData.monthlyPackage
+        let defaultPackage = TestData.annualPackage
+        let workflowCtx = WorkflowPackageContext(selectedPackage: defaultPackage, packages: [defaultPackage, snapshot])
+
+        let result = RootView.restoredPackageAfterSheetDismissal(
+            workflowPackageContext: workflowCtx,
+            packageBeforeSheet: snapshot,
+            defaultPackage: defaultPackage
+        )
+
+        expect(result?.identifier) == snapshot.identifier
+    }
+
+    /// In a workflow context with no snapshot (sheet opened before any selection was cached),
+    /// dismissal falls back to the step default.
+    func testWorkflowContextFallsBackToDefaultWhenNoSnapshot() {
+        let defaultPackage = TestData.annualPackage
+        let workflowCtx = WorkflowPackageContext(selectedPackage: defaultPackage, packages: [defaultPackage])
+
+        let result = RootView.restoredPackageAfterSheetDismissal(
+            workflowPackageContext: workflowCtx,
+            packageBeforeSheet: nil,
+            defaultPackage: defaultPackage
+        )
+
+        expect(result?.identifier) == defaultPackage.identifier
+    }
+
+    /// Outside a workflow context the sheet always resets to the step default,
+    /// even when a non-nil snapshot exists (it should be ignored).
+    func testNonWorkflowContextAlwaysRestoresDefault() {
+        let snapshot = TestData.monthlyPackage
+        let defaultPackage = TestData.annualPackage
+
+        let result = RootView.restoredPackageAfterSheetDismissal(
+            workflowPackageContext: nil,
+            packageBeforeSheet: snapshot,
+            defaultPackage: defaultPackage
+        )
+
+        expect(result?.identifier) == defaultPackage.identifier
+    }
+
+    /// A nil default package (no packages in the offering) is a valid state; the result should be nil.
+    func testWorkflowContextReturnsNilWhenBothSnapshotAndDefaultAreNil() {
+        let workflowCtx = WorkflowPackageContext(selectedPackage: TestData.monthlyPackage, packages: [])
+
+        let result = RootView.restoredPackageAfterSheetDismissal(
+            workflowPackageContext: workflowCtx,
+            packageBeforeSheet: nil,
+            defaultPackage: nil
+        )
+
+        expect(result).to(beNil())
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/RootViewSheetDismissalTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/RootViewSheetDismissalTests.swift
@@ -30,7 +30,7 @@ final class RootViewSheetDismissalTests: TestCase {
 
         let result = RootView.restoredPackageAfterSheetDismissal(
             workflowPackageContext: workflowCtx,
-            packageBeforeSheet: snapshot,
+            packageBeforeOpeningSheet: snapshot,
             defaultPackage: defaultPackage
         )
 
@@ -45,7 +45,7 @@ final class RootViewSheetDismissalTests: TestCase {
 
         let result = RootView.restoredPackageAfterSheetDismissal(
             workflowPackageContext: workflowCtx,
-            packageBeforeSheet: nil,
+            packageBeforeOpeningSheet: nil,
             defaultPackage: defaultPackage
         )
 
@@ -60,7 +60,7 @@ final class RootViewSheetDismissalTests: TestCase {
 
         let result = RootView.restoredPackageAfterSheetDismissal(
             workflowPackageContext: nil,
-            packageBeforeSheet: snapshot,
+            packageBeforeOpeningSheet: snapshot,
             defaultPackage: defaultPackage
         )
 
@@ -73,7 +73,7 @@ final class RootViewSheetDismissalTests: TestCase {
 
         let result = RootView.restoredPackageAfterSheetDismissal(
             workflowPackageContext: workflowCtx,
-            packageBeforeSheet: nil,
+            packageBeforeOpeningSheet: nil,
             defaultPackage: nil
         )
 

--- a/Tests/RevenueCatUITests/PaywallsV2/TabsPackageInheritanceTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/TabsPackageInheritanceTests.swift
@@ -1049,6 +1049,100 @@ final class TabsPackageInheritanceTests: TestCase {
     }
 }
 
+// MARK: - Workflow Revisit Tests
+//
+// These tests cover the interaction between WorkflowPaywallView's per-step PackageContext cache
+// and LoadedTabsComponentView's tab initialization.
+//
+// Bug: on a workflow step revisit, effectiveWorkflowPackageContext always carries the authored
+// default (static config). It reaches LoadedTabsComponentView as workflowDefaultPackage.
+// The tab init used `workflowDefaultPackage ?? tabViewModel.defaultSelectedPackage`, ignoring
+// the parent PackageContext that already holds the user's cached selection. The onAppear then
+// propagated the authored default back up through the shared PackageContext reference,
+// overwriting the user's choice.
+//
+// Fix: prefer parentPackageContext.package when it is present in the tab's package list.
+// This is expressed as LoadedTabsComponentView.initialPackage(parentPackage:tabPackages:
+// workflowDefaultPackage:tabDefaultPackage:) so it can be unit-tested without constructing
+// the full SwiftUI view.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension TabsPackageInheritanceTests {
+
+    func testInitialPackagePrefersParentCachedSelectionWhenAvailableInTab() {
+        // Scenario: user selected A (monthly) on this step before navigating away.
+        // WorkflowPaywallView restores the cached PackageContext (package = A), but
+        // effectiveWorkflowPackageContext still has the authored default (B / annual).
+        // The tab offers both A and B, so A should win over the authored default.
+        let result = LoadedTabsComponentView.initialPackage(
+            parentPackage: self.parentPackageA,
+            tabPackages: [self.parentPackageA, self.parentPackageB],
+            workflowDefaultPackage: self.parentPackageB,
+            tabDefaultPackage: self.parentPackageB
+        )
+
+        expect(result?.identifier) == self.parentPackageA.identifier
+    }
+
+    func testInitialPackageFallsBackToWorkflowDefaultWhenParentPackageAbsentFromTab() {
+        // Scenario: parent holds C (weekly) but this tab only has A and B.
+        // Since C is not in the tab's package list, fall back to workflowDefaultPackage (B).
+        let result = LoadedTabsComponentView.initialPackage(
+            parentPackage: self.tabPackageC,
+            tabPackages: [self.parentPackageA, self.parentPackageB],
+            workflowDefaultPackage: self.parentPackageB,
+            tabDefaultPackage: self.parentPackageA
+        )
+
+        expect(result?.identifier) == self.parentPackageB.identifier
+    }
+
+    func testInitialPackageUsesTabDefaultWhenNoWorkflowDefaultAndParentAbsent() {
+        // Scenario: no workflow context (singleStepFallbackId not set) and parent
+        // package is nil (packageless step). Tab's own default (A) should be used.
+        let result = LoadedTabsComponentView.initialPackage(
+            parentPackage: nil,
+            tabPackages: [self.parentPackageA, self.parentPackageB],
+            workflowDefaultPackage: nil,
+            tabDefaultPackage: self.parentPackageA
+        )
+
+        expect(result?.identifier) == self.parentPackageA.identifier
+    }
+
+    @MainActor
+    func testOnAppearDoesNotOverwriteCachedSelectionWhenTabSeededFromParent() {
+        // Scenario: with the fix in place the tab is seeded from parentPackageContext.package (A).
+        // onAppear propagates the tab package back up to packageContext — same reference as the
+        // cached context. Since both have A, this is a no-op and the cache is preserved.
+
+        // Given: cached PackageContext holds A (user's selection)
+        let parentContext = PackageContext(
+            package: self.parentPackageA,
+            variableContext: .init(packages: [self.parentPackageA, self.parentPackageB])
+        )
+
+        // Given: tab was seeded with A (fixed behaviour — prefers parent's cached selection)
+        let tabContext = PackageContext(
+            package: LoadedTabsComponentView.initialPackage(
+                parentPackage: self.parentPackageA,
+                tabPackages: [self.parentPackageA, self.parentPackageB],
+                workflowDefaultPackage: self.parentPackageB,
+                tabDefaultPackage: self.parentPackageB
+            ),
+            variableContext: .init(packages: [self.parentPackageA, self.parentPackageB])
+        )
+
+        // When: simulating onAppear (wasConfigured = false on new view identity):
+        if let pkg = tabContext.package {
+            parentContext.update(package: pkg, variableContext: tabContext.variableContext)
+        }
+
+        // Then: cached selection A survives — onAppear is effectively a no-op.
+        expect(parentContext.package?.identifier) == self.parentPackageA.identifier
+    }
+
+}
+
 // MARK: - Test Helpers
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowNavigatorTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowNavigatorTests.swift
@@ -213,6 +213,51 @@ final class WorkflowNavigatorTests: TestCase {
         expect(navigator.canNavigateBack) == false
     }
 
+    func testBackNavigationDestinationIsNilFromInitialStep() throws {
+        let workflow = try Self.makeWorkflow(initialStepId: "step_1")
+        let navigator = WorkflowNavigator(workflow: workflow)
+
+        expect(navigator.backNavigationDestination).to(beNil())
+    }
+
+    func testBackNavigationDestinationDoesNotMutateNavigator() throws {
+        let workflow = try Self.makeWorkflow(
+            steps: [
+                makeStep(id: "step_1", triggers: [("btn_abc", "btn_abc")], triggerActions: [("btn_abc", "step_2")]),
+                makeStep(id: "step_2")
+            ],
+            initialStepId: "step_1"
+        )
+        let navigator = WorkflowNavigator(workflow: workflow)
+        navigator.triggerAction(componentId: "btn_abc")
+
+        let destination = navigator.backNavigationDestination
+
+        expect(destination?.step.id) == "step_1"
+        expect(destination?.canNavigateBackAfterNavigation) == false
+        expect(navigator.currentStepId) == "step_2"
+        expect(navigator.canNavigateBack) == true
+    }
+
+    func testBackNavigationDestinationReportsCanNavigateBackAfterNavigation() throws {
+        let workflow = try Self.makeWorkflow(
+            steps: [
+                makeStep(id: "step_1", triggers: [("btn_1", "btn_1")], triggerActions: [("btn_1", "step_2")]),
+                makeStep(id: "step_2", triggers: [("btn_2", "btn_2")], triggerActions: [("btn_2", "step_3")]),
+                makeStep(id: "step_3")
+            ],
+            initialStepId: "step_1"
+        )
+        let navigator = WorkflowNavigator(workflow: workflow)
+        navigator.triggerAction(componentId: "btn_1")
+        navigator.triggerAction(componentId: "btn_2")
+
+        let destination = navigator.backNavigationDestination
+
+        expect(destination?.step.id) == "step_2"
+        expect(destination?.canNavigateBackAfterNavigation) == true
+    }
+
     // MARK: - Multiple navigations
 
     func testMultipleForwardAndBackNavigationsWorkCorrectly() throws {

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -267,29 +267,6 @@ extension WorkflowPaywallViewTests {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension WorkflowPaywallViewTests {
 
-    /// Guards that `PackageContext` is a reference type.
-    /// `WorkflowPaywallView` stores one `PackageContext` per step in `stepPackageContexts`
-    /// and passes the same instance as `selectedPackageContextOverride` to `PaywallsV2View`.
-    /// Mutations made inside `PaywallsV2View` (user selecting a different package) must be
-    /// visible through the cached reference so that back-then-forward navigation restores the
-    /// user's choice rather than the authored default.
-    /// If `PackageContext` is ever refactored to a struct, this test breaks before behaviour does.
-    func testPackageContextMutationsPropagateThroughStepCacheReference() {
-        let ctx = PackageContext(
-            package: TestData.annualPackage,
-            variableContext: .init(packages: [TestData.annualPackage, TestData.monthlyPackage],
-                                   showZeroDecimalPlacePrices: false)
-        )
-        // Simulate what WorkflowPaywallView does: store the instance in the per-step cache.
-        let cache: [String: PackageContext] = ["step_terminal": ctx]
-
-        // Simulate the user selecting a different package (mutation inside PaywallsV2View).
-        ctx.package = TestData.monthlyPackage
-
-        // The cache entry must reflect the mutation — same object, not a copy.
-        expect(cache["step_terminal"]?.package?.identifier) == TestData.monthlyPackage.identifier
-    }
-
     /// Verifies that `buildPackageContext` carries the user's current selection forward when
     /// the preferred package exists in the next step's available packages.
     /// This is the forward-navigation path: user picks annual on step 1, navigates to step 2
@@ -323,6 +300,9 @@ extension WorkflowPaywallViewTests {
     /// Step2 must show monthly (the user's own previous selection), not annual (the new carry-forward).
     /// `WorkflowPaywallView.renderedPageForStep` implements this via the cache-hit path that skips
     /// `buildPackageContext` entirely when the step already has a `PackageContext` in `stepPackageContexts`.
+    ///
+    /// This also guards that `PackageContext` is a reference type: the mutation at line
+    /// `cachedCtx.package = monthly` must be visible through `stepCache` for the cache to work.
     func testCachedStepContextTakesPrecedenceOverCarryForwardOnRevisit() throws {
         let context = try Self.makeContext(
             singleStepFallbackId: "step_terminal",

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -311,11 +311,11 @@ extension WorkflowPaywallViewTests {
         expect(stepCache["step_terminal"]?.package?.identifier) == TestData.annualPackage.identifier
     }
 
-    /// Verifies that `buildPackageContext` carries the user's current selection forward when
+    /// Verifies that `buildPackageInput` carries the user's current selection forward when
     /// the preferred package exists in the next step's available packages.
     /// This is the forward-navigation path: user picks annual on step 1, navigates to step 2
     /// which also offers annual — step 2 should pre-select annual, not fall back to its own default.
-    func testBuildPackageContextCarriesForwardPreferredPackageWhenAvailableInStep() throws {
+    func testBuildPackageInputCarriesForwardPreferredPackageWhenAvailableInStep() throws {
         // step_terminal has annual (default) and monthly.
         let context = try Self.makeContext(
             singleStepFallbackId: "step_terminal",
@@ -325,15 +325,16 @@ extension WorkflowPaywallViewTests {
             context.packageContext(for: "step_terminal")?.packages.first { $0.identifier == "$rc_monthly" }
         )
 
-        let packageContext = WorkflowPaywallView.buildPackageContext(
+        let packageInput = WorkflowPaywallView.buildPackageInput(
             stepId: "step_terminal",
             context: context,
             preferredPackage: monthly,
             showZeroDecimalPlacePrices: false
         )
 
-        expect(packageContext.package?.identifier) == "$rc_monthly"
-        expect(packageContext.variableContext.mostExpensivePricePerMonth).toNot(beNil())
+        expect(packageInput.packageContext.package?.identifier) == "$rc_monthly"
+        expect(packageInput.effectiveWorkflowPackageContext?.selectedPackage.identifier) == "$rc_monthly"
+        expect(packageInput.packageContext.variableContext.mostExpensivePricePerMonth).toNot(beNil())
     }
 
     /// Verifies that once a step's `PackageContext` is cached, subsequent navigations to that step
@@ -342,8 +343,8 @@ extension WorkflowPaywallViewTests {
     /// Scenario: user navigates step1 → step2 (annual carried forward), selects monthly on step2,
     /// returns to step1, then navigates forward to step2 again.
     /// Step2 must show monthly (the user's own previous selection), not annual (the new carry-forward).
-    /// `WorkflowPaywallView.renderedPageForStep` implements this via the cache-hit path that skips
-    /// `buildPackageContext` entirely when the step already has a `PackageContext` in `stepPackageContexts`.
+    /// `WorkflowPaywallView.renderedPageForForwardNavigation` implements this via the cache-hit path that skips
+    /// `buildPackageInput` entirely when the step already has a `PackageContext` in `stepPackageContexts`.
     ///
     /// This also guards that `PackageContext` is a reference type: the mutation at line
     /// `cachedCtx.package = monthly` must be visible through `stepCache` for the cache to work.
@@ -360,12 +361,13 @@ extension WorkflowPaywallViewTests {
         )
 
         // First forward navigation: annual carried forward → step gets annual.
-        let cachedCtx = WorkflowPaywallView.buildPackageContext(
+        let cachedInput = WorkflowPaywallView.buildPackageInput(
             stepId: "step_terminal",
             context: context,
             preferredPackage: annual,
             showZeroDecimalPlacePrices: false
         )
+        let cachedCtx = cachedInput.packageContext
         expect(cachedCtx.package?.identifier) == annual.identifier
 
         // User selects monthly on the step (mutation through the reference stored in stepPackageContexts).
@@ -375,9 +377,9 @@ extension WorkflowPaywallViewTests {
         let stepCache: [String: PackageContext] = ["step_terminal": cachedCtx]
 
         // Second forward navigation would carry annual again — but the step is already cached.
-        // WorkflowPaywallView.renderedPageForStep takes the cache-hit path and skips buildPackageContext.
+        // WorkflowPaywallView.renderedPageForForwardNavigation takes the cache-hit path and skips buildPackageInput.
         // Demonstrate the divergence: carry-forward would produce annual, cache has monthly.
-        let wouldBeWithCarryForward = WorkflowPaywallView.buildPackageContext(
+        let wouldBeWithCarryForward = WorkflowPaywallView.buildPackageInput(
             stepId: "step_terminal",
             context: context,
             preferredPackage: annual,
@@ -387,24 +389,25 @@ extension WorkflowPaywallViewTests {
         // Cache-hit path: user's own selection (monthly) is preserved.
         expect(stepCache["step_terminal"]?.package?.identifier) == monthly.identifier
         // Cache-miss path would have produced annual — confirming cache hit takes precedence.
-        expect(wouldBeWithCarryForward.package?.identifier) == annual.identifier
+        expect(wouldBeWithCarryForward.packageContext.package?.identifier) == annual.identifier
     }
 
-    /// Verifies that `buildPackageContext` returns an empty `PackageContext` for a step that
+    /// Verifies that `buildPackageInput` returns an empty `PackageContext` for a step that
     /// has no package components and no workflow fallback (nil `effectivePackageContext`).
-    func testBuildPackageContextReturnsEmptyContextForPackagelessStepWithNoFallback() throws {
+    func testBuildPackageInputReturnsEmptyContextForPackagelessStepWithNoFallback() throws {
         // No singleStepFallbackId → no global workflow package context.
         let context = try Self.makeContext(singleStepFallbackId: nil)
 
-        let packageContext = WorkflowPaywallView.buildPackageContext(
+        let packageInput = WorkflowPaywallView.buildPackageInput(
             stepId: "step_initial",
             context: context,
             preferredPackage: nil,
             showZeroDecimalPlacePrices: false
         )
 
-        expect(packageContext.package).to(beNil())
-        expect(packageContext.variableContext.mostExpensivePricePerMonth).to(beNil())
+        expect(packageInput.packageContext.package).to(beNil())
+        expect(packageInput.effectiveWorkflowPackageContext).to(beNil())
+        expect(packageInput.packageContext.variableContext.mostExpensivePricePerMonth).to(beNil())
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -315,6 +315,57 @@ extension WorkflowPaywallViewTests {
         expect(packageContext.variableContext.mostExpensivePricePerMonth).toNot(beNil())
     }
 
+    /// Verifies that once a step's `PackageContext` is cached, subsequent navigations to that step
+    /// reuse the cached instance (preserving any user mutations) rather than re-applying carry-forward.
+    ///
+    /// Scenario: user navigates step1 → step2 (annual carried forward), selects monthly on step2,
+    /// returns to step1, then navigates forward to step2 again.
+    /// Step2 must show monthly (the user's own previous selection), not annual (the new carry-forward).
+    /// `WorkflowPaywallView.renderedPageForStep` implements this via the cache-hit path that skips
+    /// `buildPackageContext` entirely when the step already has a `PackageContext` in `stepPackageContexts`.
+    func testCachedStepContextTakesPrecedenceOverCarryForwardOnRevisit() throws {
+        let context = try Self.makeContext(
+            singleStepFallbackId: "step_terminal",
+            workflowPackages: [(id: "$rc_annual", isDefault: true), (id: "$rc_monthly", isDefault: false)]
+        )
+        let annual = try XCTUnwrap(
+            context.packageContext(for: "step_terminal")?.packages.first { $0.identifier == "$rc_annual" }
+        )
+        let monthly = try XCTUnwrap(
+            context.packageContext(for: "step_terminal")?.packages.first { $0.identifier == "$rc_monthly" }
+        )
+
+        // First forward navigation: annual carried forward → step gets annual.
+        let cachedCtx = WorkflowPaywallView.buildPackageContext(
+            stepId: "step_terminal",
+            context: context,
+            preferredPackage: annual,
+            showZeroDecimalPlacePrices: false
+        )
+        expect(cachedCtx.package?.identifier) == annual.identifier
+
+        // User selects monthly on the step (mutation through the reference stored in stepPackageContexts).
+        cachedCtx.package = monthly
+
+        // Simulate the per-step cache that WorkflowPaywallView maintains.
+        let stepCache: [String: PackageContext] = ["step_terminal": cachedCtx]
+
+        // Second forward navigation would carry annual again — but the step is already cached.
+        // WorkflowPaywallView.renderedPageForStep takes the cache-hit path and skips buildPackageContext.
+        // Demonstrate the divergence: carry-forward would produce annual, cache has monthly.
+        let wouldBeWithCarryForward = WorkflowPaywallView.buildPackageContext(
+            stepId: "step_terminal",
+            context: context,
+            preferredPackage: annual,
+            showZeroDecimalPlacePrices: false
+        )
+
+        // Cache-hit path: user's own selection (monthly) is preserved.
+        expect(stepCache["step_terminal"]?.package?.identifier) == monthly.identifier
+        // Cache-miss path would have produced annual — confirming cache hit takes precedence.
+        expect(wouldBeWithCarryForward.package?.identifier) == annual.identifier
+    }
+
     /// Verifies that `buildPackageContext` returns an empty `PackageContext` for a step that
     /// has no package components and no workflow fallback (nil `effectivePackageContext`).
     func testBuildPackageContextReturnsEmptyContextForPackagelessStepWithNoFallback() throws {

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -220,6 +220,48 @@ extension WorkflowPaywallViewTests {
 
 }
 
+// MARK: - packageContext(for:) via WorkflowContext
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension WorkflowPaywallViewTests {
+
+    func testPackageContextForStepWithOwnPackagesReturnsStepLocalPackages() throws {
+        // Package-bearing step: step has its own package components.
+        // packageContext(for:) must return the step's own packages, not the workflow fallback.
+        let context = try Self.makeContext(
+            singleStepFallbackId: "step_terminal",
+            workflowPackages: [(id: "$rc_monthly", isDefault: false), (id: "$rc_annual", isDefault: true)]
+        )
+
+        // step_terminal has the terminal screen with $rc_annual as default
+        let result = context.packageContext(for: "step_terminal")
+
+        expect(result?.selectedPackage.identifier) == "$rc_annual"
+        expect(result?.packages.map(\.identifier)) == ["$rc_monthly", "$rc_annual"]
+    }
+
+    func testPackageContextForPackagelessStepReturnsNil() throws {
+        // Packageless step: step_initial has no package components.
+        // packageContext(for:) must return nil so callers can fall back to the workflow context.
+        let context = try Self.makeContext(
+            singleStepFallbackId: "step_terminal",
+            workflowPackages: [(id: "$rc_annual", isDefault: true)]
+        )
+
+        // step_initial uses screen_initial which has no packages
+        let result = context.packageContext(for: "step_initial")
+
+        expect(result).to(beNil())
+    }
+
+    func testPackageContextForMissingStepReturnsNil() throws {
+        let context = try Self.makeContext(singleStepFallbackId: nil)
+
+        expect(context.packageContext(for: "nonexistent_step")).to(beNil())
+    }
+
+}
+
 // MARK: - variableContext population tests
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -218,6 +218,36 @@ extension WorkflowPaywallViewTests {
         expect(context.workflowPackageContext?.packages.map(\.identifier)) == ["$rc_weekly"]
     }
 
+    func testPageWorkflowPackageContextUsesScreenPackagesInsteadOfFallbackPackages() throws {
+        let context = try Self.makeContext(
+            singleStepFallbackId: "step_terminal",
+            workflowPackages: [(id: "$rc_monthly", isDefault: true)],
+            initialScreenJSON: Self.makeScreenJSON(
+                packages: [(id: "$rc_annual", isDefault: true)],
+                offeringId: "offering_test"
+            )
+        )
+        let initialScreen = try XCTUnwrap(context.workflow.screens["screen_initial"])
+        let initialOffering = try XCTUnwrap(context.offering(for: initialScreen.offeringIdentifier))
+        let pagePackageContext = context.workflowPackageContext(for: initialScreen, offering: initialOffering)
+
+        expect(context.workflowPackageContext?.selectedPackage.identifier) == "$rc_monthly"
+        expect(pagePackageContext?.selectedPackage.identifier) == "$rc_annual"
+        expect(pagePackageContext?.packages.map(\.identifier)) == ["$rc_annual"]
+    }
+
+    func testPageWorkflowPackageContextReturnsNilForPackagelessScreen() throws {
+        let context = try Self.makeContext(
+            singleStepFallbackId: "step_terminal",
+            workflowPackages: [(id: "$rc_monthly", isDefault: true)]
+        )
+        let initialScreen = try XCTUnwrap(context.workflow.screens["screen_initial"])
+        let initialOffering = try XCTUnwrap(context.offering(for: initialScreen.offeringIdentifier))
+
+        expect(context.workflowPackageContext?.selectedPackage.identifier) == "$rc_monthly"
+        expect(context.workflowPackageContext(for: initialScreen, offering: initialOffering)).to(beNil())
+    }
+
 }
 
 // MARK: - packageContext(for:) via WorkflowContext
@@ -408,6 +438,7 @@ private extension WorkflowPaywallViewTests {
     static func makeContext(
         singleStepFallbackId: String?,
         workflowPackages: [PackageSpec] = [],
+        initialScreenJSON: String? = nil,
         terminalScreenJSON: String? = nil,
         extraOfferings: [Offering] = []
     ) throws -> WorkflowContext {
@@ -415,6 +446,7 @@ private extension WorkflowPaywallViewTests {
         let workflow = try makeWorkflow(
             singleStepFallbackId: singleStepFallbackId,
             workflowPackages: workflowPackages,
+            initialScreenJSON: initialScreenJSON,
             terminalScreenJSON: terminalScreenJSON,
             offeringId: offeringId
         )
@@ -462,10 +494,13 @@ private extension WorkflowPaywallViewTests {
     static func makeWorkflow(
         singleStepFallbackId: String?,
         workflowPackages: [PackageSpec],
+        initialScreenJSON customInitialScreenJSON: String? = nil,
         terminalScreenJSON customTerminalScreenJSON: String? = nil,
         offeringId: String
     ) throws -> PublishedWorkflow {
         let workflowStepIdJSON = singleStepFallbackId.map { "\"single_step_fallback_id\": \"\($0)\"," } ?? ""
+        let initialScreenJSON = customInitialScreenJSON
+            ?? makeScreenJSON(packages: [], offeringId: offeringId)
 
         let terminalStepJSON: String
         let terminalScreenJSON: String
@@ -495,7 +530,7 @@ private extension WorkflowPaywallViewTests {
             "step_placeholder": { "id": "step_placeholder", "type": "screen" }
           },
           "screens": {
-            "screen_initial": \(makeScreenJSON(packages: [], offeringId: offeringId)),
+            "screen_initial": \(initialScreenJSON),
             \(terminalScreenJSON)
             "screen_placeholder": \(makeScreenJSON(packages: [], offeringId: offeringId))
           },

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -227,9 +227,7 @@ extension WorkflowPaywallViewTests {
                 offeringId: "offering_test"
             )
         )
-        let initialScreen = try XCTUnwrap(context.workflow.screens["screen_initial"])
-        let initialOffering = try XCTUnwrap(context.offering(for: initialScreen.offeringIdentifier))
-        let pagePackageContext = context.workflowPackageContext(for: initialScreen, offering: initialOffering)
+        let pagePackageContext = context.packageContext(for: "step_initial")
 
         expect(context.workflowPackageContext?.selectedPackage.identifier) == "$rc_monthly"
         expect(pagePackageContext?.selectedPackage.identifier) == "$rc_annual"
@@ -241,11 +239,9 @@ extension WorkflowPaywallViewTests {
             singleStepFallbackId: "step_terminal",
             workflowPackages: [(id: "$rc_monthly", isDefault: true)]
         )
-        let initialScreen = try XCTUnwrap(context.workflow.screens["screen_initial"])
-        let initialOffering = try XCTUnwrap(context.offering(for: initialScreen.offeringIdentifier))
 
         expect(context.workflowPackageContext?.selectedPackage.identifier) == "$rc_monthly"
-        expect(context.workflowPackageContext(for: initialScreen, offering: initialOffering)).to(beNil())
+        expect(context.packageContext(for: "step_initial")).to(beNil())
     }
 
 }
@@ -296,6 +292,24 @@ extension WorkflowPaywallViewTests {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension WorkflowPaywallViewTests {
+
+    func testPackageContextRemainsReferenceType() {
+        func requiresReferenceType<T: AnyObject>(_: T.Type) {}
+
+        requiresReferenceType(PackageContext.self)
+    }
+
+    func testCachedPackageContextMutationsPropagateThroughReference() {
+        let cached = PackageContext(
+            package: TestData.monthlyPackage,
+            variableContext: .init(packages: [TestData.monthlyPackage, TestData.annualPackage])
+        )
+        let stepCache: [String: PackageContext] = ["step_terminal": cached]
+
+        cached.package = TestData.annualPackage
+
+        expect(stepCache["step_terminal"]?.package?.identifier) == TestData.annualPackage.identifier
+    }
 
     /// Verifies that `buildPackageContext` carries the user's current selection forward when
     /// the preferred package exists in the next step's available packages.

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -262,6 +262,78 @@ extension WorkflowPaywallViewTests {
 
 }
 
+// MARK: - Step package context cache
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension WorkflowPaywallViewTests {
+
+    /// Guards that `PackageContext` is a reference type.
+    /// `WorkflowPaywallView` stores one `PackageContext` per step in `stepPackageContexts`
+    /// and passes the same instance as `selectedPackageContextOverride` to `PaywallsV2View`.
+    /// Mutations made inside `PaywallsV2View` (user selecting a different package) must be
+    /// visible through the cached reference so that back-then-forward navigation restores the
+    /// user's choice rather than the authored default.
+    /// If `PackageContext` is ever refactored to a struct, this test breaks before behaviour does.
+    func testPackageContextMutationsPropagateThroughStepCacheReference() {
+        let ctx = PackageContext(
+            package: TestData.annualPackage,
+            variableContext: .init(packages: [TestData.annualPackage, TestData.monthlyPackage],
+                                   showZeroDecimalPlacePrices: false)
+        )
+        // Simulate what WorkflowPaywallView does: store the instance in the per-step cache.
+        let cache: [String: PackageContext] = ["step_terminal": ctx]
+
+        // Simulate the user selecting a different package (mutation inside PaywallsV2View).
+        ctx.package = TestData.monthlyPackage
+
+        // The cache entry must reflect the mutation — same object, not a copy.
+        expect(cache["step_terminal"]?.package?.identifier) == TestData.monthlyPackage.identifier
+    }
+
+    /// Verifies that `buildPackageContext` carries the user's current selection forward when
+    /// the preferred package exists in the next step's available packages.
+    /// This is the forward-navigation path: user picks annual on step 1, navigates to step 2
+    /// which also offers annual — step 2 should pre-select annual, not fall back to its own default.
+    func testBuildPackageContextCarriesForwardPreferredPackageWhenAvailableInStep() throws {
+        // step_terminal has annual (default) and monthly.
+        let context = try Self.makeContext(
+            singleStepFallbackId: "step_terminal",
+            workflowPackages: [(id: "$rc_annual", isDefault: true), (id: "$rc_monthly", isDefault: false)]
+        )
+        let monthly = try XCTUnwrap(
+            context.packageContext(for: "step_terminal")?.packages.first { $0.identifier == "$rc_monthly" }
+        )
+
+        let packageContext = WorkflowPaywallView.buildPackageContext(
+            stepId: "step_terminal",
+            context: context,
+            preferredPackage: monthly,
+            showZeroDecimalPlacePrices: false
+        )
+
+        expect(packageContext.package?.identifier) == "$rc_monthly"
+        expect(packageContext.variableContext.mostExpensivePricePerMonth).toNot(beNil())
+    }
+
+    /// Verifies that `buildPackageContext` returns an empty `PackageContext` for a step that
+    /// has no package components and no workflow fallback (nil `effectivePackageContext`).
+    func testBuildPackageContextReturnsEmptyContextForPackagelessStepWithNoFallback() throws {
+        // No singleStepFallbackId → no global workflow package context.
+        let context = try Self.makeContext(singleStepFallbackId: nil)
+
+        let packageContext = WorkflowPaywallView.buildPackageContext(
+            stepId: "step_initial",
+            context: context,
+            preferredPackage: nil,
+            showZeroDecimalPlacePrices: false
+        )
+
+        expect(packageContext.package).to(beNil())
+        expect(packageContext.variableContext.mostExpensivePricePerMonth).to(beNil())
+    }
+
+}
+
 // MARK: - variableContext population tests
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
@@ -159,7 +159,7 @@ final class WorkflowContextTests: TestCase {
         expect(context.packageContext(for: "step_terminal")?.selectedPackage.identifier) == "$rc_annual"
     }
 
-    // MARK: - effectivePackageContext(for:)
+    // MARK: - effectivePackageContext(for:preferring: nil)
 
     func testEffectivePackageContextForPackageBearingStepUsesStepContextNotGlobalFallback() throws {
         // Workflow: global fallback = annual (step_fallback), step_own has monthly + weekly.
@@ -170,7 +170,7 @@ final class WorkflowContextTests: TestCase {
             ownStepPackages: [(id: "$rc_monthly", isDefault: true), (id: "$rc_weekly", isDefault: false)]
         )
 
-        let effective = context.effectivePackageContext(for: "step_own")
+        let effective = context.effectivePackageContext(for: "step_own", preferring: nil)
 
         expect(effective?.selectedPackage.identifier) == "$rc_monthly"
         expect(effective?.packages.map(\.identifier)) == ["$rc_monthly", "$rc_weekly"]
@@ -184,7 +184,7 @@ final class WorkflowContextTests: TestCase {
             ownStepPackages: []
         )
 
-        let effective = context.effectivePackageContext(for: "step_own")
+        let effective = context.effectivePackageContext(for: "step_own", preferring: nil)
 
         expect(effective?.selectedPackage.identifier) == "$rc_annual"
     }
@@ -195,8 +195,8 @@ final class WorkflowContextTests: TestCase {
             packages: []
         )
 
-        expect(context.effectivePackageContext(for: "step_terminal")).to(beNil())
-        expect(context.effectivePackageContext(for: "step_initial")).to(beNil())
+        expect(context.effectivePackageContext(for: "step_terminal", preferring: nil)).to(beNil())
+        expect(context.effectivePackageContext(for: "step_initial", preferring: nil)).to(beNil())
     }
 
     func testEffectivePackageContextForFallbackStepMatchesWorkflowPackageContext() throws {
@@ -206,7 +206,7 @@ final class WorkflowContextTests: TestCase {
             singleStepFallbackId: "step_terminal"
         )
 
-        let effective = context.effectivePackageContext(for: "step_terminal")
+        let effective = context.effectivePackageContext(for: "step_terminal", preferring: nil)
 
         expect(effective?.selectedPackage.identifier) == context.workflowPackageContext?.selectedPackage.identifier
     }

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
@@ -211,6 +211,89 @@ final class WorkflowContextTests: TestCase {
         expect(effective?.selectedPackage.identifier) == context.workflowPackageContext?.selectedPackage.identifier
     }
 
+    // MARK: - effectivePackageContext(for:preferring:)
+
+    func testEffectivePackageContextPreferredPackageSelectedWhenAvailableInStep() throws {
+        // step_own has [monthly (default), weekly]. Preferred = weekly.
+        // weekly IS in step_own → should be selected.
+        let context = try Self.makeWorkflowContextWithFallbackAndOwnStep(
+            fallbackPackages: [(id: "$rc_annual", isDefault: true)],
+            ownStepPackages: [(id: "$rc_monthly", isDefault: true), (id: "$rc_weekly", isDefault: false)]
+        )
+        let weekly = try XCTUnwrap(
+            context.packageContext(for: "step_own")?.packages.first(where: { $0.identifier == "$rc_weekly" })
+        )
+
+        let result = context.effectivePackageContext(for: "step_own", preferring: weekly)
+
+        expect(result?.selectedPackage.identifier) == "$rc_weekly"
+        expect(result?.packages.map(\.identifier)) == ["$rc_monthly", "$rc_weekly"]
+    }
+
+    func testEffectivePackageContextPreferredNotInStepFallsBackToWorkflowDefault() throws {
+        // step_own has [monthly, annual]. Global fallback default = annual.
+        // step_fallback has [annual (default), weekly].
+        // Preferred = weekly (NOT in step_own). Workflow default (annual) IS in step_own → use annual.
+        let context = try Self.makeWorkflowContextWithFallbackAndOwnStep(
+            fallbackPackages: [(id: "$rc_annual", isDefault: true), (id: "$rc_weekly", isDefault: false)],
+            ownStepPackages: [(id: "$rc_monthly", isDefault: true), (id: "$rc_annual", isDefault: false)]
+        )
+        let weekly = try XCTUnwrap(
+            context.workflowPackageContext?.packages.first(where: { $0.identifier == "$rc_weekly" })
+        )
+
+        let result = context.effectivePackageContext(for: "step_own", preferring: weekly)
+
+        expect(result?.selectedPackage.identifier) == "$rc_annual"
+        expect(result?.packages.map(\.identifier)) == ["$rc_monthly", "$rc_annual"]
+    }
+
+    func testEffectivePackageContextNilPreferredReturnsStepOwnDefault() throws {
+        // No carry-forward (nil preferred) → use the step's own isSelectedByDefault.
+        let context = try Self.makeWorkflowContextWithFallbackAndOwnStep(
+            fallbackPackages: [(id: "$rc_annual", isDefault: true)],
+            ownStepPackages: [(id: "$rc_monthly", isDefault: true), (id: "$rc_weekly", isDefault: false)]
+        )
+
+        let result = context.effectivePackageContext(for: "step_own", preferring: nil)
+
+        expect(result?.selectedPackage.identifier) == "$rc_monthly"
+    }
+
+    func testEffectivePackageContextPreferredCarriedThroughPackagelessStep() throws {
+        // step_own has no package components → falls back to workflowPackageContext.
+        // workflowPackageContext has [annual (default), monthly].
+        // Preferred = monthly (IS in the workflow context's packages) → should be selected.
+        let context = try Self.makeWorkflowContextWithFallbackAndOwnStep(
+            fallbackPackages: [(id: "$rc_annual", isDefault: true), (id: "$rc_monthly", isDefault: false)],
+            ownStepPackages: []
+        )
+        let monthly = try XCTUnwrap(
+            context.workflowPackageContext?.packages.first(where: { $0.identifier == "$rc_monthly" })
+        )
+
+        let result = context.effectivePackageContext(for: "step_own", preferring: monthly)
+
+        expect(result?.selectedPackage.identifier) == "$rc_monthly"
+    }
+
+    func testEffectivePackageContextPreferredNotInStepAndNoWorkflowDefaultFallsBackToStepDefault() throws {
+        // step_own has [monthly (default), weekly]. Global fallback has [annual].
+        // annual is NOT in step_own. Preferred = annual (not in step_own, wfDefault = annual also not in step_own).
+        // Last resort: step_own's own default (monthly).
+        let context = try Self.makeWorkflowContextWithFallbackAndOwnStep(
+            fallbackPackages: [(id: "$rc_annual", isDefault: true)],
+            ownStepPackages: [(id: "$rc_monthly", isDefault: true), (id: "$rc_weekly", isDefault: false)]
+        )
+        let annual = try XCTUnwrap(
+            context.workflowPackageContext?.selectedPackage
+        )
+
+        let result = context.effectivePackageContext(for: "step_own", preferring: annual)
+
+        expect(result?.selectedPackage.identifier) == "$rc_monthly"
+    }
+
     // MARK: - exitOfferOfferingId
 
     func testExitOfferOfferingReturnsNilWhenNoSingleStepFallbackId() throws {
@@ -438,8 +521,6 @@ private extension WorkflowContextTests {
 
     typealias PackageSpec = (id: String, isDefault: Bool)
 
-    /// Builds a `WorkflowContext` containing one step with package components,
-    /// backed by an offering that has all the named packages.
     /// Builds a `WorkflowContext` with two package-bearing steps:
     /// - `step_fallback` (set as `singleStepFallbackId`) with `fallbackPackages`
     /// - `step_own` with `ownStepPackages` (may be empty to simulate a packageless step)

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
@@ -99,7 +99,67 @@ final class WorkflowContextTests: TestCase {
         expect(context.offering(for: "offering_missing")).to(beNil())
     }
 
-    // MARK: - exitOfferOffering (single-page)
+    // MARK: - packageContext(for:)
+
+    func testPackageContextForStepWithPackagesReturnsSelectedByDefaultPackage() throws {
+        let context = try Self.makeWorkflowContextWithPackageStep(
+            stepId: "step_terminal",
+            packages: [
+                (id: "$rc_monthly", isDefault: false),
+                (id: "$rc_annual", isDefault: true)
+            ]
+        )
+
+        let result = context.packageContext(for: "step_terminal")
+
+        expect(result?.selectedPackage.identifier) == "$rc_annual"
+        expect(result?.packages.map(\.identifier)) == ["$rc_monthly", "$rc_annual"]
+    }
+
+    func testPackageContextForStepWithPackagesReturnsFirstWhenNoneIsDefault() throws {
+        let context = try Self.makeWorkflowContextWithPackageStep(
+            stepId: "step_terminal",
+            packages: [
+                (id: "$rc_monthly", isDefault: false),
+                (id: "$rc_annual", isDefault: false)
+            ]
+        )
+
+        let result = context.packageContext(for: "step_terminal")
+
+        expect(result?.selectedPackage.identifier) == "$rc_monthly"
+    }
+
+    func testPackageContextForPackagelessStepReturnsNil() throws {
+        let context = try Self.makeWorkflowContextWithPackageStep(
+            stepId: "step_terminal",
+            packages: []
+        )
+
+        expect(context.packageContext(for: "step_terminal")).to(beNil())
+    }
+
+    func testPackageContextForMissingStepReturnsNil() throws {
+        let context = try Self.makeWorkflowContextWithPackageStep(
+            stepId: "step_terminal",
+            packages: [(id: "$rc_annual", isDefault: true)]
+        )
+
+        expect(context.packageContext(for: "step_missing")).to(beNil())
+    }
+
+    func testWorkflowPackageContextDelegatesToPackageContextForFallbackStep() throws {
+        let context = try Self.makeWorkflowContextWithPackageStep(
+            stepId: "step_terminal",
+            packages: [(id: "$rc_annual", isDefault: true)],
+            singleStepFallbackId: "step_terminal"
+        )
+
+        expect(context.workflowPackageContext?.selectedPackage.identifier) == "$rc_annual"
+        expect(context.packageContext(for: "step_terminal")?.selectedPackage.identifier) == "$rc_annual"
+    }
+
+    // MARK: - exitOfferOfferingId
 
     func testExitOfferOfferingReturnsNilWhenNoSingleStepFallbackId() throws {
         let offering = Self.makeOffering(identifier: "offering_a")
@@ -322,6 +382,120 @@ private extension WorkflowContextTests {
             placementIdentifier: "home_screen",
             targetingContext: .init(revision: 7, ruleId: "rule_1")
         )
+    }
+
+    typealias PackageSpec = (id: String, isDefault: Bool)
+
+    /// Builds a `WorkflowContext` containing one step with package components,
+    /// backed by an offering that has all the named packages.
+    static func makeWorkflowContextWithPackageStep(
+        stepId: String,
+        packages: [PackageSpec],
+        singleStepFallbackId: String? = nil
+    ) throws -> WorkflowContext {
+        let offeringId = "offering_test"
+        let fallbackJSON = singleStepFallbackId.map { "\"single_step_fallback_id\": \"\($0)\"," } ?? ""
+        let componentsJSON = packages
+            .map { pkg in
+                """
+                {
+                    "type": "package",
+                    "packageId": "\(pkg.id)",
+                    "isSelectedByDefault": \(pkg.isDefault),
+                    "stack": \(Self.minimalStackJSON())
+                }
+                """
+            }
+            .joined(separator: ",")
+
+        let json = """
+        {
+          "id": "wf_test",
+          "display_name": "Test",
+          "initial_step_id": "step_initial",
+          \(fallbackJSON)
+          "steps": {
+            "step_initial": { "id": "step_initial", "type": "screen" },
+            "\(stepId)": { "id": "\(stepId)", "type": "screen", "screen_id": "screen_target" }
+          },
+          "screens": {
+            "screen_target": {
+              "template_name": "tmpl",
+              "asset_base_url": "https://assets.revenuecat.com",
+              "default_locale": "en_US",
+              "offering_identifier": "\(offeringId)",
+              "components_localizations": {},
+              "components_config": {
+                "base": {
+                  "stack": \(Self.minimalStackJSON(components: "[\(componentsJSON)]")),
+                  "background": { "type": "color", "value": { "light": { "type": "hex", "value": "#FFFFFF" } } }
+                }
+              }
+            }
+          },
+          "ui_config": {
+            "app": { "colors": {}, "fonts": {} },
+            "localizations": {}
+          }
+        }
+        """
+        let workflow = try JSONDecoder.default.decode(
+            PublishedWorkflow.self,
+            from: XCTUnwrap(json.data(using: .utf8))
+        )
+
+        let rcPackages = packages.map { spec in
+            Package(
+                identifier: spec.id,
+                packageType: .custom,
+                storeProduct: TestData.monthlyPackage.storeProduct,
+                offeringIdentifier: offeringId,
+                webCheckoutUrl: nil
+            )
+        }
+        let offering = Offering(
+            identifier: offeringId,
+            serverDescription: "Test",
+            metadata: [:],
+            paywall: nil,
+            availablePackages: rcPackages,
+            webCheckoutUrl: nil
+        )
+        let offerings = Offerings(
+            offerings: [offeringId: offering],
+            currentOfferingID: nil,
+            placements: nil,
+            targeting: nil,
+            contents: .init(
+                response: .init(
+                    currentOfferingId: nil,
+                    offerings: [],
+                    placements: nil,
+                    targeting: nil,
+                    uiConfig: nil
+                ),
+                httpResponseOriginalSource: .mainServer
+            ),
+            loadedFromDiskCache: false
+        )
+        return WorkflowContext(
+            workflow: workflow,
+            allOfferings: offerings,
+            initialOffering: offering,
+            presentedOfferingContext: nil
+        )
+    }
+
+    static func minimalStackJSON(components: String = "[]") -> String {
+        return """
+        {
+          "type": "stack", "components": \(components),
+          "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+          "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+          "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+          "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+        }
+        """
     }
 
     static func makeWorkflow() throws -> PublishedWorkflow {

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
@@ -294,6 +294,54 @@ final class WorkflowContextTests: TestCase {
         expect(result?.selectedPackage.identifier) == "$rc_monthly"
     }
 
+    func testEffectivePackageContextPreferringCarryForwardSelectsDestinationOfferingsPackage() throws {
+        // Multi-offering: step_fallback uses "offering_a", step_own uses "offering_b".
+        // Both expose $rc_monthly — same identifier but different Package objects from different offerings.
+        // Carry-forward must return the $rc_monthly from offering_b (the destination step),
+        // not offering_a's instance (the source).
+        let context = try Self.makeWorkflowContextWithMultiOfferingSteps(
+            fallbackOfferingId: "offering_a",
+            fallbackPackages: [(id: "$rc_monthly", isDefault: true)],
+            ownOfferingId: "offering_b",
+            ownPackages: [(id: "$rc_monthly", isDefault: true)]
+        )
+        let monthlyFromFallback = try XCTUnwrap(
+            context.packageContext(for: "step_fallback")?.selectedPackage
+        )
+        expect(monthlyFromFallback.offeringIdentifier) == "offering_a"
+
+        let result = try XCTUnwrap(
+            context.effectivePackageContext(for: "step_own", preferring: monthlyFromFallback)
+        )
+
+        expect(result.selectedPackage.identifier) == "$rc_monthly"
+        expect(result.selectedPackage.offeringIdentifier) == "offering_b"
+    }
+
+    func testEffectivePackageContextWorkflowDefaultFallbackSelectsDestinationOfferingsPackage() throws {
+        // Multi-offering: step_fallback (offering_a) has [annual (default), weekly].
+        //                 step_own    (offering_b) has [annual, monthly].
+        // Preferred = weekly (not in step_own) → triggers the wfDefault path (lines 99-101).
+        // wfDefault = annual from offering_a IS present in step_own by identifier.
+        // Result must use annual from offering_b, not offering_a's instance.
+        let context = try Self.makeWorkflowContextWithMultiOfferingSteps(
+            fallbackOfferingId: "offering_a",
+            fallbackPackages: [(id: "$rc_annual", isDefault: true), (id: "$rc_weekly", isDefault: false)],
+            ownOfferingId: "offering_b",
+            ownPackages: [(id: "$rc_annual", isDefault: false), (id: "$rc_monthly", isDefault: true)]
+        )
+        let weeklyFromFallback = try XCTUnwrap(
+            context.packageContext(for: "step_fallback")?.packages.first { $0.identifier == "$rc_weekly" }
+        )
+
+        let result = try XCTUnwrap(
+            context.effectivePackageContext(for: "step_own", preferring: weeklyFromFallback)
+        )
+
+        expect(result.selectedPackage.identifier) == "$rc_annual"
+        expect(result.selectedPackage.offeringIdentifier) == "offering_b"
+    }
+
     // MARK: - exitOfferOfferingId
 
     func testExitOfferOfferingReturnsNilWhenNoSingleStepFallbackId() throws {
@@ -720,6 +768,122 @@ private extension WorkflowContextTests {
             workflow: workflow,
             allOfferings: offerings,
             initialOffering: offering,
+            presentedOfferingContext: nil
+        )
+    }
+
+    /// Builds a `WorkflowContext` where `step_fallback` and `step_own` each resolve to a
+    /// *distinct* offering. Use this helper to verify that carry-forward logic selects the
+    /// Package object that belongs to the **destination** step's offering, not the source's.
+    static func makeWorkflowContextWithMultiOfferingSteps(
+        fallbackOfferingId: String,
+        fallbackPackages: [PackageSpec],
+        ownOfferingId: String,
+        ownPackages: [PackageSpec]
+    ) throws -> WorkflowContext {
+        func rcPackages(_ specs: [PackageSpec], offeringId: String) -> [Package] {
+            specs.map { spec in
+                Package(
+                    identifier: spec.id,
+                    packageType: .custom,
+                    storeProduct: TestData.monthlyPackage.storeProduct,
+                    offeringIdentifier: offeringId,
+                    webCheckoutUrl: nil
+                )
+            }
+        }
+
+        let fallbackOffering = Offering(
+            identifier: fallbackOfferingId,
+            serverDescription: "Fallback",
+            metadata: [:],
+            paywall: nil,
+            availablePackages: rcPackages(fallbackPackages, offeringId: fallbackOfferingId),
+            webCheckoutUrl: nil
+        )
+        let ownOffering = Offering(
+            identifier: ownOfferingId,
+            serverDescription: "Own",
+            metadata: [:],
+            paywall: nil,
+            availablePackages: rcPackages(ownPackages, offeringId: ownOfferingId),
+            webCheckoutUrl: nil
+        )
+        let offerings = Offerings(
+            offerings: [fallbackOfferingId: fallbackOffering, ownOfferingId: ownOffering],
+            currentOfferingID: nil,
+            placements: nil,
+            targeting: nil,
+            contents: .init(
+                response: .init(
+                    currentOfferingId: nil,
+                    offerings: [],
+                    placements: nil,
+                    targeting: nil,
+                    uiConfig: nil
+                ),
+                httpResponseOriginalSource: .mainServer
+            ),
+            loadedFromDiskCache: false
+        )
+
+        func screenJSON(packages: [PackageSpec], offeringId: String) -> String {
+            let componentsJSON = packages.map { pkg in
+                """
+                {
+                    "type": "package",
+                    "packageId": "\(pkg.id)",
+                    "isSelectedByDefault": \(pkg.isDefault),
+                    "stack": \(Self.minimalStackJSON())
+                }
+                """
+            }.joined(separator: ",")
+            return """
+            {
+              "template_name": "tmpl",
+              "asset_base_url": "https://assets.revenuecat.com",
+              "default_locale": "en_US",
+              "offering_identifier": "\(offeringId)",
+              "components_localizations": {},
+              "components_config": {
+                "base": {
+                  "stack": \(Self.minimalStackJSON(components: "[\(componentsJSON)]")),
+                  "background": { "type": "color", "value": { "light": { "type": "hex", "value": "#FFFFFF" } } }
+                }
+              }
+            }
+            """
+        }
+
+        let json = """
+        {
+          "id": "wf_test",
+          "display_name": "Test",
+          "initial_step_id": "step_initial",
+          "single_step_fallback_id": "step_fallback",
+          "steps": {
+            "step_initial": { "id": "step_initial", "type": "screen" },
+            "step_fallback": { "id": "step_fallback", "type": "screen", "screen_id": "screen_fallback" },
+            "step_own": { "id": "step_own", "type": "screen", "screen_id": "screen_own" }
+          },
+          "screens": {
+            "screen_fallback": \(screenJSON(packages: fallbackPackages, offeringId: fallbackOfferingId)),
+            "screen_own": \(screenJSON(packages: ownPackages, offeringId: ownOfferingId))
+          },
+          "ui_config": {
+            "app": { "colors": {}, "fonts": {} },
+            "localizations": {}
+          }
+        }
+        """
+        let workflow = try JSONDecoder.default.decode(
+            PublishedWorkflow.self,
+            from: XCTUnwrap(json.data(using: .utf8))
+        )
+        return WorkflowContext(
+            workflow: workflow,
+            allOfferings: offerings,
+            initialOffering: fallbackOffering,
             presentedOfferingContext: nil
         )
     }

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
@@ -159,6 +159,58 @@ final class WorkflowContextTests: TestCase {
         expect(context.packageContext(for: "step_terminal")?.selectedPackage.identifier) == "$rc_annual"
     }
 
+    // MARK: - effectivePackageContext(for:)
+
+    func testEffectivePackageContextForPackageBearingStepUsesStepContextNotGlobalFallback() throws {
+        // Workflow: global fallback = annual (step_fallback), step_own has monthly + weekly.
+        // effectivePackageContext for step_own must return monthly — the step's own default —
+        // not annual (the global fallback).
+        let context = try Self.makeWorkflowContextWithFallbackAndOwnStep(
+            fallbackPackages: [(id: "$rc_annual", isDefault: true)],
+            ownStepPackages: [(id: "$rc_monthly", isDefault: true), (id: "$rc_weekly", isDefault: false)]
+        )
+
+        let effective = context.effectivePackageContext(for: "step_own")
+
+        expect(effective?.selectedPackage.identifier) == "$rc_monthly"
+        expect(effective?.packages.map(\.identifier)) == ["$rc_monthly", "$rc_weekly"]
+    }
+
+    func testEffectivePackageContextForPackagelessStepFallsBackToGlobalWorkflowContext() throws {
+        // Packageless step (step_initial) has no package components.
+        // effectivePackageContext must return the global fallback (annual).
+        let context = try Self.makeWorkflowContextWithFallbackAndOwnStep(
+            fallbackPackages: [(id: "$rc_annual", isDefault: true)],
+            ownStepPackages: []
+        )
+
+        let effective = context.effectivePackageContext(for: "step_own")
+
+        expect(effective?.selectedPackage.identifier) == "$rc_annual"
+    }
+
+    func testEffectivePackageContextReturnsNilWhenNoPackagesAnywhere() throws {
+        let context = try Self.makeWorkflowContextWithPackageStep(
+            stepId: "step_terminal",
+            packages: []
+        )
+
+        expect(context.effectivePackageContext(for: "step_terminal")).to(beNil())
+        expect(context.effectivePackageContext(for: "step_initial")).to(beNil())
+    }
+
+    func testEffectivePackageContextForFallbackStepMatchesWorkflowPackageContext() throws {
+        let context = try Self.makeWorkflowContextWithPackageStep(
+            stepId: "step_terminal",
+            packages: [(id: "$rc_annual", isDefault: true)],
+            singleStepFallbackId: "step_terminal"
+        )
+
+        let effective = context.effectivePackageContext(for: "step_terminal")
+
+        expect(effective?.selectedPackage.identifier) == context.workflowPackageContext?.selectedPackage.identifier
+    }
+
     // MARK: - exitOfferOfferingId
 
     func testExitOfferOfferingReturnsNilWhenNoSingleStepFallbackId() throws {
@@ -388,6 +440,111 @@ private extension WorkflowContextTests {
 
     /// Builds a `WorkflowContext` containing one step with package components,
     /// backed by an offering that has all the named packages.
+    /// Builds a `WorkflowContext` with two package-bearing steps:
+    /// - `step_fallback` (set as `singleStepFallbackId`) with `fallbackPackages`
+    /// - `step_own` with `ownStepPackages` (may be empty to simulate a packageless step)
+    static func makeWorkflowContextWithFallbackAndOwnStep(
+        fallbackPackages: [PackageSpec],
+        ownStepPackages: [PackageSpec]
+    ) throws -> WorkflowContext {
+        let offeringId = "offering_test"
+        let allPackages = (fallbackPackages + ownStepPackages)
+            .map { spec in
+                Package(
+                    identifier: spec.id,
+                    packageType: .custom,
+                    storeProduct: TestData.monthlyPackage.storeProduct,
+                    offeringIdentifier: offeringId,
+                    webCheckoutUrl: nil
+                )
+            }
+        let offering = Offering(
+            identifier: offeringId,
+            serverDescription: "Test",
+            metadata: [:],
+            paywall: nil,
+            availablePackages: allPackages,
+            webCheckoutUrl: nil
+        )
+        let offerings = Offerings(
+            offerings: [offeringId: offering],
+            currentOfferingID: nil,
+            placements: nil,
+            targeting: nil,
+            contents: .init(
+                response: .init(
+                    currentOfferingId: nil,
+                    offerings: [],
+                    placements: nil,
+                    targeting: nil,
+                    uiConfig: nil
+                ),
+                httpResponseOriginalSource: .mainServer
+            ),
+            loadedFromDiskCache: false
+        )
+
+        func screenJSON(packages: [PackageSpec]) -> String {
+            let componentsJSON = packages.map { pkg in
+                """
+                {
+                    "type": "package",
+                    "packageId": "\(pkg.id)",
+                    "isSelectedByDefault": \(pkg.isDefault),
+                    "stack": \(Self.minimalStackJSON())
+                }
+                """
+            }.joined(separator: ",")
+            return """
+            {
+              "template_name": "tmpl",
+              "asset_base_url": "https://assets.revenuecat.com",
+              "default_locale": "en_US",
+              "offering_identifier": "\(offeringId)",
+              "components_localizations": {},
+              "components_config": {
+                "base": {
+                  "stack": \(Self.minimalStackJSON(components: "[\(componentsJSON)]")),
+                  "background": { "type": "color", "value": { "light": { "type": "hex", "value": "#FFFFFF" } } }
+                }
+              }
+            }
+            """
+        }
+
+        let json = """
+        {
+          "id": "wf_test",
+          "display_name": "Test",
+          "initial_step_id": "step_initial",
+          "single_step_fallback_id": "step_fallback",
+          "steps": {
+            "step_initial": { "id": "step_initial", "type": "screen" },
+            "step_fallback": { "id": "step_fallback", "type": "screen", "screen_id": "screen_fallback" },
+            "step_own": { "id": "step_own", "type": "screen", "screen_id": "screen_own" }
+          },
+          "screens": {
+            "screen_fallback": \(screenJSON(packages: fallbackPackages)),
+            "screen_own": \(screenJSON(packages: ownStepPackages))
+          },
+          "ui_config": {
+            "app": { "colors": {}, "fonts": {} },
+            "localizations": {}
+          }
+        }
+        """
+        let workflow = try JSONDecoder.default.decode(
+            PublishedWorkflow.self,
+            from: XCTUnwrap(json.data(using: .utf8))
+        )
+        return WorkflowContext(
+            workflow: workflow,
+            allOfferings: offerings,
+            initialOffering: offering,
+            presentedOfferingContext: nil
+        )
+    }
+
     static func makeWorkflowContextWithPackageStep(
         stepId: String,
         packages: [PackageSpec],


### PR DESCRIPTION
Supersedes and closes #6735.

### Checklist
- [x] Unit tests
- [ ] Follow-up issues for `purchases-android` and hybrids

### Motivation

Multi-step workflow paywalls had no way to carry the user's package selection forward. If a user picked Annual on step 1 and navigated to step 2, that step would fall back to the workflow's `singleStepFallbackId` default or its own page default. The same issue applied on back navigation — returning to a previous step and going forward again re-applied a stale default.

Android counterpart: RevenueCat/purchases-android#3431

### Description

**Per-step `PackageContext` cache**

`WorkflowPaywallView` now maintains a `[String: PackageContext]` dictionary keyed by step ID. The first time a step is rendered its `PackageContext` is built and stored; subsequent renders (e.g. back + forward) reuse the cached instance, so any in-flight user selection is preserved across navigation.

**Step-scoped `workflowPackageContext` environment**

Each page now injects its own `effectiveWorkflowPackageContext` (the per-step `WorkflowPackageContext`) into the environment rather than broadcasting the global `singleStepFallbackId` context for every step. This means `TabsComponentView` and any other package-initialisation code reads the correct step-local default, not the workflow fallback.

`WorkflowContext.effectivePackageContext(for:)` — new helper that returns the step's own package context when the step has packages, falling back to the global `workflowPackageContext` for packageless steps.

**`selectedPackageContextOverride` on `PaywallsV2View`**

An optional override allows `WorkflowPaywallView` to inject the pre-built (and potentially already-mutated by the user) `PackageContext` directly instead of having `PaywallsV2View` construct a fresh one on every render.

**Analytics `defaultPackage` fix**

`planSelectionDefaultPackage` now derives from the stable, configured default rather than the mutable current selection. The code in `LoadedPaywallsV2View.body` is unchanged — it still reads `self.workflowPackageContext?.selectedPackage` — but the value it sees is now the step-local `effectiveWorkflowPackageContext` injected per-step rather than the global workflow context broadcast to every step. Since `WorkflowPackageContext.selectedPackage` is immutable, this is always the step's configured default, not the user's in-flight selection.

**Sheet dismissal fix**

`RootView` snapshots the package before a selection sheet opens; when the sheet is dismissed without a new choice in a workflow context, it restores the snapshot rather than falling back to the global workflow default.

### Testing

`WorkflowContextTests` — `packageContext(for:)` and `effectivePackageContext(for:)`: selected-by-default, first-package fallback, packageless step (nil), missing step (nil), step-local beats global fallback, packageless step falls back to global, no packages anywhere (nil).

`WorkflowPaywallViewTests` — `packageContext(for:)` via `WorkflowContext` for a step with own packages, a packageless step, and a missing step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates workflow navigation and package-selection state in Paywalls V2, so regressions could affect which package is preselected/purchased across steps, tabs, and sheets.
> 
> **Overview**
> Enables *package selection carry-forward* across multi-step Paywalls V2 workflows by caching a per-step `PackageContext` in `WorkflowPaywallView`, injecting a step-scoped `workflowPackageContext`, and letting `PaywallsV2View` accept a `selectedPackageContextOverride` so cached selections are reused rather than rebuilt.
> 
> `WorkflowContext` now exposes `packageContext(for:)` and `effectivePackageContext(for:preferring:)` to resolve step-local packages with fallback to the workflow’s `singleStepFallbackId` package context, and `TabsComponentView`/`RootView` were adjusted to avoid overwriting cached selections (tab initialization prefers the parent’s cached package; sheet dismissal restores the pre-sheet snapshot in workflow contexts).
> 
> Adds focused unit tests for the new workflow back-navigation destination API, package-context resolution/carry-forward behavior, tab revisit inheritance, and sheet dismissal restoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d39f2501c6276d6fd8b7dc76d406aaa503c44c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->