### PR TITLE
Warm intro eligibility cache for all offerings

### DIFF
--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -22,6 +22,9 @@ protocol PaywallCacheWarmingType: Sendable {
     func warmUpEligibilityCache(offerings: Offerings) async
 
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
+    func clearEligibilityCache() async
+
+    @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
     func warmUpPaywallImagesCache(offerings: Offerings) async
 
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
@@ -57,7 +60,7 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
     private let fontsManager: PaywallFontManagerType
     private let fileRepository: FileRepositoryType
 
-    private var hasLoadedEligibility = false
+    private var warmedEligibilityProductIdentifiers: Set<String> = []
     private var hasLoadedImages = false
     private var hasLoadedVideos = false
     private var warmedWorkflowIDs: Set<String> = []
@@ -73,15 +76,51 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
         self.fileRepository = fileRepository
     }
 
-    func warmUpEligibilityCache(offerings: Offerings) {
-        guard !self.hasLoadedEligibility else { return }
-        self.hasLoadedEligibility = true
+    /// Warms up the intro eligibility cache for products across all offerings.
+    ///
+    /// To avoid penalizing the current offering's warm-up with the cost of fetching eligibility for
+    /// the rest of the offerings, the work is staggered: the current offering's products are
+    /// warmed up first, and only after that completes are the remaining offerings warmed up.
+    ///
+    /// Products that have already been warmed up are skipped on subsequent calls.
+    /// Call ``clearEligibilityCache()`` to reset the tracking (e.g. when `CustomerInfo` changes).
+    func warmUpEligibilityCache(offerings: Offerings) async {
+        let currentProducts = offerings.productIdentifiersInCurrentOffering
+            .subtracting(self.warmedEligibilityProductIdentifiers)
 
-        let productIdentifiers = offerings.allProductIdentifiersInPaywalls
-        guard !productIdentifiers.isEmpty else { return }
+        if !currentProducts.isEmpty {
+            self.warmedEligibilityProductIdentifiers.formUnion(currentProducts)
+            await Self.checkEligibility(productIdentifiers: currentProducts, checker: self.introEligibiltyChecker)
+        }
 
+        let remainingProducts = offerings.allProductIdentifiers
+            .subtracting(self.warmedEligibilityProductIdentifiers)
+
+        if !remainingProducts.isEmpty {
+            self.warmedEligibilityProductIdentifiers.formUnion(remainingProducts)
+            await Self.checkEligibility(productIdentifiers: remainingProducts, checker: self.introEligibiltyChecker)
+        }
+    }
+
+    /// Resets the set of product identifiers that have been warmed up for intro eligibility.
+    ///
+    /// Should be called whenever the underlying eligibility cache is cleared (e.g. on
+    /// `CustomerInfo` changes) so that the next call to ``warmUpEligibilityCache(offerings:)``
+    /// re-populates the cache.
+    func clearEligibilityCache() {
+        self.warmedEligibilityProductIdentifiers.removeAll(keepingCapacity: false)
+    }
+
+    private static func checkEligibility(
+        productIdentifiers: Set<String>,
+        checker: TrialOrIntroPriceEligibilityCheckerType
+    ) async {
         Logger.debug(Strings.paywalls.warming_up_eligibility_cache(products: productIdentifiers))
-        self.introEligibiltyChecker.checkEligibility(productIdentifiers: productIdentifiers) { _ in }
+        _ = await Async.call { completion in
+            checker.checkEligibility(productIdentifiers: productIdentifiers) { result in
+                completion(result)
+            }
+        }
     }
 
     func warmUpPaywallImagesCache(offerings: Offerings) async {
@@ -278,12 +317,16 @@ private extension Offerings {
         return self.current.map { [$0] } ?? []
     }
 
-    var allProductIdentifiersInPaywalls: Set<String> {
-        return .init(
-            self
-                .offeringsToPreWarm
-                .lazy
-                .flatMap(\.productIdentifiersInPaywall)
+    var productIdentifiersInCurrentOffering: Set<String> {
+        guard let current = self.current else { return [] }
+        return Set(current.availablePackages.lazy.map(\.storeProduct.productIdentifier))
+    }
+
+    var allProductIdentifiers: Set<String> {
+        return Set(
+            self.all.values.lazy
+                .flatMap(\.availablePackages)
+                .map(\.storeProduct.productIdentifier)
         )
     }
 
@@ -357,21 +400,6 @@ private extension Offerings {
 
     #endif
 
-}
-
-private extension Offering {
-
-    var productIdentifiersInPaywall: Set<String> {
-        guard let paywall = self.paywall else { return [] }
-
-        let packageTypes = Set(paywall.config.packages)
-        return Set(
-            self.availablePackages
-                .lazy
-                .filter { packageTypes.contains($0.identifier) }
-                .map(\.storeProduct.productIdentifier)
-        )
-    }
 }
 
 private extension PaywallData.Configuration.Images {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -957,7 +957,11 @@ public extension Purchases {
     ) {
         self.offeringsManager.offerings(appUserID: self.appUserID,
                                         fetchPolicy: fetchPolicy,
-                                        fetchCurrent: fetchCurrent) { @Sendable result in
+                                        fetchCurrent: fetchCurrent) { [weak self] result in
+            if #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *),
+               let offerings = result.value {
+                self?.warmUpCaches(offerings: offerings)
+            }
             completion(result.value, result.error?.asPublicError)
         }
     }
@@ -2407,6 +2411,13 @@ private extension Purchases {
         if old != nil {
             self.trialOrIntroPriceEligibilityChecker.clearCache()
             self.purchasedProductsFetcher?.clearCache()
+
+            if #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *),
+               let cache = self.paywallCache {
+                self.operationDispatcher.dispatchOnWorkerThread {
+                    await cache.clearEligibilityCache()
+                }
+            }
         }
 
         self.delegate?.purchases?(self, receivedUpdated: new)

--- a/Tests/UnitTests/Mocks/MockPaywallCacheWarming.swift
+++ b/Tests/UnitTests/Mocks/MockPaywallCacheWarming.swift
@@ -35,6 +35,25 @@ final class MockPaywallCacheWarming: PaywallCacheWarmingType {
 
     // MARK: -
 
+    private let _invokedClearEligibilityCache: Atomic<Bool> = false
+    private let _invokedClearEligibilityCacheCount: Atomic<Int> = .init(0)
+
+    var invokedClearEligibilityCache: Bool {
+        get { return self._invokedClearEligibilityCache.value }
+        set { self._invokedClearEligibilityCache.value = newValue }
+    }
+    var invokedClearEligibilityCacheCount: Int {
+        get { return self._invokedClearEligibilityCacheCount.value }
+        set { self._invokedClearEligibilityCacheCount.value = newValue }
+    }
+
+    func clearEligibilityCache() {
+        self.invokedClearEligibilityCache = true
+        self._invokedClearEligibilityCacheCount.modify { $0 += 1 }
+    }
+
+    // MARK: -
+
     private let _invokedWarmUpPaywallImagesCache: Atomic<Bool> = false
     private let _invokedWarmUpPaywallImagesCacheOfferings: Atomic<Offerings?> = nil
 

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -30,15 +30,13 @@ final class PaywallCacheWarmingTests: TestCase {
         self.cache = PaywallCacheWarming(introEligibiltyChecker: self.eligibilityChecker)
     }
 
-    func testOfferingsWithNoPaywallsDoesNotCheckEligibility() async throws {
+    func testOfferingsWithNoProductsDoesNotCheckEligibility() async throws {
         await self.cache.warmUpEligibilityCache(
             offerings: try Self.createOfferings([
                 Self.createOffering(
                     identifier: Self.offeringIdentifier,
                     paywall: nil,
-                    products: [
-                        (.monthly, "product_1")
-                    ]
+                    products: []
                 )
             ])
         )
@@ -46,12 +44,11 @@ final class PaywallCacheWarmingTests: TestCase {
         expect(self.eligibilityChecker.invokedCheckTrialOrIntroPriceEligibilityFromOptimalStore) == false
     }
 
-    func testWarmsUpEligibilityCacheForCurrentOffering() async throws {
-        let paywall = try Self.loadPaywall("PaywallData-Sample1")
+    func testWarmsUpEligibilityCacheForCurrentOfferingFirstThenRest() async throws {
         let offerings = try Self.createOfferings([
             Self.createOffering(
                 identifier: Self.offeringIdentifier,
-                paywall: paywall,
+                paywall: nil,
                 products: [
                     (.monthly, "product_1"),
                     (.weekly, "product_2")
@@ -59,38 +56,42 @@ final class PaywallCacheWarmingTests: TestCase {
             ),
             Self.createOffering(
                 identifier: "offering_2",
-                paywall: paywall,
+                paywall: nil,
                 products: [
                     (.annual, "product_3")
                 ]
             )
         ])
 
-        // Paywall filters packages so only `monthly` and `annual` is used.
-        // `product_3` is not part of the current offering, so that is ignored too.
-        let expectedProducts: Set<String> = ["product_1"]
+        let expectedCurrent: Set<String> = ["product_1", "product_2"]
+        let expectedRemaining: Set<String> = ["product_3"]
 
         await self.cache.warmUpEligibilityCache(offerings: offerings)
 
+        // Two staggered calls: the current offering's products first, then the rest.
         expect(self.eligibilityChecker.invokedCheckTrialOrIntroPriceEligibilityFromOptimalStore) == true
-        expect(self.eligibilityChecker.invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreCount) == 1
+        expect(self.eligibilityChecker.invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreCount) == 2
 
-        expect(
-            self.eligibilityChecker.invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreParameters
-        ) == expectedProducts
+        let invocations = self.eligibilityChecker
+            .invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreParametersList
+        expect(invocations.first) == expectedCurrent
+        expect(invocations.last) == expectedRemaining
 
         self.logger.verifyMessageWasLogged(
-            Strings.paywalls.warming_up_eligibility_cache(products: expectedProducts),
+            Strings.paywalls.warming_up_eligibility_cache(products: expectedCurrent),
+            level: .debug
+        )
+        self.logger.verifyMessageWasLogged(
+            Strings.paywalls.warming_up_eligibility_cache(products: expectedRemaining),
             level: .debug
         )
     }
 
-    func testOnlyWarmsUpEligibilityCacheOnce() async throws {
-        let paywall = try Self.loadPaywall("PaywallData-Sample1")
+    func testWarmsUpEligibilityCacheOnlyOnceForSameOfferings() async throws {
         let offerings = try Self.createOfferings([
             Self.createOffering(
                 identifier: Self.offeringIdentifier,
-                paywall: paywall,
+                paywall: nil,
                 products: [
                     (.monthly, "product_1")
                 ]
@@ -101,6 +102,8 @@ final class PaywallCacheWarmingTests: TestCase {
         await self.cache.warmUpEligibilityCache(offerings: offerings)
 
         expect(self.eligibilityChecker.invokedCheckTrialOrIntroPriceEligibilityFromOptimalStore) == true
+        // Only one call for the current offering; the second `warmUpEligibilityCache` is a no-op
+        // because all products are already in the warmed set.
         expect(self.eligibilityChecker.invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreCount) == 1
 
         self.logger.verifyMessageWasLogged(
@@ -108,6 +111,72 @@ final class PaywallCacheWarmingTests: TestCase {
             level: .debug,
             expectedCount: 1
         )
+    }
+
+    func testWarmsUpEligibilityCacheIncrementallyForNewProducts() async throws {
+        let firstOfferings = try Self.createOfferings([
+            Self.createOffering(
+                identifier: Self.offeringIdentifier,
+                paywall: nil,
+                products: [
+                    (.monthly, "product_1")
+                ]
+            )
+        ])
+
+        let secondOfferings = try Self.createOfferings([
+            Self.createOffering(
+                identifier: Self.offeringIdentifier,
+                paywall: nil,
+                products: [
+                    (.monthly, "product_1"),
+                    (.weekly, "product_2")
+                ]
+            ),
+            Self.createOffering(
+                identifier: "offering_2",
+                paywall: nil,
+                products: [
+                    (.annual, "product_3")
+                ]
+            )
+        ])
+
+        await self.cache.warmUpEligibilityCache(offerings: firstOfferings)
+        await self.cache.warmUpEligibilityCache(offerings: secondOfferings)
+
+        // The second call should only warm up products that haven't been warmed yet.
+        // Current offering already had `product_1`, so only `product_2` is new there.
+        // Then the remaining offering's `product_3` is warmed.
+        let invocations = self.eligibilityChecker
+            .invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreParametersList
+        expect(invocations) == [
+            ["product_1"],
+            ["product_2"],
+            ["product_3"]
+        ]
+    }
+
+    func testClearEligibilityCacheAllowsRewarming() async throws {
+        let offerings = try Self.createOfferings([
+            Self.createOffering(
+                identifier: Self.offeringIdentifier,
+                paywall: nil,
+                products: [
+                    (.monthly, "product_1")
+                ]
+            )
+        ])
+
+        await self.cache.warmUpEligibilityCache(offerings: offerings)
+        await self.cache.clearEligibilityCache()
+        await self.cache.warmUpEligibilityCache(offerings: offerings)
+
+        expect(self.eligibilityChecker.invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreCount) == 2
+
+        let invocations = self.eligibilityChecker
+            .invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreParametersList
+        expect(invocations) == [["product_1"], ["product_1"]]
     }
 
 #if !os(tvOS) // For Paywalls V2

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -164,6 +164,32 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
         expect(self.paywallCache.invokedWarmUpPaywallImagesCacheOfferings) == offerings
     }
 
+    func testGetOfferingsWarmsUpEligibilityCache() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        self.setupPurchases()
+
+        let offerings = try XCTUnwrap(
+            self.offeringsFactory.createOfferings(from: [:],
+                                                  contents: .mockContents,
+                                                  loadedFromDiskCache: false)
+        )
+        self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(offerings)
+
+        // Reset any warm-up that may have been triggered during configure.
+        self.paywallCache.invokedWarmUpEligibilityCache = false
+        self.paywallCache.invokedWarmUpEligibilityCacheOfferings = nil
+
+        waitUntil { completed in
+            self.purchases.getOfferings { _, _ in
+                completed()
+            }
+        }
+
+        expect(self.paywallCache.invokedWarmUpEligibilityCache).toEventually(beTrue())
+        expect(self.paywallCache.invokedWarmUpEligibilityCacheOfferings) === offerings
+    }
+
     // MARK: - overridePreferredUILocale
 
     func testOverridePreferredUILocaleInvalidatesInMemoryCache() {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -285,6 +285,28 @@ class ExistingUserPurchasesLogInTests: BasePurchasesLogInTests {
         expect(self.mockPurchasedProductsFetcher.invokedClearCacheCount).toEventually(equal(2))
     }
 
+    func testLogInClearsPaywallEligibilityCache() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        // set up updates customer info, which clears cache once. wait until it's done before checking the rest.
+        expect(self.paywallCache.invokedClearEligibilityCacheCount).toEventually(equal(1))
+
+        self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
+        let newAppUserID = "newAppUserID"
+
+        waitUntil { completed in
+            self.purchases.logIn(newAppUserID) { customerInfo, _, _ in
+                // since we're using a mocked identity manager, we need to manually call
+                // customer info manager to update the customer info and trigger an actual
+                // call in the monitorChanges observation
+                self.customerInfoManager.cache(customerInfo: customerInfo!, appUserID: newAppUserID)
+                completed()
+            }
+        }
+
+        expect(self.paywallCache.invokedClearEligibilityCacheCount).toEventually(equal(2))
+    }
+
 }
 
 // MARK: -


### PR DESCRIPTION
### Checklist
- [x] Unit tests added

### Motivation
Apps presenting a paywall hit a cold intro/trial eligibility cache when the paywall isn't tied to the current offering's paywall-configured packages, or when `getOfferings` runs outside of configure/foreground/login. This adds a visible loading delay on prices the first time those paywalls are shown.

### Description
- Widens the warm-up to every product across every offering.
- Staggers: current offering first, then the rest, preserving today's responsiveness.
- Triggers the warm-up on `getOfferings` completion (in addition to configure/foreground/login/user-switch).
- Resets the warmed product set when `CustomerInfo` changes.

### Notes
The prior warm-up has a blind spot: it only looks at `offering.paywall` (V1) and filters by `paywall.config.packages`. V2 paywall offerings (`paywallComponents`) are never warmed, and on V1 only packages wired into `paywall.config.packages` get warmed. Combined with the current-offering-only scope, today's warm-up covers a narrow slice.