### PR TITLE
Expand `DangerousSettings` API tester coverage

### DIFF
--- a/Tests/APITesters/AllAPITests/AllAPITests.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/AllAPITests/AllAPITests.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2D4C617B2C5AD31A00A29FD2 /* RCOfferingAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D4C61592C5AD31600A29FD2 /* RCOfferingAPI.m */; };
 		2D4C617C2C5AD31A00A29FD2 /* RCStoreKitVersionAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D4C61562C5AD31600A29FD2 /* RCStoreKitVersionAPI.m */; };
 		2D4C617D2C5AD31A00A29FD2 /* RCConfigurationAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D4C614E2C5AD31500A29FD2 /* RCConfigurationAPI.m */; };
+		A0BBCCDD2E000001AABBCC03 /* RCDangerousSettingsAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A0BBCCDD2E000001AABBCC02 /* RCDangerousSettingsAPI.m */; };
 		2D4C617E2C5AD31A00A29FD2 /* RCPromotionalOfferAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D4C61632C5AD31700A29FD2 /* RCPromotionalOfferAPI.m */; };
 		2D4C617F2C5AD31A00A29FD2 /* RCEntitlementInfoAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D4C615E2C5AD31700A29FD2 /* RCEntitlementInfoAPI.m */; };
 		2D4C61802C5AD31A00A29FD2 /* RCStoreProductAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D4C61712C5AD31900A29FD2 /* RCStoreProductAPI.m */; };
@@ -257,6 +258,8 @@
 		2D4C615A2C5AD31600A29FD2 /* RCRefundRequestStatusAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCRefundRequestStatusAPI.h; sourceTree = "<group>"; };
 		2D4C615B2C5AD31700A29FD2 /* RCRefundRequestStatusAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCRefundRequestStatusAPI.m; sourceTree = "<group>"; };
 		2D4C615C2C5AD31700A29FD2 /* RCConfigurationAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCConfigurationAPI.h; sourceTree = "<group>"; };
+		A0BBCCDD2E000001AABBCC01 /* RCDangerousSettingsAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCDangerousSettingsAPI.h; sourceTree = "<group>"; };
+		A0BBCCDD2E000001AABBCC02 /* RCDangerousSettingsAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCDangerousSettingsAPI.m; sourceTree = "<group>"; };
 		2D4C615D2C5AD31700A29FD2 /* RCPackageAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCPackageAPI.h; sourceTree = "<group>"; };
 		2D4C615E2C5AD31700A29FD2 /* RCEntitlementInfoAPI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCEntitlementInfoAPI.m; sourceTree = "<group>"; };
 		2D4C615F2C5AD31700A29FD2 /* RCTransactionAPI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTransactionAPI.m; sourceTree = "<group>"; };
@@ -503,6 +506,8 @@
 				2D4C61572C5AD31600A29FD2 /* RCAttributionNetworkAPI.m */,
 				2D4C615C2C5AD31700A29FD2 /* RCConfigurationAPI.h */,
 				2D4C614E2C5AD31500A29FD2 /* RCConfigurationAPI.m */,
+				A0BBCCDD2E000001AABBCC01 /* RCDangerousSettingsAPI.h */,
+				A0BBCCDD2E000001AABBCC02 /* RCDangerousSettingsAPI.m */,
 				2D4C616C2C5AD31900A29FD2 /* RCCustomerInfoAPI.h */,
 				2D4C614D2C5AD31500A29FD2 /* RCCustomerInfoAPI.m */,
 				2D4C61612C5AD31700A29FD2 /* RCEntitlementInfoAPI.h */,
@@ -1009,6 +1014,7 @@
 			files = (
 				2D4C618E2C5AD31A00A29FD2 /* RCOtherAPI.m in Sources */,
 				2D4C617D2C5AD31A00A29FD2 /* RCConfigurationAPI.m in Sources */,
+				A0BBCCDD2E000001AABBCC03 /* RCDangerousSettingsAPI.m in Sources */,
 				2D4C617E2C5AD31A00A29FD2 /* RCPromotionalOfferAPI.m in Sources */,
 				2D4C61912C5AD31A00A29FD2 /* RCIntroEligibilityAPI.m in Sources */,
 				FD2A4F982D721D2100ED3367 /* RCVirtualCurrencyAPI.m in Sources */,

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCDangerousSettingsAPI.h
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCDangerousSettingsAPI.h
@@ -1,0 +1,26 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RCDangerousSettingsAPI.h
+//  ObjCAPITester
+//
+//  Created by Antonio Pallares on 17/5/26.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCDangerousSettingsAPI : NSObject
+
++ (void)checkAPI;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCDangerousSettingsAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCDangerousSettingsAPI.m
@@ -1,0 +1,30 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RCDangerousSettingsAPI.m
+//  ObjCAPITester
+//
+//  Created by Antonio Pallares on 17/5/26.
+//
+
+#import "RCDangerousSettingsAPI.h"
+
+@import RevenueCat;
+
+@implementation RCDangerousSettingsAPI
+
++ (void)checkAPI {
+    RCDangerousSettings *defaultSettings __unused = [[RCDangerousSettings alloc] init];
+    RCDangerousSettings *settings = [[RCDangerousSettings alloc] initWithAutoSyncPurchases:true];
+
+    BOOL autoSyncPurchases __unused = settings.autoSyncPurchases;
+    BOOL customEntitlementComputation __unused = settings.customEntitlementComputation;
+}
+
+@end

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/main.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/main.m
@@ -11,6 +11,7 @@
 #import "RCAttributionNetworkAPI.h"
 #import "RCConfigurationAPI.h"
 #import "RCCustomerInfoAPI.h"
+#import "RCDangerousSettingsAPI.h"
 #import "RCEntitlementInfoAPI.h"
 #import "RCEntitlementInfosAPI.h"
 #import "RCIntroEligibilityAPI.h"
@@ -69,6 +70,8 @@ int main(int argc, const char * argv[]) {
         [RCPurchasesAPI checkEnums];
 
         [RCConfigurationAPI checkAPI];
+
+        [RCDangerousSettingsAPI checkAPI];
 
         [RCPurchasesErrorCodeAPI checkEnums];
 

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
@@ -14,5 +14,11 @@
 @_spi(Internal) import RevenueCat
 
 func checkDangerousSettingsAPI() {
-    let _: DangerousSettings = DangerousSettings(uiPreviewMode: true)
+    let _: DangerousSettings = DangerousSettings()
+    let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true)
+    let settings: DangerousSettings = DangerousSettings(uiPreviewMode: true)
+
+    let _: Bool = settings.autoSyncPurchases
+    let _: Bool = settings.customEntitlementComputation
+    let _: Bool = settings.uiPreviewMode
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Establish a safety net for the public surface of `DangerousSettings` before #6811, which backs it (and `Configuration`, `PlatformInfo`) with internal `Hashable` value-type storage. Lands first, on its own, so we can prove the tests pass against today's `main` rather than only after the refactor.

### Description
- Swift API tester: exercise `DangerousSettings()`, `DangerousSettings(autoSyncPurchases:)`, and read all three public properties.
- Obj-C API tester: new `RCDangerousSettingsAPI.{h,m}` mirroring the `RCConfigurationAPI` pattern, wired into `main.m` and the `AllAPITests.xcodeproj`. Covers `-init`, `-initWithAutoSyncPurchases:`, and reads of the two Obj-C-bridged properties (`uiPreviewMode` is `@_spi(Internal)` and not bridged).

Verified by building `All API Tests` against this branch:

```bash
xcodebuild -workspace RevenueCat-Tuist.xcworkspace -scheme "All API Tests" -destination "generic/platform=iOS Simulator" -configuration release build
```

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to API surface compile-time testers and Xcode project wiring, with no production runtime behavior modified.
> 
> **Overview**
> Adds broader API-surface coverage for `DangerousSettings` in the API tester suite.
> 
> Updates the Swift tester to exercise additional initializers and property reads, and introduces a new Objective-C tester (`RCDangerousSettingsAPI`) that instantiates `RCDangerousSettings` and verifies bridged properties; the Obj-C tester is wired into `main.m` and the `AllAPITests.xcodeproj` sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 376631970288d4ef3b5c9c0b853db8225dc8a858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->