### PR TITLE
Fix: erroneous initializations of the PurchaseHandler from a button

### DIFF
--- a/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
+++ b/RevenueCatUI/CustomerCenter/View+PresentCustomerCenter.swift
@@ -176,6 +176,22 @@ extension View {
             )
         )
     }
+
+    func presentCustomerCenter(
+        isPresented: Binding<Bool>,
+        purchaseHandler: PurchaseHandler,
+        onDismiss: (() -> Void)? = nil
+    ) -> some View {
+        self.modifier(
+            PresentingCustomerCenterModifier(
+                isPresented: isPresented,
+                onDismiss: onDismiss,
+                myAppPurchaseLogic: nil,
+                presentationMode: .default,
+                purchaseHandler: purchaseHandler
+            )
+        )
+    }
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -121,8 +121,14 @@ struct ButtonComponentView: View {
                 SafariView(url: self.inAppBrowserURL!)
             }
             #if os(iOS)
-            .presentCustomerCenter(isPresented: self.$showCustomerCenter, onDismiss: {
-                self.showCustomerCenter = false
+            .applyIf(self.viewModel.opensCustomerCenter, apply: { view in
+                view.presentCustomerCenter(
+                    isPresented: self.$showCustomerCenter,
+                    purchaseHandler: self.purchaseHandler,
+                    onDismiss: {
+                        self.showCustomerCenter = false
+                    }
+                )
             })
             #endif
             #endif
@@ -285,6 +291,21 @@ struct ButtonComponentView: View {
         onDismiss()
     }
 }
+
+#if os(iOS)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension ButtonComponentViewModel {
+
+    var opensCustomerCenter: Bool {
+        guard case .navigateTo(destination: .customerCenter) = self.action else {
+            return false
+        }
+
+        return true
+    }
+
+}
+#endif
 
 #if DEBUG
 


### PR DESCRIPTION


<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

All buttons initialized new purchase handlers whether or not the customer center would get presented by the button. This resulted in 1 purchase handler instance per button, and there were many created during the draw phase only to get deinitialized in moments

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->


Conditionally apply the logic that caused that problem

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped presentation and handler reuse for Customer Center buttons; no auth or purchase API surface changes beyond using the existing environment handler.
> 
> **Overview**
> Paywalls V2 **button** views no longer attach Customer Center presentation (and a fresh **`PurchaseHandler`**) on every draw. **`ButtonComponentView`** now uses **`applyIf`** so **`.presentCustomerCenter`** runs only when the button action is **navigate to Customer Center**, via a new **`opensCustomerCenter`** check on **`ButtonComponentViewModel`**.
> 
> An internal **`presentCustomerCenter(isPresented:purchaseHandler:onDismiss:)`** overload wires the sheet through **`PresentingCustomerCenterModifier`** with the paywall’s existing **`purchaseHandler`** from the environment instead of **`PurchaseHandler.default()`**, so Customer Center shares the same handler instance when it is shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d43b2a29642ae4ffc060e99ce37dd96249e5cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->