### PR TITLE
Pass Customer Center's change plans configuration when loading expired transactions

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -310,7 +310,7 @@ private extension CustomerCenterViewModel {
             transaction: inactiveSub,
             customerInfo: customerInfo,
             purchasesProvider: purchasesProvider,
-            changePlans: [],
+            changePlans: configuration.changePlans,
             customerCenterStoreKitUtilities: customerCenterStoreKitUtilities,
             localization: configuration.localization
         )


### PR DESCRIPTION
### Motivation
When a subscription is expired, and we have filtered subscription by configuring `Configure switchable subscriptions` in the Customer Center, the filter wouldn't be applied.

### Description
Fix the bug. Pass the change plans configuration when loading expired subscriptions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bug fix that only changes how `changePlans` configuration is passed when constructing purchase info for expired subscriptions; no auth or data persistence changes.
> 
> **Overview**
> Fixes Customer Center subscription filtering for expired subscriptions by passing `configuration.changePlans` (instead of an empty list) when building `PurchaseInformation` for the most recent expired transaction.
> 
> This makes the *switchable subscriptions* / change-plan configuration apply consistently for both active and expired subscription displays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f3d68718dd7d396d4d0eaa64e9d9edb212df47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->