### PR TITLE
Add local paywall JSON override to Paywalls Tester

### DIFF
--- a/Projects/PaywallsTester/Project.swift
+++ b/Projects/PaywallsTester/Project.swift
@@ -145,6 +145,20 @@ let project = Project(
                 .storeKit
             ],
             settings: .appTarget(including: ([:] as SettingsDictionary).appendingTuistSwiftConditions())
+        ),
+        .target(
+            name: "PaywallsTesterTests",
+            destinations: [.iPhone, .iPad, .macCatalyst],
+            product: .unitTests,
+            bundleId: "com.revenuecat.PaywallsTesterTests",
+            deploymentTargets: allDeploymentTargets,
+            infoPlist: .default,
+            sources: [
+                "../../Tests/TestingApps/PaywallsTester/PaywallsTesterTests/LocalPaywallOfferingsOverrideTests.swift"
+            ],
+            dependencies: [
+                .target(name: "PaywallsTester")
+            ]
         )
     ],
     schemes: schemes,

--- a/Projects/PaywallsTester/Project.swift
+++ b/Projects/PaywallsTester/Project.swift
@@ -98,6 +98,15 @@ let schemes: [Scheme] = [
             )
         )
     ),
+    .scheme(
+        name: "PaywallsTesterTests",
+        shared: true,
+        buildAction: .buildAction(targets: ["PaywallsTesterTests"]),
+        testAction: .targets([
+            .testableTarget(target: .init(stringLiteral: "PaywallsTesterTests"))
+        ]),
+        runAction: .runAction(configuration: "Debug")
+    ),
     // hack to avoid having `PaywallsTester` visible in the scheme list (hidden: true)
     .scheme(
         name: "PaywallsTester",

--- a/Projects/PaywallsTester/Project.swift
+++ b/Projects/PaywallsTester/Project.swift
@@ -132,7 +132,9 @@ if hasCustomStoreKit {
 let project = Project(
     name: "PaywallsTester",
     organizationName: .revenueCatOrgName,
-    packages: .projectPackages,
+    packages: .projectPackages + [
+        .package(path: .relativeToRoot("Tests/TestingApps/PaywallsTester/SnapshotTestingStub"))
+    ],
     settings: .appProject,
     targets: [
         .target(
@@ -163,10 +165,11 @@ let project = Project(
             deploymentTargets: allDeploymentTargets,
             infoPlist: .default,
             sources: [
-                "../../Tests/TestingApps/PaywallsTester/PaywallsTesterTests/LocalPaywallOfferingsOverrideTests.swift"
+                "../../Tests/TestingApps/PaywallsTester/PaywallsTesterTests/**/*.swift"
             ],
             dependencies: [
-                .target(name: "PaywallsTester")
+                .target(name: "PaywallsTester"),
+                .external(name: "SnapshotTestingStub")
             ]
         )
     ],

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -28,6 +28,10 @@
 		88BEB9262BF537F200A3D05F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BEB9222BF537F200A3D05F /* Constants.swift */; };
 		88BEB9272BF537F200A3D05F /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BEB9232BF537F200A3D05F /* Configuration.swift */; };
 		88BEB9282BF537F200A3D05F /* SamplePaywalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BEB9242BF537F200A3D05F /* SamplePaywalls.swift */; };
+		C57A20112E4F000000000011 /* LocalPaywallOfferingsOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57A20012E4F000000000001 /* LocalPaywallOfferingsOverride.swift */; };
+		C57A20122E4F000000000012 /* LocalPaywallOfferingsURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57A20022E4F000000000002 /* LocalPaywallOfferingsURLProtocol.swift */; };
+		C57A20132E4F000000000013 /* LocalPaywallOverrideEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57A20032E4F000000000003 /* LocalPaywallOverrideEditorView.swift */; };
+		C57A20142E4F000000000014 /* LocalPaywallOfferingsOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57A20042E4F000000000004 /* LocalPaywallOfferingsOverrideTests.swift */; };
 		88DFC18D2BCF3AD100273B6D /* AsyncButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC18A2BCF3ACA00273B6D /* AsyncButton.swift */; };
 		88DFC18E2BCF3AD100273B6D /* ErrorDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DFC18B2BCF3ACA00273B6D /* ErrorDisplay.swift */; };
 		DF1A26D5115387F97D465BF3 /* CustomVariablesEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17CBE9A504CBA10F6A8A57C /* CustomVariablesEditorView.swift */; };
@@ -91,6 +95,10 @@
 		88BEB9222BF537F200A3D05F /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = Config/Constants.swift; sourceTree = "<group>"; };
 		88BEB9232BF537F200A3D05F /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Config/Configuration.swift; sourceTree = "<group>"; };
 		88BEB9242BF537F200A3D05F /* SamplePaywalls.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SamplePaywalls.swift; path = Config/SamplePaywalls.swift; sourceTree = "<group>"; };
+		C57A20012E4F000000000001 /* LocalPaywallOfferingsOverride.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LocalPaywallOfferingsOverride.swift; path = Config/LocalPaywallOfferingsOverride.swift; sourceTree = "<group>"; };
+		C57A20022E4F000000000002 /* LocalPaywallOfferingsURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LocalPaywallOfferingsURLProtocol.swift; path = Config/LocalPaywallOfferingsURLProtocol.swift; sourceTree = "<group>"; };
+		C57A20032E4F000000000003 /* LocalPaywallOverrideEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPaywallOverrideEditorView.swift; sourceTree = "<group>"; };
+		C57A20042E4F000000000004 /* LocalPaywallOfferingsOverrideTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPaywallOfferingsOverrideTests.swift; sourceTree = "<group>"; };
 		88DFC18A2BCF3ACA00273B6D /* AsyncButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncButton.swift; sourceTree = "<group>"; };
 		88DFC18B2BCF3ACA00273B6D /* ErrorDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDisplay.swift; sourceTree = "<group>"; };
 		B17CBE9A504CBA10F6A8A57C /* CustomVariablesEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariablesEditorView.swift; sourceTree = "<group>"; };
@@ -124,6 +132,7 @@
 			isa = PBXGroup;
 			children = (
 				4D2E84DB2D00EDA100C639D9 /* PaywallsTesterTests.swift */,
+				C57A20042E4F000000000004 /* LocalPaywallOfferingsOverrideTests.swift */,
 			);
 			path = PaywallsTesterTests;
 			sourceTree = "<group>";
@@ -193,6 +202,8 @@
 			children = (
 				88BEB9222BF537F200A3D05F /* Constants.swift */,
 				88BEB9232BF537F200A3D05F /* Configuration.swift */,
+				C57A20012E4F000000000001 /* LocalPaywallOfferingsOverride.swift */,
+				C57A20022E4F000000000002 /* LocalPaywallOfferingsURLProtocol.swift */,
 				88BEB9242BF537F200A3D05F /* SamplePaywalls.swift */,
 				4FC882E02A5870C6005BE85E /* Info.plist */,
 				4FC046BF2A572E3700A28BCF /* Assets.xcassets */,
@@ -225,6 +236,7 @@
 				4F71CDD12A992292001B9BEF /* CustomPaywallContent.swift */,
 				2DBCEDFC2AC4BC060064C274 /* PaywallViewMode+Extensions.swift */,
 				B17CBE9A504CBA10F6A8A57C /* CustomVariablesEditorView.swift */,
+				C57A20032E4F000000000003 /* LocalPaywallOverrideEditorView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -368,6 +380,8 @@
 				88A543E92C387DB00039C6A5 /* APIKeyDashboardList.swift in Sources */,
 				88BEB9262BF537F200A3D05F /* Constants.swift in Sources */,
 				88BEB9272BF537F200A3D05F /* Configuration.swift in Sources */,
+				C57A20112E4F000000000011 /* LocalPaywallOfferingsOverride.swift in Sources */,
+				C57A20122E4F000000000012 /* LocalPaywallOfferingsURLProtocol.swift in Sources */,
 				88B2F9B62BE5554100B43E0B /* PaywallsTesterApp.swift in Sources */,
 				4F71CDD22A992292001B9BEF /* CustomPaywallContent.swift in Sources */,
 				4F4EE7CF2A572F5D00D7EAE1 /* DebugView.swift in Sources */,
@@ -378,6 +392,7 @@
 				FD33CD622D0351BE000D13A4 /* CustomerCenterUIKitView.swift in Sources */,
 				4F34FF632A60AD9A00AADF11 /* AppContentView.swift in Sources */,
 				DF1A26D5115387F97D465BF3 /* CustomVariablesEditorView.swift in Sources */,
+				C57A20132E4F000000000013 /* LocalPaywallOverrideEditorView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -386,6 +401,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				83156FF72E1756B400E37C70 /* PaywallsTesterTests.swift in Sources */,
+				C57A20142E4F000000000014 /* LocalPaywallOfferingsOverrideTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
@@ -22,17 +22,32 @@ enum Configuration {
     static func configure() {
         Purchases.logLevel = .verbose
         Purchases.proxyURL = Constants.proxyURL.flatMap { URL(string: $0) }
+        let configurationBuilder = Self.configurationBuilder()
         #if canImport(ObjectiveC) && (os(iOS) || targetEnvironment(macCatalyst))
         // Keep the protocol in the SDK session and let it no-op until a local JSON draft exists.
         LocalPaywallOfferingsInterceptor.install()
         #endif
 
         Purchases.configure(
-            with: .init(withAPIKey: Constants.apiKey)
+            with: configurationBuilder
                 .with(entitlementVerificationMode: .informational)
                 .with(diagnosticsEnabled: true)
                 .with(purchasesAreCompletedBy: .revenueCat, storeKitVersion: .storeKit2)
         )
+    }
+
+}
+
+private extension Configuration {
+
+    static func configurationBuilder() -> RevenueCat.Configuration.Builder {
+        let builder = RevenueCat.Configuration.Builder(withAPIKey: Constants.apiKey)
+
+        if let appUserID = LocalPaywallOfferingsOverrideStore.settings.appUserID {
+            _ = builder.with(appUserID: appUserID)
+        }
+
+        return builder
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
@@ -22,6 +22,10 @@ enum Configuration {
     static func configure() {
         Purchases.logLevel = .verbose
         Purchases.proxyURL = Constants.proxyURL.flatMap { URL(string: $0) }
+        #if canImport(ObjectiveC) && (os(iOS) || targetEnvironment(macCatalyst))
+        // Keep the protocol in the SDK session and let it no-op until a local JSON draft exists.
+        LocalPaywallOfferingsInterceptor.install()
+        #endif
 
         Purchases.configure(
             with: .init(withAPIKey: Constants.apiKey)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
@@ -41,13 +41,14 @@ enum Configuration {
 private extension Configuration {
 
     static func configurationBuilder() -> RevenueCat.Configuration.Builder {
-        let builder = RevenueCat.Configuration.Builder(withAPIKey: Constants.apiKey)
-
-        if let appUserID = LocalPaywallOfferingsOverrideStore.settings.appUserID {
-            _ = builder.with(appUserID: appUserID)
+        if LocalPaywallOfferingsOverrideStore.isActive, Purchases.isConfigured {
+            LocalPaywallOfferingsOverrideStore.rememberNormalAppUserIDIfNeeded(Purchases.shared.appUserID)
         }
 
-        return builder
+        return RevenueCat.Configuration.Builder(
+            withAPIKey: Constants.apiKey,
+            appUserID: LocalPaywallOfferingsOverrideStore.configurationAppUserID
+        )
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/LocalPaywallOfferingsOverride.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/LocalPaywallOfferingsOverride.swift
@@ -1,0 +1,252 @@
+//
+//  LocalPaywallOfferingsOverride.swift
+//  PaywallsTester
+//
+//  Created by RevenueCat on 5/21/26.
+//
+
+import Foundation
+
+struct LocalPaywallOfferingsOverrideSettings: Codable, Equatable {
+
+    var paywallComponentsJSON: String
+    var productIdentifiersByPackageIdentifier: [String: String]
+    var uiConfigJSON: String
+
+    var isActive: Bool {
+        return !self.paywallComponentsJSON.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var sanitizedProductIdentifiersByPackageIdentifier: [String: String] {
+        return self.productIdentifiersByPackageIdentifier.reduce(into: [:]) { result, element in
+            let packageIdentifier = element.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            let productIdentifier = element.value.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if !packageIdentifier.isEmpty, !productIdentifier.isEmpty {
+                result[packageIdentifier] = productIdentifier
+            }
+        }
+    }
+
+    static let `default`: Self = .init(
+        paywallComponentsJSON: "",
+        productIdentifiersByPackageIdentifier: Self.defaultProductIdentifiersByPackageIdentifier,
+        uiConfigJSON: Self.defaultUIConfigJSON
+    )
+
+    static let defaultProductIdentifiersByPackageIdentifier = [
+        "$rc_weekly": "com.revenuecat.simpleapp.weekly",
+        "$rc_monthly": "com.revenuecat.simpleapp.monthly",
+        "$rc_annual": "com.revenuecat.simpleapp.yearly",
+        "$rc_lifetime": "com.revenuecat.simpleapp.lifetime"
+    ]
+
+    static let defaultUIConfigJSON = """
+    {
+      "app": {
+        "colors": {},
+        "fonts": {}
+      },
+      "localizations": {
+        "en_US": {}
+      },
+      "custom_variables": {
+        "user_name": {
+          "default_value": "anon",
+          "type": "string"
+        }
+      },
+      "variable_config": {
+        "function_compatibility_map": {},
+        "variable_compatibility_map": {}
+      }
+    }
+    """
+
+}
+
+enum LocalPaywallOfferingsOverrideStore {
+
+    private static let userDefaultsKey = "com.revenuecat.PaywallsTester.localPaywallOfferingsOverride"
+
+    static var settings: LocalPaywallOfferingsOverrideSettings {
+        get {
+            guard
+                let data = UserDefaults.standard.data(forKey: Self.userDefaultsKey),
+                let settings = try? JSONDecoder().decode(LocalPaywallOfferingsOverrideSettings.self, from: data)
+            else {
+                return .default
+            }
+
+            return settings
+        }
+        set {
+            if let data = try? JSONEncoder().encode(newValue) {
+                UserDefaults.standard.set(data, forKey: Self.userDefaultsKey)
+            }
+        }
+    }
+
+    static var isActive: Bool {
+        return Self.settings.isActive
+    }
+
+}
+
+enum LocalPaywallOfferingsResponseFactory {
+
+    static func makeOfferingsResponseData(settings: LocalPaywallOfferingsOverrideSettings) throws -> Data {
+        let payload = try Self.makeOfferingsResponseJSONObject(settings: settings)
+
+        return try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    static func makeOfferingsResponseJSONObject(
+        settings: LocalPaywallOfferingsOverrideSettings
+    ) throws -> [String: Any] {
+        let paywallComponents = try Self.loadJSONObject(
+            from: settings.paywallComponentsJSON,
+            emptyError: .missingPaywallComponentsJSON,
+            invalidError: .invalidPaywallComponentsJSON
+        )
+        let offeringIdentifier = Self.offeringIdentifier(in: paywallComponents)
+        let packages = Self.makePackages(from: paywallComponents, settings: settings)
+
+        return [
+            "current_offering_id": offeringIdentifier,
+            "offerings": [
+                [
+                    "identifier": offeringIdentifier,
+                    "description": "Local Paywalls Tester override",
+                    "metadata": [:],
+                    "packages": packages,
+                    "paywall_components": paywallComponents
+                ]
+            ],
+            "ui_config": try Self.uiConfigJSONObject(from: settings.uiConfigJSON)
+        ]
+    }
+
+}
+
+private extension LocalPaywallOfferingsResponseFactory {
+
+    static func loadJSONObject(
+        from jsonString: String,
+        emptyError: LocalPaywallOfferingsOverrideError,
+        invalidError: LocalPaywallOfferingsOverrideError
+    ) throws -> [String: Any] {
+        let trimmedJSON = jsonString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedJSON.isEmpty else {
+            throw emptyError
+        }
+
+        let data = Data(trimmedJSON.utf8)
+        let jsonObject = try JSONSerialization.jsonObject(with: data)
+
+        guard let json = jsonObject as? [String: Any] else {
+            throw invalidError
+        }
+
+        return json
+    }
+
+    static func uiConfigJSONObject(from jsonString: String) throws -> [String: Any] {
+        if jsonString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return try Self.loadJSONObject(
+                from: LocalPaywallOfferingsOverrideSettings.defaultUIConfigJSON,
+                emptyError: .invalidUIConfigJSON,
+                invalidError: .invalidUIConfigJSON
+            )
+        }
+
+        return try Self.loadJSONObject(
+            from: jsonString,
+            emptyError: .invalidUIConfigJSON,
+            invalidError: .invalidUIConfigJSON
+        )
+    }
+
+    static func offeringIdentifier(in paywallComponents: [String: Any]) -> String {
+        let rawIdentifier = paywallComponents["offering_id"] as? String
+            ?? paywallComponents["offeringId"] as? String
+
+        return rawIdentifier.flatMap { $0.isEmpty ? nil : $0 } ?? "debug_local_paywall"
+    }
+
+    static func makePackages(
+        from paywallComponents: [String: Any],
+        settings: LocalPaywallOfferingsOverrideSettings
+    ) -> [[String: String]] {
+        let mappings = settings.sanitizedProductIdentifiersByPackageIdentifier
+        let extractedPackageIdentifiers = Array(Set(Self.packageIdentifiers(in: paywallComponents))).sorted()
+        let packageIdentifiers = extractedPackageIdentifiers.isEmpty
+            ? Array(mappings.keys).sorted()
+            : extractedPackageIdentifiers
+        let packages = packageIdentifiers.compactMap { identifier -> [String: String]? in
+            guard let productIdentifier = mappings[identifier] else {
+                return nil
+            }
+
+            return [
+                "identifier": identifier,
+                "platform_product_identifier": productIdentifier
+            ]
+        }
+
+        if packages.isEmpty, !extractedPackageIdentifiers.isEmpty {
+            return mappings.keys.sorted().map { identifier in
+                [
+                    "identifier": identifier,
+                    "platform_product_identifier": mappings[identifier] ?? ""
+                ]
+            }
+        }
+
+        return packages
+    }
+
+    static func packageIdentifiers(in object: Any) -> [String] {
+        if let dictionary = object as? [String: Any] {
+            return dictionary.flatMap { key, value -> [String] in
+                if (key == "package_id" || key == "packageId"), let identifier = value as? String {
+                    return [identifier]
+                }
+
+                return Self.packageIdentifiers(in: value)
+            }
+        }
+
+        if let array = object as? [Any] {
+            return array.flatMap(Self.packageIdentifiers(in:))
+        }
+
+        return []
+    }
+
+}
+
+enum LocalPaywallOfferingsOverrideError: LocalizedError {
+
+    case invalidRequestURL
+    case invalidResponse
+    case missingPaywallComponentsJSON
+    case invalidPaywallComponentsJSON
+    case invalidUIConfigJSON
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRequestURL:
+            return "The intercepted RevenueCat request did not include a valid URL."
+        case .invalidResponse:
+            return "Failed to create a mock RevenueCat HTTP response."
+        case .missingPaywallComponentsJSON:
+            return "Paste paywall component JSON before enabling the local override."
+        case .invalidPaywallComponentsJSON:
+            return "Paywall component JSON must be a JSON object."
+        case .invalidUIConfigJSON:
+            return "UI config JSON must be a JSON object."
+        }
+    }
+
+}

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/LocalPaywallOfferingsOverride.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/LocalPaywallOfferingsOverride.swift
@@ -33,7 +33,7 @@ struct LocalPaywallOfferingsOverrideSettings: Codable, Equatable {
             return nil
         }
 
-        return "paywalls-tester-local-override-\(self.cacheKey)"
+        return Self.localOverrideAppUserIDPrefix + self.cacheKey
     }
 
     static let `default`: Self = .init(
@@ -48,6 +48,8 @@ struct LocalPaywallOfferingsOverrideSettings: Codable, Equatable {
         "$rc_annual": "com.revenuecat.simpleapp.yearly",
         "$rc_lifetime": "com.revenuecat.simpleapp.lifetime"
     ]
+
+    static let localOverrideAppUserIDPrefix = "paywalls-tester-local-override-"
 
     static let defaultUIConfigJSON = """
     {
@@ -103,6 +105,8 @@ private extension LocalPaywallOfferingsOverrideSettings {
 enum LocalPaywallOfferingsOverrideStore {
 
     private static let userDefaultsKey = "com.revenuecat.PaywallsTester.localPaywallOfferingsOverride"
+    private static let normalAppUserIDKey = "com.revenuecat.PaywallsTester.normalAppUserID"
+    private static let defaultAppUserID = "paywalls-tester-default"
 
     static var settings: LocalPaywallOfferingsOverrideSettings {
         get {
@@ -124,6 +128,29 @@ enum LocalPaywallOfferingsOverrideStore {
 
     static var isActive: Bool {
         return Self.settings.isActive
+    }
+
+    static var configurationAppUserID: String {
+        return Self.appUserID(for: Self.settings, normalAppUserID: Self.normalAppUserID)
+    }
+
+    static func appUserID(
+        for settings: LocalPaywallOfferingsOverrideSettings,
+        normalAppUserID: String?
+    ) -> String {
+        return settings.appUserID ?? normalAppUserID ?? Self.defaultAppUserID
+    }
+
+    static func rememberNormalAppUserIDIfNeeded(_ appUserID: String) {
+        guard !appUserID.hasPrefix(LocalPaywallOfferingsOverrideSettings.localOverrideAppUserIDPrefix) else {
+            return
+        }
+
+        UserDefaults.standard.set(appUserID, forKey: Self.normalAppUserIDKey)
+    }
+
+    private static var normalAppUserID: String? {
+        return UserDefaults.standard.string(forKey: Self.normalAppUserIDKey)
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/LocalPaywallOfferingsOverride.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/LocalPaywallOfferingsOverride.swift
@@ -28,6 +28,14 @@ struct LocalPaywallOfferingsOverrideSettings: Codable, Equatable {
         }
     }
 
+    var appUserID: String? {
+        guard self.isActive else {
+            return nil
+        }
+
+        return "paywalls-tester-local-override-\(self.cacheKey)"
+    }
+
     static let `default`: Self = .init(
         paywallComponentsJSON: "",
         productIdentifiersByPackageIdentifier: Self.defaultProductIdentifiersByPackageIdentifier,
@@ -62,6 +70,33 @@ struct LocalPaywallOfferingsOverrideSettings: Codable, Equatable {
       }
     }
     """
+
+}
+
+private extension LocalPaywallOfferingsOverrideSettings {
+
+    var cacheKey: String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+
+        func append(_ string: String) {
+            for byte in string.utf8 {
+                hash ^= UInt64(byte)
+                hash = hash &* 1_099_511_628_211
+            }
+        }
+
+        append(self.paywallComponentsJSON)
+        append(self.uiConfigJSON)
+
+        for packageIdentifier in self.productIdentifiersByPackageIdentifier.keys.sorted() {
+            append(packageIdentifier)
+            append("\n")
+            append(self.productIdentifiersByPackageIdentifier[packageIdentifier] ?? "")
+            append("\n")
+        }
+
+        return String(hash, radix: 16)
+    }
 
 }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/LocalPaywallOfferingsURLProtocol.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/LocalPaywallOfferingsURLProtocol.swift
@@ -1,0 +1,166 @@
+//
+//  LocalPaywallOfferingsURLProtocol.swift
+//  PaywallsTester
+//
+//  Created by RevenueCat on 5/21/26.
+//
+
+import Foundation
+#if canImport(ObjectiveC)
+import ObjectiveC.runtime
+#endif
+
+#if canImport(ObjectiveC) && (os(iOS) || targetEnvironment(macCatalyst))
+
+enum LocalPaywallOfferingsInterceptor {
+
+    static func install() {
+        URLSessionConfiguration.enableLocalPaywallOfferingsInterception()
+    }
+
+}
+
+final class LocalPaywallOfferingsURLProtocol: URLProtocol {
+
+    private static let revenueCatPrimaryHost = "api.revenuecat.com"
+    private static let revenueCatHostSuffix = ".revenuecat.com"
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return Self.shouldIntercept(request)
+    }
+
+    override class func canInit(with task: URLSessionTask) -> Bool {
+        guard let request = task.currentRequest ?? task.originalRequest else {
+            return false
+        }
+
+        return Self.shouldIntercept(request)
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        do {
+            let payload = try LocalPaywallOfferingsResponseFactory.makeOfferingsResponseData(
+                settings: LocalPaywallOfferingsOverrideStore.settings
+            )
+            let response = try Self.makeHTTPResponse(for: self.request.url)
+
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: payload)
+            self.client?.urlProtocolDidFinishLoading(self)
+
+            if let url = self.request.url {
+                print("Intercepted RevenueCat offerings request with local paywall JSON: \(url.absoluteString)")
+            }
+        } catch {
+            self.client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+}
+
+private extension LocalPaywallOfferingsURLProtocol {
+
+    static func shouldIntercept(_ request: URLRequest) -> Bool {
+        guard
+            LocalPaywallOfferingsOverrideStore.isActive,
+            (request.httpMethod ?? "GET").uppercased() == "GET",
+            let url = request.url,
+            let host = url.host?.lowercased()
+        else {
+            return false
+        }
+
+        let proxyHost = Constants.proxyURL.flatMap { URL(string: $0)?.host?.lowercased() }
+        let isRevenueCatRequest = host == Self.revenueCatPrimaryHost
+            || host.hasSuffix(Self.revenueCatHostSuffix)
+            || proxyHost.map { host == $0 } ?? false
+        let isOfferingsRequest = url.path.contains("/subscribers/") && url.path.contains("/offerings")
+
+        return isRevenueCatRequest && isOfferingsRequest
+    }
+
+    static func makeHTTPResponse(for url: URL?) throws -> HTTPURLResponse {
+        guard let url else {
+            throw LocalPaywallOfferingsOverrideError.invalidRequestURL
+        }
+
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: [
+                "Content-Type": "application/json",
+                "Cache-Control": "no-store"
+            ]
+        ) else {
+            throw LocalPaywallOfferingsOverrideError.invalidResponse
+        }
+
+        return response
+    }
+
+}
+
+private extension URLSessionConfiguration {
+
+    static func enableLocalPaywallOfferingsInterception() {
+        _ = Self.swizzleLocalPaywallOfferingsInterception
+    }
+
+    static let swizzleLocalPaywallOfferingsInterception: Void = {
+        guard
+            let defaultMethod = class_getClassMethod(
+                URLSessionConfiguration.self,
+                #selector(getter: URLSessionConfiguration.default)
+            ),
+            let swizzledDefaultMethod = class_getClassMethod(
+                URLSessionConfiguration.self,
+                #selector(getter: URLSessionConfiguration.paywallsTester_interceptedDefault)
+            ),
+            let ephemeralMethod = class_getClassMethod(
+                URLSessionConfiguration.self,
+                #selector(getter: URLSessionConfiguration.ephemeral)
+            ),
+            let swizzledEphemeralMethod = class_getClassMethod(
+                URLSessionConfiguration.self,
+                #selector(getter: URLSessionConfiguration.paywallsTester_interceptedEphemeral)
+            )
+        else {
+            return
+        }
+
+        method_exchangeImplementations(defaultMethod, swizzledDefaultMethod)
+        method_exchangeImplementations(ephemeralMethod, swizzledEphemeralMethod)
+    }()
+
+    @objc dynamic class var paywallsTester_interceptedDefault: URLSessionConfiguration {
+        return Self.inject(LocalPaywallOfferingsURLProtocol.self, into: Self.paywallsTester_interceptedDefault)
+    }
+
+    @objc dynamic class var paywallsTester_interceptedEphemeral: URLSessionConfiguration {
+        return Self.inject(LocalPaywallOfferingsURLProtocol.self, into: Self.paywallsTester_interceptedEphemeral)
+    }
+
+    static func inject(
+        _ protocolClass: AnyClass,
+        into configuration: URLSessionConfiguration
+    ) -> URLSessionConfiguration {
+        var protocolClasses = configuration.protocolClasses ?? []
+
+        if !protocolClasses.contains(where: { ObjectIdentifier($0) == ObjectIdentifier(protocolClass) }) {
+            protocolClasses.insert(protocolClass, at: 0)
+        }
+
+        configuration.protocolClasses = protocolClasses
+        return configuration
+    }
+
+}
+
+#endif

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/LocalPaywallOverrideEditorView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/LocalPaywallOverrideEditorView.swift
@@ -1,0 +1,299 @@
+//
+//  LocalPaywallOverrideEditorView.swift
+//  PaywallsTester
+//
+//  Created by RevenueCat on 5/21/26.
+//
+
+import SwiftUI
+
+#if os(iOS)
+
+struct LocalPaywallOverrideEditorView: View {
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State
+    private var settings = LocalPaywallOfferingsOverrideStore.settings
+
+    @State
+    private var packageMappings: [PackageMappingItem] = []
+
+    @State
+    private var isAddingPackageMapping = false
+
+    @State
+    private var newPackageIdentifier = ""
+
+    @State
+    private var newProductIdentifier = ""
+
+    var onSave: () -> Void
+
+    var body: some View {
+        NavigationView {
+            List {
+                statusSection
+                paywallComponentsSection
+                packageMappingsSection
+                uiConfigSection
+            }
+            .navigationTitle("Local Paywall JSON")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Save") {
+                        save()
+                    }
+                    .disabled(settings.isActive && validationMessage != nil)
+                }
+            }
+            .onAppear {
+                loadPackageMappings()
+            }
+        }
+    }
+
+}
+
+private extension LocalPaywallOverrideEditorView {
+
+    var statusSection: some View {
+        Section {
+            if settings.isActive {
+                Label("Local offerings override enabled", systemImage: "checkmark.circle.fill")
+                    .foregroundColor(.green)
+            } else {
+                Label("Paste paywall JSON to enable the override", systemImage: "pause.circle")
+                    .foregroundColor(.secondary)
+            }
+
+            if let validationMessage {
+                Text(validationMessage)
+                    .font(.footnote)
+                    .foregroundColor(.red)
+            } else if settings.isActive {
+                Text("Save and refresh Live Paywalls to load this JSON through the SDK offerings endpoint.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    var paywallComponentsSection: some View {
+        Section {
+            TextEditor(text: $settings.paywallComponentsJSON)
+                .font(.system(.caption, design: .monospaced))
+                .frame(minHeight: 220)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+
+            Button("Clear Paywall JSON", role: .destructive) {
+                settings.paywallComponentsJSON = ""
+            }
+            .disabled(settings.paywallComponentsJSON.isEmpty)
+        } header: {
+            Text("Paywall components JSON")
+        } footer: {
+            Text("Paste the dashboard paywall components object. Clearing this field disables the override.")
+        }
+    }
+
+    var packageMappingsSection: some View {
+        Section {
+            if packageMappings.isEmpty {
+                Text("No package mappings defined.")
+                    .foregroundColor(.secondary)
+            } else {
+                ForEach($packageMappings) { $mapping in
+                    VStack(alignment: .leading, spacing: 8) {
+                        TextField("Package identifier", text: $mapping.packageIdentifier)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                        TextField("Product identifier", text: $mapping.productIdentifier)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                    }
+                }
+                .onDelete(perform: deletePackageMappings)
+            }
+
+            if isAddingPackageMapping {
+                addPackageMappingView
+            }
+
+            HStack {
+                Button {
+                    resetPackageMappings()
+                } label: {
+                    Label("Reset defaults", systemImage: "arrow.counterclockwise")
+                }
+                .buttonStyle(.borderless)
+
+                Spacer()
+
+                Button {
+                    withAnimation {
+                        isAddingPackageMapping = true
+                    }
+                } label: {
+                    Label("Add", systemImage: "plus")
+                }
+                .buttonStyle(.bordered)
+                .disabled(isAddingPackageMapping)
+            }
+        } header: {
+            Text("Package to product mapping")
+        } footer: {
+            Text("Package IDs found in the JSON are mapped to StoreKit product IDs from the tester configuration.")
+        }
+    }
+
+    var uiConfigSection: some View {
+        Section {
+            TextEditor(text: $settings.uiConfigJSON)
+                .font(.system(.caption, design: .monospaced))
+                .frame(minHeight: 180)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+
+            HStack {
+                Button("Use default UI config") {
+                    settings.uiConfigJSON = LocalPaywallOfferingsOverrideSettings.defaultUIConfigJSON
+                }
+                .buttonStyle(.borderless)
+
+                Spacer()
+
+                Button("Clear") {
+                    settings.uiConfigJSON = ""
+                }
+                .buttonStyle(.borderless)
+            }
+        } header: {
+            Text("Mock UI config JSON")
+        } footer: {
+            Text("Leave empty to use the tester default mock UI config.")
+        }
+    }
+
+    var addPackageMappingView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            TextField("Package identifier", text: $newPackageIdentifier)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+
+            TextField("Product identifier", text: $newProductIdentifier)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+
+            HStack {
+                Button("Cancel", role: .destructive) {
+                    cancelAddPackageMapping()
+                }
+                .buttonStyle(.borderless)
+
+                Spacer()
+
+                Button("Add") {
+                    addPackageMapping()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!canAddPackageMapping)
+            }
+        }
+    }
+
+    var validationMessage: String? {
+        guard settings.isActive else {
+            return nil
+        }
+
+        do {
+            var candidate = settings
+            candidate.productIdentifiersByPackageIdentifier = packageMappingsDictionary
+            _ = try LocalPaywallOfferingsResponseFactory.makeOfferingsResponseData(settings: candidate)
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    var packageMappingsDictionary: [String: String] {
+        return packageMappings.reduce(into: [:]) { result, item in
+            let packageIdentifier = item.packageIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+            let productIdentifier = item.productIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if !packageIdentifier.isEmpty, !productIdentifier.isEmpty {
+                result[packageIdentifier] = productIdentifier
+            }
+        }
+    }
+
+    var canAddPackageMapping: Bool {
+        return !newPackageIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !newProductIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    func loadPackageMappings() {
+        packageMappings = settings.productIdentifiersByPackageIdentifier
+            .map { PackageMappingItem(packageIdentifier: $0.key, productIdentifier: $0.value) }
+            .sorted { $0.packageIdentifier < $1.packageIdentifier }
+    }
+
+    func save() {
+        settings.productIdentifiersByPackageIdentifier = packageMappingsDictionary
+        LocalPaywallOfferingsOverrideStore.settings = settings
+        onSave()
+        dismiss()
+    }
+
+    func addPackageMapping() {
+        packageMappings.append(
+            .init(
+                packageIdentifier: newPackageIdentifier.trimmingCharacters(in: .whitespacesAndNewlines),
+                productIdentifier: newProductIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        )
+        packageMappings.sort { $0.packageIdentifier < $1.packageIdentifier }
+        cancelAddPackageMapping()
+    }
+
+    func cancelAddPackageMapping() {
+        withAnimation {
+            isAddingPackageMapping = false
+        }
+        newPackageIdentifier = ""
+        newProductIdentifier = ""
+    }
+
+    func deletePackageMappings(at offsets: IndexSet) {
+        packageMappings.remove(atOffsets: offsets)
+    }
+
+    func resetPackageMappings() {
+        settings.productIdentifiersByPackageIdentifier =
+            LocalPaywallOfferingsOverrideSettings.defaultProductIdentifiersByPackageIdentifier
+        loadPackageMappings()
+    }
+
+}
+
+private struct PackageMappingItem: Identifiable {
+
+    let id = UUID()
+    var packageIdentifier: String
+    var productIdentifier: String
+
+}
+
+#Preview {
+    LocalPaywallOverrideEditorView(onSave: {})
+}
+
+#endif

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -65,6 +65,11 @@ struct APIKeyDashboardList: View {
     @State
     private var isShowingVariablesEditor = false
 
+    #if os(iOS)
+    @State
+    private var isShowingLocalPaywallOverrideEditor = false
+    #endif
+
     @State
     private var searchText = Constants.sandboxPaywallSearch
 
@@ -79,6 +84,16 @@ struct APIKeyDashboardList: View {
                     .toolbar {
                         ToolbarItem(placement: .automatic) {
                             HStack(spacing: 16) {
+                                #if os(iOS)
+                                Button {
+                                    isShowingLocalPaywallOverrideEditor = true
+                                } label: {
+                                    Image(systemName: LocalPaywallOfferingsOverrideStore.isActive
+                                          ? "doc.text.fill"
+                                          : "doc.text")
+                                }
+                                #endif
+
                                 Button {
                                     isShowingVariablesEditor = true
                                 } label: {
@@ -101,6 +116,16 @@ struct APIKeyDashboardList: View {
                     .sheet(isPresented: $isShowingVariablesEditor) {
                         CustomVariablesEditorView(variables: $customVariables)
                     }
+                    #if os(iOS)
+                    .sheet(isPresented: $isShowingLocalPaywallOverrideEditor) {
+                        LocalPaywallOverrideEditorView {
+                            Configuration.configure()
+                            Task {
+                                await fetchOfferings()
+                            }
+                        }
+                    }
+                    #endif
             }
             .task {
                 await fetchOfferings()

--- a/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/LocalPaywallOfferingsOverrideTests.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/LocalPaywallOfferingsOverrideTests.swift
@@ -1,0 +1,203 @@
+//
+//  LocalPaywallOfferingsOverrideTests.swift
+//  PaywallsTesterTests
+//
+//  Created by RevenueCat on 5/21/26.
+//
+
+@testable import PaywallsTester
+import XCTest
+
+final class LocalPaywallOfferingsOverrideTests: XCTestCase {
+
+    func testBuildsOfferingsPayloadFromPaywallComponentsJSON() throws {
+        let settings = LocalPaywallOfferingsOverrideSettings(
+            paywallComponentsJSON: Self.paywallComponentsJSON,
+            productIdentifiersByPackageIdentifier: [
+                "$rc_monthly": "monthly_from_editor"
+            ],
+            uiConfigJSON: Self.uiConfigJSON
+        )
+
+        let payload = try LocalPaywallOfferingsResponseFactory.makeOfferingsResponseJSONObject(settings: settings)
+
+        XCTAssertEqual(payload["current_offering_id"] as? String, "local_editor_offering")
+
+        let offerings = try XCTUnwrap(payload["offerings"] as? [[String: Any]])
+        let offering = try XCTUnwrap(offerings.first)
+        XCTAssertEqual(offering["identifier"] as? String, "local_editor_offering")
+        XCTAssertEqual(offering["description"] as? String, "Local Paywalls Tester override")
+
+        let packages = try XCTUnwrap(offering["packages"] as? [[String: String]])
+        XCTAssertEqual(packages, [
+            [
+                "identifier": "$rc_monthly",
+                "platform_product_identifier": "monthly_from_editor"
+            ]
+        ])
+
+        let paywallComponents = try XCTUnwrap(offering["paywall_components"] as? [String: Any])
+        XCTAssertEqual(paywallComponents["template_name"] as? String, "componentsTEST")
+
+        let uiConfig = try XCTUnwrap(payload["ui_config"] as? [String: Any])
+        let customVariables = try XCTUnwrap(uiConfig["custom_variables"] as? [String: Any])
+        XCTAssertNotNil(customVariables["user_name"])
+    }
+
+    func testUsesAllMappingsWhenPaywallComponentsDoNotReferencePackages() throws {
+        let settings = LocalPaywallOfferingsOverrideSettings(
+            paywallComponentsJSON: Self.paywallComponentsWithoutPackagesJSON,
+            productIdentifiersByPackageIdentifier: [
+                "$rc_annual": "annual_from_editor",
+                "$rc_monthly": "monthly_from_editor"
+            ],
+            uiConfigJSON: ""
+        )
+
+        let payload = try LocalPaywallOfferingsResponseFactory.makeOfferingsResponseJSONObject(settings: settings)
+        let offerings = try XCTUnwrap(payload["offerings"] as? [[String: Any]])
+        let offering = try XCTUnwrap(offerings.first)
+        let packages = try XCTUnwrap(offering["packages"] as? [[String: String]])
+
+        XCTAssertEqual(packages, [
+            [
+                "identifier": "$rc_annual",
+                "platform_product_identifier": "annual_from_editor"
+            ],
+            [
+                "identifier": "$rc_monthly",
+                "platform_product_identifier": "monthly_from_editor"
+            ]
+        ])
+    }
+
+    func testEmptyPaywallComponentsJSONDisablesOverride() {
+        let settings = LocalPaywallOfferingsOverrideSettings(
+            paywallComponentsJSON: "   \n",
+            productIdentifiersByPackageIdentifier: [
+                "$rc_monthly": "monthly_from_editor"
+            ],
+            uiConfigJSON: Self.uiConfigJSON
+        )
+
+        XCTAssertFalse(settings.isActive)
+        XCTAssertThrowsError(
+            try LocalPaywallOfferingsResponseFactory.makeOfferingsResponseData(settings: settings)
+        )
+    }
+
+    private static let paywallComponentsJSON = """
+    {
+      "offering_id": "local_editor_offering",
+      "default_locale": "en_US",
+      "revision": 3,
+      "template_name": "componentsTEST",
+      "asset_base_url": "https://assets.pawwalls.com",
+      "components_localizations": {},
+      "components_config": {
+        "base": {
+          "background": {
+            "type": "color",
+            "value": {
+              "light": {
+                "type": "hex",
+                "value": "#220000ff"
+              }
+            }
+          },
+          "stack": {
+            "type": "stack",
+            "components": [
+              {
+                "type": "package",
+                "package_id": "$rc_monthly"
+              }
+            ],
+            "margin": {},
+            "padding": {},
+            "size": {
+              "width": {
+                "type": "fill"
+              },
+              "height": {
+                "type": "fill"
+              }
+            },
+            "dimension": {
+              "type": "vertical",
+              "alignment": "center",
+              "distribution": "center"
+            },
+            "spacing": 16
+          }
+        }
+      }
+    }
+    """
+
+    private static let paywallComponentsWithoutPackagesJSON = """
+    {
+      "default_locale": "en_US",
+      "revision": 3,
+      "template_name": "componentsTEST",
+      "asset_base_url": "https://assets.pawwalls.com",
+      "components_localizations": {},
+      "components_config": {
+        "base": {
+          "background": {
+            "type": "color",
+            "value": {
+              "light": {
+                "type": "hex",
+                "value": "#220000ff"
+              }
+            }
+          },
+          "stack": {
+            "type": "stack",
+            "components": [],
+            "margin": {},
+            "padding": {},
+            "size": {
+              "width": {
+                "type": "fill"
+              },
+              "height": {
+                "type": "fill"
+              }
+            },
+            "dimension": {
+              "type": "vertical",
+              "alignment": "center",
+              "distribution": "center"
+            },
+            "spacing": 16
+          }
+        }
+      }
+    }
+    """
+
+    private static let uiConfigJSON = """
+    {
+      "app": {
+        "colors": {},
+        "fonts": {}
+      },
+      "localizations": {
+        "en_US": {}
+      },
+      "custom_variables": {
+        "user_name": {
+          "default_value": "anon",
+          "type": "string"
+        }
+      },
+      "variable_config": {
+        "function_compatibility_map": {},
+        "variable_compatibility_map": {}
+      }
+    }
+    """
+
+}

--- a/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/LocalPaywallOfferingsOverrideTests.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/LocalPaywallOfferingsOverrideTests.swift
@@ -112,6 +112,34 @@ final class LocalPaywallOfferingsOverrideTests: XCTestCase {
         XCTAssertNotEqual(firstActiveSettings.appUserID, secondActiveSettings.appUserID)
     }
 
+    func testConfigurationAppUserIDRestoresNormalUserWhenOverrideIsInactive() {
+        let inactiveSettings = LocalPaywallOfferingsOverrideSettings(
+            paywallComponentsJSON: "",
+            productIdentifiersByPackageIdentifier: [:],
+            uiConfigJSON: ""
+        )
+        let activeSettings = LocalPaywallOfferingsOverrideSettings(
+            paywallComponentsJSON: Self.paywallComponentsJSON,
+            productIdentifiersByPackageIdentifier: [
+                "$rc_monthly": "monthly_from_editor"
+            ],
+            uiConfigJSON: Self.uiConfigJSON
+        )
+
+        XCTAssertEqual(
+            LocalPaywallOfferingsOverrideStore.appUserID(for: inactiveSettings, normalAppUserID: "normal_user"),
+            "normal_user"
+        )
+        XCTAssertEqual(
+            LocalPaywallOfferingsOverrideStore.appUserID(for: inactiveSettings, normalAppUserID: nil),
+            "paywalls-tester-default"
+        )
+        XCTAssertEqual(
+            LocalPaywallOfferingsOverrideStore.appUserID(for: activeSettings, normalAppUserID: "normal_user"),
+            activeSettings.appUserID
+        )
+    }
+
     private static let paywallComponentsJSON = """
     {
       "offering_id": "local_editor_offering",

--- a/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/LocalPaywallOfferingsOverrideTests.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/LocalPaywallOfferingsOverrideTests.swift
@@ -86,6 +86,32 @@ final class LocalPaywallOfferingsOverrideTests: XCTestCase {
         )
     }
 
+    func testAppUserIDIsNilWhenInactiveAndChangesWithOverrideSettings() {
+        let inactiveSettings = LocalPaywallOfferingsOverrideSettings(
+            paywallComponentsJSON: "",
+            productIdentifiersByPackageIdentifier: [:],
+            uiConfigJSON: ""
+        )
+        let firstActiveSettings = LocalPaywallOfferingsOverrideSettings(
+            paywallComponentsJSON: Self.paywallComponentsJSON,
+            productIdentifiersByPackageIdentifier: [
+                "$rc_monthly": "monthly_from_editor"
+            ],
+            uiConfigJSON: Self.uiConfigJSON
+        )
+        let secondActiveSettings = LocalPaywallOfferingsOverrideSettings(
+            paywallComponentsJSON: Self.paywallComponentsWithoutPackagesJSON,
+            productIdentifiersByPackageIdentifier: [
+                "$rc_monthly": "monthly_from_editor"
+            ],
+            uiConfigJSON: Self.uiConfigJSON
+        )
+
+        XCTAssertNil(inactiveSettings.appUserID)
+        XCTAssertNotNil(firstActiveSettings.appUserID)
+        XCTAssertNotEqual(firstActiveSettings.appUserID, secondActiveSettings.appUserID)
+    }
+
     private static let paywallComponentsJSON = """
     {
       "offering_id": "local_editor_offering",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Paywalls Tester needs a local workflow for trying Paywalls V2 JSON without requiring a dashboard offering update. This lets testers paste paywall component JSON, adjust package-to-product mappings, and override UI config data directly in the iOS tester.

### Description
- Adds a Paywalls Tester local offerings override backed by persisted paywall component JSON, package/product mappings, and UI config JSON.
- Installs a URLProtocol override into the SDK URLSession configuration at startup; it only intercepts RevenueCat offerings requests while paywall JSON is present, so clearing the JSON disables the override.
- Uses a deterministic local override app user ID derived from the saved JSON/mapping/config to isolate SDK offerings cache per local draft, remembers the non-local tester identity before activation, and restores/falls back to a stable non-local identity when the override is inactive.
- Adds an iOS editor sheet in the Live Paywalls toolbar and reconfigures/refetches after saving so SDK offerings are refreshed.
- Adds focused tests for mock offerings payload construction and local override cache identity behavior, while keeping the existing PaywallsTesterTests source/dependency wiring aligned in both Tuist and the checked-in Xcode project.

Testing:
- `git diff --check` passed.
- New Swift file line-length check passed.
- `tuist test PaywallsTesterTests` could not run in this Linux cloud image because `tuist` is not installed.
- `swiftlint` could not run because `swiftlint` is not installed.
- `swift --version` could not run because the Swift toolchain is not installed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d240442a-5e5b-4dab-a016-572dea6e57a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d240442a-5e5b-4dab-a016-572dea6e57a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

