### PR TITLE
[Billing Plans]: Fix: Dont return products for compound product IDs when in SK1 Mode

### DIFF
--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -63,6 +63,8 @@ enum StoreKitStrings {
 
     case sk1_finish_transaction_called_with_existing_completion(SKPaymentTransaction)
 
+    case sk1_does_not_support_billing_plans(compoundProductIdentifier: CompoundProductIdentifier)
+
     case sk1_product_request_too_slow
 
     case sk2_product_request_too_slow
@@ -205,6 +207,10 @@ extension StoreKitStrings: LogMessage {
         case let .sk1_finish_transaction_called_with_existing_completion(transaction):
             return "StoreKit1Wrapper.finishTransaction was called for '\(transaction.productIdentifier ?? "")' " +
             "but found an existing completion block."
+
+        case .sk1_does_not_support_billing_plans(let compoundProductIdentifier):
+            return "Products with billing plans are not supported when using StoreKit 1. Will not return " +
+            "a product for \(compoundProductIdentifier.compoundProductIdentifier)"
 
         case .sk1_product_request_too_slow:
             return "StoreKit 1 product request took longer than expected"

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -72,16 +72,10 @@ class ProductsManager: NSObject, ProductsManagerType {
                     return nil
                 }
 
-                // Don't return products with billing plans if running on <iOS 26.4, where they aren't supported
-                if #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
-                    return compoundIdentifier
+                if compoundIdentifier.productPlanIdentifier == nil {
+                    return compoundIdentifier   // Basic product with no billing plan
                 } else {
-                    guard compoundIdentifier.productPlanIdentifier == nil else {
-                        Logger.warn(
-                            StoreKitStrings.sk2_billing_plans_are_unavailable_on_this_os_version(
-                                compoundProductIdentifier: compoundIdentifier
-                            )
-                        )
+                    guard self.areProductsWithBillingPlansSupported(compoundIdentifier: compoundIdentifier) else {
                         return nil
                     }
 
@@ -295,6 +289,31 @@ private extension ProductsManager {
         }
     }
 
+}
+
+// MARK: - Products w/ Billing Plans
+private extension ProductsManager {
+    private func areProductsWithBillingPlansSupported(compoundIdentifier: CompoundProductIdentifier) -> Bool {
+        guard self.systemInfo.storeKitVersion.isStoreKit2EnabledAndAvailable else {
+            Logger.warn(
+                StoreKitStrings.sk1_does_not_support_billing_plans(
+                    compoundProductIdentifier: compoundIdentifier
+                )
+            )
+            return false
+        }
+
+        if #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
+            return true
+        } else {
+            Logger.warn(
+                StoreKitStrings.sk2_billing_plans_are_unavailable_on_this_os_version(
+                    compoundProductIdentifier: compoundIdentifier
+                )
+            )
+            return false
+        }
+    }
 }
 
 // MARK: - ProductsManagerType async

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -79,18 +79,34 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         let product = try XCTUnwrap(unwrappedProducts.onlyElement).product
 
         expect(product.productIdentifier) == storeKitProductIdentifier
-        expect(self.logger.messages).toNot(containElementSatisfying { message in
-            message.level == .warn
-                && message.message == Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
-                    compoundProductIdentifier: compoundIdentifier
-                ).description
-        })
-        expect(self.logger.messages).toNot(containElementSatisfying { message in
-            message.level == .warn
-                && message.message == Strings.storeKit.sk1_does_not_support_billing_plans(
-                    compoundProductIdentifier: compoundIdentifier
-                ).description
-        })
+        if #available(iOS 16.0, *) {
+            self.logger.verifyMessageWasLogged(
+                Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
+                    compoundProductIdentifier: compoundProductIdentifier
+                ),
+                level: .warn
+            )
+            expect(self.logger.messages).toNot(containElementSatisfying { message in
+                message.level == .warn
+                    && message.message == Strings.storeKit.sk1_does_not_support_billing_plans(
+                        compoundProductIdentifier: compoundProductIdentifier
+                    ).description
+            })
+        } else {
+            // On iOS 14/15, the StoreKit 1 check happens first, so they'll see the SK1 warning log instead
+            self.logger.verifyMessageWasLogged(
+                Strings.storeKit.sk1_does_not_support_billing_plans(
+                    compoundProductIdentifier: compoundProductIdentifier
+                ).description,
+                level: .warn
+            )
+            expect(self.logger.messages).toNot(containElementSatisfying { message in
+                message.level == .warn
+                    && message.message == Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
+                        compoundProductIdentifier: compoundProductIdentifier
+                    )
+            })
+        }
     }
 
     func testFetchProductsWithCompoundIdentifierWithBillingPlanDoesNotRequestProductOnUnsupportedOSVersions() throws {

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -131,8 +131,6 @@ class ProductsManagerTests: StoreKitConfigTestCase {
     }
 
     func testFetchProductsWithCompoundIdentifierWithBillingPlanDoesNotRequestProductWithStoreKit1() throws {
-        try AvailabilityChecks.iOS264APINotAvailableOrSkipTest()
-
         let productsRequestFactory = MockProductsRequestFactory()
         let manager = self.createManager(
             storeKitVersion: .storeKit1,

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -135,28 +135,28 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         if #available(iOS 16.0, *) {
             self.logger.verifyMessageWasLogged(
                 Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
-                    compoundProductIdentifier: compoundIdentifier
+                    compoundProductIdentifier: compoundProductIdentifier
                 ),
                 level: .warn
             )
             expect(self.logger.messages).toNot(containElementSatisfying { message in
                 message.level == .warn
                     && message.message == Strings.storeKit.sk1_does_not_support_billing_plans(
-                        compoundProductIdentifier: compoundIdentifier
+                        compoundProductIdentifier: compoundProductIdentifier
                     ).description
             })
         } else {
             // On iOS 14/15, the StoreKit 1 check happens first, so they'll see the SK1 warning log instead
             self.logger.verifyMessageWasLogged(
                 Strings.storeKit.sk1_does_not_support_billing_plans(
-                    compoundProductIdentifier: compoundIdentifier
+                    compoundProductIdentifier: compoundProductIdentifier
                 ).description,
                 level: .warn
             )
             expect(self.logger.messages).toNot(containElementSatisfying { message in
                 message.level == .warn
                     && message.message == Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
-                        compoundProductIdentifier: compoundIdentifier
+                        compoundProductIdentifier: compoundProductIdentifier
                     ).description
             })
         }

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -104,7 +104,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
                 message.level == .warn
                     && message.message == Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
                         compoundProductIdentifier: compoundIdentifier
-                    )
+                    ).description
             })
         }
     }

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -132,18 +132,34 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         let unwrappedProducts = try XCTUnwrap(receivedProducts?.get())
         expect(unwrappedProducts).to(beEmpty())
         expect(productsRequestFactory.invokedRequest) == false
-        self.logger.verifyMessageWasLogged(
-            Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
-                compoundProductIdentifier: compoundProductIdentifier
-            ),
-            level: .warn
-        )
-        expect(self.logger.messages).toNot(containElementSatisfying { message in
-            message.level == .warn
-                && message.message == Strings.storeKit.sk1_does_not_support_billing_plans(
-                    compoundProductIdentifier: compoundProductIdentifier
-                ).description
-        })
+        if #available(iOS 16.0, *) {
+            self.logger.verifyMessageWasLogged(
+                Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
+                    compoundProductIdentifier: compoundIdentifier
+                ),
+                level: .warn
+            )
+            expect(self.logger.messages).toNot(containElementSatisfying { message in
+                message.level == .warn
+                    && message.message == Strings.storeKit.sk1_does_not_support_billing_plans(
+                        compoundProductIdentifier: compoundIdentifier
+                    ).description
+            })
+        } else {
+            // On iOS 14/15, the StoreKit 1 check happens first, so they'll see the SK1 warning log instead
+            self.logger.verifyMessageWasLogged(
+                Strings.storeKit.sk1_does_not_support_billing_plans(
+                    compoundProductIdentifier: compoundIdentifier
+                ).description,
+                level: .warn
+            )
+            expect(self.logger.messages).toNot(containElementSatisfying { message in
+                message.level == .warn
+                    && message.message == Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
+                        compoundProductIdentifier: compoundIdentifier
+                    ).description
+            })
+        }
     }
 
     func testFetchProductsWithCompoundIdentifierWithBillingPlanDoesNotRequestProductWithStoreKit1() throws {

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -132,7 +132,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
 
     func testFetchProductsWithCompoundIdentifierWithBillingPlanDoesNotRequestProductWithStoreKit1() throws {
         try AvailabilityChecks.iOS264APINotAvailableOrSkipTest()
-        
+
         let productsRequestFactory = MockProductsRequestFactory()
         let manager = self.createManager(
             storeKitVersion: .storeKit1,

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -82,28 +82,28 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         if #available(iOS 16.0, *) {
             self.logger.verifyMessageWasLogged(
                 Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
-                    compoundProductIdentifier: compoundProductIdentifier
+                    compoundProductIdentifier: compoundIdentifier
                 ),
                 level: .warn
             )
             expect(self.logger.messages).toNot(containElementSatisfying { message in
                 message.level == .warn
                     && message.message == Strings.storeKit.sk1_does_not_support_billing_plans(
-                        compoundProductIdentifier: compoundProductIdentifier
+                        compoundProductIdentifier: compoundIdentifier
                     ).description
             })
         } else {
             // On iOS 14/15, the StoreKit 1 check happens first, so they'll see the SK1 warning log instead
             self.logger.verifyMessageWasLogged(
                 Strings.storeKit.sk1_does_not_support_billing_plans(
-                    compoundProductIdentifier: compoundProductIdentifier
+                    compoundProductIdentifier: compoundIdentifier
                 ).description,
                 level: .warn
             )
             expect(self.logger.messages).toNot(containElementSatisfying { message in
                 message.level == .warn
                     && message.message == Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
-                        compoundProductIdentifier: compoundProductIdentifier
+                        compoundProductIdentifier: compoundIdentifier
                     )
             })
         }

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -85,6 +85,12 @@ class ProductsManagerTests: StoreKitConfigTestCase {
                     compoundProductIdentifier: compoundIdentifier
                 ).description
         })
+        expect(self.logger.messages).toNot(containElementSatisfying { message in
+            message.level == .warn
+                && message.message == Strings.storeKit.sk1_does_not_support_billing_plans(
+                    compoundProductIdentifier: compoundIdentifier
+                ).description
+        })
     }
 
     func testFetchProductsWithCompoundIdentifierWithBillingPlanDoesNotRequestProductOnUnsupportedOSVersions() throws {
@@ -112,6 +118,43 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         expect(productsRequestFactory.invokedRequest) == false
         self.logger.verifyMessageWasLogged(
             Strings.storeKit.sk2_billing_plans_are_unavailable_on_this_os_version(
+                compoundProductIdentifier: compoundProductIdentifier
+            ),
+            level: .warn
+        )
+        expect(self.logger.messages).toNot(containElementSatisfying { message in
+            message.level == .warn
+                && message.message == Strings.storeKit.sk1_does_not_support_billing_plans(
+                    compoundProductIdentifier: compoundProductIdentifier
+                ).description
+        })
+    }
+
+    func testFetchProductsWithCompoundIdentifierWithBillingPlanDoesNotRequestProductWithStoreKit1() throws {
+        try AvailabilityChecks.iOS264APINotAvailableOrSkipTest()
+        
+        let productsRequestFactory = MockProductsRequestFactory()
+        let manager = self.createManager(
+            storeKitVersion: .storeKit1,
+            productsRequestFactory: productsRequestFactory
+        )
+        self.logger.clearMessages()
+
+        let compoundProductIdentifier = try XCTUnwrap(
+            CompoundProductIdentifier(compoundProductIdentifier: "com.revenuecat.subscription:monthly")
+        )
+        let receivedProducts = waitUntilValue(timeout: Self.requestDispatchTimeout) { completed in
+            manager.products(
+                withIdentifiers: Set([compoundProductIdentifier.compoundProductIdentifier]),
+                completion: completed
+            )
+        }
+
+        let unwrappedProducts = try XCTUnwrap(receivedProducts?.get())
+        expect(unwrappedProducts).to(beEmpty())
+        expect(productsRequestFactory.invokedRequest) == false
+        self.logger.verifyMessageWasLogged(
+            Strings.storeKit.sk1_does_not_support_billing_plans(
                 compoundProductIdentifier: compoundProductIdentifier
             ),
             level: .warn
@@ -272,7 +315,6 @@ class ProductsManagerTests: StoreKitConfigTestCase {
             requestTimeout: Self.requestTimeout
         )
     }
-
 }
 
 // swiftlint:disable type_name


### PR DESCRIPTION
### Description
This PR fixes a bug where requesting a product with a compound product ID, like `com.rc.product:monthly`, when running the SDK in StoreKit 1 mode, would return a `StoreProduct` with no InstallmentsInfo object. This is incorrect behavior and could result in you getting back the same product twice if you requested both `com.rc.product:monthly` and `com.rc.product`.

This PR fixes this by:
- Not returning any products for compound product identifiers when running in SK1 mode
- Adds a warning log for it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes product identifier normalization and filtering so compound billing-plan IDs are ignored in StoreKit 1, which can alter which products are returned and which requests are made.
> 
> **Overview**
> Fixes product fetching so *compound product identifiers with billing plans* (e.g. `com.app.sub:monthly`) are **never returned or requested** when running in StoreKit 1, preventing duplicate/incorrect `StoreProduct` results.
> 
> Adds a new warning log `sk1_does_not_support_billing_plans` and centralizes billing-plan support checks in `ProductsManager.areProductsWithBillingPlansSupported` (SK2 + OS availability), with updated/expanded unit tests to assert the correct empty results and warning behavior across OS versions and StoreKit modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbcd8a7fb8f2c0fc9a770aff1b9840d857967192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->