### PR TITLE
Fix workflow paywall safe area clipping

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -19,48 +19,12 @@
       }
     },
     {
-      "identity" : "flyingfox",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swhitty/FlyingFox.git",
-      "state" : {
-        "revision" : "f7829d4aca8cbfecb410a1cce872b1b045224aa1",
-        "version" : "0.16.0"
-      }
-    },
-    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quick/nimble",
       "state" : {
         "revision" : "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
         "version" : "13.7.1"
-      }
-    },
-    {
-      "identity" : "ohhttpstubs",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
-      "state" : {
-        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
-        "version" : "9.1.0"
-      }
-    },
-    {
-      "identity" : "simpledebugger",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/EmergeTools/SimpleDebugger.git",
-      "state" : {
-        "revision" : "f065263eb5db95874b690408d136b573c939db9e",
-        "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "snapshotpreviews",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/EmergeTools/SnapshotPreviews.git",
-      "state" : {
-        "revision" : "d42446f0439217941a4e3a2ca58a643c1ac328c4",
-        "version" : "0.14.1"
       }
     },
     {

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -235,9 +235,7 @@ struct WorkflowPaywallView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .mask(alignment: .top) {
-                self.transitionClipMask(proxy: proxy)
-            }
+            .transitionClipMask(proxy: proxy)
         }
         .allowsHitTesting(!self.transitionState.isTransitioning)
         // Re-emitted on every step change because navigator is @StateObject with @Published
@@ -262,19 +260,6 @@ struct WorkflowPaywallView: View {
     }
 
     // MARK: - Helpers
-
-    // Keep workflow transitions clipped horizontally, but let page backgrounds render into safe areas.
-    // Pages already ignore the bottom safe area, but this GeometryReader is laid out inside the
-    // safe-area bounds. A plain `.clipped()` trims that page overflow and exposes the presenting view.
-    // alignment: .top in the mask call site is required: the offset(y:) anchors from the top edge.
-    private func transitionClipMask(proxy: GeometryProxy) -> some View {
-        Rectangle()
-            .frame(
-                width: proxy.size.width,
-                height: proxy.size.height + proxy.safeAreaInsets.top + proxy.safeAreaInsets.bottom
-            )
-            .offset(y: -proxy.safeAreaInsets.top)
-    }
 
     private var displayedPages: [DisplayedPage] {
         return [
@@ -596,6 +581,25 @@ private struct CurrentStepContent {
 struct RenderedPagePackageInput {
     let packageContext: PackageContext
     let effectiveWorkflowPackageContext: WorkflowPackageContext?
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension View {
+
+    // Keep workflow transitions clipped horizontally, but let page backgrounds render into safe areas.
+    // Pages already ignore the bottom safe area, but this GeometryReader is laid out inside the
+    // safe-area bounds. A plain `.clipped()` trims that page overflow and exposes the presenting view.
+    func transitionClipMask(proxy: GeometryProxy) -> some View {
+        self.mask(alignment: .top) {
+            Rectangle()
+                .frame(
+                    width: proxy.size.width,
+                    height: proxy.size.height + proxy.safeAreaInsets.top + proxy.safeAreaInsets.bottom
+                )
+                .offset(y: -proxy.safeAreaInsets.top)
+        }
+    }
+
 }
 
 #endif

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -235,7 +235,7 @@ struct WorkflowPaywallView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .mask(alignment: .top) {
+            .mask {
                 self.transitionClipMask(proxy: proxy)
             }
         }
@@ -273,6 +273,7 @@ struct WorkflowPaywallView: View {
                 height: proxy.size.height + proxy.safeAreaInsets.top + proxy.safeAreaInsets.bottom
             )
             .offset(y: -proxy.safeAreaInsets.top)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
     private var displayedPages: [DisplayedPage] {

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -235,7 +235,7 @@ struct WorkflowPaywallView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .mask {
+            .mask(alignment: .top) {
                 self.transitionClipMask(proxy: proxy)
             }
         }
@@ -266,6 +266,7 @@ struct WorkflowPaywallView: View {
     // Keep workflow transitions clipped horizontally, but let page backgrounds render into safe areas.
     // Pages already ignore the bottom safe area, but this GeometryReader is laid out inside the
     // safe-area bounds. A plain `.clipped()` trims that page overflow and exposes the presenting view.
+    // alignment: .top in the mask call site is required: the offset(y:) anchors from the top edge.
     private func transitionClipMask(proxy: GeometryProxy) -> some View {
         Rectangle()
             .frame(
@@ -273,7 +274,6 @@ struct WorkflowPaywallView: View {
                 height: proxy.size.height + proxy.safeAreaInsets.top + proxy.safeAreaInsets.bottom
             )
             .offset(y: -proxy.safeAreaInsets.top)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
     private var displayedPages: [DisplayedPage] {

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -235,9 +235,11 @@ struct WorkflowPaywallView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .mask(alignment: .top) {
+                self.transitionClipMask(proxy: proxy)
+            }
         }
         .allowsHitTesting(!self.transitionState.isTransitioning)
-        .clipped()
         // Re-emitted on every step change because navigator is @StateObject with @Published
         // currentStepId. The exit offer is resolved synchronously from allOfferings on the
         // triggering step; when the user navigates away the value becomes nil, clearing
@@ -260,6 +262,18 @@ struct WorkflowPaywallView: View {
     }
 
     // MARK: - Helpers
+
+    // Keep workflow transitions clipped horizontally, but let page backgrounds render into safe areas.
+    // Pages already ignore the bottom safe area, but this GeometryReader is laid out inside the
+    // safe-area bounds. A plain `.clipped()` trims that page overflow and exposes the presenting view.
+    private func transitionClipMask(proxy: GeometryProxy) -> some View {
+        Rectangle()
+            .frame(
+                width: proxy.size.width,
+                height: proxy.size.height + proxy.safeAreaInsets.top + proxy.safeAreaInsets.bottom
+            )
+            .offset(y: -proxy.safeAreaInsets.top)
+    }
 
     private var displayedPages: [DisplayedPage] {
         return [


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Workflow paywall pages ignore the bottom safe area so their backgrounds extend edge-to-edge. The transition container was using `.clipped()`, which trimmed that overflow and exposed the presenting view as a white stripe at the bottom during and after transitions.

### Description
Replace `.clipped()` on the `GeometryReader` page stack with a custom `transitionClipMask(proxy:)` modifier defined in a private `View` extension.

The mask still clips horizontal slide transitions to the view width, but its rectangle is expanded to cover the full safe area: height is `proxy.size.height + safeAreaInsets.top + safeAreaInsets.bottom`, offset upward by `safeAreaInsets.top`, and anchored with `mask(alignment: .top)`. This lets page backgrounds render through both safe areas while keeping transitions horizontally bounded.

The `mask(alignment: .top)` and the `offset(y: -safeAreaInsets.top)` calculation are co-located in the same extension method so they cannot be accidentally decoupled.

Tested manually with PaywallsTester (`TUIST_LAUNCH_ARGUMENTS="-EnableWorkflowsEndpoint"`) on iPhone 17 Pro Max (iOS 26) — single-page and multi-page workflow paywalls with and without header/hero images, verifying no white stripe at the bottom and no top safe area clipping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SwiftUI layout change in workflow paywall presentation; no auth, purchase, or data-path changes.
> 
> **Overview**
> Fixes a **workflow paywall layout bug** where edge-to-edge page backgrounds showed a white stripe at the bottom during and after step transitions.
> 
> On the `GeometryReader` page stack in `WorkflowPaywallView`, **`.clipped()` is removed** and replaced with a private **`transitionClipMask(proxy:)`** modifier. The mask still bounds horizontal slide transitions to the view width, but the mask rectangle is sized to include top and bottom safe area insets (with a top-aligned offset) so full-bleed backgrounds can draw through the safe areas without exposing the presenter underneath.
> 
> `Package.resolved` also drops several unused Swift package pins (e.g. FlyingFox, OHHTTPStubs, SimpleDebugger, SnapshotPreviews).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b8180ddd7b3d58abe7d0be4e40f754b55a9211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->