### PR TITLE
[Billing Plans]: Check eligibility for intro offers on monthly billing plan 

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1340,6 +1340,9 @@
 		FD2472F02F4CBAF50074D28A /* CustomerInfoActiveDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2472EF2F4CBAF50074D28A /* CustomerInfoActiveDatesTests.swift */; };
 		FD25F3542F32AA20007C1A91 /* PostIsPurchaseAllowedByRestoreBehaviorOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD25F3532F32AA20007C1A91 /* PostIsPurchaseAllowedByRestoreBehaviorOperation.swift */; };
 		FD25F3782F33D502007C1A91 /* BackendIsPurchaseAllowedByRestoreBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD25F3772F33D502007C1A91 /* BackendIsPurchaseAllowedByRestoreBehaviorTests.swift */; };
+		FD299C732FC5E7B700A58C89 /* CompoundProductIdentifierResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD299C722FC5E7B700A58C89 /* CompoundProductIdentifierResolver.swift */; };
+		FD299C7E2FC5EB9500A58C89 /* CompoundProductIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD299C7C2FC5EB9500A58C89 /* CompoundProductIdentifierTests.swift */; };
+		FD299C802FC5F08800A58C89 /* CompoundProductIdentifierResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD299C7F2FC5F08800A58C89 /* CompoundProductIdentifierResolverTests.swift */; };
 		FD2E6C9F2C480FF000CB4BD7 /* OHHTTPStubs in Frameworks */ = {isa = PBXBuildFile; productRef = FD2E6C9E2C480FF000CB4BD7 /* OHHTTPStubs */; };
 		FD2E6CA12C48100900CB4BD7 /* OHHTTPStubsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = FD2E6CA02C48100900CB4BD7 /* OHHTTPStubsSwift */; };
 		FD3A85FC2DDE7532005F3C79 /* VirtualCurrencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A85FB2DDE7532005F3C79 /* VirtualCurrencies.swift */; };
@@ -1351,7 +1354,6 @@
 		FD4E63422F34E0B60040BA46 /* PurchasesIsPurchaseAllowedByRestoreBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4E63412F34E0B60040BA46 /* PurchasesIsPurchaseAllowedByRestoreBehaviorTests.swift */; };
 		FD5EB2702DFB19B800DA1974 /* BackendGetVirtualCurrenciesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5EB26F2DFB19B800DA1974 /* BackendGetVirtualCurrenciesTests.swift */; };
 		FD6D87502FAE3D3800CAF0F2 /* CompoundProductIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6D874E2FAE3D3800CAF0F2 /* CompoundProductIdentifier.swift */; };
-		FD6D87572FAE3D7700CAF0F2 /* CompoundProductIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6D87562FAE3D7700CAF0F2 /* CompoundProductIdentifierTests.swift */; };
 		FD6D87582FAE4CD400CAF0F2 /* MockProductsRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35F783903362B65FB7AF3 /* MockProductsRequestFactory.swift */; };
 		FD6D87592FAE4CF700CAF0F2 /* MockProductsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35B08709090FBBFB16EBD /* MockProductsRequest.swift */; };
 		FD6D87632FAE79E700CAF0F2 /* InstallmentsInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6D87622FAE79E700CAF0F2 /* InstallmentsInfo.swift */; };
@@ -2879,7 +2881,6 @@
 		FACD00072F61A1230073D2DE /* PackageComponentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentViewTests.swift; sourceTree = "<group>"; };
 		FACD00092F61A1230073D2DE /* PackageValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageValidatorTests.swift; sourceTree = "<group>"; };
 		FACD000B2F61A1230073D2DE /* PackageVisibilityPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageVisibilityPreview.swift; sourceTree = "<group>"; };
-		0E4CCD8E9E454A2EB3760E06 /* ButtonComponentViewModelMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentViewModelMappingTests.swift; sourceTree = "<group>"; };
 		FB5A72012F65F5B9005C64A1 /* ViewModelFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelFactoryTests.swift; sourceTree = "<group>"; };
 		FD05A7192EE2430E00FE671F /* StoreKit2PromotionalOfferPurchaseOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2PromotionalOfferPurchaseOptions.swift; sourceTree = "<group>"; };
 		FD15AF572DF9A8F30062467E /* VirtualCurrenciesScrollViewWithOSBackgroundSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualCurrenciesScrollViewWithOSBackgroundSection.swift; sourceTree = "<group>"; };
@@ -2898,6 +2899,9 @@
 		FD2472EF2F4CBAF50074D28A /* CustomerInfoActiveDatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoActiveDatesTests.swift; sourceTree = "<group>"; };
 		FD25F3532F32AA20007C1A91 /* PostIsPurchaseAllowedByRestoreBehaviorOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostIsPurchaseAllowedByRestoreBehaviorOperation.swift; sourceTree = "<group>"; };
 		FD25F3772F33D502007C1A91 /* BackendIsPurchaseAllowedByRestoreBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendIsPurchaseAllowedByRestoreBehaviorTests.swift; sourceTree = "<group>"; };
+		FD299C722FC5E7B700A58C89 /* CompoundProductIdentifierResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundProductIdentifierResolver.swift; sourceTree = "<group>"; };
+		FD299C7C2FC5EB9500A58C89 /* CompoundProductIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundProductIdentifierTests.swift; sourceTree = "<group>"; };
+		FD299C7F2FC5F08800A58C89 /* CompoundProductIdentifierResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundProductIdentifierResolverTests.swift; sourceTree = "<group>"; };
 		FD33CD5F2D03500C000D13A4 /* CustomerCenterUIKitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterUIKitView.swift; sourceTree = "<group>"; };
 		FD3A85FB2DDE7532005F3C79 /* VirtualCurrencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualCurrencies.swift; sourceTree = "<group>"; };
 		FD3A85FD2DDE76CD005F3C79 /* VirtualCurrenciesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualCurrenciesTests.swift; sourceTree = "<group>"; };
@@ -2909,7 +2913,6 @@
 		FD4E63412F34E0B60040BA46 /* PurchasesIsPurchaseAllowedByRestoreBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesIsPurchaseAllowedByRestoreBehaviorTests.swift; sourceTree = "<group>"; };
 		FD5EB26F2DFB19B800DA1974 /* BackendGetVirtualCurrenciesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetVirtualCurrenciesTests.swift; sourceTree = "<group>"; };
 		FD6D874E2FAE3D3800CAF0F2 /* CompoundProductIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundProductIdentifier.swift; sourceTree = "<group>"; };
-		FD6D87562FAE3D7700CAF0F2 /* CompoundProductIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundProductIdentifierTests.swift; sourceTree = "<group>"; };
 		FD6D875A2FAE691A00CAF0F2 /* FetchProductsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchProductsView.swift; sourceTree = "<group>"; };
 		FD6D87622FAE79E700CAF0F2 /* InstallmentsInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallmentsInfo.swift; sourceTree = "<group>"; };
 		FD89DB862DB97D2E00A8C231 /* VirtualCurrencyBalancesScreenViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualCurrencyBalancesScreenViewModelTests.swift; sourceTree = "<group>"; };
@@ -3483,7 +3486,8 @@
 				FD18ED4D2837F89200C5AA4F /* StoreKitWorkaroundsTests.swift */,
 				4D24EF3F2B04EA6000E586D2 /* StoreEnvironmentTests.swift */,
 				5733D01028D00354008638D8 /* PromotionalOfferTests.swift */,
-				FD6D87562FAE3D7700CAF0F2 /* CompoundProductIdentifierTests.swift */,
+				FD299C7C2FC5EB9500A58C89 /* CompoundProductIdentifierTests.swift */,
+				FD299C7F2FC5F08800A58C89 /* CompoundProductIdentifierResolverTests.swift */,
 			);
 			path = StoreKitAbstractions;
 			sourceTree = "<group>";
@@ -6208,6 +6212,7 @@
 		FD6D874F2FAE3D3800CAF0F2 /* Products with Billing Plans */ = {
 			isa = PBXGroup;
 			children = (
+				FD299C722FC5E7B700A58C89 /* CompoundProductIdentifierResolver.swift */,
 				FD6D874E2FAE3D3800CAF0F2 /* CompoundProductIdentifier.swift */,
 			);
 			path = "Products with Billing Plans";
@@ -7344,6 +7349,7 @@
 				4F5C05BD2A43A21A00651C7D /* Locale+Extensions.swift in Sources */,
 				2C9107F02CE2ED8700189565 /* PaywallComponentsData.swift in Sources */,
 				2D9F4A5526C30CA800B07B43 /* PurchasesOrchestrator.swift in Sources */,
+				FD299C732FC5E7B700A58C89 /* CompoundProductIdentifierResolver.swift in Sources */,
 				57C2931528BFEF4F0054EDFC /* PurchasesError.swift in Sources */,
 				57FD7B1528DA4037009CA4E4 /* PurchasesType.swift in Sources */,
 				57C381DA2796153D009E3940 /* SK1StoreProductDiscount.swift in Sources */,
@@ -7537,6 +7543,8 @@
 				57544C28285FA94B004E54D5 /* MockAttributeSyncing.swift in Sources */,
 				4F34AEEC2A5DCCBA00F4BCB0 /* VerificationResultTests.swift in Sources */,
 				FD2046832CB833CD00166727 /* MockStoreKit2PurchaseIntentListenerDelegate.swift in Sources */,
+				FD299C7E2FC5EB9500A58C89 /* CompoundProductIdentifierTests.swift in Sources */,
+				FD299C802FC5F08800A58C89 /* CompoundProductIdentifierResolverTests.swift in Sources */,
 				356523AC2CF890F400B6E3EA /* CustomerCenterEventsRequestTests.swift in Sources */,
 				1EFA95102CDB7FAA00CA5951 /* WebPurchaseRedemptionHelperTests.swift in Sources */,
 				35AAEB4C2BBC39D100A12548 /* DiagnosticsFileHandlerTests.swift in Sources */,
@@ -7674,7 +7682,6 @@
 				903A05B42EB3B9D4009B9CE4 /* PaywallFeatureEventsRequestTests.swift in Sources */,
 				AA110006AABB0001CCDD0001 /* CustomPaywallEventTests.swift in Sources */,
 				903A05B52EB3B9D4009B9CE4 /* BackendPaywallEventTests.swift in Sources */,
-				FD6D87572FAE3D7700CAF0F2 /* CompoundProductIdentifierTests.swift in Sources */,
 				2DDF41EA24F6F844005BC22D /* SKProductSubscriptionDurationExtensions.swift in Sources */,
 				351B517A26D44FF000BD2BD7 /* MockRequestFetcher.swift in Sources */,
 				351B514E26D44ACE00BD2BD7 /* SubscriberAttributesManagerTests.swift in Sources */,

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -57,7 +57,6 @@ class ProductsManager: NSObject, ProductsManagerType {
         }
     }
 
-    // swiftlint:disable:next function_body_length
     func products(withIdentifiers identifiers: Set<String>, completion: @escaping Completion) {
         let startTime = self.dateProvider.now()
 
@@ -101,7 +100,9 @@ class ProductsManager: NSObject, ProductsManagerType {
                 var invalidProductIdentifiers: Set<String> = []
                 let compoundProductIdentifiers: Set<CompoundProductIdentifier> = Set(
                     identifiers.compactMap { identifier in
-                        guard let compoundIdentifier = CompoundProductIdentifier(compoundProductIdentifier: identifier) else {
+                        guard let compoundIdentifier = CompoundProductIdentifier(
+                            compoundProductIdentifier: identifier
+                        ) else {
                             invalidProductIdentifiers.insert(identifier)
                             return nil
                         }
@@ -109,7 +110,9 @@ class ProductsManager: NSObject, ProductsManagerType {
                         if compoundIdentifier.productPlanIdentifier == nil {
                             return compoundIdentifier   // Basic product with no billing plan
                         } else {
-                            guard self.areProductsWithBillingPlansSupported(compoundIdentifier: compoundIdentifier) else {
+                            guard self.areProductsWithBillingPlansSupported(
+                                compoundIdentifier: compoundIdentifier
+                            ) else {
                                 return nil
                             }
 

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -27,8 +27,6 @@ class ProductsManager: NSObject, ProductsManagerType {
 
     private let _productsFetcherSK2: (any Sendable)?
 
-    private let installmentsInfoFactory: InstallmentsInfoFactoryType
-
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     private var productsFetcherSK2: ProductsFetcherSK2 {
         // swiftlint:disable:next force_cast force_unwrapping
@@ -48,10 +46,9 @@ class ProductsManager: NSObject, ProductsManagerType {
         self.diagnosticsTracker = diagnosticsTracker
         self.systemInfo = systemInfo
         self.dateProvider = dateProvider
-        self.installmentsInfoFactory = installmentsInfoFactory
 
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
-            self._productsFetcherSK2 = ProductsFetcherSK2()
+            self._productsFetcherSK2 = ProductsFetcherSK2(installmentsInfoFactory: installmentsInfoFactory)
         } else {
             self._productsFetcherSK2 = nil
         }
@@ -94,153 +91,13 @@ class ProductsManager: NSObject, ProductsManagerType {
     func sk2Products(withIdentifiers identifiers: Set<String>, completion: @escaping SK2Completion) {
         Async.call(with: completion) {
             do {
-                // It's possible for developers to request compound product identifiers that represent both
-                // a product and a billing plan, like com.rc.sub:monthly. However, StoreKit doesn't recognize
-                // these product IDs, so here, we convert them to product IDs that StoreKit can recognize.
-                var invalidProductIdentifiers: Set<String> = []
-                let compoundProductIdentifiers: Set<CompoundProductIdentifier> = Set(
-                    identifiers.compactMap { identifier in
-                        guard let compoundIdentifier = CompoundProductIdentifier(
-                            compoundProductIdentifier: identifier
-                        ) else {
-                            invalidProductIdentifiers.insert(identifier)
-                            return nil
-                        }
-
-                        if compoundIdentifier.productPlanIdentifier == nil {
-                            return compoundIdentifier   // Basic product with no billing plan
-                        } else {
-                            guard self.areProductsWithBillingPlansSupported(
-                                compoundIdentifier: compoundIdentifier
-                            ) else {
-                                return nil
-                            }
-
-                            return compoundIdentifier
-                        }
-                    }
-                )
-                if !invalidProductIdentifiers.isEmpty {
-                    Logger.warn(Strings.storeKit.invalid_product_identifiers(identifiers: invalidProductIdentifiers))
-                }
-
-                let storeKitIdentifiers: Set<String> = Set(
-                    compoundProductIdentifiers.map(\.storeKitProductIdentifier)
-                )
-
-                let products = try await self.productsFetcherSK2.products(identifiers: storeKitIdentifiers)
-                let productsTakingBillingPlansIntoAccount = self.populateSK2CompoundProductsIfSupported(
-                    requestedIdentifiers: compoundProductIdentifiers, products: products
-                )
-
+                let products = try await self.productsFetcherSK2.products(identifiers: identifiers)
                 Logger.debug(Strings.storeKit.store_product_request_finished)
-                return productsTakingBillingPlansIntoAccount
+                return products
             } catch let error as NSError {
                 Logger.debug(Strings.storeKit.store_products_request_failed(error))
                 throw ErrorUtils.storeProblemError(error: error)
             }
-        }
-    }
-
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    // swiftlint:disable:next function_body_length
-    func populateSK2CompoundProductsIfSupported(
-        requestedIdentifiers: Set<CompoundProductIdentifier>,
-        products: Set<SK2StoreProduct>
-    ) -> Set<SK2StoreProduct> {
-        // Billing plans were introduced with Xcode 26.5, which shipped with Swift version 6.3.2.
-        #if compiler(>=6.3.2)
-        if #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
-            let requestedIdentifiersWithPlanIdentifiers = requestedIdentifiers.filter {
-                $0.productPlanIdentifier != nil
-            }
-            guard !requestedIdentifiersWithPlanIdentifiers.isEmpty else {
-                return products
-            }
-
-            let productsByStoreKitProductIdentifier = products.dictionaryWithKeys({ $0.productIdentifier })
-            var productsIncludingBillingPlanProducts = products
-
-            // When the user requests a compound product ID but not the base product ID,
-            // we only want to return the compound product
-            func removeBaseProductIfNotRequested(_ product: SK2StoreProduct) {
-                guard Self.shouldRemoveBaseSK2Product(
-                    productIdentifier: product.productIdentifier,
-                    requestedIdentifiers: requestedIdentifiers
-                ) else {
-                    return
-                }
-
-                productsIncludingBillingPlanProducts.remove(product)
-            }
-
-            for compoundProductIdentifier in requestedIdentifiersWithPlanIdentifiers {
-                let storeKitProductIdentifier = compoundProductIdentifier.storeKitProductIdentifier
-                guard let productFromStoreKit = productsByStoreKitProductIdentifier[storeKitProductIdentifier] else {
-                    continue
-                }
-
-                guard let requestedBillingPlanType = compoundProductIdentifier.sk2BillingPlanType else {
-                    // Unrecognized billing plan type. Return no products for this request.
-                    Logger.warn(
-                        StoreKitStrings.sk2_no_billing_plan_found(compoundProductIdentifier: compoundProductIdentifier)
-                    )
-                    removeBaseProductIfNotRequested(productFromStoreKit)
-                    continue
-                }
-                guard let pricingTerms = productFromStoreKit.underlyingSK2Product.subscription?.pricingTerms else {
-                    Logger.warn(
-                        StoreKitStrings.sk2_no_pricing_terms_found(compoundProductIdentifier: compoundProductIdentifier)
-                    )
-                    removeBaseProductIfNotRequested(productFromStoreKit)
-                    continue
-                }
-
-                if let requestedPricingTerms = pricingTerms.first(
-                    where: { $0.billingPlanType == requestedBillingPlanType }
-                ) {
-                    let installmentsInfo: InstallmentsInfo? = installmentsInfoFactory.buildInstallmentsInfo(
-                        from: productFromStoreKit.underlyingSK2Product,
-                        billingPlanType: requestedBillingPlanType,
-                        pricingTerms: requestedPricingTerms
-                    )
-
-                    let billingPlanProduct = SK2StoreProduct(
-                        sk2Product: productFromStoreKit.underlyingSK2Product,
-                        compoundProductIdentifier: compoundProductIdentifier,
-                        installmentsInfo: installmentsInfo
-                    )
-                    productsIncludingBillingPlanProducts.insert(billingPlanProduct)
-                    removeBaseProductIfNotRequested(productFromStoreKit)
-                } else {
-                    // The requested billing plan isn't available for this user. Return no products for this request.
-                    Logger.warn(
-                        StoreKitStrings.sk2_user_not_eligible_for_billing_plan(
-                            compoundProductIdentifier: compoundProductIdentifier
-                        )
-                    )
-                    removeBaseProductIfNotRequested(productFromStoreKit)
-                }
-            }
-
-            return productsIncludingBillingPlanProducts
-        } else {
-            return products
-        }
-
-        #else
-        // Billing plans aren't supported
-        return products
-        #endif
-    }
-
-    static func shouldRemoveBaseSK2Product(
-        productIdentifier: String,
-        requestedIdentifiers: Set<CompoundProductIdentifier>
-    ) -> Bool {
-        return !requestedIdentifiers.contains {
-            $0.productPlanIdentifier == nil
-                && $0.storeKitProductIdentifier == productIdentifier
         }
     }
 
@@ -320,31 +177,6 @@ private extension ProductsManager {
         }
     }
 
-}
-
-// MARK: - Products w/ Billing Plans
-private extension ProductsManager {
-    private func areProductsWithBillingPlansSupported(compoundIdentifier: CompoundProductIdentifier) -> Bool {
-        guard self.systemInfo.storeKitVersion.isStoreKit2EnabledAndAvailable else {
-            Logger.warn(
-                StoreKitStrings.sk1_does_not_support_billing_plans(
-                    compoundProductIdentifier: compoundIdentifier
-                )
-            )
-            return false
-        }
-
-        if #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
-            return true
-        } else {
-            Logger.warn(
-                StoreKitStrings.sk2_billing_plans_are_unavailable_on_this_os_version(
-                    compoundProductIdentifier: compoundIdentifier
-                )
-            )
-            return false
-        }
-    }
 }
 
 // MARK: - ProductsManagerType async

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -264,11 +264,13 @@ private extension ProductsManager {
     func sk1Products(withIdentifiers identifiers: Set<String>,
                      completion: @escaping (Result<Set<SK1StoreProduct>, PurchasesError>) -> Void) {
         // Filter out compound product identifiers
+        var invalidProductIdentifiers: Set<String> = []
         let storeKitProductIDs: Set<String> = Set(
             identifiers.compactMap { identifier in
                 guard let compoundIdentifier = CompoundProductIdentifier(
                     compoundProductIdentifier: identifier
                 ) else {
+                    invalidProductIdentifiers.insert(identifier)
                     return nil
                 }
 
@@ -284,6 +286,9 @@ private extension ProductsManager {
                 }
             }
         )
+        if !invalidProductIdentifiers.isEmpty {
+            Logger.warn(Strings.storeKit.invalid_product_identifiers(identifiers: invalidProductIdentifiers))
+        }
 
         return self.productsFetcherSK1.products(
             withIdentifiers: storeKitProductIDs,

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -61,63 +61,28 @@ class ProductsManager: NSObject, ProductsManagerType {
     func products(withIdentifiers identifiers: Set<String>, completion: @escaping Completion) {
         let startTime = self.dateProvider.now()
 
-        // It's possible for developers to request compound product identifiers that represent both
-        // a product and a billing plan, like com.rc.sub:monthly. However, StoreKit doesn't recognize
-        // these product IDs, so here, we convert them to product IDs that StoreKit can recognize.
-        var invalidProductIdentifiers: Set<String> = []
-        let compoundProductIdentifiers: Set<CompoundProductIdentifier> = Set(
-            identifiers.compactMap { identifier in
-                guard let compoundIdentifier = CompoundProductIdentifier(compoundProductIdentifier: identifier) else {
-                    invalidProductIdentifiers.insert(identifier)
-                    return nil
-                }
-
-                if compoundIdentifier.productPlanIdentifier == nil {
-                    return compoundIdentifier   // Basic product with no billing plan
-                } else {
-                    guard self.areProductsWithBillingPlansSupported(compoundIdentifier: compoundIdentifier) else {
-                        return nil
-                    }
-
-                    return compoundIdentifier
-                }
-            }
-        )
-        if !invalidProductIdentifiers.isEmpty {
-            Logger.warn(Strings.storeKit.invalid_product_identifiers(identifiers: invalidProductIdentifiers))
-        }
-
-        let storeKitIdentifiers: Set<String> = Set(
-            compoundProductIdentifiers.map(\.storeKitProductIdentifier)
-        )
-
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
            self.systemInfo.storeKitVersion.isStoreKit2EnabledAndAvailable {
-            self.sk2Products(withIdentifiers: storeKitIdentifiers) { result in
-                let notFoundProducts = storeKitIdentifiers.subtracting(result.value?.map(\.productIdentifier) ?? [])
+            self.sk2Products(withIdentifiers: identifiers) { result in
+                let notFoundProducts = identifiers.subtracting(result.value?.map(\.productIdentifier) ?? [])
                 self.trackProductsRequestIfNeeded(startTime,
-                                                  requestedProductIds: storeKitIdentifiers,
+                                                  requestedProductIds: identifiers,
                                                   notFoundProductIds: notFoundProducts,
                                                   storeKitVersion: .storeKit2,
                                                   error: result.error)
 
                 switch result {
                 case .success(let storeProductsFromStoreKit):
-                    let productsTakingBillingPlansIntoAccount = self.populateSK2CompoundProductsIfSupported(
-                        requestedIdentifiers: compoundProductIdentifiers,
-                        products: storeProductsFromStoreKit
-                    )
-                    let storeProducts = Set(productsTakingBillingPlansIntoAccount.map(StoreProduct.from(product:)))
-                    completion(.success(storeProducts))
+                    completion(.success(Set(storeProductsFromStoreKit.map(StoreProduct.from(product:)))))
                 case .failure(let error):
                     completion(.failure(error))
                 }
             }
         } else {
-            self.sk1Products(withIdentifiers: storeKitIdentifiers) { result in
-                let notFoundProducts = storeKitIdentifiers.subtracting(result.value?.map(\.productIdentifier) ?? [])
+            self.sk1Products(withIdentifiers: identifiers) { result in
+                let notFoundProducts = identifiers.subtracting(result.value?.map(\.productIdentifier) ?? [])
                 self.trackProductsRequestIfNeeded(startTime,
-                                                  requestedProductIds: storeKitIdentifiers,
+                                                  requestedProductIds: identifiers,
                                                   notFoundProductIds: notFoundProducts,
                                                   storeKitVersion: .storeKit1,
                                                   error: result.error)
@@ -130,10 +95,43 @@ class ProductsManager: NSObject, ProductsManagerType {
     func sk2Products(withIdentifiers identifiers: Set<String>, completion: @escaping SK2Completion) {
         Async.call(with: completion) {
             do {
-                let products = try await self.productsFetcherSK2.products(identifiers: identifiers)
+                // It's possible for developers to request compound product identifiers that represent both
+                // a product and a billing plan, like com.rc.sub:monthly. However, StoreKit doesn't recognize
+                // these product IDs, so here, we convert them to product IDs that StoreKit can recognize.
+                var invalidProductIdentifiers: Set<String> = []
+                let compoundProductIdentifiers: Set<CompoundProductIdentifier> = Set(
+                    identifiers.compactMap { identifier in
+                        guard let compoundIdentifier = CompoundProductIdentifier(compoundProductIdentifier: identifier) else {
+                            invalidProductIdentifiers.insert(identifier)
+                            return nil
+                        }
+
+                        if compoundIdentifier.productPlanIdentifier == nil {
+                            return compoundIdentifier   // Basic product with no billing plan
+                        } else {
+                            guard self.areProductsWithBillingPlansSupported(compoundIdentifier: compoundIdentifier) else {
+                                return nil
+                            }
+
+                            return compoundIdentifier
+                        }
+                    }
+                )
+                if !invalidProductIdentifiers.isEmpty {
+                    Logger.warn(Strings.storeKit.invalid_product_identifiers(identifiers: invalidProductIdentifiers))
+                }
+
+                let storeKitIdentifiers: Set<String> = Set(
+                    compoundProductIdentifiers.map(\.storeKitProductIdentifier)
+                )
+
+                let products = try await self.productsFetcherSK2.products(identifiers: storeKitIdentifiers)
+                let productsTakingBillingPlansIntoAccount = self.populateSK2CompoundProductsIfSupported(
+                    requestedIdentifiers: compoundProductIdentifiers, products: products
+                )
 
                 Logger.debug(Strings.storeKit.store_product_request_finished)
-                return Set(products)
+                return productsTakingBillingPlansIntoAccount
             } catch let error as NSError {
                 Logger.debug(Strings.storeKit.store_products_request_failed(error))
                 throw ErrorUtils.storeProblemError(error: error)

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -63,7 +63,7 @@ class ProductsManager: NSObject, ProductsManagerType {
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
            self.systemInfo.storeKitVersion.isStoreKit2EnabledAndAvailable {
             self.sk2Products(withIdentifiers: identifiers) { result in
-                let notFoundProducts = identifiers.subtracting(result.value?.map(\.productIdentifier) ?? [])
+                let notFoundProducts = identifiers.subtracting(result.value?.map(\.id) ?? [])
                 self.trackProductsRequestIfNeeded(startTime,
                                                   requestedProductIds: identifiers,
                                                   notFoundProductIds: notFoundProducts,

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -263,7 +263,32 @@ private extension ProductsManager {
 
     func sk1Products(withIdentifiers identifiers: Set<String>,
                      completion: @escaping (Result<Set<SK1StoreProduct>, PurchasesError>) -> Void) {
-        return self.productsFetcherSK1.products(withIdentifiers: identifiers, completion: completion)
+        // Filter out compound product identifiers
+        let storeKitProductIDs: Set<String> = Set(
+            identifiers.compactMap { identifier in
+                guard let compoundIdentifier = CompoundProductIdentifier(
+                    compoundProductIdentifier: identifier
+                ) else {
+                    return nil
+                }
+
+                if compoundIdentifier.productPlanIdentifier == nil {
+                    return compoundIdentifier.productIdentifier
+                } else {
+                    Logger.warn(
+                        StoreKitStrings.sk1_does_not_support_billing_plans(
+                            compoundProductIdentifier: compoundIdentifier
+                        )
+                    )
+                    return nil
+                }
+            }
+        )
+
+        return self.productsFetcherSK1.products(
+            withIdentifiers: storeKitProductIDs,
+            completion: completion
+        )
     }
 
     func trackProductsRequestIfNeeded(_ startTime: Date,

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -120,35 +120,8 @@ private extension ProductsManager {
 
     func sk1Products(withIdentifiers identifiers: Set<String>,
                      completion: @escaping (Result<Set<SK1StoreProduct>, PurchasesError>) -> Void) {
-        // Filter out compound product identifiers
-        var invalidProductIdentifiers: Set<String> = []
-        let storeKitProductIDs: Set<String> = Set(
-            identifiers.compactMap { identifier in
-                guard let compoundIdentifier = CompoundProductIdentifier(
-                    compoundProductIdentifier: identifier
-                ) else {
-                    invalidProductIdentifiers.insert(identifier)
-                    return nil
-                }
-
-                if compoundIdentifier.productPlanIdentifier == nil {
-                    return compoundIdentifier.productIdentifier
-                } else {
-                    Logger.warn(
-                        StoreKitStrings.sk1_does_not_support_billing_plans(
-                            compoundProductIdentifier: compoundIdentifier
-                        )
-                    )
-                    return nil
-                }
-            }
-        )
-        if !invalidProductIdentifiers.isEmpty {
-            Logger.warn(Strings.storeKit.invalid_product_identifiers(identifiers: invalidProductIdentifiers))
-        }
-
         return self.productsFetcherSK1.products(
-            withIdentifiers: storeKitProductIDs,
+            withIdentifiers: identifiers,
             completion: completion
         )
     }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1306,7 +1306,7 @@ public extension Purchases {
 
     func checkTrialOrIntroDiscountEligibility(packages: [Package]) async -> [Package: IntroEligibility] {
         let result = await self.checkTrialOrIntroDiscountEligibility(
-            productIdentifiers: packages.map(\.storeProduct.productIdentifier)
+            productIdentifiers: packages.map(\.storeProduct.id)
         )
 
         return Set(packages)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1311,7 +1311,7 @@ public extension Purchases {
 
         return Set(packages)
             .dictionaryWithValues { (package: Package) in
-                result[package.storeProduct.productIdentifier] ?? .init(eligibilityStatus: .unknown)
+                result[package.storeProduct.id] ?? .init(eligibilityStatus: .unknown)
             }
     }
 

--- a/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -53,11 +53,16 @@ final class ProductsFetcherSK1: NSObject {
 
     func products(withIdentifiers identifiers: Set<String>,
                   completion: @escaping (Result<Set<SK1StoreProduct>, PurchasesError>) -> Void) {
+        let resolvedIdentifiers = CompoundProductIdentifierResolver.resolve(
+            identifiers,
+            supportsBillingPlans: Self.areProductsWithBillingPlansSupported
+        )
+
         TimingUtil.measureAndLogIfTooSlow(
             threshold: .productRequest,
             message: Strings.storeKit.sk1_product_request_too_slow,
             work: { completion in
-                self.sk1Products(withIdentifiers: identifiers) { skProducts in
+                self.sk1Products(withIdentifiers: resolvedIdentifiers.storeKitProductIdentifiers) { skProducts in
                     completion(skProducts.map { Set($0.map(SK1StoreProduct.init)) })
                 }
             },
@@ -103,6 +108,16 @@ final class ProductsFetcherSK1: NSObject {
 }
 
 private extension ProductsFetcherSK1 {
+
+    static func areProductsWithBillingPlansSupported(compoundIdentifier: CompoundProductIdentifier) -> Bool {
+        Logger.warn(
+            StoreKitStrings.sk1_does_not_support_billing_plans(
+                compoundProductIdentifier: compoundIdentifier
+            )
+        )
+
+        return false
+    }
 
     struct ProductRequest {
         let identifiers: Set<String>

--- a/Sources/Purchasing/StoreKit2/Products with Billing Plans/CompoundProductIdentifierResolver.swift
+++ b/Sources/Purchasing/StoreKit2/Products with Billing Plans/CompoundProductIdentifierResolver.swift
@@ -28,10 +28,12 @@ internal struct CompoundProductIdentifierResolver {
         let compoundProductIdentifiers: Set<CompoundProductIdentifier>
 
         /// Base product identifiers that can be requested from StoreKit.
-        var storeKitProductIdentifiers: Set<String> {
-            return Set(self.compoundProductIdentifiers.map(\.storeKitProductIdentifier))
-        }
+        let storeKitProductIdentifiers: Set<String>
 
+        init(compoundProductIdentifiers: Set<CompoundProductIdentifier>) {
+            self.compoundProductIdentifiers = compoundProductIdentifiers
+            self.storeKitProductIdentifiers = Set(compoundProductIdentifiers.map(\.storeKitProductIdentifier))
+        }
     }
 
     /// Parses and filters SDK-facing product identifiers.

--- a/Sources/Purchasing/StoreKit2/Products with Billing Plans/CompoundProductIdentifierResolver.swift
+++ b/Sources/Purchasing/StoreKit2/Products with Billing Plans/CompoundProductIdentifierResolver.swift
@@ -1,0 +1,79 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CompoundProductIdentifierResolver.swift
+//
+//  Created by Will Taylor on 5/26/2026.
+//
+
+import Foundation
+
+/// Converts SDK-facing product identifier strings into the identifiers that StoreKit can request.
+///
+/// The SDK can receive identifiers that include both a StoreKit product ID and an optional billing-plan ID,
+/// such as `com.revenuecat.subscription:monthly`. StoreKit product lookups only accept the base product ID, so
+/// this resolver centralizes parsing, invalid identifier logging, billing-plan filtering, and conversion to
+/// StoreKit-facing product identifiers.
+// swiftlint:disable:next convenience_type
+internal struct CompoundProductIdentifierResolver {
+
+    /// The result of resolving SDK-facing product identifiers.
+    internal struct ResolvedIdentifiers {
+        let compoundProductIdentifiers: Set<CompoundProductIdentifier>
+
+        /// Base product identifiers that can be requested from StoreKit.
+        var storeKitProductIdentifiers: Set<String> {
+            return Set(self.compoundProductIdentifiers.map(\.storeKitProductIdentifier))
+        }
+
+    }
+
+    /// Parses and filters SDK-facing product identifiers.
+    ///
+    /// Invalid identifiers are dropped and logged once. Base product identifiers are always retained. Billing-plan
+    /// identifiers are retained only when `supportsBillingPlans` returns `true`, which lets SK1 and SK2 use the same
+    /// parsing logic while keeping their StoreKit-specific support rules and warning messages separate.
+    ///
+    /// - Parameters:
+    ///   - identifiers: SDK-facing product identifiers requested by the caller.
+    ///   - supportsBillingPlans: StoreKit-specific policy called for identifiers with a product plan.
+    /// - Returns: Parsed compound identifiers and their StoreKit-requestable base identifiers.
+    static func resolve(
+        _ identifiers: Set<String>,
+        supportsBillingPlans: (CompoundProductIdentifier) -> Bool
+    ) -> ResolvedIdentifiers {
+        var invalidProductIdentifiers: Set<String> = []
+
+        let compoundProductIdentifiers: Set<CompoundProductIdentifier> = Set(
+            identifiers.compactMap { identifier in
+                guard let compoundIdentifier = CompoundProductIdentifier(
+                    compoundProductIdentifier: identifier
+                ) else {
+                    invalidProductIdentifiers.insert(identifier)
+                    return nil
+                }
+
+                guard compoundIdentifier.productPlanIdentifier != nil else {
+                    return compoundIdentifier
+                }
+
+                return supportsBillingPlans(compoundIdentifier)
+                    ? compoundIdentifier
+                    : nil
+            }
+        )
+
+        if !invalidProductIdentifiers.isEmpty {
+            Logger.warn(Strings.storeKit.invalid_product_identifiers(identifiers: invalidProductIdentifiers))
+        }
+
+        return .init(compoundProductIdentifiers: compoundProductIdentifiers)
+    }
+
+}

--- a/Sources/Purchasing/StoreKit2/ProductsFetcherSK2.swift
+++ b/Sources/Purchasing/StoreKit2/ProductsFetcherSK2.swift
@@ -31,14 +31,14 @@ actor ProductsFetcherSK2 {
 
     /// - Throws: `ProductsFetcherSK2.Error`
     func products(identifiers: Set<String>) async throws -> Set<SK2StoreProduct> {
-        let compoundProductIdentifiers = self.compoundProductIdentifiers(from: identifiers)
-        let storeKitIdentifiers: Set<String> = Set(
-            compoundProductIdentifiers.map(\.storeKitProductIdentifier)
+        let resolvedIdentifiers = CompoundProductIdentifierResolver.resolve(
+            identifiers,
+            supportsBillingPlans: Self.areProductsWithBillingPlansSupported
         )
 
-        let products = try await self.storeKitProducts(identifiers: storeKitIdentifiers)
+        let products = try await self.storeKitProducts(identifiers: resolvedIdentifiers.storeKitProductIdentifiers)
         return self.populateSK2CompoundProductsIfSupported(
-            requestedIdentifiers: compoundProductIdentifiers,
+            requestedIdentifiers: resolvedIdentifiers.compoundProductIdentifiers,
             products: products
         )
     }
@@ -62,40 +62,6 @@ private extension ProductsFetcherSK2 {
         } catch {
             throw Error.productsRequestError(innerError: error)
         }
-    }
-
-    func compoundProductIdentifiers(from identifiers: Set<String>) -> Set<CompoundProductIdentifier> {
-        // It's possible for developers to request compound product identifiers that represent both
-        // a product and a billing plan, like com.rc.sub:monthly. However, StoreKit doesn't recognize
-        // these product IDs, so here, we convert them to product IDs that StoreKit can recognize.
-        var invalidProductIdentifiers: Set<String> = []
-        let compoundProductIdentifiers: Set<CompoundProductIdentifier> = Set(
-            identifiers.compactMap { identifier in
-                guard let compoundIdentifier = CompoundProductIdentifier(
-                    compoundProductIdentifier: identifier
-                ) else {
-                    invalidProductIdentifiers.insert(identifier)
-                    return nil
-                }
-
-                if compoundIdentifier.productPlanIdentifier == nil {
-                    return compoundIdentifier   // Basic product with no billing plan
-                } else {
-                    guard Self.areProductsWithBillingPlansSupported(
-                        compoundIdentifier: compoundIdentifier
-                    ) else {
-                        return nil
-                    }
-
-                    return compoundIdentifier
-                }
-            }
-        )
-        if !invalidProductIdentifiers.isEmpty {
-            Logger.warn(Strings.storeKit.invalid_product_identifiers(identifiers: invalidProductIdentifiers))
-        }
-
-        return compoundProductIdentifiers
     }
 
     static func areProductsWithBillingPlansSupported(compoundIdentifier: CompoundProductIdentifier) -> Bool {

--- a/Sources/Purchasing/StoreKit2/ProductsFetcherSK2.swift
+++ b/Sources/Purchasing/StoreKit2/ProductsFetcherSK2.swift
@@ -17,14 +17,38 @@ import StoreKit
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 actor ProductsFetcherSK2 {
 
+    private let installmentsInfoFactory: InstallmentsInfoFactoryType
+
     enum Error: Swift.Error {
 
         case productsRequestError(innerError: Swift.Error)
 
     }
 
+    init(installmentsInfoFactory: InstallmentsInfoFactoryType = InstallmentsInfoFactory()) {
+        self.installmentsInfoFactory = installmentsInfoFactory
+    }
+
     /// - Throws: `ProductsFetcherSK2.Error`
     func products(identifiers: Set<String>) async throws -> Set<SK2StoreProduct> {
+        let compoundProductIdentifiers = self.compoundProductIdentifiers(from: identifiers)
+        let storeKitIdentifiers: Set<String> = Set(
+            compoundProductIdentifiers.map(\.storeKitProductIdentifier)
+        )
+
+        let products = try await self.storeKitProducts(identifiers: storeKitIdentifiers)
+        return self.populateSK2CompoundProductsIfSupported(
+            requestedIdentifiers: compoundProductIdentifiers,
+            products: products
+        )
+    }
+
+}
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+private extension ProductsFetcherSK2 {
+
+    func storeKitProducts(identifiers: Set<String>) async throws -> Set<SK2StoreProduct> {
         do {
             let storeKitProducts = try await TimingUtil.measureAndLogIfTooSlow(
                 threshold: .productRequest,
@@ -37,6 +61,164 @@ actor ProductsFetcherSK2 {
             return Set(storeKitProducts.map { SK2StoreProduct(sk2Product: $0) })
         } catch {
             throw Error.productsRequestError(innerError: error)
+        }
+    }
+
+    func compoundProductIdentifiers(from identifiers: Set<String>) -> Set<CompoundProductIdentifier> {
+        // It's possible for developers to request compound product identifiers that represent both
+        // a product and a billing plan, like com.rc.sub:monthly. However, StoreKit doesn't recognize
+        // these product IDs, so here, we convert them to product IDs that StoreKit can recognize.
+        var invalidProductIdentifiers: Set<String> = []
+        let compoundProductIdentifiers: Set<CompoundProductIdentifier> = Set(
+            identifiers.compactMap { identifier in
+                guard let compoundIdentifier = CompoundProductIdentifier(
+                    compoundProductIdentifier: identifier
+                ) else {
+                    invalidProductIdentifiers.insert(identifier)
+                    return nil
+                }
+
+                if compoundIdentifier.productPlanIdentifier == nil {
+                    return compoundIdentifier   // Basic product with no billing plan
+                } else {
+                    guard Self.areProductsWithBillingPlansSupported(
+                        compoundIdentifier: compoundIdentifier
+                    ) else {
+                        return nil
+                    }
+
+                    return compoundIdentifier
+                }
+            }
+        )
+        if !invalidProductIdentifiers.isEmpty {
+            Logger.warn(Strings.storeKit.invalid_product_identifiers(identifiers: invalidProductIdentifiers))
+        }
+
+        return compoundProductIdentifiers
+    }
+
+    static func areProductsWithBillingPlansSupported(compoundIdentifier: CompoundProductIdentifier) -> Bool {
+        if #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
+            return true
+        } else {
+            Logger.warn(
+                StoreKitStrings.sk2_billing_plans_are_unavailable_on_this_os_version(
+                    compoundProductIdentifier: compoundIdentifier
+                )
+            )
+            return false
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    func populateSK2CompoundProductsIfSupported(
+        requestedIdentifiers: Set<CompoundProductIdentifier>,
+        products: Set<SK2StoreProduct>
+    ) -> Set<SK2StoreProduct> {
+        // Billing plans were introduced with Xcode 26.5, which shipped with Swift version 6.3.2.
+        #if compiler(>=6.3.2)
+        if #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
+            let requestedIdentifiersWithPlanIdentifiers = requestedIdentifiers.filter {
+                $0.productPlanIdentifier != nil
+            }
+            guard !requestedIdentifiersWithPlanIdentifiers.isEmpty else {
+                return products
+            }
+
+            let productsByStoreKitProductIdentifier = products.dictionaryWithKeys({ $0.productIdentifier })
+            var productsIncludingBillingPlanProducts = products
+
+            // When the user requests a compound product ID but not the base product ID,
+            // we only want to return the compound product.
+            func removeBaseProductIfNotRequested(_ product: SK2StoreProduct) {
+                guard Self.shouldRemoveBaseSK2Product(
+                    productIdentifier: product.productIdentifier,
+                    requestedIdentifiers: requestedIdentifiers
+                ) else {
+                    return
+                }
+
+                productsIncludingBillingPlanProducts.remove(product)
+            }
+
+            for compoundProductIdentifier in requestedIdentifiersWithPlanIdentifiers {
+                let storeKitProductIdentifier = compoundProductIdentifier.storeKitProductIdentifier
+                guard let productFromStoreKit = productsByStoreKitProductIdentifier[storeKitProductIdentifier] else {
+                    continue
+                }
+
+                guard let requestedBillingPlanType = compoundProductIdentifier.sk2BillingPlanType else {
+                    // Unrecognized billing plan type. Return no products for this request.
+                    Logger.warn(
+                        StoreKitStrings.sk2_no_billing_plan_found(compoundProductIdentifier: compoundProductIdentifier)
+                    )
+                    removeBaseProductIfNotRequested(productFromStoreKit)
+                    continue
+                }
+                guard let pricingTerms = productFromStoreKit.underlyingSK2Product.subscription?.pricingTerms else {
+                    Logger.warn(
+                        StoreKitStrings.sk2_no_pricing_terms_found(compoundProductIdentifier: compoundProductIdentifier)
+                    )
+                    removeBaseProductIfNotRequested(productFromStoreKit)
+                    continue
+                }
+
+                if let requestedPricingTerms = pricingTerms.first(
+                    where: { $0.billingPlanType == requestedBillingPlanType }
+                ) {
+                    let installmentsInfo: InstallmentsInfo? = installmentsInfoFactory.buildInstallmentsInfo(
+                        from: productFromStoreKit.underlyingSK2Product,
+                        billingPlanType: requestedBillingPlanType,
+                        pricingTerms: requestedPricingTerms
+                    )
+
+                    let billingPlanProduct = SK2StoreProduct(
+                        sk2Product: productFromStoreKit.underlyingSK2Product,
+                        compoundProductIdentifier: compoundProductIdentifier,
+                        installmentsInfo: installmentsInfo
+                    )
+                    productsIncludingBillingPlanProducts.insert(billingPlanProduct)
+                    removeBaseProductIfNotRequested(productFromStoreKit)
+                } else {
+                    // The requested billing plan isn't available for this user. Return no products for this request.
+                    Logger.warn(
+                        StoreKitStrings.sk2_user_not_eligible_for_billing_plan(
+                            compoundProductIdentifier: compoundProductIdentifier
+                        )
+                    )
+                    removeBaseProductIfNotRequested(productFromStoreKit)
+                }
+            }
+
+            return productsIncludingBillingPlanProducts
+        } else {
+            return products
+        }
+
+        #else
+        // Billing plans aren't supported.
+        return products
+        #endif
+    }
+}
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+extension ProductsFetcherSK2 {
+
+    /// Returns `true` when StoreKit returned the base product only as an intermediate lookup result
+    /// for a requested compound product identifier.
+    ///
+    /// StoreKit can only fetch the base product identifier. If the caller requested `product:monthly`
+    /// without also requesting `product`, the base product should be replaced by the billing-plan
+    /// product so the response only contains products matching the original request.
+    static func shouldRemoveBaseSK2Product(
+        productIdentifier: String,
+        requestedIdentifiers: Set<CompoundProductIdentifier>
+    ) -> Bool {
+        return !requestedIdentifiers.contains {
+            $0.productPlanIdentifier == nil
+                && $0.storeKitProductIdentifier == productIdentifier
         }
     }
 

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -139,6 +139,33 @@ private extension SK2StoreProduct {
 
 }
 
+#if compiler(>=6.3.2)
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+extension SK2StoreProduct {
+    func contains(
+        subscriptionOfferType: StoreKit.Product.SubscriptionOffer.OfferType,
+        on billingPlanType: BillingPlanType
+    ) -> Bool {
+        if let subscription = self.underlyingSK2Product.subscription,
+            #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
+            // Check to make sure that an intro offer is available on the billing plan
+            guard let applicablePricingTerms = subscription.pricingTerms.first(where: {
+                $0.billingPlanType == billingPlanType.skBillingPlanType
+            }) else {
+                return false
+            }
+
+            return applicablePricingTerms.subscriptionOffers.contains(where: {
+                $0.type == subscriptionOfferType
+            })
+        } else {
+            // Billing plan doesn't exist
+            return false
+        }
+    }
+}
+#endif
+
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 extension SK2StoreProduct: Hashable {
 

--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -172,20 +172,13 @@ class TrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheckerTy
 
         #if compiler(>=6.3.2)
         if let installmentsInfo = sk2StoreProduct.installmentsInfo,
-           let subscription = sk2Product.subscription,
-            #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
-            // Check to make sure that an intro offer is available on the billing plan
-            guard let applicablePricingTerms = subscription.pricingTerms.first(where: {
-                $0.billingPlanType == installmentsInfo.billingPlanType.skBillingPlanType
-            }) else {
-                return .unknown
-            }
+           let subscription = sk2Product.subscription {
+            let billingPlanContainsIntroOffer = sk2StoreProduct.contains(
+                subscriptionOfferType: .introductory,
+                on: installmentsInfo.billingPlanType
+            )
 
-            let containsIntroOffer = applicablePricingTerms.subscriptionOffers.contains(where: {
-                $0.type == .introductory
-            })
-
-            guard containsIntroOffer else {
+            guard billingPlanContainsIntroOffer else {
                 return .noIntroOfferExists
             }
 

--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -152,32 +152,62 @@ class TrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheckerTy
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func sk2CheckEligibility(_ productIdentifiers: Set<String>) async throws -> [String: IntroEligibility] {
-        var introDictionary: [String: IntroEligibility] = productIdentifiers.dictionaryWithValues { _ in
+    func sk2CheckEligibility(_ compoundProductIdentifiers: Set<String>) async throws -> [String: IntroEligibility] {
+        var introDictionary: [String: IntroEligibility] = compoundProductIdentifiers.dictionaryWithValues { _ in
                 .init(eligibilityStatus: .unknown)
         }
 
-        let products = try await self.productsManager.sk2Products(withIdentifiers: productIdentifiers)
+        let products = try await self.productsManager.sk2Products(withIdentifiers: compoundProductIdentifiers)
         for sk2StoreProduct in products {
-            let sk2Product = sk2StoreProduct.underlyingSK2Product
-
-            let eligibilityStatus: IntroEligibilityStatus
-
-            if let subscription = sk2Product.subscription, subscription.introductoryOffer != nil {
-                let isEligible = await TimingUtil.measureAndLogIfTooSlow(
-                    threshold: .introEligibility,
-                    message: Strings.eligibility.sk2_intro_eligibility_too_slow.description) {
-                        return await subscription.isEligibleForIntroOffer
-                    }
-                eligibilityStatus = isEligible ? .eligible : .ineligible
-            } else {
-                eligibilityStatus = .noIntroOfferExists
-            }
-
-            introDictionary[sk2StoreProduct.productIdentifier] = .init(eligibilityStatus: eligibilityStatus)
+            let eligibilityStatus: IntroEligibilityStatus = await checkEligibility(for: sk2StoreProduct)
+            introDictionary[sk2StoreProduct.id] = .init(eligibilityStatus: eligibilityStatus)
         }
 
         return introDictionary
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    private func checkEligibility(for sk2StoreProduct: SK2StoreProduct) async -> IntroEligibilityStatus {
+        let sk2Product = sk2StoreProduct.underlyingSK2Product
+
+        #if compiler(>=6.3.2)
+        if let installmentsInfo = sk2StoreProduct.installmentsInfo,
+           let subscription = sk2Product.subscription,
+            #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
+            // Check to make sure that an intro offer is available on the billing plan
+            guard let applicablePricingTerms = subscription.pricingTerms.first(where: {
+                $0.billingPlanType == installmentsInfo.billingPlanType.skBillingPlanType
+            }) else {
+                return .unknown
+            }
+
+            let containsIntroOffer = applicablePricingTerms.subscriptionOffers.contains(where: {
+                $0.type == .introductory
+            })
+
+            guard containsIntroOffer else {
+                return .noIntroOfferExists
+            }
+
+            let isEligible = await TimingUtil.measureAndLogIfTooSlow(
+                threshold: .introEligibility,
+                message: Strings.eligibility.sk2_intro_eligibility_too_slow.description) {
+                    return await subscription.isEligibleForIntroOffer
+                }
+            return isEligible ? .eligible : .ineligible
+        }
+        #endif
+
+        if let subscription = sk2Product.subscription, subscription.introductoryOffer != nil {
+            let isEligible = await TimingUtil.measureAndLogIfTooSlow(
+                threshold: .introEligibility,
+                message: Strings.eligibility.sk2_intro_eligibility_too_slow.description) {
+                    return await subscription.isEligibleForIntroOffer
+                }
+            return isEligible ? .eligible : .ineligible
+        } else {
+            return .noIntroOfferExists
+        }
     }
 
 }
@@ -186,8 +216,8 @@ class TrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheckerTy
 extension TrialOrIntroPriceEligibilityCheckerType {
 
     func checkEligibility(product: StoreProductType, completion: @escaping (IntroEligibilityStatus) -> Void) {
-        self.checkEligibility(productIdentifiers: [product.productIdentifier]) { eligibility in
-            completion(eligibility[product.productIdentifier]?.status ?? .unknown)
+        self.checkEligibility(productIdentifiers: [product.id]) { eligibility in
+            completion(eligibility[product.id]?.status ?? .unknown)
         }
     }
 

--- a/Tests/StoreKitUnitTests/ProductsFetcherSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/ProductsFetcherSK2Tests.swift
@@ -35,4 +35,29 @@ class ProductsFetcherSK2Tests: StoreKitConfigTestCase {
 
     }
 
+    func testBaseSK2ProductIsRemovedWhenOnlyCompoundIdentifierIsRequested() throws {
+        let storeKitProductIdentifier = "com.revenuecat.subscription"
+        let requestedIdentifiers: Set<CompoundProductIdentifier> = [
+            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: "\(storeKitProductIdentifier):monthly"))
+        ]
+
+        expect(ProductsFetcherSK2.shouldRemoveBaseSK2Product(
+            productIdentifier: storeKitProductIdentifier,
+            requestedIdentifiers: requestedIdentifiers
+        )) == true
+    }
+
+    func testBaseSK2ProductIsKeptWhenBaseAndCompoundIdentifiersAreRequested() throws {
+        let storeKitProductIdentifier = "com.revenuecat.subscription"
+        let requestedIdentifiers: Set<CompoundProductIdentifier> = [
+            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: storeKitProductIdentifier)),
+            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: "\(storeKitProductIdentifier):monthly"))
+        ]
+
+        expect(ProductsFetcherSK2.shouldRemoveBaseSK2Product(
+            productIdentifier: storeKitProductIdentifier,
+            requestedIdentifiers: requestedIdentifiers
+        )) == false
+    }
+
 }

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -244,31 +244,6 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         })
     }
 
-    func testBaseSK2ProductIsRemovedWhenOnlyCompoundIdentifierIsRequested() throws {
-        let storeKitProductIdentifier = "com.revenuecat.subscription"
-        let requestedIdentifiers: Set<CompoundProductIdentifier> = [
-            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: "\(storeKitProductIdentifier):monthly"))
-        ]
-
-        expect(ProductsManager.shouldRemoveBaseSK2Product(
-            productIdentifier: storeKitProductIdentifier,
-            requestedIdentifiers: requestedIdentifiers
-        )) == true
-    }
-
-    func testBaseSK2ProductIsKeptWhenBaseAndCompoundIdentifiersAreRequested() throws {
-        let storeKitProductIdentifier = "com.revenuecat.subscription"
-        let requestedIdentifiers: Set<CompoundProductIdentifier> = [
-            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: storeKitProductIdentifier)),
-            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: "\(storeKitProductIdentifier):monthly"))
-        ]
-
-        expect(ProductsManager.shouldRemoveBaseSK2Product(
-            productIdentifier: storeKitProductIdentifier,
-            requestedIdentifiers: requestedIdentifiers
-        )) == false
-    }
-
     func testClearCacheAfterStorefrontChangesSK1() async throws {
         let manager = self.createManager(storeKitVersion: .storeKit1)
 

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -194,7 +194,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
     func testFetchProductsWithInvalidCompoundIdentifiersLogsWarning() throws {
         let productsRequestFactory = MockProductsRequestFactory()
         let manager = self.createManager(
-            storeKitVersion: .storeKit1,
+            storeKitVersion: .storeKit2,
             productsRequestFactory: productsRequestFactory
         )
         self.logger.clearMessages()
@@ -224,7 +224,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
     func testFetchProductsWithValidCompoundIdentifiersDoesNotLogWarning() throws {
         let productsRequestFactory = MockProductsRequestFactory()
         let manager = self.createManager(
-            storeKitVersion: .storeKit1,
+            storeKitVersion: .storeKit2,
             productsRequestFactory: productsRequestFactory
         )
         self.logger.clearMessages()
@@ -238,7 +238,6 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         }
 
         _ = try XCTUnwrap(receivedProducts?.get())
-        expect(productsRequestFactory.invokedRequestParameters) == ["com.revenuecat.sub"]
         expect(self.logger.messages).toNot(containElementSatisfying { message in
             message.level == .warn
                 && message.message.contains("Invalid product identifiers were ignored")

--- a/Tests/UnitTests/Purchasing/StoreKitAbstractions/CompoundProductIdentifierResolverTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitAbstractions/CompoundProductIdentifierResolverTests.swift
@@ -1,0 +1,146 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CompoundProductIdentifierResolverTests.swift
+//
+//  Created by Will Taylor on 5/26/26.
+//
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+class CompoundProductIdentifierResolverTests: TestCase {
+
+    func testResolverDropsInvalidIdentifiersAndLogsWarningOnce() throws {
+        self.logger.clearMessages()
+
+        let resolvedIdentifiers = CompoundProductIdentifierResolver.resolve(
+            [
+                "",
+                "com.revenuecat.subscription",
+                "com.revenuecat.subscription:monthly:extra"
+            ],
+            supportsBillingPlans: { _ in true }
+        )
+
+        expect(resolvedIdentifiers.compoundProductIdentifiers) == Set([
+            try XCTUnwrap(CompoundProductIdentifier(
+                compoundProductIdentifier: "com.revenuecat.subscription"
+            ))
+        ])
+        expect(resolvedIdentifiers.storeKitProductIdentifiers) == Set(["com.revenuecat.subscription"])
+
+        let invalidIdentifierWarningCount = self.logger.messages.filter { message in
+            message.level == .warn
+                && message.message.contains("Invalid product identifiers were ignored")
+        }.count
+        expect(invalidIdentifierWarningCount) == 1
+        self.logger.verifyMessageWasLogged(
+            regexPattern: "Invalid product identifiers were ignored: .*com\\.revenuecat\\.subscription:monthly:extra",
+            level: .warn
+        )
+        self.logger.verifyMessageWasLogged(
+            regexPattern: "Invalid product identifiers were ignored: .*\"\"",
+            level: .warn
+        )
+    }
+
+    func testResolverRetainsBaseIdentifiers() throws {
+        let resolvedIdentifiers = CompoundProductIdentifierResolver.resolve(
+            [
+                "com.revenuecat.monthly",
+                "com.revenuecat.annual"
+            ],
+            supportsBillingPlans: { _ in false }
+        )
+
+        expect(resolvedIdentifiers.compoundProductIdentifiers) == Set([
+            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: "com.revenuecat.monthly")),
+            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: "com.revenuecat.annual"))
+        ])
+        expect(resolvedIdentifiers.storeKitProductIdentifiers) == Set([
+            "com.revenuecat.monthly",
+            "com.revenuecat.annual"
+        ])
+    }
+
+    func testResolverRetainsBillingPlanIdentifiersWhenSupported() throws {
+        let resolvedIdentifiers = CompoundProductIdentifierResolver.resolve(
+            [
+                "com.revenuecat.subscription:monthly",
+                "com.revenuecat.subscription:upFront"
+            ],
+            supportsBillingPlans: { _ in true }
+        )
+
+        expect(resolvedIdentifiers.compoundProductIdentifiers) == Set([
+            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: "com.revenuecat.subscription:monthly")),
+            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: "com.revenuecat.subscription:upFront"))
+        ])
+        expect(resolvedIdentifiers.storeKitProductIdentifiers) == Set(["com.revenuecat.subscription"])
+    }
+
+    func testResolverDropsBillingPlanIdentifiersWhenUnsupported() {
+        let resolvedIdentifiers = CompoundProductIdentifierResolver.resolve(
+            [
+                "com.revenuecat.subscription:monthly",
+                "com.revenuecat.subscription:upFront"
+            ],
+            supportsBillingPlans: { _ in false }
+        )
+
+        expect(resolvedIdentifiers.compoundProductIdentifiers).to(beEmpty())
+        expect(resolvedIdentifiers.storeKitProductIdentifiers).to(beEmpty())
+    }
+
+    func testResolverDeduplicatesStoreKitProductIdentifiersForSharedBaseProduct() throws {
+        let resolvedIdentifiers = CompoundProductIdentifierResolver.resolve(
+            [
+                "com.revenuecat.subscription",
+                "com.revenuecat.subscription:monthly",
+                "com.revenuecat.subscription:upFront"
+            ],
+            supportsBillingPlans: { _ in true }
+        )
+
+        expect(resolvedIdentifiers.compoundProductIdentifiers) == Set([
+            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: "com.revenuecat.subscription")),
+            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: "com.revenuecat.subscription:monthly")),
+            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: "com.revenuecat.subscription:upFront"))
+        ])
+        expect(resolvedIdentifiers.storeKitProductIdentifiers) == Set(["com.revenuecat.subscription"])
+    }
+
+    func testResolverResolvesMixedInput() throws {
+        let resolvedIdentifiers = CompoundProductIdentifierResolver.resolve(
+            [
+                "",
+                "com.revenuecat.base",
+                "com.revenuecat.subscription:monthly",
+                "com.revenuecat.other_subscription:upFront",
+                "com.revenuecat.invalid:monthly:extra"
+            ],
+            supportsBillingPlans: { compoundIdentifier in
+                compoundIdentifier.productPlanIdentifier == "monthly"
+            }
+        )
+
+        expect(resolvedIdentifiers.compoundProductIdentifiers) == Set([
+            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: "com.revenuecat.base")),
+            try XCTUnwrap(CompoundProductIdentifier(compoundProductIdentifier: "com.revenuecat.subscription:monthly"))
+        ])
+        expect(resolvedIdentifiers.storeKitProductIdentifiers) == Set([
+            "com.revenuecat.base",
+            "com.revenuecat.subscription"
+        ])
+    }
+
+}


### PR DESCRIPTION
### Motiviation
Determining intro offer eligibility when using billing plans is a bit nuanced. Before using billing plans, we could simply check if:
- The product is a subscription
- The product has an introductory offer on it
- `subscription.isEligibleForIntroOffer`

However, developers can specify separate offers for each billing plan on a product. To determine if a user is eligible for an introductory offer on a specific billing plan, we must first check if the billing plan has an intro offer on it, and then check `subscription.isEligibleForIntroOffer`.

### Description
Updates the logic for determining intro offer eligibility by first checking if an intro offer is available on the requested billing plan before checking `subscription.isEligibleForIntroOffer`.

### Testing
- Manually tested the changes through the purchase tester app.
- Unfortunately, we can't write integration tests for this yet since we can't fetch products on iOS 26.4+ due to a StoreKit bug 🥺

### Follow Up PRs
Similar PRs will need to be created for checking promo offer and winback offer eligibility. Those checks were intentionally left out of this PR to keep its size down.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches product fetch and intro-eligibility paths for billing-plan compound IDs; behavior changes for SK2 plan-specific products but is guarded by OS/compiler availability and covered by new unit tests.
> 
> **Overview**
> Refactors **billing-plan / compound product ID** handling and fixes **StoreKit 2 intro-offer eligibility** when products use plan-specific IDs (e.g. `com.app.sub:monthly`).
> 
> **Compound product resolution** is centralized in `CompoundProductIdentifierResolver`, which parses SDK-facing IDs, logs invalid ones, filters billing-plan requests via StoreKit-specific policy, and maps to base StoreKit product IDs. **SK1** and **SK2 fetchers** now call the resolver (SK1 always rejects billing plans with a warning; SK2 allows them on iOS 26.4+). **Billing-plan product expansion** (pricing terms, installments, replacing base products when only a compound ID was requested) moves from `ProductsManager` into `ProductsFetcherSK2`; `ProductsManager` delegates fetches without duplicating that logic.
> 
> **Intro eligibility** for SK2 now checks whether the **requested billing plan** actually has an introductory offer (`SK2StoreProduct.contains`) before using `subscription.isEligibleForIntroOffer`, instead of relying only on the subscription-level intro offer. Package-level eligibility lookups use `storeProduct.id` (compound ID when applicable) so results align with billing-plan products.
> 
> Tests for the resolver and `shouldRemoveBaseSK2Product` are added/relocated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe450ed9e4c2a3a876e4eb36f3ebdc0a34276244. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->