### PR TITLE
refactor(ads/admob): propagate FailureReason through poller and dispatcher

### DIFF
--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Dispatcher.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Dispatcher.swift
@@ -72,7 +72,7 @@ private extension RewardVerification.Outcome {
     var logDescription: String {
         switch self {
         case .verified: return "verified"
-        case .failed: return "failed"
+        case .failed(let reason): return "failed(\(reason))"
         }
     }
 }

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Outcome.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Outcome.swift
@@ -15,7 +15,14 @@ internal extension RewardVerification {
     /// Terminal SSV verdict delivered by `Dispatcher`.
     enum Outcome: Sendable {
         case verified(RevenueCat.VerifiedReward)
-        case failed
+        case failed(FailureReason)
+    }
+
+    /// Internal classification of why verification failed.
+    enum FailureReason: Sendable, Equatable {
+        case timeout
+        case backendError
+        case unknown
     }
 }
 

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Poller.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Poller.swift
@@ -84,7 +84,7 @@ internal extension RewardVerification {
 
                 if Task.isCancelled {
                     Logger.debug(RewardVerificationStrings.poll_cancelled(transactionID: clientTransactionID))
-                    return .failed
+                    return .failed(.unknown)
                 }
                 if attempt > 0 {
                     try? await self.sleeper.sleep(seconds: self.jitter.sample())
@@ -98,7 +98,7 @@ internal extension RewardVerification {
                     ))
                     switch status {
                     case .verified(let reward): return .verified(reward)
-                    case .failed: return .failed
+                    case .failed: return .failed(.backendError)
                     case .pending, .unknown: continue
                     }
                 } catch let code as ErrorCode where code.isTransientPolling {
@@ -112,7 +112,9 @@ internal extension RewardVerification {
                         error: error,
                         transactionID: clientTransactionID
                     ))
-                    return .failed
+                    // Non-transient ErrorCode is a backend rejection; everything else (CancellationError,
+                    // custom error types) is unclassifiable and surfaces as .unknown.
+                    return .failed(error is ErrorCode ? .backendError : .unknown)
                 }
             }
 
@@ -120,7 +122,7 @@ internal extension RewardVerification {
                 maxAttempts: self.maxAttempts,
                 transactionID: clientTransactionID
             ))
-            return .failed
+            return .failed(.timeout)
         }
     }
 

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/DispatcherTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/DispatcherTests.swift
@@ -44,8 +44,8 @@ final class DispatcherTests: AdapterTestCase {
         )
 
         let outcomes = recorder.snapshot()
-        guard case .failed = outcomes.first else {
-            return XCTFail("Expected .failed, got \(String(describing: outcomes.first))")
+        guard case .failed(.backendError) = outcomes.first else {
+            return XCTFail("Expected .failed(.backendError), got \(String(describing: outcomes.first))")
         }
     }
 
@@ -61,8 +61,8 @@ final class DispatcherTests: AdapterTestCase {
             outcomeHandler: { recorder.append($0) }
         )
 
-        guard case .failed = recorder.snapshot().first else {
-            return XCTFail("Expected .failed, got \(String(describing: recorder.snapshot().first))")
+        guard case .failed(.timeout) = recorder.snapshot().first else {
+            return XCTFail("Expected .failed(.timeout), got \(String(describing: recorder.snapshot().first))")
         }
     }
 
@@ -82,8 +82,10 @@ final class DispatcherTests: AdapterTestCase {
         )
 
         let outcomes = recorder.snapshot()
-        guard case .failed = outcomes.first else {
-            return XCTFail("Expected .failed for transient-only attempts, got \(String(describing: outcomes.first))")
+        guard case .failed(.timeout) = outcomes.first else {
+            return XCTFail(
+                "Expected .failed(.timeout) for transient-only attempts, got \(String(describing: outcomes.first))"
+            )
         }
         XCTAssertEqual(throwingPoller.callCount, 3,
                        "Transient throws should be retried up to the attempt budget")
@@ -105,8 +107,10 @@ final class DispatcherTests: AdapterTestCase {
         )
 
         let outcomes = recorder.snapshot()
-        guard case .failed = outcomes.first else {
-            return XCTFail("Expected .failed for terminal ErrorCode, got \(String(describing: outcomes.first))")
+        guard case .failed(.backendError) = outcomes.first else {
+            return XCTFail(
+                "Expected .failed(.backendError) for terminal ErrorCode, got \(String(describing: outcomes.first))"
+            )
         }
         XCTAssertEqual(throwingPoller.callCount, 1,
                        "Terminal ErrorCode must surface as .failed without retries")

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/OutcomeTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/OutcomeTests.swift
@@ -37,12 +37,13 @@ final class OutcomeTests: AdapterTestCase {
         }
     }
 
-    func testFailedIsConstructible() {
-        let outcome = RewardVerification.Outcome.failed
+    func testFailedCarriesFailureReason() {
+        let outcome = RewardVerification.Outcome.failed(.timeout)
 
-        guard case .failed = outcome else {
+        guard case .failed(let reason) = outcome else {
             return XCTFail("Expected .failed, got \(outcome)")
         }
+        XCTAssertEqual(reason, .timeout)
     }
 
     func testAllCasesAreConstructibleAndExhaustiveInSwitch() {
@@ -50,7 +51,9 @@ final class OutcomeTests: AdapterTestCase {
             .verified(.virtualCurrency(VirtualCurrencyReward(code: "coins", amount: 1))),
             .verified(.noReward),
             .verified(.unsupportedReward),
-            .failed
+            .failed(.timeout),
+            .failed(.backendError),
+            .failed(.unknown)
         ]
 
         for outcome in cases {
@@ -59,7 +62,7 @@ final class OutcomeTests: AdapterTestCase {
             case .failed: continue
             }
         }
-        XCTAssertEqual(cases.count, 4)
+        XCTAssertEqual(cases.count, 6)
     }
 }
 

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/OutcomeTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/OutcomeTests.swift
@@ -37,15 +37,6 @@ final class OutcomeTests: AdapterTestCase {
         }
     }
 
-    func testFailedCarriesFailureReason() {
-        let outcome = RewardVerification.Outcome.failed(.timeout)
-
-        guard case .failed(let reason) = outcome else {
-            return XCTFail("Expected .failed, got \(outcome)")
-        }
-        XCTAssertEqual(reason, .timeout)
-    }
-
     func testAllCasesAreConstructibleAndExhaustiveInSwitch() {
         let cases: [RewardVerification.Outcome] = [
             .verified(.virtualCurrency(VirtualCurrencyReward(code: "coins", amount: 1))),

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PollerTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PollerTests.swift
@@ -37,8 +37,8 @@ final class PollerTests: AdapterTestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed, got \(outcome)")
+        guard case .failed(.backendError) = outcome else {
+            return XCTFail("Expected .failed(.backendError), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.receivedIDs, ["tx-1"])
         XCTAssertTrue(sleeper.delays.isEmpty)
@@ -65,8 +65,8 @@ final class PollerTests: AdapterTestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed, got \(outcome)")
+        guard case .failed(.timeout) = outcome else {
+            return XCTFail("Expected .failed(.timeout), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.receivedIDs.count, 10)
         XCTAssertEqual(sleeper.delays.count, 9)
@@ -95,8 +95,8 @@ final class PollerTests: AdapterTestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed, got \(outcome)")
+        guard case .failed(.backendError) = outcome else {
+            return XCTFail("Expected .failed(.backendError), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.receivedIDs.count, 3)
         XCTAssertEqual(sleeper.delays.count, 2)
@@ -160,8 +160,10 @@ final class PollerTests: AdapterTestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed after exhausting the budget on transient throws, got \(outcome)")
+        guard case .failed(.timeout) = outcome else {
+            return XCTFail(
+                "Expected .failed(.timeout) after exhausting the budget on transient throws, got \(outcome)"
+            )
         }
         XCTAssertEqual(statusPoller.callCount, 5,
                        "Every attempt should have been tried; transient throws are not terminal")
@@ -181,8 +183,8 @@ final class PollerTests: AdapterTestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed, got \(outcome)")
+        guard case .failed(.timeout) = outcome else {
+            return XCTFail("Expected .failed(.timeout), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 5)
         XCTAssertEqual(sleeper.delays.count, 4)
@@ -215,8 +217,8 @@ final class PollerTests: AdapterTestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed, got \(outcome)")
+        guard case .failed(.backendError) = outcome else {
+            return XCTFail("Expected .failed(.backendError), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 1, "Terminal ErrorCode must not be retried")
         XCTAssertTrue(sleeper.delays.isEmpty)
@@ -229,8 +231,8 @@ final class PollerTests: AdapterTestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed, got \(outcome)")
+        guard case .failed(.backendError) = outcome else {
+            return XCTFail("Expected .failed(.backendError), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 1)
     }
@@ -243,8 +245,8 @@ final class PollerTests: AdapterTestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed, got \(outcome)")
+        guard case .failed(.backendError) = outcome else {
+            return XCTFail("Expected .failed(.backendError), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 1)
     }
@@ -259,8 +261,8 @@ final class PollerTests: AdapterTestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed, got \(outcome)")
+        guard case .failed(.backendError) = outcome else {
+            return XCTFail("Expected .failed(.backendError), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 2)
     }
@@ -268,17 +270,16 @@ final class PollerTests: AdapterTestCase {
     // MARK: - Catch-all behaviour
 
     func testCancellationErrorFromPollStatusReturnsFailedWithoutRetrying() async {
-        // `Poller` does not distinguish `CancellationError` from any other non-transient throw —
-        // both collapse to `.failed`. `Dispatcher` is what swallows the delivery when the
-        // surrounding `Task` is actually cancelled.
+        // `CancellationError` is not an `ErrorCode`, so the poller's terminal-ErrorCode path
+        // doesn't apply — it falls through to the catch-all and surfaces `.unknown`.
         let statusPoller = ThrowingStatusPoller(error: CancellationError())
         let sleeper = RecordingSleeper()
         let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper)
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed, got \(outcome)")
+        guard case .failed(.unknown) = outcome else {
+            return XCTFail("Expected .failed(.unknown), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 1, "Cancellation throws are not retried")
         XCTAssertTrue(sleeper.delays.isEmpty)
@@ -291,8 +292,8 @@ final class PollerTests: AdapterTestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed, got \(outcome)")
+        guard case .failed(.unknown) = outcome else {
+            return XCTFail("Expected .failed(.unknown), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 1, "Unrecognised throws are not retried")
     }
@@ -308,8 +309,8 @@ final class PollerTests: AdapterTestCase {
         task.cancel()
         let outcome = await task.value
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed after cancellation, got \(outcome)")
+        guard case .failed(.unknown) = outcome else {
+            return XCTFail("Expected .failed(.unknown) after cancellation, got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 0,
                        "Cancellation must short-circuit before any pollStatus call")
@@ -340,8 +341,8 @@ final class PollerTests: AdapterTestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed, got \(outcome)")
+        guard case .failed(.timeout) = outcome else {
+            return XCTFail("Expected .failed(.timeout), got \(outcome)")
         }
         XCTAssertTrue(statusPoller.receivedIDs.isEmpty)
         XCTAssertTrue(sleeper.delays.isEmpty)
@@ -354,8 +355,8 @@ final class PollerTests: AdapterTestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed = outcome else {
-            return XCTFail("Expected .failed, got \(outcome)")
+        guard case .failed(.timeout) = outcome else {
+            return XCTFail("Expected .failed(.timeout), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.receivedIDs, ["tx-1"])
         XCTAssertTrue(sleeper.delays.isEmpty)

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentMappingTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentMappingTests.swift
@@ -42,7 +42,7 @@ final class PresentMappingTests: AdapterTestCase {
     }
 
     func testMapOutcomeFailed() {
-        let result = RewardVerification.mapOutcome(.failed)
+        let result = RewardVerification.mapOutcome(.failed(.unknown))
         XCTAssertTrue(result.isFailed)
         XCTAssertNil(result.verifiedReward)
     }


### PR DESCRIPTION
### Checklist
- [x] Unit tests (Outcome / Poller / Dispatcher assertions tightened to the specific `FailureReason` per classification path)
- [x] No public API impact — internal-only refactor

### Motivation

The verification polling loop currently collapses every non-verified terminal state into a single `Outcome.failed` case. As a result, downstream consumers can't tell *why* verification failed — timeout, backend rejection, network noise, or something unrecognised. Carrying that information out of `Poller` opens the door for surfacing a structured failure reason on future telemetry / events without changing the public `RewardVerificationResult.failed`.

### Description

- `RewardVerification.Outcome.failed` gains an associated `FailureReason` payload (`.timeout` / `.backendError` / `.unknown`).
- `Poller.run` classifies failures:
  - Loop budget exhausted (all attempts pending, transient throws, or unknown statuses) → `.failed(.timeout)`.
  - Backend returns explicit `.failed` status → `.failed(.backendError)`.
  - Non-transient `ErrorCode` throw → `.failed(.backendError)`.
  - Any other throw (`CancellationError`, unrecognised error types) → `.failed(.unknown)`.
  - `Task.isCancelled` before an attempt → `.failed(.unknown)`. `Dispatcher` separately swallows the delivery on real cancellation, so this is only observable in unit tests.
- `Dispatcher`'s `logDescription` includes the reason for debugging.
- `mapOutcome` in `RewardedAds+RewardVerification` continues to pattern-match `.failed` without binding, so the public `RewardVerificationResult.failed` stays parameter-less.

### Test plan
- `swift build` (adapter + tests) + `swiftlint` clean.
- `OutcomeTests`: case construction asserts the new associated value; exhaustive-switch test enumerates all three `FailureReason` variants.
- `PollerTests`: every previously bare `case .failed = outcome` now asserts the specific reason produced by that classification path.
- `DispatcherTests`: same tightening.
- Stale comment on the cancellation test updated to reflect the new distinction (`CancellationError` is not an `ErrorCode`, so it falls through to the catch-all and surfaces `.unknown`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal-only typing and classification in the AdMob adapter; public reward verification results are unchanged.
> 
> **Overview**
> Internal AdMob reward verification now attaches a **`FailureReason`** (`.timeout`, `.backendError`, `.unknown`) to **`Outcome.failed`** instead of a bare failure case, so the polling loop can distinguish *why* SSV did not succeed.
> 
> **`Poller.run`** maps outcomes: exhausted attempt budget → `.timeout`; explicit backend `.failed` status or non-transient **`ErrorCode`** → `.backendError`; cancellation before polling, **`CancellationError`**, and other unclassified throws → `.unknown`. **`Dispatcher`** logging includes the reason in **`logDescription`**.
> 
> **`mapOutcome`** still collapses any **`.failed`** to the public parameter-less **`RewardVerificationResult.failed`**, so there is no app-facing API change—only richer internal signal for future telemetry. Unit tests assert the specific reason on each path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d05d0ebb1a9bc058e2578b22e55d7a1362e9a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->