### PR TITLE
feat(ads/admob): fire reward events from adapter lifecycle

### DIFF
--- a/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/RewardedAdManager.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/RewardedAdManager.swift
@@ -59,7 +59,7 @@ final class RewardedAdManager: NSObject, ObservableObject {
         self.presentingAdObjectID = presentingAdObjectID
         self.shouldReportDismissedBeforeReward = true
         self.message = Message.Rewarded.waitingForReward
-        loadedAd.present(from: viewController, userDidEarnRewardHandler: { [weak self] in
+        loadedAd.present(from: viewController, placement: "rewarded_main", userDidEarnRewardHandler: { [weak self] in
             guard let self else { return }
             guard self.presentingAdObjectID == presentingAdObjectID else { return }
             let reward = loadedAd.adReward

--- a/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/RewardedInterstitialAdManager.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/RewardedInterstitialAdManager.swift
@@ -59,15 +59,19 @@ final class RewardedInterstitialAdManager: NSObject, ObservableObject {
         self.presentingAdObjectID = presentingAdObjectID
         self.shouldReportDismissedBeforeReward = true
         self.message = Message.Rewarded.waitingForReward
-        loadedAd.present(from: viewController, userDidEarnRewardHandler: { [weak self] in
-            guard let self else { return }
-            guard self.presentingAdObjectID == presentingAdObjectID else { return }
-            let reward = loadedAd.adReward
-            self.presentingAdObjectID = nil
-            self.shouldReportDismissedBeforeReward = false
-            self.message = Message.Rewarded.rewardGranted(amount: reward.amount, type: reward.type)
-            print("✅ User earned reward (rewarded interstitial)")
-        })
+        loadedAd.present(
+            from: viewController,
+            placement: "rewarded_interstitial_main",
+            userDidEarnRewardHandler: { [weak self] in
+                guard let self else { return }
+                guard self.presentingAdObjectID == presentingAdObjectID else { return }
+                let reward = loadedAd.adReward
+                self.presentingAdObjectID = nil
+                self.shouldReportDismissedBeforeReward = false
+                self.message = Message.Rewarded.rewardGranted(amount: reward.amount, type: reward.type)
+                print("✅ User earned reward (rewarded interstitial)")
+            }
+        )
     }
 
 }

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
@@ -163,11 +163,14 @@ internal extension RewardVerification.CapableAd {
     /// RevenueCat reward-verification polling results.
     ///
     /// - Parameter poller: For unit tests; pass `nil` in production to use ``RewardVerification.Poller/makeDefault()``.
+    /// - Parameter tracker: For unit tests; defaults to the shared adapter tracker.
     @MainActor
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     func createUserDidEarnRewardHandler(
         rewardVerificationStarted: (@MainActor () -> Void)?,
         rewardVerificationCompleted: (@MainActor (RewardVerificationResult) -> Void)?,
         poller: RewardVerification.Poller? = nil,
+        tracker: Tracking.Tracker = Tracking.Adapter.shared.tracker,
         invalidateVirtualCurrenciesCache: @escaping @MainActor () -> Void
             = RewardVerification.SideEffects.invalidateVirtualCurrenciesCacheIfConfigured
     ) -> (() -> Void) {
@@ -181,7 +184,17 @@ internal extension RewardVerification.CapableAd {
             )
         }
 
-        return {
+        let rewardVerificationEnabled = (state != nil)
+
+        return { [weak self] in
+            guard let self else { return }
+            let impressionId = state?.impressionId ?? self.impressionId
+            self.fireEarnedUnverifiedEvent(
+                tracker: tracker,
+                impressionId: impressionId,
+                rewardVerificationEnabled: rewardVerificationEnabled
+            )
+
             rewardVerificationStarted?()
 
             guard let rewardVerificationCompleted else {
@@ -193,12 +206,46 @@ internal extension RewardVerification.CapableAd {
                 return
             }
 
+            let networkName = self.responseInfo.loadedAdNetworkResponseInfo?.adNetworkClassName
+            let placement = Tracking.Adapter.shared.fullScreenDelegateStore.retrieve(for: self)?.placement
+            let adFormat = self.rewardedAdFormat
+            let adUnitId = self.adUnitID
             let resolvedPoller = poller ?? .makeDefault()
             RewardVerification.Dispatcher.dispatch(
                 clientTransactionID: state.clientTransactionID,
                 state: state,
                 poller: resolvedPoller,
                 outcomeHandler: { internalOutcome in
+                    if tracker.isConfigured {
+                        switch internalOutcome {
+                        case .verified(let reward):
+                            tracker.trackAdRewardVerified(.init(
+                                networkName: networkName,
+                                mediatorName: .adMob,
+                                adFormat: adFormat,
+                                placement: placement,
+                                adUnitId: adUnitId,
+                                impressionId: impressionId,
+                                reward: reward
+                            ))
+                        case .failed(let reason):
+                            let failureReason: RevenueCat.AdRewardFailureReason
+                            switch reason {
+                            case .timeout: failureReason = .timeout
+                            case .backendError: failureReason = .backendError
+                            case .unknown: failureReason = .unknown
+                            }
+                            tracker.trackAdRewardFailedToVerify(.init(
+                                networkName: networkName,
+                                mediatorName: .adMob,
+                                adFormat: adFormat,
+                                placement: placement,
+                                adUnitId: adUnitId,
+                                impressionId: impressionId,
+                                failureReason: failureReason
+                            ))
+                        }
+                    }
                     if case .verified(let reward) = internalOutcome, reward.virtualCurrency != nil {
                         invalidateVirtualCurrenciesCache()
                     }
@@ -213,6 +260,7 @@ internal extension RewardVerification.CapableAd {
 
 @available(iOS 15.0, *)
 internal extension RewardVerification {
+
     static func mapOutcome(_ outcome: Outcome) -> RewardVerificationResult {
         switch outcome {
         case .verified(let reward):

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Setup.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Setup.swift
@@ -8,7 +8,7 @@ import Foundation
 
 #if os(iOS) && canImport(GoogleMobileAds)
 import GoogleMobileAds
-@_spi(Internal) import RevenueCat
+@_spi(Internal) @_spi(Experimental) import RevenueCat
 
 @available(iOS 15.0, *)
 internal extension RewardVerification {
@@ -17,6 +17,9 @@ internal extension RewardVerification {
     protocol CapableAd: AnyObject {
         var serverSideVerificationOptions: GoogleMobileAds.ServerSideVerificationOptions? { get set }
         var responseInfo: GoogleMobileAds.ResponseInfo { get }
+        var adUnitID: String { get }
+        var adReward: GoogleMobileAds.AdReward { get }
+        var rewardedAdFormat: RevenueCat.AdFormat { get }
     }
 
     /// Load-time SSV setup for rewarded AdMob ads.
@@ -69,7 +72,7 @@ internal extension RewardVerification {
             options.customRewardText = customRewardText
             loadedAd.serverSideVerificationOptions = options
 
-            let state = State(clientTransactionID: clientTransactionID)
+            let state = State(clientTransactionID: clientTransactionID, impressionId: impressionId)
             RewardVerification.stateStore.set(state, for: loadedAd)
             return state
         }
@@ -100,9 +103,43 @@ internal extension RewardVerification {
 }
 
 @available(iOS 15.0, *)
-extension GoogleMobileAds.RewardedAd: RewardVerification.CapableAd {}
+extension GoogleMobileAds.RewardedAd: RewardVerification.CapableAd {
+    internal var rewardedAdFormat: RevenueCat.AdFormat { .rewarded }
+}
 
 @available(iOS 15.0, *)
-extension GoogleMobileAds.RewardedInterstitialAd: RewardVerification.CapableAd {}
+extension GoogleMobileAds.RewardedInterstitialAd: RewardVerification.CapableAd {
+    internal var rewardedAdFormat: RevenueCat.AdFormat { .rewardedInterstitial }
+}
+
+@available(iOS 15.0, *)
+internal extension RewardVerification.CapableAd {
+    /// Impression identifier derived from the loaded ad, with the canonical fallback applied.
+    var impressionId: String {
+        Tracking.Adapter.impressionID(from: self.responseInfo)
+    }
+
+    @MainActor
+    func fireEarnedUnverifiedEvent(
+        tracker: Tracking.Tracker,
+        impressionId: String,
+        rewardVerificationEnabled: Bool
+    ) {
+        guard tracker.isConfigured else { return }
+        let placement = Tracking.Adapter.shared.fullScreenDelegateStore
+            .retrieve(for: self)?.placement
+        tracker.trackAdRewardEarnedUnverified(.init(
+            networkName: self.responseInfo.loadedAdNetworkResponseInfo?.adNetworkClassName,
+            mediatorName: .adMob,
+            adFormat: self.rewardedAdFormat,
+            placement: placement,
+            adUnitId: self.adUnitID,
+            impressionId: impressionId,
+            rewardVerificationEnabled: rewardVerificationEnabled,
+            rewardItem: self.adReward.type,
+            rewardAmount: self.adReward.amount.intValue
+        ))
+    }
+}
 
 #endif

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/State.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/State.swift
@@ -17,11 +17,13 @@ internal extension RewardVerification {
     final class State {
 
         let clientTransactionID: String
+        let impressionId: String
 
         private var didFire = false
 
-        init(clientTransactionID: String) {
+        init(clientTransactionID: String, impressionId: String) {
             self.clientTransactionID = clientTransactionID
+            self.impressionId = impressionId
         }
 
         /// Returns `true` exactly once per instance; subsequent calls return `false`.

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/FullScreenAd+Tracking.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/FullScreenAd+Tracking.swift
@@ -4,6 +4,8 @@
 //  Created by RevenueCat on 2/13/26.
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 
 #if os(iOS) && canImport(GoogleMobileAds)
@@ -204,6 +206,8 @@ internal extension GoogleMobileAds.RewardedAd {
     ///
     /// Call this instead of `present(from:userDidEarnRewardHandler:)` when you want to specify or override
     /// the placement at show time. The placement passed here takes precedence over any placement provided at load time.
+    ///
+    /// Fires `AdRewardEarnedUnverified` (with `rewardVerificationEnabled: false`) before invoking the handler.
     @MainActor
     func present(
         from viewController: UIViewController,
@@ -211,7 +215,16 @@ internal extension GoogleMobileAds.RewardedAd {
         userDidEarnRewardHandler: @escaping () -> Void
     ) {
         Tracking.Adapter.shared.fullScreenDelegateStore.retrieve(for: self)?.placement = placement
-        self.present(from: viewController, userDidEarnRewardHandler: userDidEarnRewardHandler)
+        self.present(from: viewController, userDidEarnRewardHandler: { [weak self] in
+            if let self {
+                self.fireEarnedUnverifiedEvent(
+                    tracker: Tracking.Adapter.shared.tracker,
+                    impressionId: self.impressionId,
+                    rewardVerificationEnabled: false
+                )
+            }
+            userDidEarnRewardHandler()
+        })
     }
 }
 
@@ -275,6 +288,8 @@ internal extension GoogleMobileAds.RewardedInterstitialAd {
     ///
     /// Call this instead of `present(from:userDidEarnRewardHandler:)` when you want to specify or override
     /// the placement at show time. The placement passed here takes precedence over any placement provided at load time.
+    ///
+    /// Fires `AdRewardEarnedUnverified` (with `rewardVerificationEnabled: false`) before invoking the handler.
     @MainActor
     func present(
         from viewController: UIViewController,
@@ -282,7 +297,16 @@ internal extension GoogleMobileAds.RewardedInterstitialAd {
         userDidEarnRewardHandler: @escaping () -> Void
     ) {
         Tracking.Adapter.shared.fullScreenDelegateStore.retrieve(for: self)?.placement = placement
-        self.present(from: viewController, userDidEarnRewardHandler: userDidEarnRewardHandler)
+        self.present(from: viewController, userDidEarnRewardHandler: { [weak self] in
+            if let self {
+                self.fireEarnedUnverifiedEvent(
+                    tracker: Tracking.Adapter.shared.tracker,
+                    impressionId: self.impressionId,
+                    rewardVerificationEnabled: false
+                )
+            }
+            userDidEarnRewardHandler()
+        })
     }
 }
 

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/PurchasesTracker.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/PurchasesTracker.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 #if os(iOS) && canImport(GoogleMobileAds)
-@_spi(Experimental) import RevenueCat
+@_spi(Internal) @_spi(Experimental) import RevenueCat
 
 @available(iOS 15.0, *)
 internal extension Tracking {
@@ -22,6 +22,15 @@ internal extension Tracking {
         func trackAdOpened(_ data: AdOpened) { Purchases.shared.adTracker.trackAdOpened(data) }
         func trackAdRevenue(_ data: AdRevenue) { Purchases.shared.adTracker.trackAdRevenue(data) }
         func trackAdFailedToLoad(_ data: AdFailedToLoad) { Purchases.shared.adTracker.trackAdFailedToLoad(data) }
+        func trackAdRewardEarnedUnverified(_ data: AdRewardEarnedUnverified) {
+            Purchases.shared.adTracker.trackAdRewardEarnedUnverified(data)
+        }
+        func trackAdRewardVerified(_ data: AdRewardVerified) {
+            Purchases.shared.adTracker.trackAdRewardVerified(data)
+        }
+        func trackAdRewardFailedToVerify(_ data: AdRewardFailedToVerify) {
+            Purchases.shared.adTracker.trackAdRewardFailedToVerify(data)
+        }
 
     }
 

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/Tracker.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/Tracker.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 #if os(iOS) && canImport(GoogleMobileAds)
-@_spi(Experimental) import RevenueCat
+@_spi(Internal) @_spi(Experimental) import RevenueCat
 
 @available(iOS 15.0, *)
 internal extension Tracking {
@@ -24,6 +24,9 @@ internal extension Tracking {
         func trackAdOpened(_ data: AdOpened)
         func trackAdRevenue(_ data: AdRevenue)
         func trackAdFailedToLoad(_ data: AdFailedToLoad)
+        func trackAdRewardEarnedUnverified(_ data: AdRewardEarnedUnverified)
+        func trackAdRewardVerified(_ data: AdRewardVerified)
+        func trackAdRewardFailedToVerify(_ data: AdRewardFailedToVerify)
     }
 
 }

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/AdapterTrackingTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/AdapterTrackingTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 #if os(iOS) && canImport(GoogleMobileAds)
 import GoogleMobileAds
-@_spi(Experimental) import RevenueCat
+@_spi(Internal) @_spi(Experimental) import RevenueCat
 @_spi(Experimental) @testable import RevenueCatAdMob
 
 @available(iOS 15.0, *)
@@ -73,6 +73,40 @@ final class MockAdTracker: Tracking.Tracker {
             adUnitId: data.adUnitId
         ))
         self.failedToLoadData.append(data)
+    }
+
+    private(set) var rewardEarnedUnverifiedData: [AdRewardEarnedUnverified] = []
+    private(set) var rewardVerifiedData: [AdRewardVerified] = []
+    private(set) var rewardFailedToVerifyData: [AdRewardFailedToVerify] = []
+
+    func trackAdRewardEarnedUnverified(_ data: AdRewardEarnedUnverified) {
+        self.calls.append(Call(
+            method: "trackAdRewardEarnedUnverified",
+            adFormat: data.adFormat.rawValue,
+            placement: data.placement,
+            adUnitId: data.adUnitId
+        ))
+        self.rewardEarnedUnverifiedData.append(data)
+    }
+
+    func trackAdRewardVerified(_ data: AdRewardVerified) {
+        self.calls.append(Call(
+            method: "trackAdRewardVerified",
+            adFormat: data.adFormat.rawValue,
+            placement: data.placement,
+            adUnitId: data.adUnitId
+        ))
+        self.rewardVerifiedData.append(data)
+    }
+
+    func trackAdRewardFailedToVerify(_ data: AdRewardFailedToVerify) {
+        self.calls.append(Call(
+            method: "trackAdRewardFailedToVerify",
+            adFormat: data.adFormat.rawValue,
+            placement: data.placement,
+            adUnitId: data.adUnitId
+        ))
+        self.rewardFailedToVerifyData.append(data)
     }
 }
 

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/DispatcherTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/DispatcherTests.swift
@@ -12,7 +12,7 @@ final class DispatcherTests: AdapterTestCase {
 
     func testRunFiresVerifiedOutcomeWithVirtualCurrencyReward() async throws {
         let reward = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 5))
-        let state = RewardVerification.State(clientTransactionID: "tx-verified")
+        let state = RewardVerification.State(clientTransactionID: "tx-verified", impressionId: "")
         let poller = self.makePoller(statuses: [.verified(.virtualCurrency(reward))])
         let recorder = OutcomeRecorder()
 
@@ -33,7 +33,7 @@ final class DispatcherTests: AdapterTestCase {
     }
 
     func testRunFiresFailedOutcomeWhenPollerReportsFailed() async {
-        let state = RewardVerification.State(clientTransactionID: "tx-failed")
+        let state = RewardVerification.State(clientTransactionID: "tx-failed", impressionId: "")
         let poller = self.makePoller(statuses: [.failed])
         let recorder = OutcomeRecorder()
 
@@ -51,7 +51,7 @@ final class DispatcherTests: AdapterTestCase {
     }
 
     func testRunFiresFailedOutcomeWhenAllAttemptsRemainPending() async {
-        let state = RewardVerification.State(clientTransactionID: "tx-pending-budget")
+        let state = RewardVerification.State(clientTransactionID: "tx-pending-budget", impressionId: "")
         let poller = self.makePoller(statuses: Array(repeating: .pending, count: 3), maxAttempts: 3)
         let recorder = OutcomeRecorder()
 
@@ -68,7 +68,7 @@ final class DispatcherTests: AdapterTestCase {
     }
 
     func testRunFiresFailedOutcomeWhenAllAttemptsThrowTransiently() async {
-        let state = RewardVerification.State(clientTransactionID: "tx-transient")
+        let state = RewardVerification.State(clientTransactionID: "tx-transient", impressionId: "")
         let throwingPoller = ThrowingStatusPoller(error: ErrorCode.networkError)
         let poller = RewardVerification.Poller(
             statusPoller: throwingPoller, sleeper: RecordingSleeper(), maxAttempts: 3
@@ -93,7 +93,7 @@ final class DispatcherTests: AdapterTestCase {
     }
 
     func testRunFiresFailedOutcomeWhenPollerThrowsTerminalErrorCode() async {
-        let state = RewardVerification.State(clientTransactionID: "tx-terminal")
+        let state = RewardVerification.State(clientTransactionID: "tx-terminal", impressionId: "")
         let throwingPoller = ThrowingStatusPoller(error: ErrorCode.signatureVerificationFailed)
         let poller = RewardVerification.Poller(
             statusPoller: throwingPoller, sleeper: RecordingSleeper(), maxAttempts: 3
@@ -118,7 +118,7 @@ final class DispatcherTests: AdapterTestCase {
     }
 
     func testRunForwardsNoRewardCaseUnchangedThroughVerifiedOutcome() async {
-        let state = RewardVerification.State(clientTransactionID: "tx-no-reward")
+        let state = RewardVerification.State(clientTransactionID: "tx-no-reward", impressionId: "")
         let poller = self.makePoller(statuses: [.verified(.noReward)])
         let recorder = OutcomeRecorder()
 
@@ -135,7 +135,7 @@ final class DispatcherTests: AdapterTestCase {
     }
 
     func testRunForwardsUnsupportedRewardCaseUnchangedThroughVerifiedOutcome() async {
-        let state = RewardVerification.State(clientTransactionID: "tx-unsupported-reward")
+        let state = RewardVerification.State(clientTransactionID: "tx-unsupported-reward", impressionId: "")
         let poller = self.makePoller(statuses: [.verified(.unsupportedReward)])
         let recorder = OutcomeRecorder()
 
@@ -156,7 +156,7 @@ final class DispatcherTests: AdapterTestCase {
     // MARK: - One-shot guard
 
     func testRunDoesNotFireWhenStateGuardAlreadyConsumed() async {
-        let state = RewardVerification.State(clientTransactionID: "tx-already-fired")
+        let state = RewardVerification.State(clientTransactionID: "tx-already-fired", impressionId: "")
         XCTAssertTrue(state.consumeFireToken(), "Pre-consume the guard before invoking the dispatcher")
         let poller = self.makePoller(statuses: [.verified(.noReward)])
         let recorder = OutcomeRecorder()
@@ -173,7 +173,7 @@ final class DispatcherTests: AdapterTestCase {
     }
 
     func testRunFiresHandlerAtMostOnceForBackToBackCalls() async {
-        let state = RewardVerification.State(clientTransactionID: "tx-once")
+        let state = RewardVerification.State(clientTransactionID: "tx-once", impressionId: "")
         let recorder = OutcomeRecorder()
 
         await RewardVerification.Dispatcher.run(
@@ -197,7 +197,7 @@ final class DispatcherTests: AdapterTestCase {
 
     func testDispatchCompletesAndForwardsVerifiedOutcome() async throws {
         let reward = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 7))
-        let state = RewardVerification.State(clientTransactionID: "tx-dispatch")
+        let state = RewardVerification.State(clientTransactionID: "tx-dispatch", impressionId: "")
         let poller = self.makePoller(statuses: [.verified(.virtualCurrency(reward))])
         let recorder = OutcomeRecorder()
 
@@ -218,7 +218,7 @@ final class DispatcherTests: AdapterTestCase {
     }
 
     func testDispatchCancellationDoesNotFireHandlerAndPreservesGuard() async {
-        let state = RewardVerification.State(clientTransactionID: "tx-dispatch-cancel")
+        let state = RewardVerification.State(clientTransactionID: "tx-dispatch-cancel", impressionId: "")
         let hangingPoller = HangingStatusPoller()
         let poller = RewardVerification.Poller(
             statusPoller: hangingPoller,
@@ -248,7 +248,7 @@ final class DispatcherTests: AdapterTestCase {
     // MARK: - Threading
 
     func testRunDeliversOutcomeOnMainActor() async {
-        let state = RewardVerification.State(clientTransactionID: "tx-main-actor")
+        let state = RewardVerification.State(clientTransactionID: "tx-main-actor", impressionId: "")
         let poller = self.makePoller(statuses: [.verified(.noReward)])
         let mainActorAssertion = MainActorAssertionRecorder()
 

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
@@ -258,9 +258,21 @@ final class PresentRewardVerificationTests: AdapterTestCase {
 // MARK: - Test doubles
 
 @available(iOS 15.0, *)
-private final class FakeCapableAd: RewardVerification.CapableAd {
+private final class FakeCapableAd: NSObject, RewardVerification.CapableAd {
     var serverSideVerificationOptions: GoogleMobileAds.ServerSideVerificationOptions?
-    let responseInfo = GoogleMobileAds.ResponseInfo()
+    let responseInfo: GoogleMobileAds.ResponseInfo = unsafeBitCast(
+        FakeResponseInfo(),
+        to: GoogleMobileAds.ResponseInfo.self
+    )
+    var adUnitID: String = "fake-ad-unit"
+    var adReward: GoogleMobileAds.AdReward = .init()
+    var rewardedAdFormat: RevenueCat.AdFormat = .rewarded
+}
+
+@available(iOS 15.0, *)
+private final class FakeResponseInfo: NSObject {
+    @objc var responseIdentifier: String? { nil }
+    @objc var loadedAdNetworkResponseInfo: AnyObject? { nil }
 }
 
 #endif

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RewardTrackingTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/RewardTrackingTests.swift
@@ -1,0 +1,207 @@
+import Nimble
+import XCTest
+
+#if os(iOS) && canImport(GoogleMobileAds)
+import GoogleMobileAds
+@_spi(Experimental) @_spi(Internal) @testable import RevenueCat
+@_spi(Experimental) @testable import RevenueCatAdMob
+
+@available(iOS 15.0, *)
+@MainActor
+final class RewardTrackingTests: AdapterTestCase {
+
+    private static let testAPIKey = "appl_test_reward_tracking"
+    private static let testAppUserID = "user_reward_tracking"
+
+    private var mockTracker: MockAdTracker!
+    private var fakeAd: FakeRewardedAd!
+
+    override func setUp() {
+        super.setUp()
+        self.mockTracker = MockAdTracker()
+        self.fakeAd = FakeRewardedAd()
+    }
+
+    // MARK: - AdRewardEarnedUnverified
+
+    func testHandlerFiresRewardEarnedUnverifiedWithStateMetadata() {
+        RewardVerification.Setup.install(on: self.fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
+
+        let handler = self.fakeAd.createUserDidEarnRewardHandler(
+            rewardVerificationStarted: nil,
+            rewardVerificationCompleted: nil,
+            tracker: self.mockTracker
+        )
+        handler()
+
+        XCTAssertEqual(self.mockTracker.rewardEarnedUnverifiedData.count, 1)
+        let event = self.mockTracker.rewardEarnedUnverifiedData[0]
+        expect(event.mediatorName) == .adMob
+        expect(event.adFormat) == .rewarded
+        expect(event.adUnitId) == self.fakeAd.adUnitID
+        expect(event.rewardVerificationEnabled) == true
+        expect(event.impressionId) == ""
+    }
+
+    func testHandlerFiresRewardEarnedUnverifiedEvenWithoutVerificationState() {
+        let handler = self.fakeAd.createUserDidEarnRewardHandler(
+            rewardVerificationStarted: nil,
+            rewardVerificationCompleted: nil,
+            tracker: self.mockTracker
+        )
+        handler()
+
+        XCTAssertEqual(self.mockTracker.rewardEarnedUnverifiedData.count, 1)
+        let event = self.mockTracker.rewardEarnedUnverifiedData[0]
+        expect(event.rewardVerificationEnabled) == false
+        expect(event.impressionId) == ""
+    }
+
+    func testFireEarnedUnverifiedEventDirectlyEmitsExpectedFields() {
+        self.fakeAd.fireEarnedUnverifiedEvent(
+            tracker: self.mockTracker,
+            impressionId: "imp-loadAndTrack",
+            rewardVerificationEnabled: false
+        )
+
+        XCTAssertEqual(self.mockTracker.rewardEarnedUnverifiedData.count, 1)
+        let event = self.mockTracker.rewardEarnedUnverifiedData[0]
+        expect(event.mediatorName) == .adMob
+        expect(event.adFormat) == .rewarded
+        expect(event.adUnitId) == self.fakeAd.adUnitID
+        expect(event.impressionId) == "imp-loadAndTrack"
+        expect(event.rewardVerificationEnabled) == false
+    }
+
+    // MARK: - AdRewardVerified
+
+    func testVirtualCurrencyOutcomeFiresVerifiedWithCurrencyFields() throws {
+        RewardVerification.Setup.install(on: self.fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
+
+        let reward = try XCTUnwrap(VirtualCurrencyReward(code: "GOLD", amount: 50))
+        let poller = self.makePoller(statuses: [.verified(.virtualCurrency(reward))])
+
+        self.runHandler(poller: poller, expectationDescription: "verified vc outcome")
+
+        XCTAssertEqual(self.mockTracker.rewardVerifiedData.count, 1)
+        let event = self.mockTracker.rewardVerifiedData[0]
+        expect(event.reward.virtualCurrency).toNot(beNil())
+        expect(event.reward.virtualCurrency?.code) == "GOLD"
+        expect(event.reward.virtualCurrency?.amount) == 50
+        XCTAssertTrue(self.mockTracker.rewardFailedToVerifyData.isEmpty)
+    }
+
+    func testNoRewardOutcomeFiresVerifiedWithNilCurrencyFields() {
+        RewardVerification.Setup.install(on: self.fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
+
+        let poller = self.makePoller(statuses: [.verified(.noReward)])
+        self.runHandler(poller: poller, expectationDescription: "verified no-reward outcome")
+
+        XCTAssertEqual(self.mockTracker.rewardVerifiedData.count, 1)
+        let event = self.mockTracker.rewardVerifiedData[0]
+        expect(event.reward) == .noReward
+        expect(event.reward.virtualCurrency).to(beNil())
+    }
+
+    func testUnsupportedRewardOutcomeFiresVerifiedWithNilCurrencyFields() {
+        RewardVerification.Setup.install(on: self.fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
+
+        let poller = self.makePoller(statuses: [.verified(.unsupportedReward)])
+        self.runHandler(poller: poller, expectationDescription: "verified unsupported outcome")
+
+        XCTAssertEqual(self.mockTracker.rewardVerifiedData.count, 1)
+        let event = self.mockTracker.rewardVerifiedData[0]
+        expect(event.reward) == .unsupportedReward
+        expect(event.reward.virtualCurrency).to(beNil())
+    }
+
+    // MARK: - AdRewardFailedToVerify
+
+    func testTimeoutFailureFiresFailedToVerify() {
+        RewardVerification.Setup.install(on: self.fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
+
+        let poller = self.makePoller(statuses: [.pending, .pending, .pending], maxAttempts: 3)
+        self.runHandler(poller: poller, expectationDescription: "timeout outcome")
+
+        XCTAssertEqual(self.mockTracker.rewardFailedToVerifyData.count, 1)
+        let event = self.mockTracker.rewardFailedToVerifyData[0]
+        expect(event.failureReason) == .timeout
+        XCTAssertTrue(self.mockTracker.rewardVerifiedData.isEmpty)
+    }
+
+    func testBackendFailureFiresFailedToVerify() {
+        RewardVerification.Setup.install(on: self.fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
+
+        let poller = self.makePoller(statuses: [.failed])
+        self.runHandler(poller: poller, expectationDescription: "backend failure outcome")
+
+        XCTAssertEqual(self.mockTracker.rewardFailedToVerifyData.count, 1)
+        expect(self.mockTracker.rewardFailedToVerifyData[0].failureReason) == .backendError
+    }
+
+    func testUnknownFailureFiresFailedToVerify() {
+        RewardVerification.Setup.install(on: self.fakeAd, apiKey: Self.testAPIKey, appUserID: Self.testAppUserID)
+
+        let throwingPoller = ThrowingStatusPoller(error: SentinelError())
+        let poller = RewardVerification.Poller(
+            statusPoller: throwingPoller,
+            sleeper: RecordingSleeper(),
+            jitter: RewardVerification.Jitter { 0 },
+            maxAttempts: 3
+        )
+        self.runHandler(poller: poller, expectationDescription: "unknown failure outcome")
+
+        XCTAssertEqual(self.mockTracker.rewardFailedToVerifyData.count, 1)
+        expect(self.mockTracker.rewardFailedToVerifyData[0].failureReason) == .unknown
+    }
+
+    // MARK: - Helpers
+
+    private func makePoller(
+        statuses: [RewardVerificationPollStatus],
+        maxAttempts: Int = 5
+    ) -> RewardVerification.Poller {
+        RewardVerification.Poller(
+            statusPoller: StubStatusPoller(statuses: statuses),
+            sleeper: RecordingSleeper(),
+            jitter: RewardVerification.Jitter { 0 },
+            maxAttempts: maxAttempts
+        )
+    }
+
+    private func runHandler(
+        poller: RewardVerification.Poller,
+        expectationDescription: String
+    ) {
+        let expectation = self.expectation(description: expectationDescription)
+        let handler = self.fakeAd.createUserDidEarnRewardHandler(
+            rewardVerificationStarted: nil,
+            rewardVerificationCompleted: { _ in expectation.fulfill() },
+            poller: poller,
+            tracker: self.mockTracker,
+            invalidateVirtualCurrenciesCache: {}
+        )
+        handler()
+        self.wait(for: [expectation], timeout: 2.0)
+    }
+}
+
+@available(iOS 15.0, *)
+private final class FakeRewardedAd: NSObject, RewardVerification.CapableAd {
+    var serverSideVerificationOptions: GoogleMobileAds.ServerSideVerificationOptions?
+    let responseInfo: GoogleMobileAds.ResponseInfo = unsafeBitCast(
+        FakeResponseInfo(),
+        to: GoogleMobileAds.ResponseInfo.self
+    )
+    var adUnitID: String = "ca-app-pub-reward-tracking"
+    var adReward: GoogleMobileAds.AdReward = .init()
+    var rewardedAdFormat: RevenueCat.AdFormat = .rewarded
+}
+
+@available(iOS 15.0, *)
+private final class FakeResponseInfo: NSObject {
+    @objc var responseIdentifier: String? { nil }
+    @objc var loadedAdNetworkResponseInfo: AnyObject? { nil }
+}
+
+#endif

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/SetupTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/SetupTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 #if os(iOS) && canImport(GoogleMobileAds)
 import GoogleMobileAds
-@_spi(Internal) import RevenueCat
+@_spi(Internal) @_spi(Experimental) import RevenueCat
 @testable import RevenueCatAdMob
 
 @available(iOS 15.0, *)
@@ -151,9 +151,21 @@ final class SetupTests: AdapterTestCase {
 // MARK: - Test doubles
 
 @available(iOS 15.0, *)
-private final class FakeRewardedAd: RewardVerification.CapableAd {
+private final class FakeRewardedAd: NSObject, RewardVerification.CapableAd {
     var serverSideVerificationOptions: GoogleMobileAds.ServerSideVerificationOptions?
-    let responseInfo = GoogleMobileAds.ResponseInfo()
+    let responseInfo: GoogleMobileAds.ResponseInfo = unsafeBitCast(
+        FakeResponseInfo(),
+        to: GoogleMobileAds.ResponseInfo.self
+    )
+    var adUnitID: String = "fake-ad-unit"
+    var adReward: GoogleMobileAds.AdReward = .init()
+    var rewardedAdFormat: RevenueCat.AdFormat = .rewarded
+}
+
+@available(iOS 15.0, *)
+private final class FakeResponseInfo: NSObject {
+    @objc var responseIdentifier: String? { nil }
+    @objc var loadedAdNetworkResponseInfo: AnyObject? { nil }
 }
 
 #endif

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/StateTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/StateTests.swift
@@ -10,7 +10,7 @@ final class StateTests: AdapterTestCase {
     // MARK: - Storage
 
     func testStoresClientTransactionID() {
-        let state = RewardVerification.State(clientTransactionID: "tx-42")
+        let state = RewardVerification.State(clientTransactionID: "tx-42", impressionId: "")
 
         XCTAssertEqual(state.clientTransactionID, "tx-42")
     }
@@ -18,7 +18,7 @@ final class StateTests: AdapterTestCase {
     // MARK: - One-shot guard
 
     func testFirstConsumeFireTokenReturnsTrueAndSubsequentReturnFalse() {
-        let state = RewardVerification.State(clientTransactionID: "tx-1")
+        let state = RewardVerification.State(clientTransactionID: "tx-1", impressionId: "")
 
         XCTAssertTrue(state.consumeFireToken())
         XCTAssertFalse(state.consumeFireToken())


### PR DESCRIPTION
### Checklist
- [x] Unit + integration tests
- [x] Stacked on #6843 (core SDK reward event types) — once that lands, this PR's base auto-rebases onto `main`

### Motivation

The AdMob adapter doesn't yet emit reward telemetry. Apps using `loadAndTrack` get impression telemetry (Loaded/Displayed/Opened/Revenue) but no information about the reward lifecycle — whether the user earned the reward, whether server-side verification succeeded, why it failed. This PR wires the three reward events introduced in the core SDK PR (#6843) into the adapter so apps get reward telemetry automatically.

### Description

- `Tracking.Tracker` protocol gains three reward methods; `PurchasesTracker` forwards them to `Purchases.shared.adTracker.trackAdReward*`.
- `RewardVerification.CapableAd` protocol gains `adUnitID`, `adReward`, `rewardedAdFormat`. A `CapableAd` extension exposes a computed `impressionId` (via `Tracking.Adapter.impressionID(from:)`) and a `fireEarnedUnverifiedEvent` helper used by both firing paths.
- `RewardVerification.State` gains an `impressionId` field, captured at install time so the post-SSV firing path uses the same identifier that was written into `customRewardText`.
- **`createUserDidEarnRewardHandler`** fires `AdRewardEarnedUnverified` at fire time and, if a `rewardVerificationCompleted` callback is set, dispatches the verification poller — its `outcomeHandler` then fires either `AdRewardVerified` or `AdRewardFailedToVerify` based on the resolved `RewardVerification.Outcome`.
- **`RewardedAd::present(from:placement:userDidEarnRewardHandler:)`** (and the matching overload on `RewardedInterstitialAd`) now wrap the user's handler so apps using `loadAndTrack` + the placement-override variant get the Earned event with `rewardVerificationEnabled: false` — without opting into SSV.
- Sample managers (`RewardedAdManager`, `RewardedInterstitialAdManager`) updated to use the placement-override variant so they demonstrate the new Earned telemetry. `Verified*Manager` pair already uses the SSV path and now emits all three events.

GMA's native `present(from:userDidEarnRewardHandler:)` cannot be intercepted from Swift without swizzling (extension methods on the same signature are silently shadowed by the type's own method), so apps that call GMA native directly still get no Earned event. A follow-up PR renames RC's `present` overloads to `presentAndTrack(...)` so the side effect is visible from the method name.

### Test plan
- `swift build` (adapter + tests) + `swiftlint` clean.
- `RewardTrackingTests`: end-to-end coverage of each `VerifiedReward` variant (`.virtualCurrency` / `.noReward` / `.unsupportedReward`) and each `FailureReason` (`.timeout` / `.backendError` / `.unknown`).
- `MockAdTracker` (in `AdapterTrackingTests`) gains conformance to the three new Tracker methods.
- `FakeCapableAd` / `FakeRewardedAd` test doubles conform to the extended `CapableAd` protocol.
- `DispatcherTests` / `StateTests` updated for the new `State.impressionId` field.