### PR TITLE
Fix repeated paywall purchase cancellations

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -501,7 +501,8 @@ struct LoadedOfferingPaywallView: View {
             .preference(key: PurchasedResultPreferenceKey.self,
                         value: .init(
                             data: self.purchaseHandler.sessionPurchaseResult,
-                            id: self.purchaseHandler.sessionPurchaseResultID
+                            id: (self.purchaseHandler.sessionPurchaseResult?.userCancelled == true) ?
+                            self.purchaseHandler.consecutiveCancellationRequestID : nil
                         ))
             .preference(key: RestoredCustomerInfoPreferenceKey.self,
                         value: self.purchaseHandler.restoredCustomerInfo)

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -501,7 +501,7 @@ struct LoadedOfferingPaywallView: View {
             .preference(key: PurchasedResultPreferenceKey.self,
                         value: .init(
                             data: self.purchaseHandler.sessionPurchaseResult,
-                            id: (self.purchaseHandler.sessionPurchaseResult?.userCancelled == true) ?
+                            diffKey: (self.purchaseHandler.sessionPurchaseResult?.userCancelled == true) ?
                             self.purchaseHandler.consecutiveCancellationRequestID : nil
                         ))
             .preference(key: RestoredCustomerInfoPreferenceKey.self,

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -499,7 +499,10 @@ struct LoadedOfferingPaywallView: View {
             .preference(key: PurchaseInProgressPreferenceKey.self,
                         value: self.purchaseHandler.packageBeingPurchased)
             .preference(key: PurchasedResultPreferenceKey.self,
-                        value: .init(data: self.purchaseHandler.sessionPurchaseResult))
+                        value: .init(
+                            data: self.purchaseHandler.sessionPurchaseResult,
+                            id: self.purchaseHandler.sessionPurchaseResultID
+                        ))
             .preference(key: RestoredCustomerInfoPreferenceKey.self,
                         value: self.purchaseHandler.restoredCustomerInfo)
             .preference(key: RestoreInProgressPreferenceKey.self,

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -883,12 +883,12 @@ struct RestoreInProgressPreferenceKey: PreferenceKey {
 struct PurchasedResultPreferenceKey: PreferenceKey {
 
     struct PurchaseResult: Equatable {
-        var id: UUID
+        var id: UUID?
         var transaction: StoreTransaction?
         var customerInfo: CustomerInfo
         var userCancelled: Bool
 
-        init(data: PurchaseResultData, id: UUID) {
+        init(data: PurchaseResultData, id: UUID?) {
             self.id = id
             self.transaction = data.transaction
             self.customerInfo = data.customerInfo
@@ -896,7 +896,7 @@ struct PurchasedResultPreferenceKey: PreferenceKey {
         }
 
         init?(data: PurchaseResultData?, id: UUID?) {
-            guard let data, let id else { return nil }
+            guard let data else { return nil }
             self.init(data: data, id: id)
         }
     }

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -12,6 +12,7 @@
 //  Created by Nacho Soto on 7/13/23.
 
 import Combine
+import Foundation
 @_spi(Internal) import RevenueCat
 import StoreKit
 import SwiftUI
@@ -78,6 +79,11 @@ final class PurchaseHandler: ObservableObject {
     /// potential future exit offer triggers (e.g., based on specific products).
     @Published
     fileprivate(set) var sessionPurchaseResult: PurchaseResultData?
+
+    /// Unique identifier for the latest `sessionPurchaseResult`.
+    /// This allows SwiftUI preference listeners to receive consecutive identical results.
+    @Published
+    fileprivate(set) var sessionPurchaseResultID: UUID?
 
     /// Whether a purchase was successfully completed in the current session.
     /// Convenience property for checking if we should skip exit offers.
@@ -220,6 +226,7 @@ final class PurchaseHandler: ObservableObject {
             self.paywallEventTracker.discardSession(sessionID: sessionID)
         }
         self.sessionPurchaseResult = nil
+        self.sessionPurchaseResultID = nil
         self.purchaseResult = nil
         self.activePaywallSessionID = nil
     }
@@ -492,6 +499,7 @@ extension PurchaseHandler {
             // onPurchaseCompleted and onPurchaseCancelled modifiers both work correctly.
             withAnimation(Constants.defaultAnimation) {
                 self.sessionPurchaseResult = result
+                self.sessionPurchaseResultID = UUID()
             }
 
             self.setResult(result)
@@ -555,6 +563,7 @@ extension PurchaseHandler {
         // onPurchaseCompleted and onPurchaseCancelled modifiers both work correctly.
         withAnimation(Constants.defaultAnimation) {
             self.sessionPurchaseResult = resultInfo
+            self.sessionPurchaseResultID = UUID()
         }
 
         self.setResult(resultInfo)
@@ -863,19 +872,21 @@ struct RestoreInProgressPreferenceKey: PreferenceKey {
 struct PurchasedResultPreferenceKey: PreferenceKey {
 
     struct PurchaseResult: Equatable {
+        var id: UUID
         var transaction: StoreTransaction?
         var customerInfo: CustomerInfo
         var userCancelled: Bool
 
-        init(data: PurchaseResultData) {
+        init(data: PurchaseResultData, id: UUID) {
+            self.id = id
             self.transaction = data.transaction
             self.customerInfo = data.customerInfo
             self.userCancelled = data.userCancelled
         }
 
-        init?(data: PurchaseResultData?) {
-            guard let data else { return nil }
-            self.init(data: data)
+        init?(data: PurchaseResultData?, id: UUID?) {
+            guard let data, let id else { return nil }
+            self.init(data: data, id: id)
         }
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -883,21 +883,21 @@ struct RestoreInProgressPreferenceKey: PreferenceKey {
 struct PurchasedResultPreferenceKey: PreferenceKey {
 
     struct PurchaseResult: Equatable {
-        var id: UUID?
+        private var diffKey: String?
         var transaction: StoreTransaction?
         var customerInfo: CustomerInfo
         var userCancelled: Bool
 
-        init(data: PurchaseResultData, id: UUID?) {
-            self.id = id
+        init(data: PurchaseResultData, diffKey: UUID? = nil) {
+            self.diffKey = diffKey?.uuidString ?? data.transaction?.id
             self.transaction = data.transaction
             self.customerInfo = data.customerInfo
             self.userCancelled = data.userCancelled
         }
 
-        init?(data: PurchaseResultData?, id: UUID?) {
+        init?(data: PurchaseResultData?, diffKey: UUID? = nil) {
             guard let data else { return nil }
-            self.init(data: data, id: id)
+            self.init(data: data, diffKey: diffKey)
         }
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -88,8 +88,10 @@ final class PurchaseHandler: ObservableObject {
 
     private func haveBothBeenCanceled(lhs: PurchaseResultData?, rhs: PurchaseResultData?) -> Bool {
         switch (lhs, rhs) {
+        case (nil, nil):
+            return false
         case let (left, right):
-            return left?.userCancelled == right?.userCancelled
+            return left?.userCancelled == true && right?.userCancelled == true
         }
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -79,15 +79,24 @@ final class PurchaseHandler: ObservableObject {
     /// potential future exit offer triggers (e.g., based on specific products).
     @Published
     fileprivate(set) var sessionPurchaseResult: PurchaseResultData? {
-        didSet {
-            self.sessionPurchaseResultID = UUID()
+        willSet {
+            if haveBothBeenCanceled(lhs: newValue, rhs: sessionPurchaseResult) {
+                self.consecutiveCancellationRequestID = UUID()
+            }
         }
     }
 
-    /// Unique identifier for the latest `sessionPurchaseResult`.
+    private func haveBothBeenCanceled(lhs: PurchaseResultData?, rhs: PurchaseResultData?) -> Bool {
+        switch (lhs, rhs) {
+        case let (left, right):
+            return left?.userCancelled == right?.userCancelled
+        }
+    }
+
+    /// Unique identifier for the latest `consecutiveCancellationRequestID`.
     /// This allows SwiftUI preference listeners to receive consecutive identical results.
     @Published
-    fileprivate(set) var sessionPurchaseResultID: UUID?
+    fileprivate(set) var consecutiveCancellationRequestID: UUID?
 
     /// Whether a purchase was successfully completed in the current session.
     /// Convenience property for checking if we should skip exit offers.
@@ -230,7 +239,7 @@ final class PurchaseHandler: ObservableObject {
             self.paywallEventTracker.discardSession(sessionID: sessionID)
         }
         self.sessionPurchaseResult = nil
-        self.sessionPurchaseResultID = nil
+        self.consecutiveCancellationRequestID = nil
         self.purchaseResult = nil
         self.activePaywallSessionID = nil
     }

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -78,7 +78,11 @@ final class PurchaseHandler: ObservableObject {
     /// More extensible than a boolean - gives access to full result data for
     /// potential future exit offer triggers (e.g., based on specific products).
     @Published
-    fileprivate(set) var sessionPurchaseResult: PurchaseResultData?
+    fileprivate(set) var sessionPurchaseResult: PurchaseResultData? {
+        didSet {
+            self.sessionPurchaseResultID = UUID()
+        }
+    }
 
     /// Unique identifier for the latest `sessionPurchaseResult`.
     /// This allows SwiftUI preference listeners to receive consecutive identical results.
@@ -499,7 +503,6 @@ extension PurchaseHandler {
             // onPurchaseCompleted and onPurchaseCancelled modifiers both work correctly.
             withAnimation(Constants.defaultAnimation) {
                 self.sessionPurchaseResult = result
-                self.sessionPurchaseResultID = UUID()
             }
 
             self.setResult(result)
@@ -563,7 +566,6 @@ extension PurchaseHandler {
         // onPurchaseCompleted and onPurchaseCancelled modifiers both work correctly.
         withAnimation(Constants.defaultAnimation) {
             self.sessionPurchaseResult = resultInfo
-            self.sessionPurchaseResultID = UUID()
         }
 
         self.setResult(resultInfo)

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -299,7 +299,10 @@ struct PaywallsV2View: View {
             .preference(key: PurchaseInProgressPreferenceKey.self,
                         value: self.purchaseHandler.packageBeingPurchased)
             .preference(key: PurchasedResultPreferenceKey.self,
-                        value: .init(data: self.purchaseHandler.sessionPurchaseResult))
+                        value: .init(
+                            data: self.purchaseHandler.sessionPurchaseResult,
+                            id: self.purchaseHandler.sessionPurchaseResultID
+                        ))
             .preference(key: RestoredCustomerInfoPreferenceKey.self,
                         value: self.purchaseHandler.restoredCustomerInfo)
             .preference(key: RestoreInProgressPreferenceKey.self,

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -301,7 +301,8 @@ struct PaywallsV2View: View {
             .preference(key: PurchasedResultPreferenceKey.self,
                         value: .init(
                             data: self.purchaseHandler.sessionPurchaseResult,
-                            id: self.purchaseHandler.sessionPurchaseResultID
+                            id: (self.purchaseHandler.sessionPurchaseResult?.userCancelled == true) ?
+                            self.purchaseHandler.consecutiveCancellationRequestID : nil
                         ))
             .preference(key: RestoredCustomerInfoPreferenceKey.self,
                         value: self.purchaseHandler.restoredCustomerInfo)

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -301,7 +301,7 @@ struct PaywallsV2View: View {
             .preference(key: PurchasedResultPreferenceKey.self,
                         value: .init(
                             data: self.purchaseHandler.sessionPurchaseResult,
-                            id: (self.purchaseHandler.sessionPurchaseResult?.userCancelled == true) ?
+                            diffKey: (self.purchaseHandler.sessionPurchaseResult?.userCancelled == true) ?
                             self.purchaseHandler.consecutiveCancellationRequestID : nil
                         ))
             .preference(key: RestoredCustomerInfoPreferenceKey.self,

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -145,6 +145,38 @@ class PurchaseCompletedHandlerTests: TestCase {
         expect(cancelled) == true
     }
 
+    func testOnPurchaseCancelledIsCalledForConsecutiveCancellations() throws {
+        let handler: PurchaseHandler = .cancelling()
+        var cancellationCount = 0
+
+        let dispose = try PaywallView(
+            offering: Self.offering.withLocalImages,
+            customerInfo: TestData.customerInfo,
+            introEligibility: .producing(eligibility: .eligible),
+            purchaseHandler: handler
+        )
+            .onPurchaseCancelled {
+                cancellationCount += 1
+            }
+            .addToHierarchy()
+
+        defer { dispose() }
+
+        Task {
+            _ = try await handler.purchase(package: Self.package)
+        }
+
+        expect(cancellationCount).toEventually(equal(1))
+        expect(handler.actionInProgress) == false
+
+        Task {
+            _ = try await handler.purchase(package: Self.package)
+        }
+
+        expect(cancellationCount).toEventually(equal(2))
+        expect(handler.actionInProgress) == false
+    }
+
     func testOnPurchaseCancelledWithCompletion() throws {
         var completed = false
         var cancelled = false

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -564,6 +564,81 @@ class PurchaseHandlerTests: TestCase {
 
         XCTAssertEqual(count, 2, "setting this should have only ouccured twice from \(job)")
     }
+
+    func test_haveBothBeenCanceled_appliesCorrectly() async throws {
+        let successfulPurchaseResult: PurchaseResultData = (
+            transaction: nil,
+            customerInfo: TestData.customerInfo,
+            userCancelled: false
+        )
+        let cancelledPurchaseResult: PurchaseResultData = (
+            transaction: nil,
+            customerInfo: TestData.customerInfo,
+            userCancelled: true
+        )
+
+        let testCases = [
+            (
+                shouldUpdate: false,
+                currentResultState: nil as PurchaseResultData?,
+                nextResultState: successfulPurchaseResult as PurchaseResultData?,
+                line: #line as UInt
+            ),
+            (false, nil, cancelledPurchaseResult, #line),
+            (false, successfulPurchaseResult, nil, #line),
+            (false, cancelledPurchaseResult, nil, #line),
+            (false, successfulPurchaseResult, successfulPurchaseResult, #line),
+            (false, successfulPurchaseResult, cancelledPurchaseResult, #line),
+            (false, cancelledPurchaseResult, successfulPurchaseResult, #line),
+            (true, cancelledPurchaseResult, cancelledPurchaseResult, #line)
+        ]
+
+        for (shouldUpdate, currentResultState, nextResultState, line) in testCases {
+            // GIVEN
+            let purchaseResult = Atomic<PurchaseResultData>(successfulPurchaseResult)
+            let purchases = MockPurchases { _, _, _ in
+                purchaseResult.value
+            } restorePurchases: {
+                TestData.customerInfo
+            } trackEvent: { event in
+                Logger.debug("Tracking event: \(event)")
+            } customerInfo: {
+                TestData.customerInfo
+            }
+
+            let handler = PurchaseHandler(
+                purchases: purchases,
+                eventTracker: .init(purchases: purchases, eventDispatcher: PaywallEventTrackerTestDispatcher.value)
+            )
+
+            var publishedRequestIDs: [UUID?] = []
+
+            let cancellable = handler.$consecutiveCancellationRequestID
+                .sink { publishedRequestIDs.append($0) }
+
+            if let currentResultState {
+                purchaseResult.value = currentResultState
+                try await handler.purchase(package: TestData.packageWithIntroOffer)
+            }
+
+            publishedRequestIDs.removeAll()
+
+            // WHEN
+            if let nextResultState {
+                purchaseResult.value = nextResultState
+                try await handler.purchase(package: TestData.packageWithIntroOffer)
+            } else {
+                handler.resetForNewSession()
+            }
+
+            // THEN
+            let didUpdate = publishedRequestIDs.contains { $0 != nil }
+            XCTAssertEqual(didUpdate, shouldUpdate, line: line)
+
+            // cleanup
+            cancellable.cancel()
+        }
+    }
 }
 
 // MARK: - Private


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

If you cancel a paywall purchase by dismissing the payment sheet—you get the callback from `onPurchaseCancelled` if you do it again… you don't.

### Description


Adds  published ID that is set everytime the purchase session result is set, this way, if there is a duplicate value set, the view has what it needs to trigger the on canceled event

<div><a href="https://cursor.com/agents/bc-fc826929-a6be-4443-929c-28295a34858a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc826929-a6be-4443-929c-28295a34858a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

