### PR TITLE
Avoid logging receipt contents

### DIFF
--- a/Sources/LocalReceiptParsing/Helpers/ReceiptStrings.swift
+++ b/Sources/LocalReceiptParsing/Helpers/ReceiptStrings.swift
@@ -89,15 +89,15 @@ extension ReceiptStrings: LogMessage {
             return "Unable to load receipt, ensure you are logged in to a valid Apple account.\n" +
             "Error: \(error)"
 
-        case let .posting_receipt(receipt, initiationSource):
+        case let .posting_receipt(_, initiationSource):
             return "Posting receipt (source: '\(initiationSource)') (note: the contents might not be up-to-date, " +
-            "but it will be refreshed with Apple's servers):\n\(receipt.debugDescription)"
+            "but it will be refreshed with Apple's servers). Receipt contents omitted from logs."
 
-        case let .posting_jws(token, initiationSource):
-            return "Posting JWS token (source: '\(initiationSource)'):\n\(token)"
+        case let .posting_jws(_, initiationSource):
+            return "Posting JWS token (source: '\(initiationSource)'). Token contents omitted from logs."
 
-        case let .posting_sk2_receipt(receipt, initiationSource):
-            return "Posting StoreKit 2 receipt (source: '\(initiationSource)'):\n\(receipt)"
+        case let .posting_sk2_receipt(_, initiationSource):
+            return "Posting StoreKit 2 receipt (source: '\(initiationSource)'). Receipt contents omitted from logs."
 
         case let .receipt_subscription_purchase_equals_expiration(
             productIdentifier,
@@ -107,9 +107,9 @@ extension ReceiptStrings: LogMessage {
             return "Receipt for product '\(productIdentifier)' has the same purchase (\(purchase)) " +
             "and expiration (\(expiration?.description ?? "")) dates. This is likely a StoreKit bug."
 
-        case let .local_receipt_missing_purchase(receipt, productIdentifier):
-            return "Local receipt is still missing purchase for '\(productIdentifier)': \n" +
-            "\((try? receipt.prettyPrintedJSON) ?? "<null>")"
+        case let .local_receipt_missing_purchase(_, productIdentifier):
+            return "Local receipt is still missing purchase for '\(productIdentifier)'. " +
+            "Receipt contents omitted from logs."
 
         case let .retrying_receipt_fetch_after(sleepDuration):
             return String(format: "Retrying receipt fetch after %2.f seconds", sleepDuration)

--- a/Tests/UnitTests/Purchasing/ReceiptStringsTests.swift
+++ b/Tests/UnitTests/Purchasing/ReceiptStringsTests.swift
@@ -160,16 +160,12 @@ final class ReceiptStringsTests: TestCase {
                 receipt,
                 initiationSource: "initiationSource"
             )
-        let expectedDescriptionPrefix = "Posting receipt (source: 'initiationSource') " +
+        let expectedDescription = "Posting receipt (source: 'initiationSource') " +
         "(note: the contents might not be up-to-date, " +
-        "but it will be refreshed with Apple's servers):"
+        "but it will be refreshed with Apple's servers). Receipt contents omitted from logs."
 
-        // The full `debugDescription` of `AppleReceipt` is not asserted against
-        // because the conformance to `CustomDebugStringConvertible` has an internal
-        // implementation of `try? self.encodedJSON`, which does not print the JSON
-        // deterministically.
         expect(subject.category).to(equal("receipt"))
-        expect(subject.description.hasPrefix(expectedDescriptionPrefix)).to(beTrue())
+        expect(subject.description).to(equal(expectedDescription))
     }
 
     func testPostingJWS() {
@@ -178,7 +174,7 @@ final class ReceiptStringsTests: TestCase {
                 "JWS",
                 initiationSource: "initiationSource"
             )
-        let expectedDescription = "Posting JWS token (source: 'initiationSource'):\nJWS"
+        let expectedDescription = "Posting JWS token (source: 'initiationSource'). Token contents omitted from logs."
 
         expect(subject.category).to(equal("receipt"))
         expect(subject.description).to(equal(expectedDescription))
@@ -190,7 +186,8 @@ final class ReceiptStringsTests: TestCase {
                 "SK2 receipt",
                 initiationSource: "initiationSource"
             )
-        let expectedDescription = "Posting StoreKit 2 receipt (source: 'initiationSource'):\nSK2 receipt"
+        let expectedDescription = "Posting StoreKit 2 receipt (source: 'initiationSource'). " +
+        "Receipt contents omitted from logs."
 
         expect(subject.category).to(equal("receipt"))
         expect(subject.description).to(equal(expectedDescription))
@@ -229,14 +226,11 @@ final class ReceiptStringsTests: TestCase {
                 receipt,
                 forProductIdentifier: "productIdentifier"
             )
-        let expectedDescriptionPrefix = "Local receipt is still missing purchase for 'productIdentifier':"
+        let expectedDescription = "Local receipt is still missing purchase for 'productIdentifier'. " +
+        "Receipt contents omitted from logs."
 
-        // The full `debugDescription` of `AppleReceipt` is not asserted against
-        // because the conformance to `CustomDebugStringConvertible` has an internal
-        // implementation of `try? self.encodedJSON`, which does not print the JSON
-        // deterministically.
         expect(subject.category).to(equal("receipt"))
-        expect(subject.description.hasPrefix(expectedDescriptionPrefix)).to(beTrue())
+        expect(subject.description).to(equal(expectedDescription))
     }
 
     func testRetryingReceiptFetchAfterDuration() {


### PR DESCRIPTION
## Summary
- avoid printing raw JWS token contents in receipt logs
- avoid printing raw StoreKit 2 receipt contents in receipt logs
- avoid printing parsed receipt contents when a local receipt is missing a purchase
- update receipt string tests for the redacted messages

## Why
Receipt and transaction payloads can include payment/subscription identifiers. Logs should confirm the operation without exposing the payload itself.

## Testing
- git diff --check for the edited files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust log message strings to avoid printing receipt/JWS payloads and update unit tests accordingly.
> 
> **Overview**
> Stops logging raw receipt/JWS payload contents in `ReceiptStrings` for `posting_receipt`, `posting_jws`, `posting_sk2_receipt`, and `local_receipt_missing_purchase`, replacing them with redacted messages that still include the initiation source/product id.
> 
> Updates `ReceiptStringsTests` expectations to match the new redacted log output (asserting exact strings rather than prefixes where payloads were previously appended).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86fc2e82114efe720d7c254b76896f2c058ec0f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->