### PR TITLE
[Billing Plans]: Update product caching cache key

### DIFF
--- a/Sources/Purchasing/CachingProductsManager.swift
+++ b/Sources/Purchasing/CachingProductsManager.swift
@@ -149,7 +149,7 @@ private extension CachingProductsManager {
     }
 
     static func cache<T: StoreProductType>(_ products: Set<T>, container: Atomic<[String: T]>) {
-        container.modify { $0 += products.dictionaryAllowingDuplicateKeys { $0.productIdentifier } }
+        container.modify { $0 += products.dictionaryAllowingDuplicateKeys { $0.id } }
     }
 
     /// - Returns: true if there is already a request in progress for these products.

--- a/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
@@ -216,7 +216,7 @@ class CachingProductsManagerTests: TestCase {
         ])
 
         expect(result) == [baseProduct, monthlyCommitmentProduct]
-        
+
         // Verify only the missing base product request was sent to the underlying manager.
         expect(self.mockManager.invokedProductsCount) == 2
         expect(self.mockManager.invokedProductsParametersList) == [

--- a/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
@@ -97,6 +97,48 @@ class CachingProductsManagerTests: TestCase {
         self.expectProductsWereFetched(times: 1, for: Self.productID)
     }
 
+    func testReturnsCachedProductUsingStoreProductID() async throws {
+        try AvailabilityChecks.iOS26APIAvailableOrSkipTest()
+
+        let product = self.createTestProduct(
+            productIdentifier: "com.revenuecat.product_id",
+            installmentsInfo: Self.installmentsInfo(billingPlanType: .monthly)
+        )
+        self.mockManager.stubbedProductsCompletionResult = .success([product])
+
+        _ = try await self.cachingManager.products(withIdentifiers: [product.id])
+        let result = try await self.cachingManager.products(withIdentifiers: [product.id])
+
+        expect(result.onlyElement) === product
+        self.expectProductsWereFetched(times: 1, for: product.id)
+    }
+
+    func testFetchesUncachedProductsByStoreProductID() async throws {
+        try AvailabilityChecks.iOS26APIAvailableOrSkipTest()
+
+        let cachedProduct = self.createTestProduct(
+            productIdentifier: "com.revenuecat.product_id",
+            installmentsInfo: Self.installmentsInfo(billingPlanType: .monthly)
+        )
+        let uncachedProduct = self.createTestProduct(
+            productIdentifier: "com.revenuecat.lifetime",
+            installmentsInfo: nil
+        )
+
+        self.mockManager.stubbedProductsCompletionResult = .success([cachedProduct])
+        _ = try await self.cachingManager.products(withIdentifiers: [cachedProduct.id])
+
+        self.mockManager.stubbedProductsCompletionResult = .success([uncachedProduct])
+        let result = try await self.cachingManager.products(withIdentifiers: [cachedProduct.id, uncachedProduct.id])
+
+        expect(result) == [cachedProduct, uncachedProduct]
+        expect(self.mockManager.invokedProductsCount) == 2
+        expect(self.mockManager.invokedProductsParametersList) == [
+            Set([cachedProduct.id]),
+            Set([uncachedProduct.id])
+        ]
+    }
+
     func testRefetchesAfterClearingCache() async throws {
         let product = self.createMockProduct()
         self.mockManager.stubbedProductsCompletionResult = .success([product])
@@ -142,6 +184,21 @@ private extension CachingProductsManagerTests {
 
     static let productID = "com.revenuecat.product_id"
 
+    static func installmentsInfo(
+        billingPlanType: BillingPlanType
+    ) -> InstallmentsInfo {
+        return InstallmentsInfo(
+            commitmentInstallmentsCount: 3,
+            commitmentInstallmentPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            installmentBillingPrice: 3.99,
+            installmentBillingDisplayPrice: "$3.99",
+            commitmentTotalPeriod: SubscriptionPeriod(value: 3, unit: .month),
+            commitmentTotalPrice: 11.97,
+            commitmentTotalDisplayPrice: "$11.97",
+            billingPlanType: billingPlanType
+        )
+    }
+
     func expectProductsWereFetched(
         times: Int,
         for identifiers: String...,
@@ -157,6 +214,24 @@ private extension CachingProductsManagerTests {
         // Using SK1 products because they can be mocked, but `CachingProductsManager
         // works with generic `StoreProduct`s regardless of what they contain
         return StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: identifier))
+    }
+
+    func createTestProduct(
+        productIdentifier: String = CachingProductsManagerTests.productID,
+        installmentsInfo: InstallmentsInfo?
+    ) -> StoreProduct {
+        return TestStoreProduct(
+            localizedTitle: "product",
+            price: 11.97,
+            currencyCode: "USD",
+            localizedPriceString: "$11.97",
+            productIdentifier: productIdentifier,
+            productType: .autoRenewableSubscription,
+            localizedDescription: "description",
+            subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            locale: Locale(identifier: "en_US"),
+            installmentsInfo: installmentsInfo
+        ).toStoreProduct()
     }
 
 }

--- a/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
@@ -98,8 +98,6 @@ class CachingProductsManagerTests: TestCase {
     }
 
     func testReturnsCachedProductUsingStoreProductID() async throws {
-        try AvailabilityChecks.iOS26APIAvailableOrSkipTest()
-
         let product = self.createTestProduct(
             productIdentifier: "com.revenuecat.product_id",
             installmentsInfo: Self.installmentsInfo(billingPlanType: .monthly)
@@ -113,9 +111,121 @@ class CachingProductsManagerTests: TestCase {
         self.expectProductsWereFetched(times: 1, for: product.id)
     }
 
-    func testFetchesUncachedProductsByStoreProductID() async throws {
-        try AvailabilityChecks.iOS26APIAvailableOrSkipTest()
+    func testReturnsBaseAndInstallmentProductsWithSameProductIdentifierUsingStoreProductID() async throws {
+        let baseProduct = self.createTestProduct(
+            productIdentifier: "com.revenuecat.product_id",
+            installmentsInfo: nil
+        )
+        let installmentProduct = self.createTestProduct(
+            productIdentifier: baseProduct.productIdentifier,
+            installmentsInfo: Self.installmentsInfo(billingPlanType: .monthly)
+        )
 
+        self.mockManager.stubbedProductsCompletionResult = .success([baseProduct])
+        _ = try await self.cachingManager.products(withIdentifiers: [baseProduct.id])
+
+        self.mockManager.stubbedProductsCompletionResult = .success([installmentProduct])
+        let result = try await self.cachingManager.products(withIdentifiers: [baseProduct.id, installmentProduct.id])
+
+        expect(result) == [baseProduct, installmentProduct]
+        expect(Set(result.map(\.productIdentifier))) == Set([baseProduct.productIdentifier])
+        expect(self.mockManager.invokedProductsCount) == 2
+        expect(self.mockManager.invokedProductsParametersList) == [
+            Set([baseProduct.id]),
+            Set([installmentProduct.id])
+        ]
+    }
+
+    func testDoesntReturnBaseProductWhenOnlyMonthlyProductIsCached() async throws {
+        let productIdentifier = "com.revenuecat.product_id"
+        let monthlyCommitmentProduct = self.createTestProduct(
+            productIdentifier: productIdentifier,
+            installmentsInfo: Self.installmentsInfo(billingPlanType: .monthly)
+        )
+        self.mockManager.stubbedProductsCompletionResult = .success([monthlyCommitmentProduct])
+
+        // Cache the monthly plan using its compound StoreProduct ID: "com.revenuecat.product_id:monthly".
+        _ = try await self.cachingManager.products(withIdentifiers: [monthlyCommitmentProduct.id])
+
+        // Requesting the base product ID should not return the cached monthly plan.
+        // It should be treated as a cache miss and fetched separately.
+        self.mockManager.stubbedProductsCompletionResult = .success([])
+        let result = try await self.cachingManager.products(withIdentifiers: [productIdentifier])
+
+        expect(result.isEmpty) == true
+        // Verify the base product request was sent to the underlying manager instead of being served from cache.
+        expect(self.mockManager.invokedProductsCount) == 2
+        expect(self.mockManager.invokedProductsParametersList) == [
+            Set([monthlyCommitmentProduct.id]),
+            Set([productIdentifier])
+        ]
+    }
+
+    func testDoesntReturnMonthlyProductWhenOnlyBaseProductIsCached() async throws {
+        let productIdentifier = "com.revenuecat.product_id"
+        let baseProduct = self.createTestProduct(
+            productIdentifier: productIdentifier,
+            installmentsInfo: nil
+        )
+        let monthlyCommitmentProduct = self.createTestProduct(
+            productIdentifier: productIdentifier,
+            installmentsInfo: Self.installmentsInfo(billingPlanType: .monthly)
+        )
+
+        self.mockManager.stubbedProductsCompletionResult = .success([baseProduct])
+
+        // Cache the base product using its StoreProduct ID: "com.revenuecat.product_id".
+        _ = try await self.cachingManager.products(withIdentifiers: [baseProduct.id])
+
+        // Requesting the monthly compound ID should not return the cached base product.
+        // It should be treated as a cache miss and fetched separately.
+        self.mockManager.stubbedProductsCompletionResult = .success([])
+        let result = try await self.cachingManager.products(withIdentifiers: [monthlyCommitmentProduct.id])
+
+        expect(result.isEmpty) == true
+        // Verify the monthly product request was sent to the underlying manager instead of being served from cache.
+        expect(self.mockManager.invokedProductsCount) == 2
+        expect(self.mockManager.invokedProductsParametersList) == [
+            Set([baseProduct.id]),
+            Set([monthlyCommitmentProduct.id])
+        ]
+    }
+
+    func testReturnsMonthlyCachedProductAndFetchesBaseProduct() async throws {
+        let productIdentifier = "com.revenuecat.product_id"
+        let baseProduct = self.createTestProduct(
+            productIdentifier: productIdentifier,
+            installmentsInfo: nil
+        )
+        let monthlyCommitmentProduct = self.createTestProduct(
+            productIdentifier: productIdentifier,
+            installmentsInfo: Self.installmentsInfo(billingPlanType: .monthly)
+        )
+
+        self.mockManager.stubbedProductsCompletionResult = .success([monthlyCommitmentProduct])
+
+        // Cache the monthly plan using its compound StoreProduct ID: "com.revenuecat.product_id:monthly".
+        _ = try await self.cachingManager.products(withIdentifiers: [monthlyCommitmentProduct.id])
+
+        // Requesting the base and monthly IDs together should reuse the cached monthly product
+        // and fetch only the missing base product.
+        self.mockManager.stubbedProductsCompletionResult = .success([baseProduct])
+        let result = try await self.cachingManager.products(withIdentifiers: [
+            baseProduct.id,
+            monthlyCommitmentProduct.id
+        ])
+
+        expect(result) == [baseProduct, monthlyCommitmentProduct]
+        
+        // Verify only the missing base product request was sent to the underlying manager.
+        expect(self.mockManager.invokedProductsCount) == 2
+        expect(self.mockManager.invokedProductsParametersList) == [
+            Set([monthlyCommitmentProduct.id]),
+            Set([baseProduct.id])
+        ]
+    }
+
+    func testFetchesUncachedProductsByStoreProductID() async throws {
         let cachedProduct = self.createTestProduct(
             productIdentifier: "com.revenuecat.product_id",
             installmentsInfo: Self.installmentsInfo(billingPlanType: .monthly)


### PR DESCRIPTION
### Description
Modifies the SDK's product cache to use `StoreProduct.id` instead of the `productIdentifier`. This allows us to avoid cache key conflicts for products with billing plans since the cache will now store separate values for `com.rc.product` and `com.rc.product:monthly`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the cache key used for StoreKit product lookups, which can alter cache hit/miss behavior and increase product fetches if any callers still request by `productIdentifier` instead of `StoreProduct.id`. Covered by new unit tests around base vs billing-plan IDs, but impacts purchasing performance/behavior paths.
> 
> **Overview**
> **Product caching now keys entries by `StoreProduct.id` instead of `productIdentifier`**, so billing-plan variants like `com.rc.product:monthly` no longer overwrite or satisfy requests for the base `com.rc.product` (and vice versa).
> 
> Adds focused unit tests to verify correct cache behavior for base vs installment/billing-plan products: cached hits by `id`, no cross-serving between base and monthly IDs, and mixed requests only fetch missing IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac1f6ce4c99fcf2d80b21ad8170739d5f5e9991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->