### PR TITLE
refactor(ads/admob)!: rename present overloads to presentAndTrack

### DIFF
--- a/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/RewardedAdManager.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/RewardedAdManager.swift
@@ -59,7 +59,7 @@ final class RewardedAdManager: NSObject, ObservableObject {
         self.presentingAdObjectID = presentingAdObjectID
         self.shouldReportDismissedBeforeReward = true
         self.message = Message.Rewarded.waitingForReward
-        loadedAd.present(from: viewController, placement: "rewarded_main", userDidEarnRewardHandler: { [weak self] in
+        loadedAd.presentAndTrack(from: viewController, userDidEarnRewardHandler: { [weak self] in
             guard let self else { return }
             guard self.presentingAdObjectID == presentingAdObjectID else { return }
             let reward = loadedAd.adReward

--- a/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/RewardedInterstitialAdManager.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/RewardedInterstitialAdManager.swift
@@ -59,9 +59,8 @@ final class RewardedInterstitialAdManager: NSObject, ObservableObject {
         self.presentingAdObjectID = presentingAdObjectID
         self.shouldReportDismissedBeforeReward = true
         self.message = Message.Rewarded.waitingForReward
-        loadedAd.present(
+        loadedAd.presentAndTrack(
             from: viewController,
-            placement: "rewarded_interstitial_main",
             userDidEarnRewardHandler: { [weak self] in
                 guard let self else { return }
                 guard self.presentingAdObjectID == presentingAdObjectID else { return }

--- a/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/VerifiedRewardedAdManager.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/VerifiedRewardedAdManager.swift
@@ -59,7 +59,7 @@ final class VerifiedRewardedAdManager: NSObject, ObservableObject {
         self.presentingAdObjectID = presentingAdObjectID
         self.shouldReportDismissedBeforeReward = true
         self.message = Message.Rewarded.waitingForReward
-        loadedAd.present(
+        loadedAd.presentAndTrack(
             from: viewController,
             placement: "rewarded_reward_verification_main",
             rewardVerificationStarted: { [weak self] in

--- a/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/VerifiedRewardedInterstitialAdManager.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/VerifiedRewardedInterstitialAdManager.swift
@@ -59,7 +59,7 @@ final class VerifiedRewardedInterstitialAdManager: NSObject, ObservableObject {
         self.presentingAdObjectID = presentingAdObjectID
         self.shouldReportDismissedBeforeReward = true
         self.message = Message.Rewarded.waitingForReward
-        loadedAd.present(
+        loadedAd.presentAndTrack(
             from: viewController,
             placement: "rewarded_interstitial_reward_verification_main",
             rewardVerificationStarted: { [weak self] in

--- a/AdapterSDKs/RevenueCatAdMob/README.md
+++ b/AdapterSDKs/RevenueCatAdMob/README.md
@@ -159,8 +159,8 @@ RewardedAd.loadAndTrack(
     self.rewardedAd = ad
 }
 
-// Later, to show (unchanged):
-rewardedAd?.present(from: self, userDidEarnRewardHandler: {
+// Later, to show with reward-earned tracking:
+rewardedAd?.presentAndTrack(from: self, userDidEarnRewardHandler: {
     // User earned reward
 })
 ```
@@ -181,7 +181,7 @@ RewardedAd.loadAndTrack(
     self.rewardedAd = ad
 }
 
-rewardedAd?.present(
+rewardedAd?.presentAndTrack(
     from: self,
     placement: "optional_placement_override",
     rewardVerificationStarted: {
@@ -240,8 +240,8 @@ RewardedInterstitialAd.loadAndTrack(
     self.rewardedInterstitialAd = ad
 }
 
-// Later, to show (unchanged):
-rewardedInterstitialAd?.present(from: self, userDidEarnRewardHandler: {
+// Later, to show with reward-earned tracking:
+rewardedInterstitialAd?.presentAndTrack(from: self, userDidEarnRewardHandler: {
     // User earned reward
 })
 ```
@@ -262,7 +262,7 @@ RewardedInterstitialAd.loadAndTrack(
     self.rewardedInterstitialAd = ad
 }
 
-rewardedInterstitialAd?.present(
+rewardedInterstitialAd?.presentAndTrack(
     from: self,
     placement: "optional_placement_override",
     rewardVerificationStarted: {

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
@@ -33,10 +33,10 @@ import GoogleMobileAds
     ///   When verification returns `.verified(.virtualCurrency(...))`, this API automatically invalidates
     ///   RevenueCat virtual currencies cache before delivering the callback.
     ///
-    /// To override the placement used for RevenueCat analytics at show time, use
-    /// ``present(from:placement:rewardVerificationStarted:rewardVerificationCompleted:)`` instead of this method.
+    /// To override the placement used for RevenueCat analytics at show time, use the
+    /// `placement:` variant of `presentAndTrack(from:...)` instead.
     @MainActor
-    func present(
+    func presentAndTrack(
         from viewController: UIViewController,
         rewardVerificationStarted: (@MainActor () -> Void)? = nil,
         rewardVerificationCompleted: @escaping @MainActor (RewardVerificationResult) -> Void
@@ -65,7 +65,7 @@ import GoogleMobileAds
     ///   When verification returns `.verified(.virtualCurrency(...))`, this API automatically invalidates
     ///   RevenueCat virtual currencies cache before delivering the callback.
     @MainActor
-    func present(
+    func presentAndTrack(
         from viewController: UIViewController,
         placement: String?,
         rewardVerificationStarted: (@MainActor () -> Void)? = nil,
@@ -106,10 +106,10 @@ import GoogleMobileAds
     ///   When verification returns `.verified(.virtualCurrency(...))`, this API automatically invalidates
     ///   RevenueCat virtual currencies cache before delivering the callback.
     ///
-    /// To override the placement used for RevenueCat analytics at show time, use
-    /// ``present(from:placement:rewardVerificationStarted:rewardVerificationCompleted:)`` instead of this method.
+    /// To override the placement used for RevenueCat analytics at show time, use the
+    /// `placement:` variant of `presentAndTrack(from:...)` instead.
     @MainActor
-    func present(
+    func presentAndTrack(
         from viewController: UIViewController,
         rewardVerificationStarted: (@MainActor () -> Void)? = nil,
         rewardVerificationCompleted: @escaping @MainActor (RewardVerificationResult) -> Void
@@ -138,7 +138,7 @@ import GoogleMobileAds
     ///   When verification returns `.verified(.virtualCurrency(...))`, this API automatically invalidates
     ///   RevenueCat virtual currencies cache before delivering the callback.
     @MainActor
-    func present(
+    func presentAndTrack(
         from viewController: UIViewController,
         placement: String?,
         rewardVerificationStarted: (@MainActor () -> Void)? = nil,

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/FullScreenAd+Tracking.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/FullScreenAd+Tracking.swift
@@ -202,19 +202,13 @@ internal extension GoogleMobileAds.RewardedAd {
         )
     }
 
-    /// Presents the rewarded ad and overrides the placement used for RevenueCat analytics.
-    ///
-    /// Call this instead of `present(from:userDidEarnRewardHandler:)` when you want to specify or override
-    /// the placement at show time. The placement passed here takes precedence over any placement provided at load time.
-    ///
-    /// Fires `AdRewardEarnedUnverified` (with `rewardVerificationEnabled: false`) before invoking the handler.
+    /// Presents the rewarded ad and fires `AdRewardEarnedUnverified` (with `rewardVerificationEnabled: false`)
+    /// before invoking the handler.
     @MainActor
-    func present(
+    func presentAndTrack(
         from viewController: UIViewController,
-        placement: String?,
         userDidEarnRewardHandler: @escaping () -> Void
     ) {
-        Tracking.Adapter.shared.fullScreenDelegateStore.retrieve(for: self)?.placement = placement
         self.present(from: viewController, userDidEarnRewardHandler: { [weak self] in
             if let self {
                 self.fireEarnedUnverifiedEvent(
@@ -225,6 +219,20 @@ internal extension GoogleMobileAds.RewardedAd {
             }
             userDidEarnRewardHandler()
         })
+    }
+
+    /// Presents the rewarded ad, overrides the placement used for RevenueCat analytics, and fires
+    /// `AdRewardEarnedUnverified` (with `rewardVerificationEnabled: false`) before invoking the handler.
+    ///
+    /// The placement passed here takes precedence over any placement provided at load time.
+    @MainActor
+    func presentAndTrack(
+        from viewController: UIViewController,
+        placement: String?,
+        userDidEarnRewardHandler: @escaping () -> Void
+    ) {
+        Tracking.Adapter.shared.fullScreenDelegateStore.retrieve(for: self)?.placement = placement
+        self.presentAndTrack(from: viewController, userDidEarnRewardHandler: userDidEarnRewardHandler)
     }
 }
 
@@ -284,19 +292,13 @@ internal extension GoogleMobileAds.RewardedInterstitialAd {
         )
     }
 
-    /// Presents the rewarded interstitial ad and overrides the placement used for RevenueCat analytics.
-    ///
-    /// Call this instead of `present(from:userDidEarnRewardHandler:)` when you want to specify or override
-    /// the placement at show time. The placement passed here takes precedence over any placement provided at load time.
-    ///
-    /// Fires `AdRewardEarnedUnverified` (with `rewardVerificationEnabled: false`) before invoking the handler.
+    /// Presents the rewarded interstitial ad and fires `AdRewardEarnedUnverified`
+    /// (with `rewardVerificationEnabled: false`) before invoking the handler.
     @MainActor
-    func present(
+    func presentAndTrack(
         from viewController: UIViewController,
-        placement: String?,
         userDidEarnRewardHandler: @escaping () -> Void
     ) {
-        Tracking.Adapter.shared.fullScreenDelegateStore.retrieve(for: self)?.placement = placement
         self.present(from: viewController, userDidEarnRewardHandler: { [weak self] in
             if let self {
                 self.fireEarnedUnverifiedEvent(
@@ -307,6 +309,20 @@ internal extension GoogleMobileAds.RewardedInterstitialAd {
             }
             userDidEarnRewardHandler()
         })
+    }
+
+    /// Presents the rewarded interstitial ad, overrides the placement used for RevenueCat analytics,
+    /// and fires `AdRewardEarnedUnverified` (with `rewardVerificationEnabled: false`) before invoking the handler.
+    ///
+    /// The placement passed here takes precedence over any placement provided at load time.
+    @MainActor
+    func presentAndTrack(
+        from viewController: UIViewController,
+        placement: String?,
+        userDidEarnRewardHandler: @escaping () -> Void
+    ) {
+        Tracking.Adapter.shared.fullScreenDelegateStore.retrieve(for: self)?.placement = placement
+        self.presentAndTrack(from: viewController, userDidEarnRewardHandler: userDidEarnRewardHandler)
     }
 }
 


### PR DESCRIPTION
### Motivation

Apps that opt into RC's tracked rewarded-ad flow have to call one of the `present(...)` overloads on `RewardedAd` / `RewardedInterstitialAd`. Those overloads are no longer "just present" — they fire reward events. The method name doesn't signal that, which makes the side effect easy to overlook (and `placement: nil` clears the load-time placement, an extra footgun on the previous shape).

This PR renames every reward `present(...)` overload to `presentAndTrack(...)` so the side effect is visible at the call site, and adds a new no-placement variant for apps that want reward telemetry without touching the load-time placement.

### Description

Four renames + one new method on `RewardedAd` (and matching set on `RewardedInterstitialAd`):

| Before | After |
| -- | -- |
| _(no equivalent)_ | `presentAndTrack(from:userDidEarnRewardHandler:)` |
| `present(from:placement:userDidEarnRewardHandler:)` | `presentAndTrack(from:placement:userDidEarnRewardHandler:)` |
| `present(from:rewardVerificationStarted:rewardVerificationCompleted:)` | `presentAndTrack(from:rewardVerificationStarted:rewardVerificationCompleted:)` |
| `present(from:placement:rewardVerificationStarted:rewardVerificationCompleted:)` | `presentAndTrack(from:placement:rewardVerificationStarted:rewardVerificationCompleted:)` |

GMA's native `present(from:userDidEarnRewardHandler:)` is untouched and continues to work — apps that don't want RC telemetry stay on it. Non-rewarded `present(from:placement:)` overloads on `InterstitialAd` / `AppOpenAd` are untouched (they never fired telemetry from the present call; impression events come from the installed `FullScreenContentDelegate`).

Sample managers and the adapter README are updated to use the new names.

#### API design — `presentAndTrack` vs alternatives

Reward telemetry has to be intercepted at *present* time (unlike the other ad events, which are intercepted at load time via `FullScreenContentDelegate` / `paidEventHandler`), because AdMob delivers `userDidEarnRewardHandler` as a per-call closure parameter on `present`, not as a delegate method on the ad object.

GMA's native `present(from:userDidEarnRewardHandler:)` cannot be intercepted from Swift without method swizzling — extension methods on the same signature are silently shadowed by the type's own method. So the design space was around RC's own present-overloads.

1. **Add the telemetry side-effect to RC's existing `present(from:placement:userDidEarnRewardHandler:)`** — the prior shape of the PR. Method name reads as "placement override," telemetry is invisible from the call site, and `placement: nil` clears the load-time placement.
2. **Flip the `placement: nil` semantic** — make `nil` preserve the load-time placement (instead of clearing). Cheap, but overloads `nil` with two meanings — fragile.
3. **`track: Bool = true` flag / options struct** — explicit per-call. Bloats every signature, and the decoupled case ("RC SSV without RC tracking") isn't a use case anyone has asked for.
4. **Wrapper type returned from `loadAndTrack`** — biggest API break: current callers get the raw GMA type and rely on it; every GMA pass-through would have to thread through a wrapper.
5. **Method swizzling** — intercept GMA's native method transparently. Invasive, interferes with anyone else customizing GMA.
6. **New method name (`presentAndTrack`)** — explicit opt-in by name, no GMA collision, no parameter weirdness. ✓

Picked **6**. Tracking is implicit in the method name (no `track:` flag) because the "RC adapter without RC tracking" case is niche — apps that don't want our tracking can opt out by using AdMob's native APIs directly.

### Test plan
- `swift build` (adapter + tests) + `swiftlint` clean.
- Existing `PresentRewardVerificationTests` and `RewardTrackingTests` (from #6851) cover the renamed methods.
- Sample managers (`RewardedAdManager`, `RewardedInterstitialAdManager`, `VerifiedRewardedAdManager`, `VerifiedRewardedInterstitialAdManager`) updated to use `presentAndTrack(...)`.