### PR TITLE
Add conditional visibility to ButtonComponent

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2868,6 +2868,7 @@
 		FACD00092F61A1230073D2DE /* PackageValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageValidatorTests.swift; sourceTree = "<group>"; };
 		FACD000B2F61A1230073D2DE /* PackageVisibilityPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageVisibilityPreview.swift; sourceTree = "<group>"; };
 		0E4CCD8E9E454A2EB3760E06 /* ButtonComponentViewModelMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentViewModelMappingTests.swift; sourceTree = "<group>"; };
+		A1D3F80D2D524F51BA60157C /* ButtonComponentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentViewTests.swift; sourceTree = "<group>"; };
 		FB5A72012F65F5B9005C64A1 /* ViewModelFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelFactoryTests.swift; sourceTree = "<group>"; };
 		FD05A7192EE2430E00FE671F /* StoreKit2PromotionalOfferPurchaseOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2PromotionalOfferPurchaseOptions.swift; sourceTree = "<group>"; };
 		FD15AF572DF9A8F30062467E /* VirtualCurrenciesScrollViewWithOSBackgroundSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualCurrenciesScrollViewWithOSBackgroundSection.swift; sourceTree = "<group>"; };
@@ -3069,6 +3070,7 @@
 				F468C7BCEB786BEC80277ECA /* WorkflowNavigatorTests.swift */,
 				6EFD5F7BD8404B6E828C4E10 /* WorkflowPaywallViewTests.swift */,
 				0E4CCD8E9E454A2EB3760E06 /* ButtonComponentViewModelMappingTests.swift */,
+				A1D3F80D2D524F51BA60157C /* ButtonComponentViewTests.swift */,
 			);
 			path = PaywallsV2;
 			sourceTree = "<group>";

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -298,6 +298,7 @@ struct ButtonComponentView_Previews: PreviewProvider {
             webCheckoutUrl: nil
         )
 
+        // Default: button renders normally
         VStack {
             ButtonComponentView(
                 viewModel: try! .init(
@@ -324,77 +325,125 @@ struct ButtonComponentView_Previews: PreviewProvider {
         }
         .previewRequiredPaywallsV2Properties()
         .environmentObject(PurchaseHandler.default())
-        .previewLayout(.fixed(width: 400, height: 400))
+        .previewLayout(.fixed(width: 400, height: 100))
         .previewDisplayName("Default")
 
-        VStack {
-            Text("Button below is hidden (visible=false):")
-                .font(.caption)
-            ButtonComponentView(
-                viewModel: try! .init(
-                    component: .init(
-                        visible: false,
-                        action: .navigateBack,
-                        stack: .init(
-                            components: [
-                                PaywallComponent.text(
-                                    PaywallComponent.TextComponent(
-                                        text: "buttonText",
-                                        color: .init(light: .hex("#000000"))
+        // visible=true vs visible=false side by side
+        VStack(spacing: 16) {
+            HStack {
+                Text("visible=true →").font(.caption).frame(width: 120, alignment: .trailing)
+                ButtonComponentView(
+                    viewModel: try! .init(
+                        component: .init(
+                            visible: true,
+                            action: .navigateBack,
+                            stack: .init(
+                                components: [
+                                    PaywallComponent.text(
+                                        PaywallComponent.TextComponent(
+                                            text: "buttonText",
+                                            color: .init(light: .hex("#000000"))
+                                        )
                                     )
-                                )
-                            ],
-                            backgroundColor: nil
-                        )
+                                ],
+                                backgroundColor: nil
+                            )
+                        ),
+                        localizationProvider: localizationProvider,
+                        offering: offering,
+                        colorScheme: .light
                     ),
-                    localizationProvider: localizationProvider,
-                    offering: offering,
-                    colorScheme: .light
-                ),
-                onDismiss: { }
-            )
+                    onDismiss: { }
+                )
+            }
+            HStack {
+                Text("visible=false →").font(.caption).frame(width: 120, alignment: .trailing)
+                ButtonComponentView(
+                    viewModel: try! .init(
+                        component: .init(
+                            visible: false,
+                            action: .navigateBack,
+                            stack: .init(
+                                components: [
+                                    PaywallComponent.text(
+                                        PaywallComponent.TextComponent(
+                                            text: "buttonText",
+                                            color: .init(light: .hex("#000000"))
+                                        )
+                                    )
+                                ],
+                                backgroundColor: nil
+                            )
+                        ),
+                        localizationProvider: localizationProvider,
+                        offering: offering,
+                        colorScheme: .light
+                    ),
+                    onDismiss: { }
+                )
+                Spacer()
+                Text("(hidden)").font(.caption).foregroundColor(.secondary)
+            }
         }
+        .padding()
         .previewRequiredPaywallsV2Properties()
         .environmentObject(PurchaseHandler.default())
-        .previewLayout(.fixed(width: 400, height: 400))
-        .previewDisplayName("Hidden (visible=false)")
+        .previewLayout(.fixed(width: 400, height: 120))
+        .previewDisplayName("visible=true vs visible=false")
 
-        VStack {
-            Text("Button below is hidden when state=selected:")
-                .font(.caption)
-            ButtonComponentView(
-                viewModel: try! .init(
-                    component: .init(
-                        action: .navigateBack,
-                        stack: .init(
-                            components: [
-                                PaywallComponent.text(
-                                    PaywallComponent.TextComponent(
-                                        text: "buttonText",
-                                        color: .init(light: .hex("#000000"))
-                                    )
-                                )
-                            ],
-                            backgroundColor: nil
-                        ),
-                        overrides: [
-                            .init(
-                                conditions: [.selected],
-                                properties: .init(visible: false)
-                            )
-                        ]
+        // Override: hide when selected — show default (visible) vs selected (hidden)
+        let selectedOverrideComponent = PaywallComponent.ButtonComponent(
+            action: .navigateBack,
+            stack: .init(
+                components: [
+                    PaywallComponent.text(
+                        PaywallComponent.TextComponent(
+                            text: "buttonText",
+                            color: .init(light: .hex("#000000"))
+                        )
+                    )
+                ],
+                backgroundColor: nil
+            ),
+            overrides: [
+                .init(conditions: [.selected], properties: .init(visible: false))
+            ]
+        )
+        VStack(spacing: 16) {
+            HStack {
+                Text("state=default →").font(.caption).frame(width: 120, alignment: .trailing)
+                ButtonComponentView(
+                    viewModel: try! .init(
+                        component: selectedOverrideComponent,
+                        localizationProvider: localizationProvider,
+                        offering: offering,
+                        colorScheme: .light
                     ),
-                    localizationProvider: localizationProvider,
-                    offering: offering,
-                    colorScheme: .light
-                ),
-                onDismiss: { }
-            )
+                    onDismiss: { }
+                )
+                .environment(\.componentViewState, .default)
+            }
+            HStack {
+                Text("state=selected →").font(.caption).frame(width: 120, alignment: .trailing)
+                ButtonComponentView(
+                    viewModel: try! .init(
+                        component: selectedOverrideComponent,
+                        localizationProvider: localizationProvider,
+                        offering: offering,
+                        colorScheme: .light
+                    ),
+                    onDismiss: { }
+                )
+                .environment(\.componentViewState, .selected)
+                Spacer()
+                Text("(hidden)").font(.caption).foregroundColor(.secondary)
+            }
         }
-        .previewRequiredPaywallsV2Properties(componentViewState: .selected)
+        .padding()
+        .previewRequiredPaywallsV2Properties()
         .environmentObject(PurchaseHandler.default())
-        .previewLayout(.fixed(width: 400, height: 400))
-        .previewDisplayName("Hidden when selected")
+        .previewLayout(.fixed(width: 400, height: 120))
+        .previewDisplayName("Override: hide when selected")
         // swiftlint:enable force_try
     }
 }

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -33,6 +33,30 @@ struct ButtonComponentView: View {
     @EnvironmentObject
     private var purchaseHandler: PurchaseHandler
 
+    @EnvironmentObject
+    private var packageContext: PackageContext
+
+    @EnvironmentObject
+    private var introOfferEligibilityContext: IntroOfferEligibilityContext
+
+    @EnvironmentObject
+    private var paywallPromoOfferCache: PaywallPromoOfferCache
+
+    @Environment(\.componentViewState)
+    private var componentViewState
+
+    @Environment(\.screenCondition)
+    private var screenCondition
+
+    @Environment(\.colorScheme)
+    private var colorScheme
+
+    @Environment(\.customPaywallVariables)
+    private var customVariables
+
+    @Environment(\.selectedPackageId)
+    private var selectedPackageId
+
     @Environment(\.componentInteractionLogger) var componentInteractionLogger
     @Environment(\.workflowTriggerAction) private var workflowTriggerAction
     @Environment(\.closeWorkflowAction) private var closeWorkflowAction
@@ -46,6 +70,21 @@ struct ButtonComponentView: View {
                   onDismiss: @escaping () -> Void) {
         self.viewModel = viewModel
         self.onDismiss = onDismiss
+    }
+
+    var isVisible: Bool {
+        return self.viewModel.visible(
+            state: self.componentViewState,
+            condition: self.screenCondition,
+            isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
+                package: self.packageContext.package
+            ),
+            isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(
+                for: self.packageContext.package
+            ),
+            selectedPackageId: self.selectedPackageId,
+            customVariables: self.customVariables
+        )
     }
 
     /// Show activity indicator only if restore action in purchase handler
@@ -69,7 +108,7 @@ struct ButtonComponentView: View {
     }
 
     var body: some View {
-        if !self.viewModel.hasUnknownAction {
+        if !self.viewModel.hasUnknownAction && self.isVisible {
             AsyncButton {
                 try await performAction()
             } label: {
@@ -317,7 +356,8 @@ fileprivate extension ButtonComponentViewModel {
             component: component,
             localizationProvider: localizationProvider,
             offering: offering,
-            stackViewModel: stackViewModel
+            stackViewModel: stackViewModel,
+            uiConfigProvider: .init(uiConfig: PreviewUIConfig.make())
         )
     }
 

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -48,9 +48,6 @@ struct ButtonComponentView: View {
     @Environment(\.screenCondition)
     private var screenCondition
 
-    @Environment(\.colorScheme)
-    private var colorScheme
-
     @Environment(\.customPaywallVariables)
     private var customVariables
 
@@ -70,21 +67,6 @@ struct ButtonComponentView: View {
                   onDismiss: @escaping () -> Void) {
         self.viewModel = viewModel
         self.onDismiss = onDismiss
-    }
-
-    var isVisible: Bool {
-        return self.viewModel.visible(
-            state: self.componentViewState,
-            condition: self.screenCondition,
-            isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
-                package: self.packageContext.package
-            ),
-            isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(
-                for: self.packageContext.package
-            ),
-            selectedPackageId: self.selectedPackageId,
-            customVariables: self.customVariables
-        )
     }
 
     /// Show activity indicator only if restore action in purchase handler
@@ -108,7 +90,19 @@ struct ButtonComponentView: View {
     }
 
     var body: some View {
-        if !self.viewModel.hasUnknownAction && self.isVisible {
+        if !self.viewModel.hasUnknownAction,
+           self.viewModel.visible(
+               state: self.componentViewState,
+               condition: self.screenCondition,
+               isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
+                   package: self.packageContext.package
+               ),
+               isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(
+                   for: self.packageContext.package
+               ),
+               selectedPackageId: self.selectedPackageId,
+               customVariables: self.customVariables
+           ) {
             AsyncButton {
                 try await performAction()
             } label: {
@@ -290,9 +284,22 @@ struct ButtonComponentView: View {
 struct ButtonComponentView_Previews: PreviewProvider {
 
     static var previews: some View {
+        // swiftlint:disable force_try
+        let localizationProvider = LocalizationProvider(
+            locale: Locale.current,
+            localizedStrings: [
+                "buttonText": PaywallComponentsData.LocalizationData.string("Do something")
+            ]
+        )
+        let offering = Offering(
+            identifier: "",
+            serverDescription: "",
+            availablePackages: [],
+            webCheckoutUrl: nil
+        )
+
         VStack {
             ButtonComponentView(
-                // swiftlint:disable:next force_try
                 viewModel: try! .init(
                     component: .init(
                         action: .navigateBack,
@@ -308,18 +315,8 @@ struct ButtonComponentView_Previews: PreviewProvider {
                             backgroundColor: nil
                         )
                     ),
-                    localizationProvider: .init(
-                        locale: Locale.current,
-                        localizedStrings: [
-                            "buttonText": PaywallComponentsData.LocalizationData.string("Do something")
-                        ]
-                    ),
-                    offering: Offering(
-                        identifier: "",
-                        serverDescription: "",
-                        availablePackages: [],
-                        webCheckoutUrl: nil
-                    ),
+                    localizationProvider: localizationProvider,
+                    offering: offering,
                     colorScheme: .light
                 ),
                 onDismiss: { }
@@ -329,6 +326,76 @@ struct ButtonComponentView_Previews: PreviewProvider {
         .environmentObject(PurchaseHandler.default())
         .previewLayout(.fixed(width: 400, height: 400))
         .previewDisplayName("Default")
+
+        VStack {
+            Text("Button below is hidden (visible=false):")
+                .font(.caption)
+            ButtonComponentView(
+                viewModel: try! .init(
+                    component: .init(
+                        visible: false,
+                        action: .navigateBack,
+                        stack: .init(
+                            components: [
+                                PaywallComponent.text(
+                                    PaywallComponent.TextComponent(
+                                        text: "buttonText",
+                                        color: .init(light: .hex("#000000"))
+                                    )
+                                )
+                            ],
+                            backgroundColor: nil
+                        )
+                    ),
+                    localizationProvider: localizationProvider,
+                    offering: offering,
+                    colorScheme: .light
+                ),
+                onDismiss: { }
+            )
+        }
+        .previewRequiredPaywallsV2Properties()
+        .environmentObject(PurchaseHandler.default())
+        .previewLayout(.fixed(width: 400, height: 400))
+        .previewDisplayName("Hidden (visible=false)")
+
+        VStack {
+            Text("Button below is hidden when state=selected:")
+                .font(.caption)
+            ButtonComponentView(
+                viewModel: try! .init(
+                    component: .init(
+                        action: .navigateBack,
+                        stack: .init(
+                            components: [
+                                PaywallComponent.text(
+                                    PaywallComponent.TextComponent(
+                                        text: "buttonText",
+                                        color: .init(light: .hex("#000000"))
+                                    )
+                                )
+                            ],
+                            backgroundColor: nil
+                        ),
+                        overrides: [
+                            .init(
+                                conditions: [.selected],
+                                properties: .init(visible: false)
+                            )
+                        ]
+                    ),
+                    localizationProvider: localizationProvider,
+                    offering: offering,
+                    colorScheme: .light
+                ),
+                onDismiss: { }
+            )
+        }
+        .previewRequiredPaywallsV2Properties(componentViewState: .selected)
+        .environmentObject(PurchaseHandler.default())
+        .previewLayout(.fixed(width: 400, height: 400))
+        .previewDisplayName("Hidden when selected")
+        // swiftlint:enable force_try
     }
 }
 

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
@@ -16,6 +16,8 @@ import Foundation
 @_spi(Internal) import RevenueCat
 #if !os(tvOS) // For Paywalls V2
 
+typealias PresentedButtonPartial = PaywallComponent.PartialButtonComponent
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class ButtonComponentViewModel {
 
@@ -51,19 +53,28 @@ class ButtonComponentViewModel {
     let stackViewModel: StackComponentViewModel
     let sheetStackViewModel: StackComponentViewModel?
 
+    private let componentVisible: Bool?
+    private let uiConfigProvider: UIConfigProvider
+    private let presentedOverrides: PresentedOverrides<PresentedButtonPartial>?
+
     // swiftlint:disable:next cyclomatic_complexity
     init(
         component: PaywallComponent.ButtonComponent,
         localizationProvider: LocalizationProvider,
         offering: Offering,
         stackViewModel: StackComponentViewModel,
-        sheetStackViewModel: StackComponentViewModel? = nil
+        sheetStackViewModel: StackComponentViewModel? = nil,
+        uiConfigProvider: UIConfigProvider,
+        discardRules: Bool = false
     ) throws {
         self.component = component
         self.id = component.id
         self.localizationProvider = localizationProvider
         self.stackViewModel = stackViewModel
         self.sheetStackViewModel = sheetStackViewModel
+        self.componentVisible = component.visible
+        self.uiConfigProvider = uiConfigProvider
+        self.presentedOverrides = component.overrides?.toPresentedOverrides(discardRules: discardRules)
 
         let localizedStrings = localizationProvider.localizedStrings
 
@@ -143,6 +154,43 @@ class ButtonComponentViewModel {
         case .sheet:
             return false
         }
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    func visible(
+        state: ComponentViewState,
+        condition: ScreenCondition,
+        isEligibleForIntroOffer: Bool,
+        isEligibleForPromoOffer: Bool,
+        selectedPackageId: String?,
+        customVariables: [String: CustomVariableValue]
+    ) -> Bool {
+        let conditionContext = self.uiConfigProvider.conditionContext(
+            selectedPackageId: selectedPackageId,
+            customVariables: customVariables
+        )
+
+        let partial = PresentedButtonPartial.buildPartial(
+            state: state,
+            condition: condition,
+            isEligibleForIntroOffer: isEligibleForIntroOffer,
+            isEligibleForPromoOffer: isEligibleForPromoOffer,
+            conditionContext: conditionContext,
+            with: self.presentedOverrides
+        )
+
+        return partial?.visible ?? self.componentVisible ?? true
+    }
+
+}
+
+extension PresentedButtonPartial: PresentedPartial {
+
+    static func combine(
+        _ base: PaywallComponent.PartialButtonComponent?,
+        with other: PaywallComponent.PartialButtonComponent?
+    ) -> Self {
+        return .init(visible: other?.visible ?? base?.visible)
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -360,9 +360,8 @@ extension PaywallComponent {
         case .stack(let component):
             return component.containsUnsupportedConditions()
         case .button(let component):
-            if component.stack.containsUnsupportedConditions() {
-                return true
-            }
+            if component.overrides?.hasUnsupportedCondition() == true { return true }
+            if component.stack.containsUnsupportedConditions() { return true }
             if case let .navigateTo(.sheet(sheet)) = component.action {
                 return sheet.stack.containsUnsupportedConditions()
             }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -188,7 +188,9 @@ struct ViewModelFactory {
                     localizationProvider: localizationProvider,
                     offering: offering,
                     stackViewModel: stackViewModel,
-                    sheetStackViewModel: sheetStackViewModel
+                    sheetStackViewModel: sheetStackViewModel,
+                    uiConfigProvider: uiConfigProvider,
+                    discardRules: discardRules
                 )
             )
         case .package(let component):

--- a/Sources/Paywalls/Components/PaywallButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallButtonComponent.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Jay Shortway on 02/10/2024.
 //
-// swiftlint:disable missing_docs nesting
+// swiftlint:disable missing_docs nesting type_body_length
 
 import Foundation
 
@@ -22,25 +22,31 @@ import Foundation
         let type: ComponentType
         public let name: String?
         public let id: String?
+        public let visible: Bool?
         public let action: Action
         public let stack: PaywallComponent.StackComponent
         public let transition: PaywallComponent.Transition?
+        public let overrides: ComponentOverrides<PartialButtonComponent>?
         /// Preserves the backend-only `close_workflow` action without growing the public enum surface.
         @_spi(Internal) public let isCloseWorkflowAction: Bool
 
         public init(
             name: String? = nil,
             id: String? = nil,
+            visible: Bool? = nil,
             action: Action,
             stack: PaywallComponent.StackComponent,
-            transition: PaywallComponent.Transition? = nil
+            transition: PaywallComponent.Transition? = nil,
+            overrides: ComponentOverrides<PartialButtonComponent>? = nil
         ) {
             self.type = .button
             self.name = name
             self.id = id
+            self.visible = visible
             self.action = action
             self.stack = stack
             self.transition = transition
+            self.overrides = overrides
             self.isCloseWorkflowAction = false
         }
 
@@ -48,9 +54,11 @@ import Foundation
             case type
             case name
             case id
+            case visible
             case action
             case stack
             case transition
+            case overrides
         }
 
         private enum ActionCodingKeys: String, CodingKey {
@@ -62,6 +70,7 @@ import Foundation
             self.type = try container.decode(ComponentType.self, forKey: .type)
             self.name = try container.decodeIfPresent(String.self, forKey: .name)
             self.id = try container.decodeIfPresent(String.self, forKey: .id)
+            self.visible = try container.decodeIfPresent(Bool.self, forKey: .visible)
             let actionContainer = try container.nestedContainer(keyedBy: ActionCodingKeys.self, forKey: .action)
             let rawActionType = try actionContainer.decode(String.self, forKey: .type)
             if rawActionType == "close_workflow" {
@@ -73,6 +82,10 @@ import Foundation
             }
             self.stack = try container.decode(PaywallComponent.StackComponent.self, forKey: .stack)
             self.transition = try container.decodeIfPresent(PaywallComponent.Transition.self, forKey: .transition)
+            self.overrides = try container.decodeIfPresent(
+                ComponentOverrides<PartialButtonComponent>.self,
+                forKey: .overrides
+            )
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -80,6 +93,7 @@ import Foundation
             try container.encode(type, forKey: .type)
             try container.encodeIfPresent(name, forKey: .name)
             try container.encodeIfPresent(id, forKey: .id)
+            try container.encodeIfPresent(visible, forKey: .visible)
             if self.isCloseWorkflowAction {
                 var actionContainer = container.nestedContainer(keyedBy: ActionCodingKeys.self, forKey: .action)
                 try actionContainer.encode("close_workflow", forKey: .type)
@@ -88,26 +102,31 @@ import Foundation
             }
             try container.encode(stack, forKey: .stack)
             try container.encodeIfPresent(transition, forKey: .transition)
+            try container.encodeIfPresent(overrides, forKey: .overrides)
         }
 
         public func hash(into hasher: inout Hasher) {
             hasher.combine(type)
             hasher.combine(name)
             hasher.combine(id)
+            hasher.combine(visible)
             hasher.combine(action)
             hasher.combine(isCloseWorkflowAction)
             hasher.combine(stack)
             hasher.combine(transition)
+            hasher.combine(overrides)
         }
 
         public static func == (lhs: ButtonComponent, rhs: ButtonComponent) -> Bool {
             return lhs.type == rhs.type &&
                    lhs.name == rhs.name &&
                    lhs.id == rhs.id &&
+                   lhs.visible == rhs.visible &&
                    lhs.action == rhs.action &&
                    lhs.isCloseWorkflowAction == rhs.isCloseWorkflowAction &&
                    lhs.stack == rhs.stack &&
-                   lhs.transition == rhs.transition
+                   lhs.transition == rhs.transition &&
+                   lhs.overrides == rhs.overrides
 
         }
 
@@ -281,4 +300,23 @@ import Foundation
             }
         }
     }
+
+    final class PartialButtonComponent: PaywallPartialComponent {
+
+        public let visible: Bool?
+
+        public init(visible: Bool? = nil) {
+            self.visible = visible
+        }
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(visible)
+        }
+
+        public static func == (lhs: PartialButtonComponent, rhs: PartialButtonComponent) -> Bool {
+            return lhs.visible == rhs.visible
+        }
+
+    }
+
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/ButtonComponentViewModelMappingTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/ButtonComponentViewModelMappingTests.swift
@@ -19,6 +19,72 @@ import XCTest
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class ButtonComponentViewModelMappingTests: TestCase {
 
+    // MARK: - visible
+
+    func testDefaultVisibility_IsTrue() throws {
+        let component = try self.decodeButton(actionType: "navigate_back")
+        let viewModel = try self.makeViewModel(for: component)
+
+        XCTAssertTrue(viewModel.visible(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            selectedPackageId: nil,
+            customVariables: [:]
+        ))
+    }
+
+    func testComponentVisible_False_ReturnsNotVisible() throws {
+        let component = try self.decodeButton(actionType: "navigate_back", visible: false)
+        let viewModel = try self.makeViewModel(for: component)
+
+        XCTAssertFalse(viewModel.visible(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            selectedPackageId: nil,
+            customVariables: [:]
+        ))
+    }
+
+    func testSelectedOverrideVisible_False_HidesWhenSelected() throws {
+        let component = try self.decodeButton(
+            actionType: "navigate_back",
+            overrideConditions: ["selected"],
+            overrideVisible: false
+        )
+        let viewModel = try self.makeViewModel(for: component)
+
+        XCTAssertFalse(viewModel.visible(
+            state: .selected,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            selectedPackageId: nil,
+            customVariables: [:]
+        ))
+    }
+
+    func testSelectedOverrideVisible_False_StillVisibleWhenNotSelected() throws {
+        let component = try self.decodeButton(
+            actionType: "navigate_back",
+            overrideConditions: ["selected"],
+            overrideVisible: false
+        )
+        let viewModel = try self.makeViewModel(for: component)
+
+        XCTAssertTrue(viewModel.visible(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            selectedPackageId: nil,
+            customVariables: [:]
+        ))
+    }
+
     // MARK: - close_workflow → .closeWorkflow mapping
 
     func testCloseWorkflowDecodedComponentMapsToCloseWorkflowAction() throws {
@@ -40,10 +106,27 @@ final class ButtonComponentViewModelMappingTests: TestCase {
 
     // MARK: - Helpers
 
-    private func decodeButton(actionType: String) throws -> PaywallComponent.ButtonComponent {
+    private func decodeButton(
+        actionType: String,
+        visible: Bool? = nil,
+        overrideConditions: [String]? = nil,
+        overrideVisible: Bool? = nil
+    ) throws -> PaywallComponent.ButtonComponent {
+        var visibleField = ""
+        if let visible {
+            visibleField = "\"visible\": \(visible),"
+        }
+        var overridesField = ""
+        if let overrideConditions, let overrideVisible {
+            let conditions = overrideConditions.map { "{\"type\": \"\($0)\"}" }.joined(separator: ",")
+            overridesField = """
+            ,"overrides": [{"conditions": [\(conditions)], "properties": {"visible": \(overrideVisible)}}]
+            """
+        }
         let json = """
         {
             "type": "button",
+            \(visibleField)
             "action": { "type": "\(actionType)" },
             "stack": {
                 "type": "stack",
@@ -53,6 +136,7 @@ final class ButtonComponentViewModelMappingTests: TestCase {
                 "margin": {"top": 0, "bottom": 0, "leading": 0, "trailing": 0},
                 "components": []
             }
+            \(overridesField)
         }
         """
         return try JSONDecoder.default.decode(
@@ -81,7 +165,8 @@ final class ButtonComponentViewModelMappingTests: TestCase {
                 availablePackages: [],
                 webCheckoutUrl: nil
             ),
-            stackViewModel: stackViewModel
+            stackViewModel: stackViewModel,
+            uiConfigProvider: uiConfigProvider
         )
     }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/ButtonComponentViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/ButtonComponentViewTests.swift
@@ -57,40 +57,6 @@ final class ButtonComponentViewTests: TestCase {
         )
     }
 
-    func testButtonWithVisibleTrue_IsRendered() throws {
-        let viewModel = try Self.makeViewModel(
-            component: PaywallComponent.ButtonComponent(
-                visible: true,
-                action: .navigateBack,
-                stack: Self.makeButtonStack(label: "Close")
-            )
-        )
-
-        let view = ButtonComponentView(viewModel: viewModel, onDismiss: {})
-            .environmentObject(PurchaseHandler.default())
-            .environmentObject(PackageContext(package: nil, variableContext: .init(packages: [])))
-            .environmentObject(
-                IntroOfferEligibilityContext(introEligibilityChecker: BaseSnapshotTest.eligibleChecker)
-            )
-            .environmentObject(
-                PaywallPromoOfferCache(subscriptionHistoryTracker: SubscriptionHistoryTracker())
-            )
-            .environment(\.componentViewState, .default)
-            .environment(\.screenCondition, .compact)
-            .environment(\.safeAreaInsets, EdgeInsets())
-
-        let (window, hostedView) = Self.host(view)
-        defer {
-            window.isHidden = true
-            window.rootViewController = nil
-        }
-
-        XCTAssertTrue(
-            hostedView.containsText("Close"),
-            "A button with visible=true should be rendered."
-        )
-    }
-
     func testSelectedOverrideVisible_False_HidesWhenSelected() throws {
         let viewModel = try Self.makeViewModel(
             component: PaywallComponent.ButtonComponent(

--- a/Tests/RevenueCatUITests/PaywallsV2/ButtonComponentViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/ButtonComponentViewTests.swift
@@ -1,0 +1,214 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ButtonComponentViewTests.swift
+//
+//  Created by RevenueCat on 5/19/26.
+
+@_spi(Internal) import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if os(iOS)
+import UIKit
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class ButtonComponentViewTests: TestCase {
+
+    func testButtonWithVisibleFalse_IsNotRendered() throws {
+        let viewModel = try Self.makeViewModel(
+            component: PaywallComponent.ButtonComponent(
+                visible: false,
+                action: .navigateBack,
+                stack: Self.makeButtonStack(label: "Close")
+            )
+        )
+
+        let view = ButtonComponentView(viewModel: viewModel, onDismiss: {})
+            .environmentObject(PurchaseHandler.default())
+            .environmentObject(PackageContext(package: nil, variableContext: .init(packages: [])))
+            .environmentObject(
+                IntroOfferEligibilityContext(introEligibilityChecker: BaseSnapshotTest.eligibleChecker)
+            )
+            .environmentObject(
+                PaywallPromoOfferCache(subscriptionHistoryTracker: SubscriptionHistoryTracker())
+            )
+            .environment(\.componentViewState, .default)
+            .environment(\.screenCondition, .compact)
+            .environment(\.safeAreaInsets, EdgeInsets())
+
+        let (window, hostedView) = Self.host(view)
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+
+        XCTAssertFalse(
+            hostedView.containsText("Close"),
+            "A button with visible=false should not be rendered."
+        )
+    }
+
+    func testButtonWithVisibleTrue_IsRendered() throws {
+        let viewModel = try Self.makeViewModel(
+            component: PaywallComponent.ButtonComponent(
+                visible: true,
+                action: .navigateBack,
+                stack: Self.makeButtonStack(label: "Close")
+            )
+        )
+
+        let view = ButtonComponentView(viewModel: viewModel, onDismiss: {})
+            .environmentObject(PurchaseHandler.default())
+            .environmentObject(PackageContext(package: nil, variableContext: .init(packages: [])))
+            .environmentObject(
+                IntroOfferEligibilityContext(introEligibilityChecker: BaseSnapshotTest.eligibleChecker)
+            )
+            .environmentObject(
+                PaywallPromoOfferCache(subscriptionHistoryTracker: SubscriptionHistoryTracker())
+            )
+            .environment(\.componentViewState, .default)
+            .environment(\.screenCondition, .compact)
+            .environment(\.safeAreaInsets, EdgeInsets())
+
+        let (window, hostedView) = Self.host(view)
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+
+        XCTAssertTrue(
+            hostedView.containsText("Close"),
+            "A button with visible=true should be rendered."
+        )
+    }
+
+    func testSelectedOverrideVisible_False_HidesWhenSelected() throws {
+        let viewModel = try Self.makeViewModel(
+            component: PaywallComponent.ButtonComponent(
+                action: .navigateBack,
+                stack: Self.makeButtonStack(label: "Close"),
+                overrides: [
+                    .init(conditions: [.selected], properties: .init(visible: false))
+                ]
+            )
+        )
+
+        let view = ButtonComponentView(viewModel: viewModel, onDismiss: {})
+            .environmentObject(PurchaseHandler.default())
+            .environmentObject(PackageContext(package: nil, variableContext: .init(packages: [])))
+            .environmentObject(
+                IntroOfferEligibilityContext(introEligibilityChecker: BaseSnapshotTest.eligibleChecker)
+            )
+            .environmentObject(
+                PaywallPromoOfferCache(subscriptionHistoryTracker: SubscriptionHistoryTracker())
+            )
+            .environment(\.componentViewState, .selected)
+            .environment(\.screenCondition, .compact)
+            .environment(\.safeAreaInsets, EdgeInsets())
+
+        let (window, hostedView) = Self.host(view)
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+
+        XCTAssertFalse(
+            hostedView.containsText("Close"),
+            "A button with a .selected override that hides should not render when selected."
+        )
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension ButtonComponentViewTests {
+
+    static func makeViewModel(
+        component: PaywallComponent.ButtonComponent
+    ) throws -> ButtonComponentViewModel {
+        let offering = Offering(
+            identifier: "default",
+            serverDescription: "",
+            availablePackages: [],
+            webCheckoutUrl: nil
+        )
+        let localizationProvider = LocalizationProvider(locale: Locale(identifier: "en_US"), localizedStrings: [
+            "Close": .string("Close")
+        ])
+        let uiConfigProvider = UIConfigProvider(uiConfig: PreviewUIConfig.make())
+        let factory = ViewModelFactory()
+
+        let stackViewModel = try factory.toStackViewModel(
+            component: component.stack,
+            packageValidator: factory.packageValidator,
+            purchaseButtonCollector: nil,
+            localizationProvider: localizationProvider,
+            uiConfigProvider: uiConfigProvider,
+            offering: offering,
+            colorScheme: .light
+        )
+
+        return try ButtonComponentViewModel(
+            component: component,
+            localizationProvider: localizationProvider,
+            offering: offering,
+            stackViewModel: stackViewModel,
+            uiConfigProvider: uiConfigProvider
+        )
+    }
+
+    static func makeButtonStack(label: String) -> PaywallComponent.StackComponent {
+        return PaywallComponent.StackComponent(
+            components: [
+                .text(
+                    PaywallComponent.TextComponent(
+                        text: label,
+                        color: .init(light: .hex("#000000"))
+                    )
+                )
+            ]
+        )
+    }
+
+    static func host<Content: View>(_ view: Content) -> (UIWindow, UIView) {
+        let controller = UIHostingController(
+            rootView: view
+                .frame(width: 300, height: 200)
+        )
+        let window = UIWindow(frame: CGRect(origin: .zero, size: CGSize(width: 300, height: 200)))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        return (window, controller.view)
+    }
+
+}
+
+private extension UIView {
+
+    func containsText(_ text: String) -> Bool {
+        if let label = self as? UILabel, label.text == text {
+            return true
+        }
+
+        if self.accessibilityLabel == text {
+            return true
+        }
+
+        return self.subviews.contains { $0.containsText(text) }
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/ToPresentedOverridesTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/ToPresentedOverridesTests.swift
@@ -420,6 +420,30 @@ class ToPresentedOverridesTests: TestCase {
         expect(PaywallComponent.button(button).containsUnsupportedConditions()).to(beFalse())
     }
 
+    func testButtonWithUnsupportedConditionInOwnOverrides_ReturnsTrue() throws {
+        let button = PaywallComponent.ButtonComponent(
+            action: .restorePurchases,
+            stack: .init(components: []),
+            overrides: [
+                .init(extendedConditions: [.unsupported], properties: .init(visible: false))
+            ]
+        )
+
+        expect(PaywallComponent.button(button).containsUnsupportedConditions()).to(beTrue())
+    }
+
+    func testButtonWithSupportedConditionInOwnOverrides_ReturnsFalse() throws {
+        let button = PaywallComponent.ButtonComponent(
+            action: .restorePurchases,
+            stack: .init(components: []),
+            overrides: [
+                .init(extendedConditions: [.selected], properties: .init(visible: false))
+            ]
+        )
+
+        expect(PaywallComponent.button(button).containsUnsupportedConditions()).to(beFalse())
+    }
+
     func testDeeplyNestedUnsupportedCondition_ReturnsTrue() throws {
         // Stack > Stack > Text with unsupported condition
         let text = PaywallComponent.TextComponent(


### PR DESCRIPTION
## Summary

Ports the `button-conditional-visibility` feature from Android to iOS. Buttons can now declare a `visible` field and an `overrides` array, allowing visibility to be toggled conditionally (e.g., hide a back button when a package is selected).

- Adds `visible: Bool?` and `overrides: ComponentOverrides<PartialButtonComponent>?` to `ButtonComponent`
- Adds `PartialButtonComponent` (mirrors Android's `PresentedButtonPartial`)
- Adds `PresentedPartial` conformance and a `visible(state:condition:...)` method on `ButtonComponentViewModel`, resolving button-level overrides independently of the stack
- Updates `ButtonComponentView.isVisible` to use button-level override resolution
- Updates `containsUnsupportedConditions()` in `PresentedPartials.swift` to recurse into a button's own overrides
- Threads `discardRules` and `uiConfigProvider` through `ViewModelFactory` into `ButtonComponentViewModel`

## Test plan

- `ButtonComponentViewModelMappingTests` — unit tests for `visible(...)` covering default visibility, `visible: false`, selected override hiding, and selected override not hiding when not selected
- `ToPresentedOverridesTests` — two new cases: button with unsupported condition in its own overrides returns `true`; button with supported condition returns `false`
- `ButtonComponentViewTests` — view-level rendering tests using `UIHostingController` confirming `visible: false` hides the button, `visible: true` shows it, and a `.selected` override with `visible: false` hides when `componentViewState = .selected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new serialized fields and override evaluation that can hide/show paywall buttons at runtime, which could unintentionally suppress navigation/restore actions if misconfigured. Changes are localized to Paywalls V2 button rendering/mapping and are covered by new unit and view tests.
> 
> **Overview**
> Adds **conditional visibility** to Paywalls V2 buttons by extending `PaywallComponent.ButtonComponent` with `visible` plus `overrides` (via new `PartialButtonComponent`) and including these fields in coding/hash/equality.
> 
> Updates `ButtonComponentViewModel`/`ButtonComponentView` to evaluate button-level overrides (using `UIConfigProvider` + selection/eligibility/custom-variable context) and skip rendering when the resolved visibility is false; `ViewModelFactory` now threads `uiConfigProvider` and the global `discardRules` flag into the button view model, and unsupported-condition detection now also checks a button’s own overrides.
> 
> Adds coverage with new/expanded tests for visibility resolution and actual SwiftUI rendering (`ButtonComponentViewTests`), and registers the new test file in the Xcode project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfc94a71804cc488becba84344ea59949b084a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->