### PR TITLE
[Billing Plans]: Add Public BillingPlanType.rawValue

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -799,13 +799,13 @@ final class PurchasesOrchestrator {
 
                 if eligibleBillingPlanTypes.contains(sk2BillingPlanType) {
                     Logger.debug(
-                        StoreKitStrings.sk2_applying_billing_plan(billingPlanType: billingPlanType.value)
+                        StoreKitStrings.sk2_applying_billing_plan(billingPlanType: billingPlanType.rawValue)
                     )
                     options.insert(.billingPlanType(sk2BillingPlanType))
                 } else {
                     Logger.error(
                         StoreKitStrings.sk2_user_not_eligible_for_billing_plan_at_purchase_time(
-                            billingPlanType: billingPlanType.value
+                            billingPlanType: billingPlanType.rawValue
                         )
                     )
                     throw ErrorUtils.productNotAvailableForPurchaseError()

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -793,18 +793,19 @@ final class PurchasesOrchestrator {
             #if compiler(>=6.3.2)
             if #available(iOS 26.4, macOS 26.4, tvOS 26.4, watchOS 26.4, visionOS 26.4, *),
                let subscriptionInfo = sk2Product.subscription, // Don't apply billing plans to OTPs
-               let sk2BillingPlanType = billingPlanType?.skBillingPlanType {
+               let billingPlanType,
+               let sk2BillingPlanType = billingPlanType.skBillingPlanType {
                 let eligibleBillingPlanTypes = Set(subscriptionInfo.pricingTerms.map({ $0.billingPlanType }))
 
                 if eligibleBillingPlanTypes.contains(sk2BillingPlanType) {
                     Logger.debug(
-                        StoreKitStrings.sk2_applying_billing_plan(billingPlanType: sk2BillingPlanType.rawValue)
+                        StoreKitStrings.sk2_applying_billing_plan(billingPlanType: billingPlanType.value)
                     )
                     options.insert(.billingPlanType(sk2BillingPlanType))
                 } else {
                     Logger.error(
                         StoreKitStrings.sk2_user_not_eligible_for_billing_plan_at_purchase_time(
-                            billingPlanType: sk2BillingPlanType.rawValue
+                            billingPlanType: billingPlanType.value
                         )
                     )
                     throw ErrorUtils.productNotAvailableForPurchaseError()

--- a/Sources/Purchasing/StoreKit2/Products with Billing Plans/CompoundProductIdentifier.swift
+++ b/Sources/Purchasing/StoreKit2/Products with Billing Plans/CompoundProductIdentifier.swift
@@ -117,7 +117,7 @@ extension CompoundProductIdentifier {
         }
 
         switch productPlanIdentifier {
-        case BillingPlanType.monthly.value:
+        case BillingPlanType.monthly.rawValue:
             return StoreKit.Product.SubscriptionInfo.BillingPlanType.monthly
         default:
             Logger.warn(

--- a/Sources/Purchasing/StoreKit2/Products with Billing Plans/CompoundProductIdentifier.swift
+++ b/Sources/Purchasing/StoreKit2/Products with Billing Plans/CompoundProductIdentifier.swift
@@ -117,7 +117,7 @@ extension CompoundProductIdentifier {
         }
 
         switch productPlanIdentifier {
-        case "monthly":
+        case BillingPlanType.monthly.value:
             return StoreKit.Product.SubscriptionInfo.BillingPlanType.monthly
         default:
             Logger.warn(

--- a/Sources/Purchasing/StoreKitAbstractions/BillingPlanType.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/BillingPlanType.swift
@@ -13,35 +13,22 @@ import StoreKit
 @objc(RCBillingPlanType)
 public final class BillingPlanType: NSObject, Sendable {
     /// Upfront billing plan, where the user pays in full when purchasing the product.
-    @objc(RCUpFront) public static let upFront = BillingPlanType(value: "upFront")
+    @objc(RCUpFront) public static let upFront = BillingPlanType(rawValue: "upFront")
 
     /// Monthly billing plan, where the user pays in monthly installments.
-    @objc(RCMonthly) public static let monthly = BillingPlanType(value: "monthly")
+    @objc(RCMonthly) public static let monthly = BillingPlanType(rawValue: "monthly")
 
-    private init(value: String) {
-        self.value = value
+    private init(rawValue: String) {
+        self.rawValue = rawValue
         super.init()
     }
 
     /// String representation of the BillingPlanType.
-    public let value: String
+    public let rawValue: String
 
     /// Pattern matching operator
     public static func ~= (lhs: BillingPlanType, rhs: BillingPlanType) -> Bool {
         lhs === rhs
-    }
-}
-
-extension BillingPlanType {
-    /// Get the billing plan type for a given value string.
-    public static func from(value: String) -> BillingPlanType? {
-        if value == BillingPlanType.monthly.value {
-            return BillingPlanType.monthly
-        } else if value == BillingPlanType.upFront.value {
-            return BillingPlanType.upFront
-        } else {
-            return nil
-        }
     }
 }
 

--- a/Sources/Purchasing/StoreKitAbstractions/BillingPlanType.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/BillingPlanType.swift
@@ -24,7 +24,7 @@ public final class BillingPlanType: NSObject, Sendable {
     }
 
     /// String representation of the BillingPlanType.
-    public let rawValue: String
+    @objc public let rawValue: String
 
     /// Pattern matching operator
     public static func ~= (lhs: BillingPlanType, rhs: BillingPlanType) -> Bool {

--- a/Sources/Purchasing/StoreKitAbstractions/BillingPlanType.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/BillingPlanType.swift
@@ -13,16 +13,35 @@ import StoreKit
 @objc(RCBillingPlanType)
 public final class BillingPlanType: NSObject, Sendable {
     /// Upfront billing plan, where the user pays in full when purchasing the product.
-    @objc(RCUpFront) public static let upFront = BillingPlanType()
+    @objc(RCUpFront) public static let upFront = BillingPlanType(value: "upFront")
 
     /// Monthly billing plan, where the user pays in monthly installments.
-    @objc(RCMonthly) public static let monthly = BillingPlanType()
+    @objc(RCMonthly) public static let monthly = BillingPlanType(value: "monthly")
 
-    private override init() {}
+    private init(value: String) {
+        self.value = value
+        super.init()
+    }
+
+    /// String representation of the BillingPlanType.
+    public let value: String
 
     /// Pattern matching operator
     public static func ~= (lhs: BillingPlanType, rhs: BillingPlanType) -> Bool {
         lhs === rhs
+    }
+}
+
+extension BillingPlanType {
+    /// Get the billing plan type for a given value string.
+    public static func from(value: String) -> BillingPlanType? {
+        if value == BillingPlanType.monthly.value {
+            return BillingPlanType.monthly
+        } else if value == BillingPlanType.upFront.value {
+            return BillingPlanType.upFront
+        } else {
+            return nil
+        }
     }
 }
 

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -169,7 +169,7 @@ extension TestStoreProduct: StoreProductType {
         if let installmentsInfo {
             switch installmentsInfo.billingPlanType {
             case .monthly:
-                return "\(self.productIdentifier):\(installmentsInfo.billingPlanType.value)"
+                return "\(self.productIdentifier):\(installmentsInfo.billingPlanType.rawValue)"
             case .upFront:
                 return self.productIdentifier
             default:

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -169,7 +169,7 @@ extension TestStoreProduct: StoreProductType {
         if let installmentsInfo {
             switch installmentsInfo.billingPlanType {
             case .monthly:
-                return "\(self.productIdentifier):monthly"
+                return "\(self.productIdentifier):\(installmentsInfo.billingPlanType.value)"
             case .upFront:
                 return self.productIdentifier
             default:

--- a/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/BillingPlanTypeAPI.swift
+++ b/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/BillingPlanTypeAPI.swift
@@ -10,5 +10,8 @@ import RevenueCat_CustomEntitlementComputation
 
 func checkBillingPlanType() {
     let _: BillingPlanType = BillingPlanType.monthly
+    let _: String = BillingPlanType.monthly.rawValue
+
     let _: BillingPlanType = BillingPlanType.upFront
+    let _: String = BillingPlanType.upFront.rawValue
 }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCBillingPlanTypeAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCBillingPlanTypeAPI.m
@@ -14,7 +14,10 @@
 
 + (void)checkAPI {
     RCBillingPlanType *monthly __unused = [RCBillingPlanType RCMonthly];
+    NSString *monthlyRawValue __unused = [RCBillingPlanType RCMonthly].rawValue;
+
     RCBillingPlanType *upFront __unused = [RCBillingPlanType RCUpFront];
+    NSString *upFrontRawValue __unused = [RCBillingPlanType RCUpFront].rawValue;
 }
 
 

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/BillingPlanTypeAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/BillingPlanTypeAPI.swift
@@ -10,5 +10,8 @@ import RevenueCat
 
 func checkBillingPlanType() {
     let _: BillingPlanType = BillingPlanType.monthly
+    let _: String = BillingPlanType.monthly.rawValue
+
     let _: BillingPlanType = BillingPlanType.upFront
+    let _: String = BillingPlanType.upFront.rawValue
 }

--- a/Tests/UnitTests/Purchasing/StoreKitAbstractions/BillingPlanTypeTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitAbstractions/BillingPlanTypeTests.swift
@@ -52,21 +52,8 @@ class BillingPlanTypeTests: TestCase {
 // MARK: - Value
 extension BillingPlanType {
     func testBillingPlanTypeValues() {
-        expect(BillingPlanType.monthly.value).to(equal("monthly"))
-        expect(BillingPlanType.upFront.value).to(equal("upFront"))
-    }
-
-    func testBillingPlanTypeFrom() {
-        expect(BillingPlanType.from(value: "monthly")).to(equal(BillingPlanType.monthly))
-        expect(BillingPlanType.from(value: "upFront")).to(equal(BillingPlanType.upFront))
-
-        expect(BillingPlanType.from(value: "")).to(equal(nil))
-        expect(BillingPlanType.from(value: ";lijsdf")).to(equal(nil))
-    }
-
-    func testBillingPlanTypeFromIsCaseSensitive() {
-        expect(BillingPlanType.from(value: "Monthly")).to(equal(nil))
-        expect(BillingPlanType.from(value: "upfront")).to(equal(nil))
+        expect(BillingPlanType.monthly.rawValue).to(equal("monthly"))
+        expect(BillingPlanType.upFront.rawValue).to(equal("upFront"))
     }
 }
 

--- a/Tests/UnitTests/Purchasing/StoreKitAbstractions/BillingPlanTypeTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitAbstractions/BillingPlanTypeTests.swift
@@ -49,6 +49,27 @@ class BillingPlanTypeTests: TestCase {
     }
 }
 
+// MARK: - Value
+extension BillingPlanType {
+    func testBillingPlanTypeValues() {
+        expect(BillingPlanType.monthly.value).to(equal("monthly"))
+        expect(BillingPlanType.upFront.value).to(equal("upFront"))
+    }
+
+    func testBillingPlanTypeFrom() {
+        expect(BillingPlanType.from(value: "monthly")).to(equal(BillingPlanType.monthly))
+        expect(BillingPlanType.from(value: "upFront")).to(equal(BillingPlanType.upFront))
+
+        expect(BillingPlanType.from(value: "")).to(equal(nil))
+        expect(BillingPlanType.from(value: ";lijsdf")).to(equal(nil))
+    }
+
+    func testBillingPlanTypeFromIsCaseSensitive() {
+        expect(BillingPlanType.from(value: "Monthly")).to(equal(nil))
+        expect(BillingPlanType.from(value: "upfront")).to(equal(nil))
+    }
+}
+
 // MARK: - To/From StoreKit BillingPlanType
 #if compiler(>=6.3.2)
 extension BillingPlanTypeTests {

--- a/Tests/UnitTests/Purchasing/StoreKitAbstractions/BillingPlanTypeTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitAbstractions/BillingPlanTypeTests.swift
@@ -49,8 +49,8 @@ class BillingPlanTypeTests: TestCase {
     }
 }
 
-// MARK: - Value
-extension BillingPlanType {
+// MARK: - BillingPlanType.rawValue
+extension BillingPlanTypeTests {
     func testBillingPlanTypeValues() {
         expect(BillingPlanType.monthly.rawValue).to(equal("monthly"))
         expect(BillingPlanType.upFront.rawValue).to(equal("upFront"))

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -2948,7 +2948,7 @@ extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
-  final public let rawValue: Swift.String
+  @objc final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -2945,9 +2945,10 @@ extension StoreKit.SKRequest : @unchecked @retroactive Swift.Sendable {
 }
 extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 }
-@_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
+@_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
+  final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -2948,7 +2948,7 @@ extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
-  final public let rawValue: Swift.String
+  @objc final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -2945,9 +2945,10 @@ extension StoreKit.SKRequest : @unchecked @retroactive Swift.Sendable {
 }
 extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 }
-@_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
+@_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
+  final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -2838,7 +2838,7 @@ extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
-  final public let rawValue: Swift.String
+  @objc final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -2835,9 +2835,10 @@ extension StoreKit.SKRequest : @unchecked @retroactive Swift.Sendable {
 }
 extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 }
-@_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
+@_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
+  final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -2815,9 +2815,10 @@ extension StoreKit.SKRequest : @unchecked @retroactive Swift.Sendable {
 }
 extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 }
-@_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
+@_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
+  final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -2818,7 +2818,7 @@ extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
-  final public let rawValue: Swift.String
+  @objc final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -2815,9 +2815,10 @@ extension StoreKit.SKRequest : @unchecked @retroactive Swift.Sendable {
 }
 extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 }
-@_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
+@_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
+  final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -2818,7 +2818,7 @@ extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
-  final public let rawValue: Swift.String
+  @objc final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -2948,7 +2948,7 @@ extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
-  final public let rawValue: Swift.String
+  @objc final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -2945,9 +2945,10 @@ extension StoreKit.SKRequest : @unchecked @retroactive Swift.Sendable {
 }
 extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 }
-@_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
+@_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
+  final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -2948,7 +2948,7 @@ extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
-  final public let rawValue: Swift.String
+  @objc final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -2945,9 +2945,10 @@ extension StoreKit.SKRequest : @unchecked @retroactive Swift.Sendable {
 }
 extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 }
-@_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
+@_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
+  final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -2816,9 +2816,10 @@ extension StoreKit.SKRequest : @unchecked @retroactive Swift.Sendable {
 }
 extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 }
-@_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
+@_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
+  final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -2819,7 +2819,7 @@ extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
-  final public let rawValue: Swift.String
+  @objc final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -2816,9 +2816,10 @@ extension StoreKit.SKRequest : @unchecked @retroactive Swift.Sendable {
 }
 extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 }
-@_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
+@_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
+  final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -2819,7 +2819,7 @@ extension StoreKit.SKProductsRequest : @unchecked @retroactive Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCBillingPlanType) final public class BillingPlanType : ObjectiveC.NSObject, Swift.Sendable {
   @objc(RCUpFront) public static let upFront: RevenueCat.BillingPlanType
   @objc(RCMonthly) public static let monthly: RevenueCat.BillingPlanType
-  final public let rawValue: Swift.String
+  @objc final public let rawValue: Swift.String
   public static func ~= (lhs: RevenueCat.BillingPlanType, rhs: RevenueCat.BillingPlanType) -> Swift.Bool
   @objc deinit
 }


### PR DESCRIPTION
### Description
Adds public `BillingPlanType.rawValue` property. Helpful for keeping track of the constant values internally, and will likely help make our lives easier when we port to the hybrids. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a public string accessor and updates a few internal call sites/tests; purchase flow behavior is unchanged aside from logging/identifier string formatting.
> 
> **Overview**
> Adds a public `BillingPlanType.rawValue` (Swift + Objective-C) and updates billing-plan constants to be value-backed rather than anonymous instances.
> 
> Updates StoreKit billing-plan mapping and purchase-time logging to use `BillingPlanType.rawValue` (and makes `TestStoreProduct` IDs derive the plan suffix from the same value), plus adds/extends API and unit tests and refreshes generated `.swiftinterface` files accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 803ed115b98ce0df7581b967ab4af168532089da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->