### PR TITLE
fix(ads/admob): update test fakes for non-optional CapableAd.responseInfo

### DIFF
--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
@@ -260,7 +260,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
 @available(iOS 15.0, *)
 private final class FakeCapableAd: RewardVerification.CapableAd {
     var serverSideVerificationOptions: GoogleMobileAds.ServerSideVerificationOptions?
-    var responseInfo: GoogleMobileAds.ResponseInfo?
+    let responseInfo = GoogleMobileAds.ResponseInfo()
 }
 
 #endif

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/SetupTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/SetupTests.swift
@@ -153,7 +153,7 @@ final class SetupTests: AdapterTestCase {
 @available(iOS 15.0, *)
 private final class FakeRewardedAd: RewardVerification.CapableAd {
     var serverSideVerificationOptions: GoogleMobileAds.ServerSideVerificationOptions?
-    var responseInfo: GoogleMobileAds.ResponseInfo?
+    let responseInfo = GoogleMobileAds.ResponseInfo()
 }
 
 #endif


### PR DESCRIPTION
## Summary
- Fix-forward for #6841: the merged change made `CapableAd.responseInfo` non-optional, but the test fakes (`FakeRewardedAd`, `FakeCapableAd`) still declared it as `ResponseInfo?`, so the `RevenueCatAdMobTests` target no longer compiles on main.
- Switches both fakes to a stored non-optional `let responseInfo = GoogleMobileAds.ResponseInfo()` to match the protocol.

## Test plan
- [x] `xcodebuild ... -workspace AdapterSDKs/RevenueCatAdMob -scheme RevenueCatAdMob test` — 168 tests pass locally
- [x] CI: `ci/circleci: revenuecat-admob-tests` green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production or security impact.
> 
> **Overview**
> Restores **RevenueCatAdMob** test compilation after `RewardVerification.CapableAd.responseInfo` became non-optional. Test doubles `FakeCapableAd` and `FakeRewardedAd` now expose `let responseInfo = GoogleMobileAds.ResponseInfo()` instead of optional `ResponseInfo?`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8db7dbabea15abee8d890c7ae6c08c2d3aa0842a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->