### PR TITLE
Removes `swiftPMImport` from cinterop package name

### DIFF
--- a/RevenueCatUI/Helpers/Bundle+Extensions.swift
+++ b/RevenueCatUI/Helpers/Bundle+Extensions.swift
@@ -36,7 +36,7 @@ extension Bundle {
         let composeResourcesPath = findComposeResourcesPath()
         let path = composeResourcesPath
             .appending("/composeResources")
-            .appending("/swiftPMImport.com.revenuecat.purchases.kn.ui.resources")
+            .appending("/com.revenuecat.purchases.kn.ui.resources")
             .appending("/files")
         let bundle = Bundle(path: path)
         guard let bundle else {


### PR DESCRIPTION
## Motivation
The `swiftPMImport` prefix was added initially because it would allow us to easily switch to KMP's own experimental SPM integration. Now that we're not doing that, it's no longer necessary. This PR cleans it up. It's a fully internal change.

## Note
This PR should be released in the same version as https://github.com/RevenueCat/purchases-kmp/pull/854.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single internal string change to the Compose Resources bundle lookup; main risk is missing resources at runtime if the bundle directory name doesn’t match the packaged output for certain build configurations.
> 
> **Overview**
> Updates the `COMPOSE_RESOURCES` bundle lookup in `Bundle+Extensions.swift` to remove the `swiftPMImport.` prefix from the Compose Resources directory name, so RevenueCatUI loads resources from `.../composeResources/com.revenuecat.purchases.kn.ui.resources/files` instead of the old path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3b3f47f87ec306c735f5c69abb3cb5e03daedf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->