### PR TITLE
Filter changePlans path for expired subscriptions in CustomerCenter

### DIFF
--- a/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
@@ -60,9 +60,11 @@ extension Array<CustomerCenterConfigData.HelpPath> {
                 && $0.refundWindowDuration?.isWithin(purchaseInformation) ?? true
             }
 
-            // can't change plans if it's not a subscription
+            // can't change plans if it's not an active subscription
             if $0.type == .changePlans {
-                if !purchaseInformation.isAppStoreRenewableSubscription || purchaseInformation.isLifetime {
+                if !purchaseInformation.isAppStoreRenewableSubscription
+                    || purchaseInformation.isLifetime
+                    || purchaseInformation.isExpired {
                     return false
                 }
             }

--- a/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
@@ -866,6 +866,25 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
         expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .cancel })).to(beFalse())
     }
 
+    func testAutoRenewableSubscriptionDoesNotShowChangePlansIfExpired() {
+        let purchase = PurchaseInformation.mock(
+            store: .appStore,
+            isSubscription: true,
+            productType: .autoRenewableSubscription,
+            isExpired: true
+        )
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: BaseManageSubscriptionViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchase,
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        // Expired subscriptions should not show change plans
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .changePlans })).to(beFalse())
+    }
+
     func testAutoRenewableSubscriptionDoesNotShowChangePlansIfLifetime() {
         let purchase = PurchaseInformation.mock(
             store: .appStore,


### PR DESCRIPTION
## Motivation

Expired subscriptions should not surface the "Change Plans" option in Customer Center — there is no active plan to switch *from*.

The `relevantPaths` filter already guarded `.changePlans` for lifetime and non-App Store subscriptions, but had no check for `isExpired`. This caused the Change Plans help path to appear whenever an expired App Store subscription was loaded (e.g. via `loadMostRecentExpiredTransaction`).

Discovered while reviewing #6809, which exposed the gap.

## Description

Adds `|| purchaseInformation.isExpired` to the existing `.changePlans` guard in `CustomerCenterConfigData.HelpPath+PurchaseInformation.swift`, and updates the comment from "not a subscription" to "not an *active* subscription" to reflect all three conditions.

## Test plan

- [x] Added `testAutoRenewableSubscriptionDoesNotShowChangePlansIfExpired` — regression test alongside the existing `testAutoRenewableSubscriptionDoesNotShowChangePlansIfLifetime`
- [x] All existing `BaseManageSubscriptionViewModelTests` continue to pass

## Notes

- Related to #6809 (which passes `configuration.changePlans` for expired transactions — that change is safe only once expired subs can't show the Change Plans button)
- Android does not implement `CHANGE_PLANS` at all yet, so there is no cross-platform reference to check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a narrow UI/help-path filtering tweak that only affects when `.changePlans` is shown, covered by a new regression test.
> 
> **Overview**
> Prevents Customer Center from surfacing the **Change Plans** help path for *expired* App Store renewable subscriptions by adding an `isExpired` guard to the existing `.changePlans` filter.
> 
> Adds a regression test (`testAutoRenewableSubscriptionDoesNotShowChangePlansIfExpired`) to ensure expired subscriptions no longer include `.changePlans` in `relevantPathsForPurchase`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbcf66eeb37df89f5c6932010f30ceace8fc6324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->