### PR TITLE
[Billing Plans]: fix: Don't return products with billing plans on unsupported OS versions

### DIFF
--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -115,6 +115,8 @@ enum StoreKitStrings {
 
     case sk2_user_not_eligible_for_billing_plan(compoundProductIdentifier: CompoundProductIdentifier)
 
+    case sk2_billing_plans_are_unavailable_on_this_os_version(compoundProductIdentifier: CompoundProductIdentifier)
+
     case sk2_applying_billing_plan(billingPlanType: String)
 
     case sk2_user_not_eligible_for_billing_plan_at_purchase_time(billingPlanType: String)
@@ -293,6 +295,10 @@ extension StoreKitStrings: LogMessage {
                 "billing plan. Will not return a product " +
                 "for \(compoundProductIdentifier.compoundProductIdentifier)"
             }
+
+        case .sk2_billing_plans_are_unavailable_on_this_os_version(let compoundProductIdentifier):
+            return "Products with billing plans are only supported on iOS 26.4+. Will not return " +
+            "a product for \(compoundProductIdentifier.compoundProductIdentifier)"
 
         case .sk2_applying_billing_plan(let billingPlanType):
             return "Applying billing plan of type \(billingPlanType) to the purchase."

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -71,7 +71,21 @@ class ProductsManager: NSObject, ProductsManagerType {
                     return nil
                 }
 
-                return compoundIdentifier
+                // Don't return products with billing plans if running on <iOS 26.4, where they aren't supported
+                if #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
+                    return compoundIdentifier
+                } else {
+                    guard compoundIdentifier.productPlanIdentifier == nil else {
+                        Logger.warn(
+                            StoreKitStrings.sk2_billing_plans_are_unavailable_on_this_os_version(
+                                compoundProductIdentifier: compoundIdentifier
+                            )
+                        )
+                        return nil
+                    }
+
+                    return compoundIdentifier
+                }
             }
         )
         if !invalidProductIdentifiers.isEmpty {

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -57,6 +57,7 @@ class ProductsManager: NSObject, ProductsManagerType {
         }
     }
 
+    // swiftlint:disable:next function_body_length
     func products(withIdentifiers identifiers: Set<String>, completion: @escaping Completion) {
         let startTime = self.dateProvider.now()
 

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -78,7 +78,6 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         let unwrappedProducts = try XCTUnwrap(receivedProducts?.get())
         let product = try XCTUnwrap(unwrappedProducts.onlyElement).product
 
-        expect(productsRequestFactory.invokedRequestParameters) == Set([storeKitProductIdentifier])
         expect(product.productIdentifier) == storeKitProductIdentifier
         expect(self.logger.messages).toNot(containElementSatisfying { message in
             message.level == .warn

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -61,12 +61,16 @@ class ProductsManagerTests: StoreKitConfigTestCase {
 
         let productsRequestFactory = MockProductsRequestFactory()
         let manager = self.createManager(
-            storeKitVersion: .storeKit1,
+            storeKitVersion: .storeKit2,
             productsRequestFactory: productsRequestFactory
         )
+        self.logger.clearMessages()
 
         let storeKitProductIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
         let compoundProductIdentifier = "\(storeKitProductIdentifier):monthly"
+        let compoundIdentifier = try XCTUnwrap(
+            CompoundProductIdentifier(compoundProductIdentifier: compoundProductIdentifier)
+        )
         let receivedProducts = waitUntilValue(timeout: Self.requestDispatchTimeout) { completed in
             manager.products(withIdentifiers: Set([compoundProductIdentifier]), completion: completed)
         }
@@ -76,6 +80,12 @@ class ProductsManagerTests: StoreKitConfigTestCase {
 
         expect(productsRequestFactory.invokedRequestParameters) == Set([storeKitProductIdentifier])
         expect(product.productIdentifier) == storeKitProductIdentifier
+        expect(self.logger.messages).toNot(containElementSatisfying { message in
+            message.level == .warn
+                && message.message == Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
+                    compoundProductIdentifier: compoundIdentifier
+                ).description
+        })
     }
 
     func testFetchProductsWithCompoundIdentifierWithBillingPlanDoesNotRequestProductOnUnsupportedOSVersions() throws {

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -57,6 +57,8 @@ class ProductsManagerTests: StoreKitConfigTestCase {
     }
 
     func testFetchProductsWithCompoundIdentifierOnlyRequestsStoreKitProductIdentifier() throws {
+        try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
+
         let productsRequestFactory = MockProductsRequestFactory()
         let manager = self.createManager(
             storeKitVersion: .storeKit1,
@@ -74,6 +76,37 @@ class ProductsManagerTests: StoreKitConfigTestCase {
 
         expect(productsRequestFactory.invokedRequestParameters) == Set([storeKitProductIdentifier])
         expect(product.productIdentifier) == storeKitProductIdentifier
+    }
+
+    func testFetchProductsWithCompoundIdentifierWithBillingPlanDoesNotRequestProductOnUnsupportedOSVersions() throws {
+        try AvailabilityChecks.iOS264APINotAvailableOrSkipTest()
+
+        let productsRequestFactory = MockProductsRequestFactory()
+        let manager = self.createManager(
+            storeKitVersion: .storeKit2,
+            productsRequestFactory: productsRequestFactory
+        )
+        self.logger.clearMessages()
+
+        let compoundProductIdentifier = try XCTUnwrap(
+            CompoundProductIdentifier(compoundProductIdentifier: "com.revenuecat.subscription:monthly")
+        )
+        let receivedProducts = waitUntilValue(timeout: Self.requestDispatchTimeout) { completed in
+            manager.products(
+                withIdentifiers: Set([compoundProductIdentifier.compoundProductIdentifier]),
+                completion: completed
+            )
+        }
+
+        let unwrappedProducts = try XCTUnwrap(receivedProducts?.get())
+        expect(unwrappedProducts).to(beEmpty())
+        expect(productsRequestFactory.invokedRequest) == false
+        self.logger.verifyMessageWasLogged(
+            Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
+                compoundProductIdentifier: compoundProductIdentifier
+            ),
+            level: .warn
+        )
     }
 
     func testFetchProductsWithInvalidCompoundIdentifiersLogsWarning() throws {

--- a/Tests/StoreKitUnitTests/TestHelpers/AvailabilityChecks.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/AvailabilityChecks.swift
@@ -94,6 +94,13 @@ enum AvailabilityChecks {
         }
     }
 
+    /// Opposite of `iOS264APIAvailableOrSkipTest`.
+    static func iOS264APINotAvailableOrSkipTest() throws {
+        if #available(iOS 26.4, tvOS 26.4, macOS 26.4, watchOS 26.4, visionOS 26.4, *) {
+            throw XCTSkip("Test only for older devices")
+        }
+    }
+
     static func skipIfTVOrWatchOSOrMacOS() throws {
         #if os(watchOS) || os(tvOS) || os(macOS)
         throw XCTSkip("Test not for watchOS or tvOS or macOS")


### PR DESCRIPTION
### Description
This fixes a bug where fetching a product with a billing plan (like `com.rc.product:monthly`) on iOS <26.4 would return the base product, but with a nil `InstallmentsInfo`. This is functionally equivalent to returning the same product twice.

The PR addresses this bug by:
1. Not returning products with compound product IDs when running on iOS < 26.4
2. Adding a log when we omit the product explaining why we don't return a product for it the request
3. Adding a unit test to assert the behavior on iOS < 26.4

I'll follow up this PR with a similar change to assert that we don't return any products for compound product identifiers when running in SK1 mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes product fetching behavior by filtering out compound product identifiers with billing plans on iOS < 26.4, which could affect apps relying on prior (buggy) fallback behavior. Logic is gated by OS availability and covered by new unit tests, reducing regression risk.
> 
> **Overview**
> Fixes SK2 product fetching so **compound product identifiers that include billing plans** (e.g. `product:monthly`) are **ignored on OS versions where billing plans aren’t supported (< iOS 26.4)**, preventing the base product from being returned as an unintended fallback.
> 
> Adds a new warning log (`sk2_billing_plans_are_unavailable_on_this_os_version`) when these requests are omitted, and updates unit tests + availability helpers to validate both supported and unsupported OS behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed1fdb6b1de879f535a9d1b0024d6d367de9d6fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->