### PR TITLE
ci(admob): run revenuecat-admob-tests on every PR push

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -2231,6 +2231,9 @@ workflows:
       - build-tv-watch-mac-and-visionos:
           context:
             - slack-secrets
+      - revenuecat-admob-tests:
+          context:
+            - slack-secrets
 
       # =============================================================
       # Hold gate for the Full Test Suite
@@ -2344,11 +2347,6 @@ workflows:
           context:
             - slack-secrets
       - spm-receipt-parser:
-          requires:
-            - approve-full-tests
-          context:
-            - slack-secrets
-      - revenuecat-admob-tests:
           requires:
             - approve-full-tests
           context:


### PR DESCRIPTION
## Summary

- Moves `revenuecat-admob-tests` out of the `approve-full-tests` gate in the `run-all-tests` workflow
- The job now runs automatically on every PR push alongside the other ungated jobs
- The `release-or-main` workflow is unchanged (it was already ungated there)

## Follow-up required (admin access needed)

Add `ci/circleci: revenuecat-admob-tests` as a required status check for `main`. Run this once the PR merges and a passing CircleCI build has reported the new context:

```bash
# Fetch current contexts
CURRENT=$(gh api repos/RevenueCat/purchases-ios/branches/main --jq '.protection.required_status_checks.contexts | @json')
# Append the new check and update
gh api repos/RevenueCat/purchases-ios/branches/main/protection/required_status_checks \
  --method PATCH \
  --field "strict=false" \
  --field "contexts=$(echo $CURRENT | python3 -c 'import sys,json; c=json.load(sys.stdin); c.append("ci/circleci: revenuecat-admob-tests"); print(json.dumps(c))')"
```

Or add it through the GitHub UI: **Settings → Branches → main → Edit → Require status checks → search for `revenuecat-admob-tests`**.

## Test plan
- [x] CircleCI runs `revenuecat-admob-tests` automatically on this PR without needing to approve the gate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; no application code, with slightly more macOS CI usage per PR push.
> 
> **Overview**
> In the **`run-all-tests`** CircleCI workflow, **`revenuecat-admob-tests`** is now part of the **reduced test suite** that runs on every PR push (with `slack-secrets`), instead of sitting behind **`approve-full-tests`**.
> 
> The job is **removed** from the gated full-suite block (no more `requires: approve-full-tests`). **`all-tasks-passed`** still depends on **`revenuecat-admob-tests`**, so merge gating can treat it as required once GitHub branch protection lists the CircleCI status check.
> 
> Follow-up outside this diff: add **`ci/circleci: revenuecat-admob-tests`** as a required check on **`main`** after a green build reports that context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eb138869270b454da19d09f02ccad0104b8b201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->