### PR TITLE
Rename InstallmentsInfo properties to shorter names

### DIFF
--- a/Sources/Purchasing/InstallmentsInfo.swift
+++ b/Sources/Purchasing/InstallmentsInfo.swift
@@ -18,10 +18,10 @@ import StoreKit
 @objc(RCInstallmentsInfo) public final class InstallmentsInfo: NSObject, Sendable {
 
     /// Number of installments the customer commits to paying.
-    @objc public let commitmentInstallmentsCount: Int
+    @objc public let installmentsCount: Int
 
     /// The duration for each installment.
-    @objc public let commitmentInstallmentPeriod: SubscriptionPeriod
+    @objc public let installmentPeriod: SubscriptionPeriod
 
     /// Price charged for each installment billing period.
     @objc public let installmentBillingPrice: Decimal
@@ -44,8 +44,8 @@ import StoreKit
     /// Creates a new ``InstallmentsInfo``.
     ///
     /// - Parameters:
-    ///   - commitmentInstallmentsCount: Number of installments the customer commits to paying.
-    ///   - commitmentInstallmentPeriod: The duration for each installment.
+    ///   - installmentsCount: Number of installments the customer commits to paying.
+    ///   - installmentPeriod: The duration for each installment.
     ///   - installmentBillingPrice: Price charged for each installment billing period.
     ///   - installmentBillingDisplayPrice: Localized display price for `installmentBillingPrice`.
     ///   - commitmentTotalPeriod: Total duration of the customer's installment commitment.
@@ -53,8 +53,8 @@ import StoreKit
     ///   - commitmentTotalDisplayPrice: Localized display price for `commitmentTotalPrice`.
     ///   - billingPlanType: Billing plan type used for the installments.
     @objc public init(
-        commitmentInstallmentsCount: Int,
-        commitmentInstallmentPeriod: SubscriptionPeriod,
+        installmentsCount: Int,
+        installmentPeriod: SubscriptionPeriod,
         installmentBillingPrice: Decimal,
         installmentBillingDisplayPrice: String,
         commitmentTotalPeriod: SubscriptionPeriod,
@@ -62,8 +62,8 @@ import StoreKit
         commitmentTotalDisplayPrice: String,
         billingPlanType: BillingPlanType
     ) {
-        self.commitmentInstallmentsCount = commitmentInstallmentsCount
-        self.commitmentInstallmentPeriod = commitmentInstallmentPeriod
+        self.installmentsCount = installmentsCount
+        self.installmentPeriod = installmentPeriod
         self.installmentBillingPrice = installmentBillingPrice
         self.installmentBillingDisplayPrice = installmentBillingDisplayPrice
         self.commitmentTotalPeriod = commitmentTotalPeriod
@@ -75,8 +75,8 @@ import StoreKit
     public override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? InstallmentsInfo else { return false }
 
-        return self.commitmentInstallmentsCount == other.commitmentInstallmentsCount
-            && self.commitmentInstallmentPeriod == other.commitmentInstallmentPeriod
+        return self.installmentsCount == other.installmentsCount
+            && self.installmentPeriod == other.installmentPeriod
             && self.installmentBillingPrice == other.installmentBillingPrice
             && self.installmentBillingDisplayPrice == other.installmentBillingDisplayPrice
             && self.commitmentTotalPeriod == other.commitmentTotalPeriod
@@ -87,8 +87,8 @@ import StoreKit
 
     public override var hash: Int {
         var hasher = Hasher()
-        hasher.combine(self.commitmentInstallmentsCount)
-        hasher.combine(self.commitmentInstallmentPeriod)
+        hasher.combine(self.installmentsCount)
+        hasher.combine(self.installmentPeriod)
         hasher.combine(self.installmentBillingPrice)
         hasher.combine(self.installmentBillingDisplayPrice)
         hasher.combine(self.commitmentTotalPeriod)

--- a/Sources/Purchasing/InstallmentsInfoFactory.swift
+++ b/Sources/Purchasing/InstallmentsInfoFactory.swift
@@ -36,7 +36,7 @@ final class InstallmentsInfoFactory: InstallmentsInfoFactoryType {
         billingPlanType: StoreKit.Product.SubscriptionInfo.BillingPlanType,
         pricingTerms: StoreKit.Product.SubscriptionInfo.PricingTerms
     ) -> InstallmentsInfo? {
-        guard let commitmentInstallmentsCount = calculateCommitmentInstallmentsCount(
+        guard let installmentsCount = calculateInstallmentsCount(
             billingPlanType: billingPlanType,
             commitmentPeriod: pricingTerms.commitmentInfo.period
         ) else { return nil }
@@ -46,7 +46,7 @@ final class InstallmentsInfoFactory: InstallmentsInfoFactoryType {
             commitmentPeriod: pricingTerms.commitmentInfo.period
         ) else { return nil }
 
-        let commitmentTotalPrice = pricingTerms.billingPrice * Decimal(commitmentInstallmentsCount)
+        let commitmentTotalPrice = pricingTerms.billingPrice * Decimal(installmentsCount)
         let commitmentTotalDisplayPrice: String = commitmentTotalPrice.formatted(product.priceFormatStyle)
 
         return self.buildInstallmentsInfo(
@@ -54,7 +54,7 @@ final class InstallmentsInfoFactory: InstallmentsInfoFactoryType {
             commitmentPeriod: pricingTerms.commitmentInfo.period,
             billingPrice: pricingTerms.billingPrice,
             billingDisplayPrice: pricingTerms.billingDisplayPrice,
-            commitmentInstallmentsCount: commitmentInstallmentsCount,
+            installmentsCount: installmentsCount,
             commitmentTotalPeriod: commitmentTotalPeriod,
             commitmentTotalDisplayPrice: commitmentTotalDisplayPrice
         )
@@ -66,17 +66,17 @@ final class InstallmentsInfoFactory: InstallmentsInfoFactoryType {
         commitmentPeriod: StoreKit.Product.SubscriptionPeriod,
         billingPrice: Decimal,
         billingDisplayPrice: String,
-        commitmentInstallmentsCount: Int? = nil,
-        commitmentInstallmentsPeriod: SubscriptionPeriod? = nil,
+        installmentsCount: Int? = nil,
+        installmentPeriod: SubscriptionPeriod? = nil,
         commitmentTotalPeriod: SubscriptionPeriod? = nil,
         commitmentTotalDisplayPrice: String
     ) -> InstallmentsInfo? {
-        guard let commitmentInstallmentsCount = commitmentInstallmentsCount ?? calculateCommitmentInstallmentsCount(
+        guard let installmentsCount = installmentsCount ?? calculateInstallmentsCount(
             billingPlanType: billingPlanType,
             commitmentPeriod: commitmentPeriod
         ) else { return nil }
 
-        guard let commitmentInstallmentPeriod = commitmentInstallmentsPeriod ?? calculateCommitmentInstallmentPeriod(
+        guard let installmentPeriod = installmentPeriod ?? calculateInstallmentPeriod(
             billingPlanType: billingPlanType
         ) else { return nil }
 
@@ -89,12 +89,12 @@ final class InstallmentsInfoFactory: InstallmentsInfoFactoryType {
             return nil
         }
 
-        let commitmentTotalPrice = billingPrice * Decimal(commitmentInstallmentsCount)
+        let commitmentTotalPrice = billingPrice * Decimal(installmentsCount)
         let installmentBillingPrice = billingPrice
         let installmentBillingDisplayPrice = billingDisplayPrice
         return InstallmentsInfo(
-            commitmentInstallmentsCount: commitmentInstallmentsCount,
-            commitmentInstallmentPeriod: commitmentInstallmentPeriod,
+            installmentsCount: installmentsCount,
+            installmentPeriod: installmentPeriod,
             installmentBillingPrice: installmentBillingPrice,
             installmentBillingDisplayPrice: installmentBillingDisplayPrice,
             commitmentTotalPeriod: commitmentTotalPeriod,
@@ -111,7 +111,7 @@ final class InstallmentsInfoFactory: InstallmentsInfoFactoryType {
 extension InstallmentsInfoFactory {
 
     @available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *)
-    func calculateCommitmentInstallmentsCount(
+    func calculateInstallmentsCount(
         billingPlanType: StoreKit.Product.SubscriptionInfo.BillingPlanType,
         commitmentPeriod: StoreKit.Product.SubscriptionPeriod
     ) -> Int? {
@@ -134,7 +134,7 @@ extension InstallmentsInfoFactory {
     }
 
     @available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *)
-    func calculateCommitmentInstallmentPeriod(
+    func calculateInstallmentPeriod(
         billingPlanType: StoreKit.Product.SubscriptionInfo.BillingPlanType
     ) -> SubscriptionPeriod? {
         switch billingPlanType {

--- a/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/InstallmentInfosAPI.swift
+++ b/Tests/APITesters/AllAPITests/CustomEntitlementComputationSwiftAPITester/InstallmentInfosAPI.swift
@@ -10,8 +10,8 @@ import Foundation
 import RevenueCat_CustomEntitlementComputation
 
 func checkInstallmentsInfo(installmentsInfo: InstallmentsInfo) {
-    let _: Int = installmentsInfo.commitmentInstallmentsCount
-    let _: SubscriptionPeriod = installmentsInfo.commitmentInstallmentPeriod
+    let _: Int = installmentsInfo.installmentsCount
+    let _: SubscriptionPeriod = installmentsInfo.installmentPeriod
     let _: Decimal = installmentsInfo.installmentBillingPrice
     let _: String = installmentsInfo.installmentBillingDisplayPrice
     let _: SubscriptionPeriod = installmentsInfo.commitmentTotalPeriod
@@ -22,8 +22,8 @@ func checkInstallmentsInfo(installmentsInfo: InstallmentsInfo) {
 
 func checkInstallmentsInfoInit() {
     let installmentsInfo: InstallmentsInfo = InstallmentsInfo(
-        commitmentInstallmentsCount: 12,
-        commitmentInstallmentPeriod: SubscriptionPeriod(value: 1, unit: .month),
+        installmentsCount: 12,
+        installmentPeriod: SubscriptionPeriod(value: 1, unit: .month),
         installmentBillingPrice: 10,
         installmentBillingDisplayPrice: "$10.00",
         commitmentTotalPeriod: SubscriptionPeriod(value: 1, unit: .year),

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCInstallmentsInfoAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCInstallmentsInfoAPI.m
@@ -15,7 +15,7 @@
 + (void)checkAPI {
     RCInstallmentsInfo *installmentsInfo;
 
-    NSInteger commitmentInstallmentsCount __unused = installmentsInfo.commitmentInstallmentsCount;
+    NSInteger installmentsCount __unused = installmentsInfo.installmentsCount;
     RCSubscriptionPeriod *commitmentTotalPeriod __unused = installmentsInfo.commitmentTotalPeriod;
     NSDecimal commitmentTotalPrice __unused = installmentsInfo.commitmentTotalPrice;
     NSString *commitmentTotalDisplayPrice __unused = installmentsInfo.commitmentTotalDisplayPrice;
@@ -26,11 +26,11 @@
 
 + (void)checkInit {
     RCSubscriptionPeriod *commitmentTotalPeriod;
-    RCSubscriptionPeriod *commitmentInstallmentPeriod;
+    RCSubscriptionPeriod *installmentPeriod;
 
     RCInstallmentsInfo *installmentsInfo __unused = [[RCInstallmentsInfo alloc]
-                                                     initWithCommitmentInstallmentsCount:12
-                                                     commitmentInstallmentPeriod:commitmentInstallmentPeriod
+                                                     initWithInstallmentsCount:12
+                                                     installmentPeriod:installmentPeriod
                                                      installmentBillingPrice:[[NSDecimalNumber alloc] initWithInt:10].decimalValue
                                                      installmentBillingDisplayPrice:@"$10.00"
                                                      commitmentTotalPeriod:commitmentTotalPeriod

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/InstallmentsInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/InstallmentsInfoAPI.swift
@@ -10,8 +10,8 @@ import Foundation
 import RevenueCat
 
 func checkInstallmentsInfo(installmentsInfo: InstallmentsInfo) {
-    let _: Int = installmentsInfo.commitmentInstallmentsCount
-    let _: SubscriptionPeriod = installmentsInfo.commitmentInstallmentPeriod
+    let _: Int = installmentsInfo.installmentsCount
+    let _: SubscriptionPeriod = installmentsInfo.installmentPeriod
     let _: Decimal = installmentsInfo.installmentBillingPrice
     let _: String = installmentsInfo.installmentBillingDisplayPrice
     let _: SubscriptionPeriod = installmentsInfo.commitmentTotalPeriod
@@ -21,8 +21,8 @@ func checkInstallmentsInfo(installmentsInfo: InstallmentsInfo) {
 
 func checkInstallmentsInfoInit() {
     let _: InstallmentsInfo = InstallmentsInfo(
-        commitmentInstallmentsCount: 12,
-        commitmentInstallmentPeriod: SubscriptionPeriod(value: 1, unit: .month),
+        installmentsCount: 12,
+        installmentPeriod: SubscriptionPeriod(value: 1, unit: .month),
         installmentBillingPrice: 10,
         installmentBillingDisplayPrice: "$10.00",
         commitmentTotalPeriod: SubscriptionPeriod(value: 1, unit: .year),

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -565,7 +565,7 @@ extension StoreProductTests {
         let storeProduct = Self.testProduct(
             productIdentifier: productIdentifier,
             installmentsInfo: Self.installmentsInfo(
-                commitmentInstallmentsCount: 3,
+                installmentsCount: 3,
                 billingPlanType: .monthly
             )
         )
@@ -578,7 +578,7 @@ extension StoreProductTests {
         let storeProduct = Self.testProduct(
             productIdentifier: productIdentifier,
             installmentsInfo: Self.installmentsInfo(
-                commitmentInstallmentsCount: 1,
+                installmentsCount: 1,
                 billingPlanType: .upFront
             )
         )
@@ -641,17 +641,17 @@ private extension StoreProductTests {
     }
 
     static func installmentsInfo(
-        commitmentInstallmentsCount: Int,
+        installmentsCount: Int,
         billingPlanType: BillingPlanType = .monthly
     ) -> InstallmentsInfo {
         return InstallmentsInfo(
-            commitmentInstallmentsCount: commitmentInstallmentsCount,
-            commitmentInstallmentPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            installmentsCount: installmentsCount,
+            installmentPeriod: SubscriptionPeriod(value: 1, unit: .month),
             installmentBillingPrice: 3.99,
             installmentBillingDisplayPrice: "$3.99",
-            commitmentTotalPeriod: SubscriptionPeriod(value: commitmentInstallmentsCount, unit: .month),
-            commitmentTotalPrice: Decimal(commitmentInstallmentsCount) * 3.99,
-            commitmentTotalDisplayPrice: "$\(commitmentInstallmentsCount * 399 / 100).99",
+            commitmentTotalPeriod: SubscriptionPeriod(value: installmentsCount, unit: .month),
+            commitmentTotalPrice: Decimal(installmentsCount) * 3.99,
+            commitmentTotalDisplayPrice: "$\(installmentsCount * 399 / 100).99",
             billingPlanType: billingPlanType
         )
     }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/FetchProductsView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/FetchProductsView.swift
@@ -67,9 +67,9 @@ struct FetchProductsView: View {
                 if let installmentsInfo = storeProduct.installmentsInfo {
                     VStack(spacing: 10) {
                         LabeledContent {
-                            Text(installmentsInfo.commitmentInstallmentsCount.description)
+                            Text(installmentsInfo.installmentsCount.description)
                         } label: {
-                            Text("commitmentInstallmentsCount")
+                            Text("installmentsCount")
                         }
                         LabeledContent {
                             Text(installmentsInfo.commitmentTotalPeriod.debugDescription)

--- a/Tests/UnitTests/Purchasing/ProductRequestDataTests.swift
+++ b/Tests/UnitTests/Purchasing/ProductRequestDataTests.swift
@@ -321,8 +321,8 @@ private extension ProductRequestDataTests {
         commitmentTotalPrice: Decimal = 11.97
     ) -> InstallmentsInfo {
         return InstallmentsInfo(
-            commitmentInstallmentsCount: 3,
-            commitmentInstallmentPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            installmentsCount: 3,
+            installmentPeriod: SubscriptionPeriod(value: 1, unit: .month),
             installmentBillingPrice: installmentBillingPrice,
             installmentBillingDisplayPrice: "$\(installmentBillingPrice)",
             commitmentTotalPeriod: SubscriptionPeriod(value: 3, unit: .month),

--- a/Tests/UnitTests/Purchasing/Purchases/TestStoreProductTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/TestStoreProductTests.swift
@@ -74,8 +74,8 @@ private extension TestStoreProductTests {
         billingPlanType: BillingPlanType
     ) -> InstallmentsInfo {
         return InstallmentsInfo(
-            commitmentInstallmentsCount: 3,
-            commitmentInstallmentPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            installmentsCount: 3,
+            installmentPeriod: SubscriptionPeriod(value: 1, unit: .month),
             installmentBillingPrice: 3.99,
             installmentBillingDisplayPrice: "$3.99",
             commitmentTotalPeriod: SubscriptionPeriod(value: 3, unit: .month),

--- a/Tests/UnitTests/Purchasing/StoreKitAbstractions/InstallmentsInfoFactoryTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitAbstractions/InstallmentsInfoFactoryTests.swift
@@ -30,7 +30,7 @@ class InstallmentsInfoFactoryTests: TestCase {
             self.buildInstallmentsInfo(commitmentPeriod: .monthly, commitmentTotalDisplayPrice: "$4.99")
         )
 
-        expect(installmentsInfo.commitmentInstallmentsCount) == 1
+        expect(installmentsInfo.installmentsCount) == 1
         expect(installmentsInfo.commitmentTotalPeriod) == SubscriptionPeriod(value: 1, unit: .month)
         expect(installmentsInfo.commitmentTotalPrice) == Self.decimal(cents: 499)
         expect(installmentsInfo.commitmentTotalDisplayPrice) == "$4.99"
@@ -43,7 +43,7 @@ class InstallmentsInfoFactoryTests: TestCase {
             self.buildInstallmentsInfo(commitmentPeriod: .everyTwoMonths, commitmentTotalDisplayPrice: "$9.98")
         )
 
-        expect(installmentsInfo.commitmentInstallmentsCount) == 2
+        expect(installmentsInfo.installmentsCount) == 2
         expect(installmentsInfo.commitmentTotalPeriod) == SubscriptionPeriod(value: 2, unit: .month)
         expect(installmentsInfo.commitmentTotalPrice) == Self.decimal(cents: 998)
         expect(installmentsInfo.commitmentTotalDisplayPrice) == "$9.98"
@@ -56,7 +56,7 @@ class InstallmentsInfoFactoryTests: TestCase {
             self.buildInstallmentsInfo(commitmentPeriod: .everyThreeMonths, commitmentTotalDisplayPrice: "$14.97")
         )
 
-        expect(installmentsInfo.commitmentInstallmentsCount) == 3
+        expect(installmentsInfo.installmentsCount) == 3
         expect(installmentsInfo.commitmentTotalPeriod) == SubscriptionPeriod(value: 3, unit: .month)
         expect(installmentsInfo.commitmentTotalPrice) == Self.decimal(cents: 1497)
         expect(installmentsInfo.commitmentTotalDisplayPrice) == "$14.97"
@@ -69,7 +69,7 @@ class InstallmentsInfoFactoryTests: TestCase {
             self.buildInstallmentsInfo(commitmentPeriod: .everySixMonths, commitmentTotalDisplayPrice: "$29.94")
         )
 
-        expect(installmentsInfo.commitmentInstallmentsCount) == 6
+        expect(installmentsInfo.installmentsCount) == 6
         expect(installmentsInfo.commitmentTotalPeriod) == SubscriptionPeriod(value: 6, unit: .month)
         expect(installmentsInfo.commitmentTotalPrice) == Self.decimal(cents: 2994)
         expect(installmentsInfo.commitmentTotalDisplayPrice) == "$29.94"
@@ -82,7 +82,7 @@ class InstallmentsInfoFactoryTests: TestCase {
             self.buildInstallmentsInfo(commitmentPeriod: .yearly, commitmentTotalDisplayPrice: "$59.88")
         )
 
-        expect(installmentsInfo.commitmentInstallmentsCount) == 12
+        expect(installmentsInfo.installmentsCount) == 12
         expect(installmentsInfo.commitmentTotalPeriod) == SubscriptionPeriod(value: 1, unit: .year)
         expect(installmentsInfo.commitmentTotalPrice) == Self.decimal(cents: 5988)
         expect(installmentsInfo.commitmentTotalDisplayPrice) == "$59.88"

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -1932,15 +1932,15 @@ extension RevenueCat.EntitlementInfos {
 extension RevenueCat.EntitlementInfos : Swift.Sendable {
 }
 @objc(RCInstallmentsInfo) final public class InstallmentsInfo : ObjectiveC.NSObject, Swift.Sendable {
-  @objc final public let commitmentInstallmentsCount: Swift.Int
-  @objc final public let commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod
+  @objc final public let installmentsCount: Swift.Int
+  @objc final public let installmentPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let installmentBillingPrice: Foundation.Decimal
   @objc final public let installmentBillingDisplayPrice: Swift.String
   @objc final public let commitmentTotalPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let commitmentTotalPrice: Foundation.Decimal
   @objc final public let commitmentTotalDisplayPrice: Swift.String
   @objc final public let billingPlanType: RevenueCat.BillingPlanType
-  @objc public init(commitmentInstallmentsCount: Swift.Int, commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
+  @objc public init(installmentsCount: Swift.Int, installmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
   #if compiler(>=5.3) && $NonescapableTypes
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   #endif

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -1932,15 +1932,15 @@ extension RevenueCat.EntitlementInfos {
 extension RevenueCat.EntitlementInfos : Swift.Sendable {
 }
 @objc(RCInstallmentsInfo) final public class InstallmentsInfo : ObjectiveC.NSObject, Swift.Sendable {
-  @objc final public let commitmentInstallmentsCount: Swift.Int
-  @objc final public let commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod
+  @objc final public let installmentsCount: Swift.Int
+  @objc final public let installmentPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let installmentBillingPrice: Foundation.Decimal
   @objc final public let installmentBillingDisplayPrice: Swift.String
   @objc final public let commitmentTotalPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let commitmentTotalPrice: Foundation.Decimal
   @objc final public let commitmentTotalDisplayPrice: Swift.String
   @objc final public let billingPlanType: RevenueCat.BillingPlanType
-  @objc public init(commitmentInstallmentsCount: Swift.Int, commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
+  @objc public init(installmentsCount: Swift.Int, installmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
   #if compiler(>=5.3) && $NonescapableTypes
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   #endif

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -1893,15 +1893,15 @@ extension RevenueCat.EntitlementInfos {
 extension RevenueCat.EntitlementInfos : Swift.Sendable {
 }
 @objc(RCInstallmentsInfo) final public class InstallmentsInfo : ObjectiveC.NSObject, Swift.Sendable {
-  @objc final public let commitmentInstallmentsCount: Swift.Int
-  @objc final public let commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod
+  @objc final public let installmentsCount: Swift.Int
+  @objc final public let installmentPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let installmentBillingPrice: Foundation.Decimal
   @objc final public let installmentBillingDisplayPrice: Swift.String
   @objc final public let commitmentTotalPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let commitmentTotalPrice: Foundation.Decimal
   @objc final public let commitmentTotalDisplayPrice: Swift.String
   @objc final public let billingPlanType: RevenueCat.BillingPlanType
-  @objc public init(commitmentInstallmentsCount: Swift.Int, commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
+  @objc public init(installmentsCount: Swift.Int, installmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
   #if compiler(>=5.3) && $NonescapableTypes
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   #endif

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -1893,15 +1893,15 @@ extension RevenueCat.EntitlementInfos {
 extension RevenueCat.EntitlementInfos : Swift.Sendable {
 }
 @objc(RCInstallmentsInfo) final public class InstallmentsInfo : ObjectiveC.NSObject, Swift.Sendable {
-  @objc final public let commitmentInstallmentsCount: Swift.Int
-  @objc final public let commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod
+  @objc final public let installmentsCount: Swift.Int
+  @objc final public let installmentPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let installmentBillingPrice: Foundation.Decimal
   @objc final public let installmentBillingDisplayPrice: Swift.String
   @objc final public let commitmentTotalPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let commitmentTotalPrice: Foundation.Decimal
   @objc final public let commitmentTotalDisplayPrice: Swift.String
   @objc final public let billingPlanType: RevenueCat.BillingPlanType
-  @objc public init(commitmentInstallmentsCount: Swift.Int, commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
+  @objc public init(installmentsCount: Swift.Int, installmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
   #if compiler(>=5.3) && $NonescapableTypes
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   #endif

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -1893,15 +1893,15 @@ extension RevenueCat.EntitlementInfos {
 extension RevenueCat.EntitlementInfos : Swift.Sendable {
 }
 @objc(RCInstallmentsInfo) final public class InstallmentsInfo : ObjectiveC.NSObject, Swift.Sendable {
-  @objc final public let commitmentInstallmentsCount: Swift.Int
-  @objc final public let commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod
+  @objc final public let installmentsCount: Swift.Int
+  @objc final public let installmentPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let installmentBillingPrice: Foundation.Decimal
   @objc final public let installmentBillingDisplayPrice: Swift.String
   @objc final public let commitmentTotalPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let commitmentTotalPrice: Foundation.Decimal
   @objc final public let commitmentTotalDisplayPrice: Swift.String
   @objc final public let billingPlanType: RevenueCat.BillingPlanType
-  @objc public init(commitmentInstallmentsCount: Swift.Int, commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
+  @objc public init(installmentsCount: Swift.Int, installmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
   #if compiler(>=5.3) && $NonescapableTypes
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   #endif

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -1932,15 +1932,15 @@ extension RevenueCat.EntitlementInfos {
 extension RevenueCat.EntitlementInfos : Swift.Sendable {
 }
 @objc(RCInstallmentsInfo) final public class InstallmentsInfo : ObjectiveC.NSObject, Swift.Sendable {
-  @objc final public let commitmentInstallmentsCount: Swift.Int
-  @objc final public let commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod
+  @objc final public let installmentsCount: Swift.Int
+  @objc final public let installmentPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let installmentBillingPrice: Foundation.Decimal
   @objc final public let installmentBillingDisplayPrice: Swift.String
   @objc final public let commitmentTotalPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let commitmentTotalPrice: Foundation.Decimal
   @objc final public let commitmentTotalDisplayPrice: Swift.String
   @objc final public let billingPlanType: RevenueCat.BillingPlanType
-  @objc public init(commitmentInstallmentsCount: Swift.Int, commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
+  @objc public init(installmentsCount: Swift.Int, installmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
   #if compiler(>=5.3) && $NonescapableTypes
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   #endif

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -1932,15 +1932,15 @@ extension RevenueCat.EntitlementInfos {
 extension RevenueCat.EntitlementInfos : Swift.Sendable {
 }
 @objc(RCInstallmentsInfo) final public class InstallmentsInfo : ObjectiveC.NSObject, Swift.Sendable {
-  @objc final public let commitmentInstallmentsCount: Swift.Int
-  @objc final public let commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod
+  @objc final public let installmentsCount: Swift.Int
+  @objc final public let installmentPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let installmentBillingPrice: Foundation.Decimal
   @objc final public let installmentBillingDisplayPrice: Swift.String
   @objc final public let commitmentTotalPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let commitmentTotalPrice: Foundation.Decimal
   @objc final public let commitmentTotalDisplayPrice: Swift.String
   @objc final public let billingPlanType: RevenueCat.BillingPlanType
-  @objc public init(commitmentInstallmentsCount: Swift.Int, commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
+  @objc public init(installmentsCount: Swift.Int, installmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
   #if compiler(>=5.3) && $NonescapableTypes
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   #endif

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -1894,15 +1894,15 @@ extension RevenueCat.EntitlementInfos {
 extension RevenueCat.EntitlementInfos : Swift.Sendable {
 }
 @objc(RCInstallmentsInfo) final public class InstallmentsInfo : ObjectiveC.NSObject, Swift.Sendable {
-  @objc final public let commitmentInstallmentsCount: Swift.Int
-  @objc final public let commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod
+  @objc final public let installmentsCount: Swift.Int
+  @objc final public let installmentPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let installmentBillingPrice: Foundation.Decimal
   @objc final public let installmentBillingDisplayPrice: Swift.String
   @objc final public let commitmentTotalPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let commitmentTotalPrice: Foundation.Decimal
   @objc final public let commitmentTotalDisplayPrice: Swift.String
   @objc final public let billingPlanType: RevenueCat.BillingPlanType
-  @objc public init(commitmentInstallmentsCount: Swift.Int, commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
+  @objc public init(installmentsCount: Swift.Int, installmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
   #if compiler(>=5.3) && $NonescapableTypes
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   #endif

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -1894,15 +1894,15 @@ extension RevenueCat.EntitlementInfos {
 extension RevenueCat.EntitlementInfos : Swift.Sendable {
 }
 @objc(RCInstallmentsInfo) final public class InstallmentsInfo : ObjectiveC.NSObject, Swift.Sendable {
-  @objc final public let commitmentInstallmentsCount: Swift.Int
-  @objc final public let commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod
+  @objc final public let installmentsCount: Swift.Int
+  @objc final public let installmentPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let installmentBillingPrice: Foundation.Decimal
   @objc final public let installmentBillingDisplayPrice: Swift.String
   @objc final public let commitmentTotalPeriod: RevenueCat.SubscriptionPeriod
   @objc final public let commitmentTotalPrice: Foundation.Decimal
   @objc final public let commitmentTotalDisplayPrice: Swift.String
   @objc final public let billingPlanType: RevenueCat.BillingPlanType
-  @objc public init(commitmentInstallmentsCount: Swift.Int, commitmentInstallmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
+  @objc public init(installmentsCount: Swift.Int, installmentPeriod: RevenueCat.SubscriptionPeriod, installmentBillingPrice: Foundation.Decimal, installmentBillingDisplayPrice: Swift.String, commitmentTotalPeriod: RevenueCat.SubscriptionPeriod, commitmentTotalPrice: Foundation.Decimal, commitmentTotalDisplayPrice: Swift.String, billingPlanType: RevenueCat.BillingPlanType)
   #if compiler(>=5.3) && $NonescapableTypes
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   #endif


### PR DESCRIPTION
## Summary
- Rename `InstallmentsInfo.commitmentInstallmentsCount` to `installmentsCount`
- Rename `InstallmentsInfo.commitmentInstallmentPeriod` to `installmentPeriod`
- Update the initializer, related factory code, API testers, unit tests, and generated Swift interface files to match

## Testing
- `swift build`