### PR TITLE
[Billing Plans]: Update POST receipt values for transactions with billing plans

### DIFF
--- a/Sources/Purchasing/ProductRequestData+Initialization.swift
+++ b/Sources/Purchasing/ProductRequestData+Initialization.swift
@@ -29,12 +29,27 @@ extension ProductRequestData {
         let subscriptionGroup = Self.extractSubscriptionGroup(for: product)
         let discounts = Self.extractDiscounts(for: product)
 
+        let price: Decimal
+        if #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *),
+           let installmentsInfo = product.installmentsInfo {
+            switch installmentsInfo.billingPlanType {
+            case .monthly:
+                price = installmentsInfo.installmentBillingPrice
+            case .upFront:
+                price = product.price
+            default:
+                price = product.price
+            }
+        } else {
+            price = product.price
+        }
+
         self.init(
-            productIdentifier: product.productIdentifier,
+            productIdentifier: product.id,
             paymentMode: paymentMode,
             currencyCode: product.priceFormatter?.currencyCode,
             storeCountry: storeCountry,
-            price: product.price as Decimal,
+            price: price,
             normalDuration: normalDuration,
             introDuration: introDuration,
             introDurationType: introDurationType,

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -2039,6 +2039,11 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
 
     func testSyncPurchasesSK2UsesStoredLocalTransactionMetadata() async throws {
         for productID in ["stored_product_from_purchase", "stored_product_from_purchase:monthly"] {
+            self.backend.invokedPostReceiptData = false
+            self.backend.invokedPostReceiptDataCount = 0
+            self.backend.invokedPostReceiptDataParameters = nil
+            self.backend.invokedPostReceiptDataParametersList = []
+
             let transaction = try await createTransaction(finished: true)
             self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = transaction
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -2038,74 +2038,76 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     }
 
     func testSyncPurchasesSK2UsesStoredLocalTransactionMetadata() async throws {
-        let transaction = try await createTransaction(finished: true)
-        self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = transaction
+        for productID in ["stored_product_from_purchase", "stored_product_from_purchase:monthly"] {
+            let transaction = try await createTransaction(finished: true)
+            self.mockTransactionFetcher.stubbedFirstVerifiedTransaction = transaction
 
-        // Store metadata for this transaction
-        let storedProductData = ProductRequestData(
-            productIdentifier: "stored_product_from_purchase",
-            paymentMode: nil,
-            currencyCode: "EUR",
-            storeCountry: "DE",
-            price: 19.99,
-            normalDuration: nil,
-            introDuration: nil,
-            introDurationType: nil,
-            introPrice: nil,
-            subscriptionGroup: nil,
-            discounts: nil
-        )
-        let storedTransactionData = PurchasedTransactionData(
-            presentedOfferingContext: .init(
-                offeringIdentifier: "stored_offering",
-                placementIdentifier: "stored_placement",
-                targetingContext: nil
+            // Store metadata for this transaction
+            let storedProductData = ProductRequestData(
+                productIdentifier: productID,
+                paymentMode: nil,
+                currencyCode: "EUR",
+                storeCountry: "DE",
+                price: 19.99,
+                normalDuration: nil,
+                introDuration: nil,
+                introDurationType: nil,
+                introPrice: nil,
+                subscriptionGroup: nil,
+                discounts: nil
             )
-        )
-        let storedMetadata = LocalTransactionMetadata(
-            transactionId: transaction.transactionIdentifier,
-            productData: storedProductData,
-            transactionData: storedTransactionData,
-            encodedAppleReceipt: .receipt("test_receipt".asData),
-            originalPurchasesAreCompletedBy: .myApp,
-            sdkOriginated: true
-        )
+            let storedTransactionData = PurchasedTransactionData(
+                presentedOfferingContext: .init(
+                    offeringIdentifier: "stored_offering",
+                    placementIdentifier: "stored_placement",
+                    targetingContext: nil
+                )
+            )
+            let storedMetadata = LocalTransactionMetadata(
+                transactionId: transaction.transactionIdentifier,
+                productData: storedProductData,
+                transactionData: storedTransactionData,
+                encodedAppleReceipt: .receipt("test_receipt".asData),
+                originalPurchasesAreCompletedBy: .myApp,
+                sdkOriginated: true
+            )
 
-        self.mockLocalTransactionMetadataStore.storeMetadata(
-            storedMetadata,
-            forTransactionId: transaction.transactionIdentifier
-        )
+            self.mockLocalTransactionMetadataStore.storeMetadata(
+                storedMetadata,
+                forTransactionId: transaction.transactionIdentifier
+            )
 
-        self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
+            self.backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
-        let customerInfo = try await self.orchestrator.syncPurchases(
-            receiptRefreshPolicy: .always,
-            isRestore: false,
-            initiationSource: .queue
-        )
+            let customerInfo = try await self.orchestrator.syncPurchases(
+                receiptRefreshPolicy: .always,
+                isRestore: false,
+                initiationSource: .queue
+            )
 
-        expect(self.backend.invokedPostReceiptData).to(beTrue())
-        expect(self.backend.invokedPostReceiptDataCount) == 1
+            expect(self.backend.invokedPostReceiptData).to(beTrue())
+            expect(self.backend.invokedPostReceiptDataCount) == 1
 
-        // Verify that stored metadata was used
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.productData?.productIdentifier
-        ) == "stored_product_from_purchase"
-        expect(self.backend.invokedPostReceiptDataParameters?.productData?.currencyCode) == "EUR"
-        expect(self.backend.invokedPostReceiptDataParameters?.productData?.price) == 19.99
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext?.offeringIdentifier
-        ) == "stored_offering"
-        expect(self.backend.invokedPostReceiptDataParameters?.originalPurchaseCompletedBy) == .myApp
-        expect(self.backend.invokedPostReceiptDataParameters?.sdkOriginated) == true
+            // Verify that stored metadata was used
+            expect(
+                self.backend.invokedPostReceiptDataParameters?.productData?.productIdentifier
+            ) == productID
+            expect(self.backend.invokedPostReceiptDataParameters?.productData?.currencyCode) == "EUR"
+            expect(self.backend.invokedPostReceiptDataParameters?.productData?.price) == 19.99
+            expect(
+                self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext?.offeringIdentifier
+            ) == "stored_offering"
+            expect(self.backend.invokedPostReceiptDataParameters?.originalPurchaseCompletedBy) == .myApp
+            expect(self.backend.invokedPostReceiptDataParameters?.sdkOriginated) == true
 
-        // Verify metadata was cleared after successful post
-        expect(self.mockLocalTransactionMetadataStore.invokedRemoveMetadata.value) == true
-        expect(
-            self.mockLocalTransactionMetadataStore.invokedRemoveMetadataTransactionId.value
-        ) == transaction.transactionIdentifier
+            // Verify metadata was cleared after successful post
+            expect(self.mockLocalTransactionMetadataStore.invokedRemoveMetadata.value) == true
+            expect(
+                self.mockLocalTransactionMetadataStore.invokedRemoveMetadataTransactionId.value
+            ) == transaction.transactionIdentifier
 
-        expect(customerInfo) == mockCustomerInfo
+            expect(customerInfo) == mockCustomerInfo
+        }
     }
 
     func testSyncPurchasesDoesntPostReceiptAndReturnsCustomerInfoIfNoTransactionsAndOriginalPurchaseDatePresent()

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -2095,7 +2095,8 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
             expect(self.backend.invokedPostReceiptDataParameters?.productData?.currencyCode) == "EUR"
             expect(self.backend.invokedPostReceiptDataParameters?.productData?.price) == 19.99
             expect(
-                self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext?.offeringIdentifier
+                self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext?
+                    .offeringIdentifier
             ) == "stored_offering"
             expect(self.backend.invokedPostReceiptDataParameters?.originalPurchaseCompletedBy) == .myApp
             expect(self.backend.invokedPostReceiptDataParameters?.sdkOriginated) == true

--- a/Tests/UnitTests/Purchasing/ProductRequestDataTests.swift
+++ b/Tests/UnitTests/Purchasing/ProductRequestDataTests.swift
@@ -210,6 +210,128 @@ class ProductRequestDataTests: TestCase {
         expect(productData.cacheKey) == "cool_product-49.99-UYU-ESP-1-0-cool_group-P3Y-P3W-2-offerid1-offerid2-offerid3"
     }
 
+    func testInitializesProductIdentifierWithBillingPlan() throws {
+        try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
+
+        let productIdentifier = "cool_product"
+        let product = Self.product(
+            productIdentifier: productIdentifier,
+            price: 11.97,
+            installmentsInfo: Self.installmentsInfo(billingPlanType: .monthly)
+        )
+
+        let productData = ProductRequestData(with: product, storeCountry: "USA")
+
+        expect(productData.productIdentifier) == "\(productIdentifier):monthly"
+    }
+
+    func testInitializesProductIdentifierWithoutBillingPlan() {
+        let productIdentifier = "cool_product"
+        let product = TestStoreProduct(
+            localizedTitle: "Cool product",
+            price: 3.99,
+            currencyCode: "USD",
+            localizedPriceString: "$3.99",
+            productIdentifier: productIdentifier,
+            productType: .autoRenewableSubscription,
+            localizedDescription: "A cool product",
+            subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            locale: Locale(identifier: "en_US"),
+            installmentsInfo: nil
+        ).toStoreProduct()
+
+        let productData = ProductRequestData(with: product, storeCountry: "USA")
+
+        expect(productData.productIdentifier) == productIdentifier
+    }
+
+    func testInitializesPriceWithInstallmentBillingPriceForMonthlyBillingPlan() throws {
+        try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
+
+        let product = Self.product(
+            price: 11.97,
+            installmentsInfo: Self.installmentsInfo(
+                billingPlanType: .monthly,
+                installmentBillingPrice: 3.99,
+                commitmentTotalPrice: 11.97
+            )
+        )
+
+        let productData = ProductRequestData(with: product, storeCountry: "USA")
+
+        expect(productData.price) == 3.99
+    }
+
+    func testInitializesPriceWithProductPriceForUpFrontBillingPlan() throws {
+        try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
+
+        let product = Self.product(
+            price: 11.97,
+            installmentsInfo: Self.installmentsInfo(
+                billingPlanType: .upFront,
+                installmentBillingPrice: 3.99,
+                commitmentTotalPrice: 11.97
+            )
+        )
+
+        let productData = ProductRequestData(with: product, storeCountry: "USA")
+
+        expect(productData.price) == 11.97
+    }
+
+    func testInitializesPriceWithProductPriceWithoutInstallmentsInfo() throws {
+        try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
+
+        let product = Self.product(
+            price: 11.97,
+            installmentsInfo: nil
+        )
+
+        let productData = ProductRequestData(with: product, storeCountry: "USA")
+
+        expect(productData.price) == 11.97
+    }
+
+}
+
+private extension ProductRequestDataTests {
+
+    static func product(
+        productIdentifier: String = "cool_product",
+        price: Decimal,
+        installmentsInfo: InstallmentsInfo?
+    ) -> StoreProduct {
+        return TestStoreProduct(
+            localizedTitle: "Cool product",
+            price: price,
+            currencyCode: "USD",
+            localizedPriceString: "$\(price)",
+            productIdentifier: productIdentifier,
+            productType: .autoRenewableSubscription,
+            localizedDescription: "A cool product",
+            subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            locale: Locale(identifier: "en_US"),
+            installmentsInfo: installmentsInfo
+        ).toStoreProduct()
+    }
+
+    static func installmentsInfo(
+        billingPlanType: BillingPlanType,
+        installmentBillingPrice: Decimal = 3.99,
+        commitmentTotalPrice: Decimal = 11.97
+    ) -> InstallmentsInfo {
+        return InstallmentsInfo(
+            commitmentInstallmentsCount: 3,
+            commitmentInstallmentPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            installmentBillingPrice: installmentBillingPrice,
+            installmentBillingDisplayPrice: "$\(installmentBillingPrice)",
+            commitmentTotalPeriod: SubscriptionPeriod(value: 3, unit: .month),
+            commitmentTotalPrice: commitmentTotalPrice,
+            commitmentTotalDisplayPrice: "$\(commitmentTotalPrice)",
+            billingPlanType: billingPlanType
+        )
+    }
+
 }
 
 private extension ProductRequestDataTests {


### PR DESCRIPTION
### Description
This PR updates the values sent through POST /receipt when purchasing a product with a billing plan. Specifically, it:
- Uses `StoreProduct.id` for `product_identifier`. This will be something like `com.rc.product` for purchases without a billing plan, and will be `com.rc.product:monthly` for a product with a monthly billing plan.
- Updates the `price` to be the price of the installment when the billing plan type is monthly, instead of the price of the product, which would be the annual price

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `POST /receipt` payload fields used for purchase validation/attribution (product identifier and price), which could affect backend processing and analytics for billing-plan purchases if mismatched.
> 
> **Overview**
> Updates `ProductRequestData` initialization to send **billing-plan-aware values** when posting receipts: it now uses `StoreProduct.id` (e.g. `product:monthly`) as `productIdentifier` and, on iOS/tvOS/watchOS/macOS/visionOS 26.4+, uses `installmentsInfo.installmentBillingPrice` for `.monthly` billing plans instead of the full product price.
> 
> Expands unit coverage to validate the new identifier/price behavior and adjusts `syncPurchases` metadata tests to accept both base and `:monthly` product identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e196597c219d405675211464f7ba1de8474743f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->