### PR TITLE
PR#1 Add infrastructure for mutable paywall variables

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		16E146AD2E99F3480089B609 /* TransactionNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E146AB2E99F1E20089B609 /* TransactionNotifications.swift */; };
 		16E146B22E99FC7E0089B609 /* PurchaseResultComparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E146B12E99FC7E0089B609 /* PurchaseResultComparator.swift */; };
 		16E2B7F12EA01DFA00F04A7A /* SynchronizedLargeItemCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E2B7F02EA01DFA00F04A7A /* SynchronizedLargeItemCacheTests.swift */; };
+		16E4A3C89791426AAD027A49 /* PlatformInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043FB8686FEB4A31B9CF48C8 /* PlatformInfoTests.swift */; };
 		16F376262E93F1E300ADF649 /* LargeItemCacheTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F376252E93F1E300ADF649 /* LargeItemCacheTypeTests.swift */; };
 		1D20E1D62EBCF80E00ABE4CD /* HTTPRequestTimeoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D20E1D52EBCF80E00ABE4CD /* HTTPRequestTimeoutManager.swift */; };
 		1D20E1D82EBCF82900ABE4CD /* HTTPRequestTimeoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D20E1D72EBCF82900ABE4CD /* HTTPRequestTimeoutManager.swift */; };
@@ -149,6 +150,7 @@
 		1EFA95132CDBA58F00CA5951 /* MockRedeemWebPurchaseAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFA95112CDBA58F00CA5951 /* MockRedeemWebPurchaseAPI.swift */; };
 		1EFA95152CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFA95142CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift */; };
 		1EFA95162CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFA95142CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift */; };
+		2A2E7BA82FD30080FE783691 /* PaywallVariableUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0059D322CB49B106704939EF /* PaywallVariableUpdateTests.swift */; };
 		2B699E6661ECFB93B146A2D9 /* SynchronizedUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B0EAB50136613F69FAA3BB /* SynchronizedUserDefaultsTests.swift */; };
 		2C08B2E92CD40DBF0024857B /* ButtonComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */; };
 		2C08B3072CD55D660024857B /* FlexHStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C08B3062CD55D590024857B /* FlexHStack.swift */; };
@@ -376,6 +378,7 @@
 		356979E02CCFDAA100EE6A9E /* CustomerInfoFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 356979DF2CCFDA9C00EE6A9E /* CustomerInfoFixtures.swift */; };
 		356E2DE82CD3CF930055AABB /* StoredEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 356E2DE72CD3CF8F0055AABB /* StoredEventTests.swift */; };
 		357349012C3BEB5C000EEB86 /* CustomerCenterConfigDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 357348FF2C3BEB0A000EEB86 /* CustomerCenterConfigDataTests.swift */; };
+		3583AF355FBB1BB0D194822C /* PaywallVariablesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961E78AC0DB3C67A981EA97B /* PaywallVariablesStore.swift */; };
 		358DECA32D9BEF85003B1CC0 /* EmergeRenderingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358DECA22D9BEF85003B1CC0 /* EmergeRenderingMode.swift */; };
 		3592E8862C2ED51700D7F91D /* CustomerCenterConfigCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3592E8852C2ED51700D7F91D /* CustomerCenterConfigCallback.swift */; };
 		3592E88A2C2ED54A00D7F91D /* CustomerCenterConfigData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3592E8882C2ED54A00D7F91D /* CustomerCenterConfigData.swift */; };
@@ -663,8 +666,6 @@
 		575642B62910116900719219 /* EligibilityStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642B52910116900719219 /* EligibilityStrings.swift */; };
 		5757EDE72DEE08C100AC4BE1 /* StoreKitVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5757EDE62DEE08C100AC4BE1 /* StoreKitVersionTests.swift */; };
 		5757EDF82DEE092900AC4BE1 /* ClockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5757EDF72DEE092900AC4BE1 /* ClockTests.swift */; };
-		F2138021CD5445218F7CE984 /* DangerousSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425B8CF8557E44A4974E502A /* DangerousSettingsTests.swift */; };
-		16E4A3C89791426AAD027A49 /* PlatformInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043FB8686FEB4A31B9CF48C8 /* PlatformInfoTests.swift */; };
 		5759B322296DEF56002472D5 /* OptionalExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B321296DEF56002472D5 /* OptionalExtensionsTests.swift */; };
 		5759B3F4296DF65D002472D5 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B36824BD268FBC5B00957E4C /* XCTest.framework */; };
 		5759B3F7296DF65D002472D5 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B335296DF65D002472D5 /* Nimble */; };
@@ -1175,6 +1176,7 @@
 		9A65E0A02591A23200DE00B0 /* OfferingStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E09F2591A23200DE00B0 /* OfferingStrings.swift */; };
 		9A65E0A52591A23500DE00B0 /* PurchaseStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E0A42591A23500DE00B0 /* PurchaseStrings.swift */; };
 		A1E0F0022F297A0100000001 /* EventsManagerStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E0F0012F297A0100000001 /* EventsManagerStrings.swift */; };
+		A4A3DD3D0CBF50C8CEA5C972 /* PaywallVariableUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9953CB2C098B285D22D5D3E /* PaywallVariableUpdate.swift */; };
 		A524378B284FFF0200E788BD /* AttributionPosterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A524378A284FFF0200E788BD /* AttributionPosterTests.swift */; };
 		A525BF4B26C320D100C354C4 /* SubscriberAttributesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A525BF4A26C320D100C354C4 /* SubscriberAttributesManager.swift */; };
 		A55D08302722368600D919E0 /* SK2BeginRefundRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55D082F2722368600D919E0 /* SK2BeginRefundRequestHelper.swift */; };
@@ -1290,6 +1292,7 @@
 		E1C0A004BEEF0001CCDD0001 /* HeaderComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C0A009BEEF0001CCDD0001 /* HeaderComponentTests.swift */; };
 		E1C0A005BEEF0001CCDD0001 /* PaywallComponentsConfigHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C0A00ABEEF0001CCDD0001 /* PaywallComponentsConfigHeaderTests.swift */; };
 		EF970D13102945639A882001 /* ATTConsentStatusIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF970D13102945639A882002 /* ATTConsentStatusIntegrationTests.swift */; };
+		F2138021CD5445218F7CE984 /* DangerousSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425B8CF8557E44A4974E502A /* DangerousSettingsTests.swift */; };
 		F516BD29282434070083480B /* StoreKit2StorefrontListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = F516BD28282434070083480B /* StoreKit2StorefrontListener.swift */; };
 		F52CFAFC28290AE500E8ABC5 /* StoreKit2StorefrontListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F516BD322828FDD90083480B /* StoreKit2StorefrontListenerTests.swift */; };
 		F530E4FF275646EF001AF6BD /* MacDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = F530E4FE275646EF001AF6BD /* MacDevice.swift */; };
@@ -1498,6 +1501,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0059D322CB49B106704939EF /* PaywallVariableUpdateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallVariableUpdateTests.swift; sourceTree = "<group>"; };
 		030890802D2B76450069677B /* VariableHandlerV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableHandlerV2.swift; sourceTree = "<group>"; };
 		030890832D2B77E20069677B /* VariableHandlerV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableHandlerV2Tests.swift; sourceTree = "<group>"; };
 		030F91892D55C1AB0085103F /* LocaleFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleFinder.swift; sourceTree = "<group>"; };
@@ -1551,7 +1555,10 @@
 		03F446252D2FE1510046129A /* MaskShapePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskShapePropertyTests.swift; sourceTree = "<group>"; };
 		03F446542D303E350046129A /* PaddingPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingPropertyTests.swift; sourceTree = "<group>"; };
 		03F446562D303FA10046129A /* CornerRadiusesPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerRadiusesPropertyTests.swift; sourceTree = "<group>"; };
+		043FB8686FEB4A31B9CF48C8 /* PlatformInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfoTests.swift; sourceTree = "<group>"; };
 		077AC81FEBE38D1468AE8670 /* VideoAutoplayHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VideoAutoplayHandlerTests.swift; sourceTree = "<group>"; };
+		08B66CF5381446F2E445B241 /* PaywallVariablesStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallVariablesStoreTests.swift; sourceTree = "<group>"; };
+		0E4CCD8E9E454A2EB3760E06 /* ButtonComponentViewModelMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentViewModelMappingTests.swift; sourceTree = "<group>"; };
 		13B0EAB50136613F69FAA3BB /* SynchronizedUserDefaultsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaultsTests.swift; sourceTree = "<group>"; };
 		161627FD2F50987800DEEDEB /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		16216FEE2EBB8641008ACFE9 /* ResumeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumeAction.swift; sourceTree = "<group>"; };
@@ -1569,7 +1576,6 @@
 		166BA7992F84022400BB46C9 /* PaywallEventTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallEventTracker.swift; sourceTree = "<group>"; };
 		166BA7A02F84028600BB46C9 /* ControlInteractionLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlInteractionLoggerTests.swift; sourceTree = "<group>"; };
 		166BA7A12F84028600BB46C9 /* PaywallEventTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallEventTrackerTests.swift; sourceTree = "<group>"; };
-		57F4B2C12F8E10A600BB46C9 /* ExitOfferHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExitOfferHelperTests.swift; sourceTree = "<group>"; };
 		167D67082EA151C400B4503F /* SynchronizedLargeItemCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedLargeItemCache.swift; sourceTree = "<group>"; };
 		1699BC2C2EEB4DBC002001FB /* PaywallWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWarning.swift; sourceTree = "<group>"; };
 		1699BC332EEB4DFD002001FB /* ColorComputationHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorComputationHelpers.swift; sourceTree = "<group>"; };
@@ -1981,6 +1987,7 @@
 		37E35F783903362B65FB7AF3 /* MockProductsRequestFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockProductsRequestFactory.swift; sourceTree = "<group>"; };
 		37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateFormatter+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		3D26169F24D341F77345716D /* ExitOfferTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExitOfferTests.swift; sourceTree = "<group>"; };
+		425B8CF8557E44A4974E502A /* DangerousSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DangerousSettingsTests.swift; sourceTree = "<group>"; };
 		48D31C8D350D427BB8A5CCF0 /* ConditionDeserializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionDeserializationTests.swift; sourceTree = "<group>"; };
 		48D31C8E350D427BB8A5CCF1 /* ToPresentedOverridesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToPresentedOverridesTests.swift; sourceTree = "<group>"; };
 		4D21041D2CF548790095D254 /* GradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
@@ -2196,8 +2203,6 @@
 		575642B52910116900719219 /* EligibilityStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EligibilityStrings.swift; sourceTree = "<group>"; };
 		5757EDE62DEE08C100AC4BE1 /* StoreKitVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitVersionTests.swift; sourceTree = "<group>"; };
 		5757EDF72DEE092900AC4BE1 /* ClockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockTests.swift; sourceTree = "<group>"; };
-		425B8CF8557E44A4974E502A /* DangerousSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DangerousSettingsTests.swift; sourceTree = "<group>"; };
-		043FB8686FEB4A31B9CF48C8 /* PlatformInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfoTests.swift; sourceTree = "<group>"; };
 		5759B321296DEF56002472D5 /* OptionalExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalExtensionsTests.swift; sourceTree = "<group>"; };
 		5759B401296DF65D002472D5 /* ReceiptParserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReceiptParserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5759B404296DF6C4002472D5 /* ReceiptParserFetchingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptParserFetchingTests.swift; sourceTree = "<group>"; };
@@ -2373,7 +2378,6 @@
 		57BF87582967880C00424254 /* MockCachingTrialOrIntroPriceEligibilityChecker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockCachingTrialOrIntroPriceEligibilityChecker.swift; sourceTree = "<group>"; };
 		57BFCD0A2EEB0E56009E5844 /* TabsPackageInheritanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsPackageInheritanceTests.swift; sourceTree = "<group>"; };
 		57BFCD0F2EEB1234009E5844 /* TabsPackageSelectionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsPackageSelectionResolverTests.swift; sourceTree = "<group>"; };
-		E7EAAD1DC166ABD68E484EAA /* RootViewSheetDismissalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewSheetDismissalTests.swift; sourceTree = "<group>"; };
 		57C0BB6829F840BD00827807 /* FrameworkDisambiguation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkDisambiguation.swift; sourceTree = "<group>"; };
 		57C2931428BFEF4F0054EDFC /* PurchasesError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesError.swift; sourceTree = "<group>"; };
 		57C381B62791E593009E3940 /* StoreKit2TransactionListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionListenerTests.swift; sourceTree = "<group>"; };
@@ -2427,6 +2431,7 @@
 		57EFDC6A27BC1F370057EC39 /* ProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductType.swift; sourceTree = "<group>"; };
 		57F2C60B29784C11009EE527 /* SwiftVersionCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftVersionCheck.swift; sourceTree = "<group>"; };
 		57F3C10429B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+ActiveDates.swift"; sourceTree = "<group>"; };
+		57F4B2C12F8E10A600BB46C9 /* ExitOfferHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExitOfferHelperTests.swift; sourceTree = "<group>"; };
 		57F7DAAA2D9E906100855622 /* RuntimeUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeUtils.swift; sourceTree = "<group>"; };
 		57F9726A2DC3EF9500C6E540 /* MockStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreProductDiscount.swift; sourceTree = "<group>"; };
 		57FD7B1428DA4037009CA4E4 /* PurchasesType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesType.swift; sourceTree = "<group>"; };
@@ -2712,6 +2717,7 @@
 		90A1B2C42F96927E00D32EDF /* VirtualCurrencyRewardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualCurrencyRewardTests.swift; sourceTree = "<group>"; };
 		90A1B2C62F96927E00D32EDF /* VerifiedRewardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedRewardTests.swift; sourceTree = "<group>"; };
 		93B46553B99148F3A60B8BFB /* CustomPaywallVariables.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomPaywallVariables.swift; sourceTree = "<group>"; };
+		961E78AC0DB3C67A981EA97B /* PaywallVariablesStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallVariablesStore.swift; sourceTree = "<group>"; };
 		9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogIntent.swift; sourceTree = "<group>"; };
 		9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigureStrings.swift; sourceTree = "<group>"; };
 		9A65E03A25918B0900DE00B0 /* CustomerInfoStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerInfoStrings.swift; sourceTree = "<group>"; };
@@ -2724,6 +2730,7 @@
 		9D09F3C92E3A859A0002840D /* eu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9D09F3CA2E3A859A0002840E /* sr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sr; path = sr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9D09F3CB2E3A859A0002840F /* sr_Latn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sr_Latn; path = sr_Latn.lproj/Localizable.strings; sourceTree = "<group>"; };
+		A1D3F80D2D524F51BA60157C /* ButtonComponentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentViewTests.swift; sourceTree = "<group>"; };
 		A1E0F0012F297A0100000001 /* EventsManagerStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsManagerStrings.swift; sourceTree = "<group>"; };
 		A524378A284FFF0200E788BD /* AttributionPosterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionPosterTests.swift; sourceTree = "<group>"; };
 		A525BF4A26C320D100C354C4 /* SubscriberAttributesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributesManager.swift; sourceTree = "<group>"; };
@@ -2739,6 +2746,7 @@
 		A5B6CDD5280F3843007629D5 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/System/Library/Frameworks/AdServices.framework; sourceTree = DEVELOPER_DIR; };
 		A5F0104D2717B3150090732D /* BeginRefundRequestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeginRefundRequestHelper.swift; sourceTree = "<group>"; };
 		A95EB89F2E7AB09C00F1022B /* PaywallDataValidationTests */ = {isa = PBXFileReference; lastKnownFileType = folder; path = PaywallDataValidationTests; sourceTree = "<group>"; };
+		A9953CB2C098B285D22D5D3E /* PaywallVariableUpdate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallVariableUpdate.swift; sourceTree = "<group>"; };
 		AA110001AABB0001CCDD0001 /* CustomPaywallEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPaywallEvent.swift; sourceTree = "<group>"; };
 		AA110003AABB0001CCDD0001 /* EventsRequest+CustomPaywallImpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EventsRequest+CustomPaywallImpression.swift"; sourceTree = "<group>"; };
 		AA110005AABB0001CCDD0001 /* CustomPaywallEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPaywallEventTests.swift; sourceTree = "<group>"; };
@@ -2833,6 +2841,7 @@
 		E1C0A008BEEF0001CCDD0001 /* HeaderComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderComponentView.swift; sourceTree = "<group>"; };
 		E1C0A009BEEF0001CCDD0001 /* HeaderComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderComponentTests.swift; sourceTree = "<group>"; };
 		E1C0A00ABEEF0001CCDD0001 /* PaywallComponentsConfigHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentsConfigHeaderTests.swift; sourceTree = "<group>"; };
+		E7EAAD1DC166ABD68E484EAA /* RootViewSheetDismissalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewSheetDismissalTests.swift; sourceTree = "<group>"; };
 		EF970D13102945639A882002 /* ATTConsentStatusIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTConsentStatusIntegrationTests.swift; sourceTree = "<group>"; };
 		EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsFetcherSK1.swift; sourceTree = "<group>"; };
 		F1A05E9E1B04B32B832DB194 /* PaywallCountdownComponent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallCountdownComponent.swift; sourceTree = "<group>"; };
@@ -2872,8 +2881,6 @@
 		FACD00072F61A1230073D2DE /* PackageComponentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentViewTests.swift; sourceTree = "<group>"; };
 		FACD00092F61A1230073D2DE /* PackageValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageValidatorTests.swift; sourceTree = "<group>"; };
 		FACD000B2F61A1230073D2DE /* PackageVisibilityPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageVisibilityPreview.swift; sourceTree = "<group>"; };
-		0E4CCD8E9E454A2EB3760E06 /* ButtonComponentViewModelMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentViewModelMappingTests.swift; sourceTree = "<group>"; };
-		A1D3F80D2D524F51BA60157C /* ButtonComponentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentViewTests.swift; sourceTree = "<group>"; };
 		FB5A72012F65F5B9005C64A1 /* ViewModelFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelFactoryTests.swift; sourceTree = "<group>"; };
 		FD05A7192EE2430E00FE671F /* StoreKit2PromotionalOfferPurchaseOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2PromotionalOfferPurchaseOptions.swift; sourceTree = "<group>"; };
 		FD15AF572DF9A8F30062467E /* VirtualCurrenciesScrollViewWithOSBackgroundSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualCurrenciesScrollViewWithOSBackgroundSection.swift; sourceTree = "<group>"; };
@@ -3077,6 +3084,7 @@
 				6EFD5F7BD8404B6E828C4E10 /* WorkflowPaywallViewTests.swift */,
 				0E4CCD8E9E454A2EB3760E06 /* ButtonComponentViewModelMappingTests.swift */,
 				A1D3F80D2D524F51BA60157C /* ButtonComponentViewTests.swift */,
+				08B66CF5381446F2E445B241 /* PaywallVariablesStoreTests.swift */,
 			);
 			path = PaywallsV2;
 			sourceTree = "<group>";
@@ -3336,6 +3344,7 @@
 				75CAC2522FA3371C00B2D089 /* RequestSizeCalculation.swift */,
 				1D76F2592F921CA100863AF8 /* PlanSelectionDefaultPackage.swift */,
 				19B7F3F7BB1256FB17221052 /* CarouselState.swift */,
+				961E78AC0DB3C67A981EA97B /* PaywallVariablesStore.swift */,
 			);
 			path = EnvironmentObjects;
 			sourceTree = "<group>";
@@ -3358,6 +3367,7 @@
 				16DA8ECC2E4EE33700283940 /* ImageComponentTests.swift */,
 				16DA8EF32E4F7A2500283940 /* VideoComponentTests.swift */,
 				164933232E5808BE00CE43A9 /* PaywallTransitionTest.swift */,
+				0059D322CB49B106704939EF /* PaywallVariableUpdateTests.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -3400,6 +3410,7 @@
 				2CC7915D2CC0493600FBE120 /* PaywallComponentBase.swift */,
 				2CC7915E2CC0493600FBE120 /* PaywallComponentLocalization.swift */,
 				2CC7915F2CC0493600FBE120 /* PaywallComponentPropertyTypes.swift */,
+				A9953CB2C098B285D22D5D3E /* PaywallVariableUpdate.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -7359,6 +7370,7 @@
 				DDD45A15A641C0FF0BEF6178 /* PaywallCountdownComponent.swift in Sources */,
 				51978277F6FF8880DDF3028D /* ExitOffer.swift in Sources */,
 				909114C714204DFB8C4F3F72 /* TransactionReason.swift in Sources */,
+				A4A3DD3D0CBF50C8CEA5C972 /* PaywallVariableUpdate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7716,6 +7728,7 @@
 				5796A38A27D6B96300653165 /* BackendGetCustomerInfoTests.swift in Sources */,
 				49554883F2D5ED48F0907FB9 /* ExitOfferTests.swift in Sources */,
 				2B699E6661ECFB93B146A2D9 /* SynchronizedUserDefaultsTests.swift in Sources */,
+				2A2E7BA82FD30080FE783691 /* PaywallVariableUpdateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8139,6 +8152,7 @@
 				97B9F00926E0977B0DAAD7D7 /* EnvironmentValues+Workflow.swift in Sources */,
 				150BEBF14F59182317CDA8DA /* WorkflowContext.swift in Sources */,
 				C53CDAA4FC3E6B51CC70D724 /* WorkflowPaywallView.swift in Sources */,
+				3583AF355FBB1BB0D194822C /* PaywallVariablesStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RevenueCatUI/Data/CustomPaywallVariables.swift
+++ b/RevenueCatUI/Data/CustomPaywallVariables.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Facundo Menzella on 1/22/26.
 
+@_spi(Internal) import RevenueCat
 import SwiftUI
 
 /// A value type for custom paywall variables that can be passed to paywalls at runtime.
@@ -124,6 +125,30 @@ public struct CustomVariableValue: Sendable, Equatable, Hashable {
     internal var isBool: Bool {
         if case .bool = storage { return true }
         return false
+    }
+
+}
+
+// MARK: - Bridging from ConditionValue
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension PaywallComponent.ConditionValue {
+
+    /// Converts a JSON-decoded `ConditionValue` (used by paywall variable defaults and runtime
+    /// mutations) into the runtime `CustomVariableValue` representation. Numeric values collapse to
+    /// `.number`; the original int/double distinction is preserved by `doubleValue` semantics inside
+    /// `CustomVariableValue` and re-asserted at comparison time in `PresentedPartials`.
+    var asCustomVariableValue: CustomVariableValue {
+        switch self {
+        case .string(let value):
+            return .string(value)
+        case .bool(let value):
+            return .bool(value)
+        case .int(let value):
+            return .number(Double(value))
+        case .double(let value):
+            return .number(value)
+        }
     }
 
 }

--- a/RevenueCatUI/Templates/V2/EnvironmentObjects/PaywallVariablesStore.swift
+++ b/RevenueCatUI/Templates/V2/EnvironmentObjects/PaywallVariablesStore.swift
@@ -27,6 +27,10 @@ import SwiftUI
     /// The current variable-value mutations. Changes trigger SwiftUI invalidation of subscribers.
     @Published public private(set) var values: [String: PaywallComponent.ConditionValue]
 
+    /// Creates a store seeded with the provided initial variable values.
+    /// - Parameter initialValues: Variable values to start the paywall with. Defaults to empty —
+    ///   typical paywalls start with no mutations and let component interactions populate the
+    ///   store via `apply(_:payload:)`.
     public init(initialValues: [String: PaywallComponent.ConditionValue] = [:]) {
         self.values = initialValues
     }

--- a/RevenueCatUI/Templates/V2/EnvironmentObjects/PaywallVariablesStore.swift
+++ b/RevenueCatUI/Templates/V2/EnvironmentObjects/PaywallVariablesStore.swift
@@ -1,0 +1,114 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallVariablesStore.swift
+
+import Foundation
+@_spi(Internal) import RevenueCat
+import SwiftUI
+
+#if !os(tvOS) // For Paywalls V2
+
+/// Paywall-instance-scoped mutable variables store.
+///
+/// Holds variable values mutated by interactive components during a single paywall presentation.
+/// Exposed to descendant components via `EnvironmentValues.paywallVariablesStore` so any view model
+/// can fold its values into a `ConditionContext` and any interactive view can dispatch updates.
+///
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@_spi(Internal) public final class PaywallVariablesStore: ObservableObject {
+
+    /// The current variable-value mutations. Changes trigger SwiftUI invalidation of subscribers.
+    @Published public private(set) var values: [String: PaywallComponent.ConditionValue]
+
+    public init(initialValues: [String: PaywallComponent.ConditionValue] = [:]) {
+        self.values = initialValues
+    }
+
+    /// Applies a batch of declarative variable updates declared on an interactive component.
+    /// - Parameters:
+    ///   - updates: The updates parsed from the component's JSON `variableUpdates` field.
+    ///   - payload: The interaction's payload value, substituted for `"$value"` references.
+    ///              Pass `nil` for interactions without a payload (e.g. button taps).
+    ///
+    /// Mutation is dispatched to the main actor so SwiftUI observers update on the main thread.
+    public func apply(
+        _ updates: [PaywallComponent.VariableUpdate],
+        payload: PaywallComponent.ConditionValue? = nil
+    ) {
+        guard !updates.isEmpty else { return }
+        if Thread.isMainThread {
+            self.applyOnMain(updates, payload: payload)
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.applyOnMain(updates, payload: payload)
+            }
+        }
+    }
+
+    private func applyOnMain(
+        _ updates: [PaywallComponent.VariableUpdate],
+        payload: PaywallComponent.ConditionValue?
+    ) {
+        var next = self.values
+        for update in updates {
+            apply(update, payload: payload, into: &next)
+        }
+        if next != self.values {
+            self.values = next
+        }
+    }
+
+    private func apply(
+        _ update: PaywallComponent.VariableUpdate,
+        payload: PaywallComponent.ConditionValue?,
+        into values: inout [String: PaywallComponent.ConditionValue]
+    ) {
+        switch update {
+        case .set(let key, let value):
+            switch value {
+            case .literal(let literal):
+                values[key] = literal
+            case .payloadReference:
+                if let payload {
+                    values[key] = payload
+                }
+                // No payload available, skip silently. Defensive: the JSON should only
+                // reference "$value" on components whose interaction provides one.
+            }
+        case .unsupported:
+            break
+        }
+    }
+
+}
+
+// MARK: - Environment integration
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct PaywallVariablesStoreKey: EnvironmentKey {
+
+    /// Default empty store. Components only read or write through this default when the paywall
+    /// root has not injected a per-instance store — in practice paywalls without any `variableUpdates`
+    /// declarations never touch the store.
+    static let defaultValue: PaywallVariablesStore = PaywallVariablesStore()
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension EnvironmentValues {
+
+    var paywallVariablesStore: PaywallVariablesStore {
+        get { self[PaywallVariablesStoreKey.self] }
+        set { self[PaywallVariablesStoreKey.self] = newValue }
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -81,6 +81,9 @@ struct PaywallsV2View: View {
     @StateObject
     private var paywallPromoOfferCache: PaywallPromoOfferCache
 
+    @StateObject
+    private var paywallVariablesStore: PaywallVariablesStore
+
     public init(
         paywallComponents: Offering.PaywallComponents,
         offering: Offering,
@@ -141,6 +144,9 @@ struct PaywallsV2View: View {
         )
         self._paywallStateManager = .init(
             wrappedValue: .init(state: initialState)
+        )
+        self._paywallVariablesStore = .init(
+            wrappedValue: PaywallVariablesStore()
         )
 
         let selectedPackageContext: PackageContext
@@ -208,6 +214,8 @@ struct PaywallsV2View: View {
         .environmentObject(self.purchaseHandler)
         .environmentObject(self.introOfferEligibilityContext)
         .environmentObject(self.paywallPromoOfferCache)
+        .environmentObject(self.paywallVariablesStore)
+        .environment(\.paywallVariablesStore, self.paywallVariablesStore)
     }
 
     @ViewBuilder

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -47,18 +47,25 @@ struct ConditionContext {
     /// The identifier of the currently selected package, or nil if none is selected.
     let selectedPackageId: String?
 
-    /// Custom variables for condition evaluation (developer-provided merged with dashboard defaults).
+    /// Effective variable values for condition evaluation. Built by layering, in order:
+    ///   1. Dashboard defaults (from `UIConfig.customVariables`).
+    ///   2. Developer-provided overrides (from the `.customPaywallVariables(...)` modifier).
+    ///   3. Mutations applied at runtime by interactive components (from `PaywallVariablesStore`).
+    /// Each layer overwrites the previous. Mutations are the highest-priority layer.
     let customVariables: [String: CustomVariableValue]
 
-    /// Creates a context with the given parameters.
-    /// Developer-provided `customVariables` take priority over `defaultCustomVariables` from the dashboard.
+    /// Creates a context by layering dashboard defaults, developer overrides, and runtime mutations.
     init(
         selectedPackageId: String? = nil,
         customVariables: [String: CustomVariableValue] = [:],
-        defaultCustomVariables: [String: CustomVariableValue] = [:]
+        defaultCustomVariables: [String: CustomVariableValue] = [:],
+        mutatedVariables: [String: CustomVariableValue] = [:]
     ) {
         self.selectedPackageId = selectedPackageId
-        self.customVariables = defaultCustomVariables.merging(customVariables) { _, developer in developer }
+        var merged = defaultCustomVariables
+        merged.merge(customVariables) { _, developer in developer }
+        merged.merge(mutatedVariables) { _, mutated in mutated }
+        self.customVariables = merged
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -71,15 +71,23 @@ final class UIConfigProvider {
         }
     }
 
-    /// Creates a `ConditionContext` by merging developer-provided custom variables with dashboard defaults.
+    /// Creates a `ConditionContext` by layering paywall variable values:
+    ///   1. Dashboard defaults (from `UIConfig.customVariables`).
+    ///   2. Developer-provided overrides (passed via `customVariables` here, sourced from
+    ///      the `.customPaywallVariables(...)` modifier).
+    ///   3. Runtime mutations (passed via `mutatedVariables`, sourced from `PaywallVariablesStore`).
+    /// Mutations are the highest-priority layer. `.variable(...)` rule conditions read the merged dict.
     func conditionContext(
         selectedPackageId: String?,
-        customVariables: [String: CustomVariableValue]
+        customVariables: [String: CustomVariableValue],
+        mutatedVariables: [String: PaywallComponent.ConditionValue] = [:]
     ) -> ConditionContext {
-        ConditionContext(
+        let mutated = mutatedVariables.mapValues { $0.asCustomVariableValue }
+        return ConditionContext(
             selectedPackageId: selectedPackageId,
             customVariables: customVariables,
-            defaultCustomVariables: self.defaultCustomVariables
+            defaultCustomVariables: self.defaultCustomVariables,
+            mutatedVariables: mutated
         )
     }
 

--- a/Sources/Paywalls/Components/Common/PaywallVariableUpdate.swift
+++ b/Sources/Paywalls/Components/Common/PaywallVariableUpdate.swift
@@ -9,7 +9,7 @@
 //
 //  PaywallVariableUpdate.swift
 //
-// swiftlint:disable missing_docs
+// swiftlint:disable missing_docs nesting
 
 import Foundation
 
@@ -32,7 +32,6 @@ import Foundation
         /// Fallback for variable-update shapes this SDK version does not understand.
         case unsupported
 
-        // swiftlint:disable:next nesting
         private enum CodingKeys: String, CodingKey {
             case set
             case to

--- a/Sources/Paywalls/Components/Common/PaywallVariableUpdate.swift
+++ b/Sources/Paywalls/Components/Common/PaywallVariableUpdate.swift
@@ -1,0 +1,95 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallVariableUpdate.swift
+//
+// swiftlint:disable missing_docs
+
+import Foundation
+
+@_spi(Internal) public extension PaywallComponent {
+
+    /// A declarative variable-store mutation applied when an interactive component's primary event fires.
+    ///
+    /// JSON shape (current operations):
+    /// ```
+    /// { "set": "variable_name", "to": <literal value | "$value"> }
+    /// ```
+    ///
+    /// The `"$value"` token instructs the runtime to substitute the interaction's payload
+    /// (e.g. selected tab id, carousel destination page index, selected package id).
+    /// Unknown shapes decode as `.unsupported` so newer JSON remains safe on older SDKs.
+    enum VariableUpdate: Codable, Sendable, Hashable, Equatable {
+
+        case set(key: String, value: VariableUpdateValue)
+
+        /// Fallback for variable-update shapes this SDK version does not understand.
+        case unsupported
+
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: String, CodingKey {
+            case set
+            case to
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            if let key = try container.decodeIfPresent(String.self, forKey: .set) {
+                let value = try container.decode(VariableUpdateValue.self, forKey: .to)
+                self = .set(key: key, value: value)
+                return
+            }
+            self = .unsupported
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .set(let key, let value):
+                try container.encode(key, forKey: .set)
+                try container.encode(value, forKey: .to)
+            case .unsupported:
+                break
+            }
+        }
+
+    }
+
+    /// The value of a `VariableUpdate.set` operation. Either a literal `ConditionValue` or a reference
+    /// to the firing component's interaction payload (`"$value"` in JSON).
+    enum VariableUpdateValue: Codable, Sendable, Hashable, Equatable {
+
+        case literal(ConditionValue)
+        case payloadReference
+
+        /// The reserved JSON string indicating the value should be taken from the interaction's payload.
+        public static let payloadReferenceToken: String = "$value"
+
+        public init(from decoder: Decoder) throws {
+            let conditionValue = try ConditionValue(from: decoder)
+            if case .string(let str) = conditionValue, str == VariableUpdateValue.payloadReferenceToken {
+                self = .payloadReference
+            } else {
+                self = .literal(conditionValue)
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .literal(let value):
+                try container.encode(value)
+            case .payloadReference:
+                try container.encode(VariableUpdateValue.payloadReferenceToken)
+            }
+        }
+
+    }
+
+}

--- a/Sources/Paywalls/Components/PaywallButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallButtonComponent.swift
@@ -29,6 +29,10 @@ import Foundation
         public let overrides: ComponentOverrides<PartialButtonComponent>?
         /// Preserves the backend-only `close_workflow` action without growing the public enum surface.
         @_spi(Internal) public let isCloseWorkflowAction: Bool
+        /// Declarative variable-store mutations to apply when this button is tapped. Optional and
+        /// absent on legacy buttons. Each entry is decoded as `PaywallComponent.VariableUpdate`;
+        /// unknown shapes fall through as `.unsupported` and are silently skipped at apply time.
+        @_spi(Internal) public let variableUpdates: [PaywallComponent.VariableUpdate]?
 
         public init(
             name: String? = nil,
@@ -37,7 +41,8 @@ import Foundation
             action: Action,
             stack: PaywallComponent.StackComponent,
             transition: PaywallComponent.Transition? = nil,
-            overrides: ComponentOverrides<PartialButtonComponent>? = nil
+            overrides: ComponentOverrides<PartialButtonComponent>? = nil,
+            variableUpdates: [PaywallComponent.VariableUpdate]? = nil
         ) {
             self.type = .button
             self.name = name
@@ -48,6 +53,7 @@ import Foundation
             self.transition = transition
             self.overrides = overrides
             self.isCloseWorkflowAction = false
+            self.variableUpdates = variableUpdates
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -59,6 +65,7 @@ import Foundation
             case stack
             case transition
             case overrides
+            case variableUpdates
         }
 
         private enum ActionCodingKeys: String, CodingKey {
@@ -86,6 +93,10 @@ import Foundation
                 ComponentOverrides<PartialButtonComponent>.self,
                 forKey: .overrides
             )
+            self.variableUpdates = try container.decodeIfPresent(
+                [PaywallComponent.VariableUpdate].self,
+                forKey: .variableUpdates
+            )
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -103,6 +114,7 @@ import Foundation
             try container.encode(stack, forKey: .stack)
             try container.encodeIfPresent(transition, forKey: .transition)
             try container.encodeIfPresent(overrides, forKey: .overrides)
+            try container.encodeIfPresent(variableUpdates, forKey: .variableUpdates)
         }
 
         public func hash(into hasher: inout Hasher) {
@@ -115,6 +127,7 @@ import Foundation
             hasher.combine(stack)
             hasher.combine(transition)
             hasher.combine(overrides)
+            hasher.combine(variableUpdates)
         }
 
         public static func == (lhs: ButtonComponent, rhs: ButtonComponent) -> Bool {
@@ -126,7 +139,8 @@ import Foundation
                    lhs.isCloseWorkflowAction == rhs.isCloseWorkflowAction &&
                    lhs.stack == rhs.stack &&
                    lhs.transition == rhs.transition &&
-                   lhs.overrides == rhs.overrides
+                   lhs.overrides == rhs.overrides &&
+                   lhs.variableUpdates == rhs.variableUpdates
 
         }
 

--- a/Sources/Paywalls/Components/PaywallCarouselComponent.swift
+++ b/Sources/Paywalls/Components/PaywallCarouselComponent.swift
@@ -136,6 +136,11 @@ import Foundation
 
         public let overrides: ComponentOverrides<PartialCarouselComponent>?
 
+        /// Variable-store mutations applied when the user changes the active page
+        /// (via swipe or page-indicator tap). The destination page index is available
+        /// as the `"$value"` payload reference.
+        @_spi(Internal) public let variableUpdates: [PaywallComponent.VariableUpdate]?
+
         public init(
             name: String? = nil,
             visible: Bool? = nil,
@@ -154,7 +159,8 @@ import Foundation
             loop: Bool = false,
             autoAdvance: PaywallComponent.CarouselComponent.AutoAdvanceSlides? = nil,
             pageControl: PageControl? = nil,
-            overrides: ComponentOverrides<PartialCarouselComponent>? = nil
+            overrides: ComponentOverrides<PartialCarouselComponent>? = nil,
+            variableUpdates: [PaywallComponent.VariableUpdate]? = nil
         ) {
             self.type = .carousel
 
@@ -176,6 +182,7 @@ import Foundation
             self.autoAdvance = autoAdvance
             self.pageControl = pageControl
             self.overrides = overrides
+            self.variableUpdates = variableUpdates
         }
 
         public static func == (lhs: CarouselComponent, rhs: CarouselComponent) -> Bool {
@@ -197,7 +204,8 @@ import Foundation
                 lhs.loop == rhs.loop &&
                 lhs.autoAdvance == rhs.autoAdvance &&
                 lhs.pageControl == rhs.pageControl &&
-                lhs.overrides == rhs.overrides
+                lhs.overrides == rhs.overrides &&
+                lhs.variableUpdates == rhs.variableUpdates
         }
 
         // MARK: - Hashable
@@ -221,6 +229,7 @@ import Foundation
             hasher.combine(autoAdvance)
             hasher.combine(pageControl)
             hasher.combine(overrides)
+            hasher.combine(variableUpdates)
         }
 
     }

--- a/Sources/Paywalls/Components/PaywallTabsComponent.swift
+++ b/Sources/Paywalls/Components/PaywallTabsComponent.swift
@@ -174,6 +174,10 @@ import Foundation
 
         public let overrides: ComponentOverrides<PartialTabsComponent>?
 
+        /// Variable-store mutations applied whenever a different tab becomes selected
+        /// (via toggle or button). The selected tab id is available as the `"$value"` payload reference.
+        @_spi(Internal) public let variableUpdates: [PaywallComponent.VariableUpdate]?
+
         public init(
             name: String? = nil,
             visible: Bool? = nil,
@@ -189,7 +193,8 @@ import Foundation
             tabs: [Tab],
             defaultTabId: String? = nil,
 
-            overrides: ComponentOverrides<PartialTabsComponent>? = nil
+            overrides: ComponentOverrides<PartialTabsComponent>? = nil,
+            variableUpdates: [PaywallComponent.VariableUpdate]? = nil
         ) {
             self.type = .stack
             self.name = name
@@ -207,6 +212,7 @@ import Foundation
             self.defaultTabId = defaultTabId
 
             self.overrides = overrides
+            self.variableUpdates = variableUpdates
         }
 
         public func hash(into hasher: inout Hasher) {
@@ -224,6 +230,7 @@ import Foundation
             hasher.combine(tabs)
             hasher.combine(defaultTabId)
             hasher.combine(overrides)
+            hasher.combine(variableUpdates)
         }
 
         public static func == (lhs: TabsComponent, rhs: TabsComponent) -> Bool {
@@ -240,7 +247,8 @@ import Foundation
                    lhs.control == rhs.control &&
                    lhs.tabs == rhs.tabs &&
                    lhs.defaultTabId == rhs.defaultTabId &&
-                   lhs.overrides == rhs.overrides
+                   lhs.overrides == rhs.overrides &&
+                   lhs.variableUpdates == rhs.variableUpdates
         }
     }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallVariablesStoreTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallVariablesStoreTests.swift
@@ -1,0 +1,170 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallVariablesStoreTests.swift
+
+import Nimble
+@_spi(Internal) import RevenueCat
+@_spi(Internal) @testable import RevenueCatUI
+import XCTest
+
+#if !os(tvOS) // For Paywalls V2
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class PaywallVariablesStoreTests: TestCase {
+
+    // MARK: - Initial state
+
+    func testStoreIsEmptyByDefault() {
+        let store = PaywallVariablesStore()
+        expect(store.values).to(beEmpty())
+    }
+
+    func testStoreSeedsWithProvidedInitialValues() {
+        let store = PaywallVariablesStore(initialValues: [
+            "selectedPlan": .string("annual"),
+            "comparisonOpen": .bool(false)
+        ])
+
+        expect(store.values["selectedPlan"]) == .string("annual")
+        expect(store.values["comparisonOpen"]) == .bool(false)
+    }
+
+    // MARK: - Literal updates
+
+    func testApplyLiteralUpdateSetsValue() {
+        let store = PaywallVariablesStore()
+
+        store.apply([.set(key: "comparisonOpen", value: .literal(.bool(true)))])
+
+        expect(store.values["comparisonOpen"]) == .bool(true)
+    }
+
+    func testApplyLiteralUpdateOverwritesExistingValue() {
+        let store = PaywallVariablesStore(initialValues: ["count": .int(0)])
+
+        store.apply([.set(key: "count", value: .literal(.int(5)))])
+
+        expect(store.values["count"]) == .int(5)
+    }
+
+    func testApplyMultipleUpdatesInOneBatch() {
+        let store = PaywallVariablesStore()
+
+        store.apply([
+            .set(key: "a", value: .literal(.string("hello"))),
+            .set(key: "b", value: .literal(.int(42))),
+            .set(key: "c", value: .literal(.bool(true)))
+        ])
+
+        expect(store.values["a"]) == .string("hello")
+        expect(store.values["b"]) == .int(42)
+        expect(store.values["c"]) == .bool(true)
+    }
+
+    func testLastWriteWinsWithinBatch() {
+        let store = PaywallVariablesStore()
+
+        store.apply([
+            .set(key: "x", value: .literal(.int(1))),
+            .set(key: "x", value: .literal(.int(2))),
+            .set(key: "x", value: .literal(.int(3)))
+        ])
+
+        expect(store.values["x"]) == .int(3)
+    }
+
+    // MARK: - $value payload reference
+
+    func testApplyPayloadReferenceUsesPayloadValue() {
+        let store = PaywallVariablesStore()
+
+        store.apply(
+            [.set(key: "selectedTab", value: .payloadReference)],
+            payload: .string("billing")
+        )
+
+        expect(store.values["selectedTab"]) == .string("billing")
+    }
+
+    func testApplyPayloadReferenceWithIntegerPayload() {
+        let store = PaywallVariablesStore()
+
+        store.apply(
+            [.set(key: "currentSlide", value: .payloadReference)],
+            payload: .int(3)
+        )
+
+        expect(store.values["currentSlide"]) == .int(3)
+    }
+
+    func testPayloadReferenceWithoutPayloadIsSkipped() {
+        let store = PaywallVariablesStore(initialValues: ["existing": .string("kept")])
+
+        store.apply(
+            [.set(key: "existing", value: .payloadReference)],
+            payload: nil
+        )
+
+        // Skipped silently — existing value remains.
+        expect(store.values["existing"]) == .string("kept")
+    }
+
+    func testMixedLiteralAndPayloadInBatch() {
+        let store = PaywallVariablesStore()
+
+        store.apply(
+            [
+                .set(key: "literalKey", value: .literal(.bool(true))),
+                .set(key: "payloadKey", value: .payloadReference)
+            ],
+            payload: .string("from-payload")
+        )
+
+        expect(store.values["literalKey"]) == .bool(true)
+        expect(store.values["payloadKey"]) == .string("from-payload")
+    }
+
+    // MARK: - No-ops
+
+    func testApplyEmptyBatchIsNoOp() {
+        let store = PaywallVariablesStore(initialValues: ["a": .int(1)])
+
+        store.apply([])
+
+        expect(store.values["a"]) == .int(1)
+        expect(store.values.count) == 1
+    }
+
+    func testUnsupportedUpdateIsSkipped() {
+        let store = PaywallVariablesStore(initialValues: ["a": .int(1)])
+
+        store.apply([.unsupported])
+
+        expect(store.values["a"]) == .int(1)
+        expect(store.values.count) == 1
+    }
+
+    // MARK: - Repeated apply calls
+
+    func testRepeatedApplyAccumulatesAndOverwrites() {
+        let store = PaywallVariablesStore()
+
+        store.apply([.set(key: "a", value: .literal(.int(1)))])
+        store.apply([.set(key: "b", value: .literal(.string("hi")))])
+        store.apply([.set(key: "a", value: .literal(.int(99)))])
+
+        expect(store.values["a"]) == .int(99)
+        expect(store.values["b"]) == .string("hi")
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
@@ -1442,6 +1442,37 @@ class PresentedPartialsTests: TestCase {
         expect(result2After?.visible).to(equal(false))
     }
 
+    // MARK: - ConditionContext layering with mutated variables
+
+    func testConditionContextLayersDefaultsThenDeveloperThenMutations() {
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: ["a": .string("developer"), "shared": .string("developer")],
+            defaultCustomVariables: ["a": .string("default"), "b": .string("default"), "shared": .string("default")],
+            mutatedVariables: ["shared": .string("mutated"), "c": .string("mutated")]
+        )
+
+        // 'a' — developer override wins over default.
+        expect(context.customVariables["a"]) == .string("developer")
+        // 'b' — supplied only by defaults.
+        expect(context.customVariables["b"]) == .string("default")
+        // 'shared' — mutation wins over both developer and default.
+        expect(context.customVariables["shared"]) == .string("mutated")
+        // 'c' — contributed only by mutations.
+        expect(context.customVariables["c"]) == .string("mutated")
+    }
+
+    func testConditionContextWithoutMutationsBehavesAsBefore() {
+        let context = ConditionContext(
+            selectedPackageId: nil,
+            customVariables: ["a": .string("developer")],
+            defaultCustomVariables: ["a": .string("default"), "b": .string("default")]
+        )
+
+        expect(context.customVariables["a"]) == .string("developer")
+        expect(context.customVariables["b"]) == .string("default")
+    }
+
 }
 
 // MARK: - Test Helpers

--- a/Tests/RevenueCatUITests/PaywallsV2/UIConfigProviderTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/UIConfigProviderTests.swift
@@ -385,6 +385,89 @@ final class UIConfigProviderTests: TestCase {
         )
     }
 
+    // MARK: - Condition context layering with mutated variables
+
+    func testConditionContextWithoutMutationsMergesDefaultsAndDeveloperOverrides() throws {
+        let uiConfigProvider = try createUIConfigProviderWithCustomVariables([
+            "playerName": UIConfig.CustomVariableDefinition(type: "string", defaultValue: "Player"),
+            "score": UIConfig.CustomVariableDefinition(type: "number", defaultValue: "0")
+        ])
+
+        let context = uiConfigProvider.conditionContext(
+            selectedPackageId: nil,
+            customVariables: ["playerName": .string("Monika")]
+        )
+
+        // Developer override wins for playerName; defaults supply score.
+        expect(context.customVariables["playerName"]) == .string("Monika")
+        expect(context.customVariables["score"]) == .number(0)
+    }
+
+    func testMutatedVariablesWinOverDeveloperOverridesAndDefaults() throws {
+        let uiConfigProvider = try createUIConfigProviderWithCustomVariables([
+            "playerName": UIConfig.CustomVariableDefinition(type: "string", defaultValue: "Player")
+        ])
+
+        let context = uiConfigProvider.conditionContext(
+            selectedPackageId: nil,
+            customVariables: ["playerName": .string("Developer")],
+            mutatedVariables: ["playerName": .string("RuntimeMutation")]
+        )
+
+        expect(context.customVariables["playerName"]) == .string("RuntimeMutation")
+    }
+
+    func testMutatedVariablesContributeNewKeysNotInDefaults() throws {
+        let uiConfigProvider = try createUIConfigProvider()
+
+        let context = uiConfigProvider.conditionContext(
+            selectedPackageId: nil,
+            customVariables: [:],
+            mutatedVariables: ["comparisonOpen": .bool(true)]
+        )
+
+        expect(context.customVariables["comparisonOpen"]) == .bool(true)
+    }
+
+    func testMutatedConditionValueTypesBridgeToCustomVariableValue() throws {
+        let uiConfigProvider = try createUIConfigProvider()
+
+        let context = uiConfigProvider.conditionContext(
+            selectedPackageId: nil,
+            customVariables: [:],
+            mutatedVariables: [
+                "boolVar": .bool(true),
+                "stringVar": .string("hello"),
+                "intVar": .int(42),
+                "doubleVar": .double(3.14)
+            ]
+        )
+
+        expect(context.customVariables["boolVar"]) == .bool(true)
+        expect(context.customVariables["stringVar"]) == .string("hello")
+        // Int collapses to .number per the bridging contract.
+        expect(context.customVariables["intVar"]) == .number(42)
+        expect(context.customVariables["doubleVar"]) == .number(3.14)
+    }
+
+    func testConditionContextWithEmptyMutationsMatchesNoMutationsCall() throws {
+        let uiConfigProvider = try createUIConfigProviderWithCustomVariables([
+            "playerName": UIConfig.CustomVariableDefinition(type: "string", defaultValue: "Player")
+        ])
+
+        let baseline = uiConfigProvider.conditionContext(
+            selectedPackageId: nil,
+            customVariables: [:]
+        )
+        let withEmptyMutations = uiConfigProvider.conditionContext(
+            selectedPackageId: nil,
+            customVariables: [:],
+            mutatedVariables: [:]
+        )
+
+        expect(withEmptyMutations.customVariables) == baseline.customVariables
+    }
+
     // MARK: - Utils
 
     private func createUIConfigProvider() throws -> UIConfigProvider {

--- a/Tests/UnitTests/Paywalls/Components/ButtonComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/ButtonComponentTests.swift
@@ -369,6 +369,63 @@ class ButtonComponentCodableTests: TestCase {
         expect(decodedButton.name).to(beNil())
     }
 
+    // MARK: - variableUpdates
+
+    func testVariableUpdatesIsNilWhenFieldAbsent() throws {
+        let jsonString = """
+        {
+            "type": "button",
+            "action": { "type": "restore_purchases" },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
+
+        expect(decodedButton.variableUpdates).to(beNil())
+    }
+
+    func testVariableUpdatesDecodesLiteralAndPayloadReference() throws {
+        let jsonString = """
+        {
+            "type": "button",
+            "action": { "type": "restore_purchases" },
+            "stack": \(jsonStringDefaultStack),
+            "variableUpdates": [
+                { "set": "comparisonOpen", "to": true },
+                { "set": "activeTab", "to": "$value" }
+            ]
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
+
+        let updates = try XCTUnwrap(decodedButton.variableUpdates)
+        XCTAssertEqual(updates.count, 2)
+        XCTAssertEqual(updates[0], .set(key: "comparisonOpen", value: .literal(.bool(true))))
+        XCTAssertEqual(updates[1], .set(key: "activeTab", value: .payloadReference))
+    }
+
+    func testVariableUpdatesRoundTripsThroughEncodeDecode() throws {
+        let button = PaywallComponent.ButtonComponent(
+            action: .restorePurchases,
+            stack: .init(
+                components: [],
+                dimension: .vertical(.center, .start),
+                size: .init(width: .fill, height: .fill)
+            ),
+            variableUpdates: [
+                .set(key: "comparisonOpen", value: .literal(.bool(true))),
+                .set(key: "activeTab", value: .payloadReference)
+            ]
+        )
+
+        let data = try JSONEncoder.default.encode(button)
+        let decoded = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: data)
+
+        XCTAssertEqual(decoded, button)
+    }
+
 }
 
 #endif

--- a/Tests/UnitTests/Paywalls/Components/PaywallVariableUpdateTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/PaywallVariableUpdateTests.swift
@@ -1,0 +1,159 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallVariableUpdateTests.swift
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+import XCTest
+
+#if !os(tvOS) // For Paywalls V2
+
+class PaywallVariableUpdateCodableTests: TestCase {
+
+    // MARK: - VariableUpdate decoding
+
+    func testDecodeSetWithStringLiteral() throws {
+        let json = """
+        { "set": "selectedPlan", "to": "annual" }
+        """
+
+        let update = try JSONDecoder.default.decode(
+            PaywallComponent.VariableUpdate.self,
+            from: Data(json.utf8)
+        )
+
+        guard case let .set(key, .literal(value)) = update else {
+            XCTFail("Expected .set with literal value, got \(update)")
+            return
+        }
+        XCTAssertEqual(key, "selectedPlan")
+        XCTAssertEqual(value, .string("annual"))
+    }
+
+    func testDecodeSetWithBoolLiteral() throws {
+        let json = """
+        { "set": "comparisonOpen", "to": true }
+        """
+
+        let update = try JSONDecoder.default.decode(
+            PaywallComponent.VariableUpdate.self,
+            from: Data(json.utf8)
+        )
+
+        guard case let .set(key, .literal(value)) = update else {
+            XCTFail("Expected .set with literal value, got \(update)")
+            return
+        }
+        XCTAssertEqual(key, "comparisonOpen")
+        XCTAssertEqual(value, .bool(true))
+    }
+
+    func testDecodeSetWithIntLiteral() throws {
+        let json = """
+        { "set": "count", "to": 7 }
+        """
+
+        let update = try JSONDecoder.default.decode(
+            PaywallComponent.VariableUpdate.self,
+            from: Data(json.utf8)
+        )
+
+        guard case let .set(_, .literal(value)) = update else {
+            XCTFail("Expected .set with literal value, got \(update)")
+            return
+        }
+        XCTAssertEqual(value, .int(7))
+    }
+
+    func testDecodeSetWithDoubleLiteral() throws {
+        let json = """
+        { "set": "ratio", "to": 1.5 }
+        """
+
+        let update = try JSONDecoder.default.decode(
+            PaywallComponent.VariableUpdate.self,
+            from: Data(json.utf8)
+        )
+
+        guard case let .set(_, .literal(value)) = update else {
+            XCTFail("Expected .set with literal value, got \(update)")
+            return
+        }
+        XCTAssertEqual(value, .double(1.5))
+    }
+
+    func testDecodeSetWithPayloadReference() throws {
+        let json = """
+        { "set": "activeTab", "to": "$value" }
+        """
+
+        let update = try JSONDecoder.default.decode(
+            PaywallComponent.VariableUpdate.self,
+            from: Data(json.utf8)
+        )
+
+        guard case let .set(key, .payloadReference) = update else {
+            XCTFail("Expected .set with payloadReference, got \(update)")
+            return
+        }
+        XCTAssertEqual(key, "activeTab")
+    }
+
+    func testDecodeUnknownShapeFallsBackToUnsupported() throws {
+        // Future operation this SDK version doesn't understand — should decode as .unsupported
+        // rather than failing so newer JSON stays safe on older SDKs.
+        let json = """
+        { "increment": "counter", "by": 1 }
+        """
+
+        let update = try JSONDecoder.default.decode(
+            PaywallComponent.VariableUpdate.self,
+            from: Data(json.utf8)
+        )
+
+        guard case .unsupported = update else {
+            XCTFail("Expected .unsupported, got \(update)")
+            return
+        }
+    }
+
+    // MARK: - VariableUpdate encoding round-trip
+
+    func testEncodeDecodeSetWithLiteralRoundTrips() throws {
+        let original: PaywallComponent.VariableUpdate = .set(key: "k", value: .literal(.string("v")))
+
+        let data = try JSONEncoder.default.encode(original)
+        let decoded = try JSONDecoder.default.decode(PaywallComponent.VariableUpdate.self, from: data)
+
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testEncodeDecodePayloadReferenceRoundTrips() throws {
+        let original: PaywallComponent.VariableUpdate = .set(key: "k", value: .payloadReference)
+
+        let data = try JSONEncoder.default.encode(original)
+        let decoded = try JSONDecoder.default.decode(PaywallComponent.VariableUpdate.self, from: data)
+
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testEncodePayloadReferenceUsesDollarValueToken() throws {
+        let update: PaywallComponent.VariableUpdate = .set(key: "k", value: .payloadReference)
+
+        let data = try JSONEncoder.default.encode(update)
+        let jsonString = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertTrue(jsonString.contains("\"$value\""),
+                      "Expected encoded JSON to contain the $value token, got: \(jsonString)")
+    }
+
+}
+
+#endif


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
First of three PRs splitting the paywall state-management into
independently shippable changes. This one adds the runtime store, the
schema fields, and the condition-evaluation plumbing, **with no
user-visible behavior change**. The next PRs wire interactive
components to write to and read from the store.

Resolves: #PWENG-44
Umbrella: #PWENG-43

### Description
- **`PaywallVariablesStore`** (`@_spi(Internal)`)  instance-scoped
  `ObservableObject` holding variable mutations applied during a single
  paywall presentation. Injected into the view environment via both
  `@EnvironmentObject` (this will follow with reactive reads in PR 2) and a custom
  `\.paywallVariablesStore` key (write-only consumers that should not
  re-render on every mutation).
- **`VariableUpdate` / `VariableUpdateValue`** schema with `$value`
  payload-reference support and a forward-compatible `.unsupported`
  fallback for unknown JSON shapes. Optional `variableUpdates` field
  on Button, Carousel, and Tabs (decode-only for now — no component
  yet reads it).
- **`ConditionContext` + `UIConfigProvider.conditionContext(...)`**
  extended with a `mutatedVariables` layer that wins over dashboard
  defaults and the developer-provided `.customPaywallVariables(...)`
  overrides. `.variable(...)` rule conditions read the merged map.
  
### Safety

- No public API change, every new type is `@_spi(Internal)`. New
  fields on Button/Carousel/Tabs are optional and decode-only.
- Existing paywalls keep evaluating overrides exactly as before: the
  store starts empty, the condition-context layering with no
  mutations is byte-for-byte equivalent to the prior merge, and no
  component reads from or writes to the store yet.
  
  ## What's *not* in this PR

- Component write-side (Button tap, Carousel page change, Tabs
  selection writing to the store), this will be included in **PR 2**, [PWENG-45](https://linear.app/revenuecat/issue/PWENG-45).
- Read-side wiring (Text and interactive components passing
  `paywallVariablesStore.values` into their `conditionContext`), this will also be part of 
  **PR 2**.
- PaywallsTester sample / preview, part of **PR 3**, [PWENG-46](https://linear.app/revenuecat/issue/PWENG-46).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> All new surface is `@_spi(Internal)` with optional JSON fields; an empty store leaves override evaluation equivalent to today until PR 2 connects components.
> 
> **Overview**
> Adds **Paywalls V2 infrastructure for mutable custom variables** with no intended behavior change until follow-up PRs wire reads/writes.
> 
> Introduces `@_spi(Internal)` **`PaywallVariableUpdate`** decoding (`set` / `"$value"` payload / `.unsupported` for forward compatibility) and optional **`variableUpdates`** on **Button**, **Carousel**, and **Tabs** JSON models. **`PaywallVariablesStore`** holds per-presentation mutations, applies updates on the main thread, and is injected from **`PaywallsV2View`** via `@EnvironmentObject` and `\.paywallVariablesStore`.
> 
> **`ConditionContext`** and **`UIConfigProvider.conditionContext`** now merge dashboard defaults → `.customPaywallVariables` → runtime mutations (highest priority), with **`ConditionValue.asCustomVariableValue`** bridging for comparisons. Unit tests cover codable updates, store behavior, and layering; interactive components do not call the store yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deece55233b294cc467ea5c8ed3ed1563eb2693d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->