### PR TITLE
Added commented hints to MagicWeatherSwiftUI for Swift strict concurrency.

### DIFF
--- a/Examples/MagicWeatherSwiftUI/MagicWeatherSwiftUI/Sources/Lifecycle/PurchasesDelegateHandler.swift
+++ b/Examples/MagicWeatherSwiftUI/MagicWeatherSwiftUI/Sources/Lifecycle/PurchasesDelegateHandler.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 import RevenueCat
+// If Swift's strict concurrency checking is enabled you'll need to import Combine.
+//import Combine
 
 /*
  The class we'll use to publish CustomerInfo data to our Magic Weather app.

--- a/Examples/MagicWeatherSwiftUI/MagicWeatherSwiftUI/Sources/ViewModels/UserViewModel.swift
+++ b/Examples/MagicWeatherSwiftUI/MagicWeatherSwiftUI/Sources/ViewModels/UserViewModel.swift
@@ -8,6 +8,8 @@
 import Foundation
 import RevenueCat
 import SwiftUI
+// If Swift's strict concurrency checking is enabled you'll need to import Combine.
+//import Combine
 
 /* Static shared model for UserView */
 class UserViewModel: ObservableObject {


### PR DESCRIPTION
### Checklist
No tests needed.  Only comments were added.

### Motivation
For the first time in years I created a new app. Once again I used the MagicWeatherSwiftUI sample project to help integrate RevenueCat into my project. I was initially confused why I was getting compile errors saying that I needed to import Combine when the sample project and my other apps didn't need to do that.  It turns out it was because I had Swift's strict concurrency checking enabled in my new app. That requires a manual import of Combine.

### Description
Added a descriptive comment in the files where I needed to manually import Combine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes that add guidance for builds using Swift strict concurrency checking; no runtime behavior or API changes.
> 
> **Overview**
> Adds a **commented guidance snippet** in MagicWeatherSwiftUI (`PurchasesDelegateHandler` and `UserViewModel`) indicating that enabling Swift’s strict concurrency checking may require manually importing `Combine`.
> 
> No functional code changes; the `Combine` import remains commented out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c9bcd37131e4f923c8fe10cf940e860ce50b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->