### PR TITLE
feat(ads/admob): add impression_id to SSV customRewardText payload

### DIFF
--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Setup.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Setup.swift
@@ -16,7 +16,7 @@ internal extension RewardVerification {
     /// AdMob ad types that accept server-side verification options.
     protocol CapableAd: AnyObject {
         var serverSideVerificationOptions: GoogleMobileAds.ServerSideVerificationOptions? { get set }
-        var responseInfo: GoogleMobileAds.ResponseInfo? { get }
+        var responseInfo: GoogleMobileAds.ResponseInfo { get }
     }
 
     /// Load-time SSV setup for rewarded AdMob ads.

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Setup.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Setup.swift
@@ -16,6 +16,7 @@ internal extension RewardVerification {
     /// AdMob ad types that accept server-side verification options.
     protocol CapableAd: AnyObject {
         var serverSideVerificationOptions: GoogleMobileAds.ServerSideVerificationOptions? { get set }
+        var responseInfo: GoogleMobileAds.ResponseInfo? { get }
     }
 
     /// Load-time SSV setup for rewarded AdMob ads.
@@ -48,10 +49,12 @@ internal extension RewardVerification {
             appUserID: String
         ) -> State? {
             let clientTransactionID = UUID().uuidString
+            let impressionId = Tracking.Adapter.impressionID(from: loadedAd.responseInfo)
 
             guard let customRewardText = self.makeCustomRewardText(
                 apiKey: apiKey,
-                clientTransactionID: clientTransactionID
+                clientTransactionID: clientTransactionID,
+                impressionId: impressionId
             ) else {
                 return nil
             }
@@ -73,10 +76,15 @@ internal extension RewardVerification {
 
         /// Encodes the SSV `customRewardString` payload as deterministic JSON
         /// (`.sortedKeys`) so logs and tests are stable.
-        static func makeCustomRewardText(apiKey: String, clientTransactionID: String) -> String? {
+        static func makeCustomRewardText(
+            apiKey: String,
+            clientTransactionID: String,
+            impressionId: String
+        ) -> String? {
             let payload: [String: String] = [
                 "api_key": apiKey,
-                "client_transaction_id": clientTransactionID
+                "client_transaction_id": clientTransactionID,
+                "impression_id": impressionId
             ]
             do {
                 let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/Adapter.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/Adapter.swift
@@ -232,6 +232,10 @@ internal extension Tracking {
             responseInfo?.responseIdentifier ?? self.fallbackValue
         }
 
+        static func impressionID(from responseInfo: GoogleMobileAds.ResponseInfo) -> String {
+            responseInfo.responseIdentifier ?? self.fallbackValue
+        }
+
         private static func adUnitID(_ adUnitID: String?) -> String {
             adUnitID ?? self.fallbackValue
         }

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/Adapter.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/Adapter.swift
@@ -222,13 +222,13 @@ internal extension Tracking {
             }
         }
 
-        // MARK: - Private helpers
+        // MARK: - Helpers
 
         private static func networkName(from responseInfo: GoogleMobileAds.ResponseInfo?) -> String {
             responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? self.fallbackValue
         }
 
-        private static func impressionID(from responseInfo: GoogleMobileAds.ResponseInfo?) -> String {
+        static func impressionID(from responseInfo: GoogleMobileAds.ResponseInfo?) -> String {
             responseInfo?.responseIdentifier ?? self.fallbackValue
         }
 

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
@@ -260,6 +260,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
 @available(iOS 15.0, *)
 private final class FakeCapableAd: RewardVerification.CapableAd {
     var serverSideVerificationOptions: GoogleMobileAds.ServerSideVerificationOptions?
+    var responseInfo: GoogleMobileAds.ResponseInfo?
 }
 
 #endif

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/SetupTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/SetupTests.swift
@@ -113,21 +113,30 @@ final class SetupTests: AdapterTestCase {
     func testMakeCustomRewardTextProducesValidJSONWithExpectedKeys() throws {
         let text = try XCTUnwrap(RewardVerification.Setup.makeCustomRewardText(
             apiKey: "key_123",
-            clientTransactionID: "txn_456"
+            clientTransactionID: "txn_456",
+            impressionId: "imp_789"
         ))
         let payload = try Self.parseJSONObject(text)
 
-        XCTAssertEqual(payload, ["api_key": "key_123", "client_transaction_id": "txn_456"])
+        XCTAssertEqual(payload, [
+            "api_key": "key_123",
+            "client_transaction_id": "txn_456",
+            "impression_id": "imp_789"
+        ])
     }
 
     func testMakeCustomRewardTextProducesSortedKeys() throws {
         let text = try XCTUnwrap(RewardVerification.Setup.makeCustomRewardText(
             apiKey: "key_123",
-            clientTransactionID: "txn_456"
+            clientTransactionID: "txn_456",
+            impressionId: "imp_789"
         ))
 
         // .sortedKeys guarantees stable byte ordering — keep tests / logs / snapshots deterministic.
-        XCTAssertEqual(text, "{\"api_key\":\"key_123\",\"client_transaction_id\":\"txn_456\"}")
+        XCTAssertEqual(
+            text,
+            "{\"api_key\":\"key_123\",\"client_transaction_id\":\"txn_456\",\"impression_id\":\"imp_789\"}"
+        )
     }
 
     // MARK: - Helpers
@@ -144,6 +153,7 @@ final class SetupTests: AdapterTestCase {
 @available(iOS 15.0, *)
 private final class FakeRewardedAd: RewardVerification.CapableAd {
     var serverSideVerificationOptions: GoogleMobileAds.ServerSideVerificationOptions?
+    var responseInfo: GoogleMobileAds.ResponseInfo?
 }
 
 #endif


### PR DESCRIPTION
### Checklist
- [x] Unit tests (`SetupTests` covers the new JSON field)
- [x] Cross-platform follow-up — no API impact; backend ingestion already keys on `impression_id`

### Motivation

The AdMob SSV `customRewardText` payload (currently `{api_key, client_transaction_id}`) carries no link back to the originating impression. SDK impression events (`Ad Loaded` / `Displayed` / `Opened` / `Revenue`) already include `impression_id` (from `responseInfo.responseIdentifier`), but the SSV webhook event ingested on the backend has no field to join against them. Adding `impression_id` to the SSV payload lets backend webhook events anchor to the same impression as the SDK events for one ad load.

### Description

- `Tracking.Adapter.impressionID(from:)` is promoted from `private` to `internal` so the reward-verification flow can reuse the same `?? ""` fallback policy as the existing event-tracking flow. Single source of truth.
- `RewardVerification.CapableAd` protocol gains `responseInfo: GoogleMobileAds.ResponseInfo? { get }`. Both `GADRewardedAd` and `GADRewardedInterstitialAd` already expose it.
- `RewardVerification.Setup.install` reads `impressionId = Tracking.Adapter.impressionID(from: loadedAd.responseInfo)` and threads it through to `makeCustomRewardText`.
- `RewardVerification.Setup.makeCustomRewardText` takes an `impressionId: String` parameter and includes it in the JSON. The payload stays `[String: String]` with sorted keys, so existing snapshot/log shapes are preserved.

No public API change. Pure additive payload field.

### Test plan
- `swift build` (adapter) + `swiftlint` clean.
- `SetupTests::testMakeCustomRewardText...` updated to pass `impressionId:` and assert the field appears in both the parsed payload and the deterministic sorted-key string output.
- `FakeRewardedAd` / `FakeCapableAd` test doubles updated to satisfy the new `responseInfo` protocol requirement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive internal payload field and shared helper exposure; no auth or public API changes, with unit test coverage.
> 
> **Overview**
> Adds **`impression_id`** to the AdMob server-side verification **`customRewardText`** JSON so SSV webhook events can be correlated with SDK ad events that already carry the same identifier.
> 
> **`RewardVerification.Setup.install`** now reads `impressionId` from the loaded ad’s `responseInfo` via **`Tracking.Adapter.impressionID`**, which is shared with the existing tracking path (promoted from `private` with an overload for non-optional `ResponseInfo`). **`CapableAd`** requires **`responseInfo`** so rewarded ads supply it at SSV install time. **`makeCustomRewardText`** accepts `impressionId` and serializes it alongside `api_key` and `client_transaction_id` with sorted keys unchanged.
> 
> Tests and fakes were updated for the new field and protocol requirement; no public API change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f4f0e86e2d2a2a93a4da46e6cd5036655072bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->