### PR TITLE
feat(remote-config): add network scaffolding for GET /v2/config endpoint

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1300,6 +1300,12 @@
 		DB3395DD2F840A790079250C /* WorkflowResponseAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3395D92F840A790079250C /* WorkflowResponseAction.swift */; };
 		DB3395E12F840AA60079250C /* WorkflowsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3395E02F840AA60079250C /* WorkflowsAPI.swift */; };
 		DB3395E32F840ACD0079250C /* BackendGetWorkflowsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3395E22F840ACD0079250C /* BackendGetWorkflowsTests.swift */; };
+		3B41364A5DFC4039B3026F40 /* RemoteConfigAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A2DB969D72432B87F48C5F /* RemoteConfigAPI.swift */; };
+		E6B064598F674333A29E0781 /* RemoteConfigCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF81FAC33B948F0947AE312 /* RemoteConfigCallback.swift */; };
+		A6CC43904EBD4860BFD2BD85 /* GetRemoteConfigOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */; };
+		D62A9C83BFD14E5FA0452CC7 /* RemoteConfigResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35BAD07C46D469D8CC7C396 /* RemoteConfigResponse.swift */; };
+		E6A54710537E4AA3810E1CB0 /* BackendGetRemoteConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BC3A5229194DFB9653FC8C /* BackendGetRemoteConfigTests.swift */; };
+		858195FCF0E04E3CAA99F9BB /* RemoteConfigResponseDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31E8A264E9F4375A3B29D78 /* RemoteConfigResponseDecodingTests.swift */; };
 		DB36994E2F435CDC00B1F049 /* PriceFormatterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */; };
 		DB55E6262ECE012600636909 /* FlexSpacer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55E6252ECE012600636909 /* FlexSpacer.swift */; };
 		DB7EA7762F964CA200BCC082 /* WorkflowResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7EA7742F964CA200BCC082 /* WorkflowResponseTests.swift */; };
@@ -2898,6 +2904,12 @@
 		DB3395D92F840A790079250C /* WorkflowResponseAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowResponseAction.swift; sourceTree = "<group>"; };
 		DB3395E02F840AA60079250C /* WorkflowsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowsAPI.swift; sourceTree = "<group>"; };
 		DB3395E22F840ACD0079250C /* BackendGetWorkflowsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetWorkflowsTests.swift; sourceTree = "<group>"; };
+		F3A2DB969D72432B87F48C5F /* RemoteConfigAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigAPI.swift; sourceTree = "<group>"; };
+		FCF81FAC33B948F0947AE312 /* RemoteConfigCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigCallback.swift; sourceTree = "<group>"; };
+		077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRemoteConfigOperation.swift; sourceTree = "<group>"; };
+		E35BAD07C46D469D8CC7C396 /* RemoteConfigResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigResponse.swift; sourceTree = "<group>"; };
+		96BC3A5229194DFB9653FC8C /* BackendGetRemoteConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetRemoteConfigTests.swift; sourceTree = "<group>"; };
+		E31E8A264E9F4375A3B29D78 /* RemoteConfigResponseDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigResponseDecodingTests.swift; sourceTree = "<group>"; };
 		DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatterExtensions.swift; sourceTree = "<group>"; };
 		DB55E6252ECE012600636909 /* FlexSpacer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexSpacer.swift; sourceTree = "<group>"; };
 		DB7EA7732F964CA200BCC082 /* WorkflowDetailProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowDetailProcessorTests.swift; sourceTree = "<group>"; };
@@ -4594,6 +4606,7 @@
 				1EDB6AA92DC95AB400C771A4 /* WebBillingHTTPRequestPath.swift */,
 				DB3395DA2F840A790079250C /* Workflows */,
 				DB3395E02F840AA60079250C /* WorkflowsAPI.swift */,
+				F3A2DB969D72432B87F48C5F /* RemoteConfigAPI.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -5084,6 +5097,7 @@
 				FDEEEEEE000000000000A001 /* RewardVerificationStatusResponseDecodingTests.swift */,
 				FDE57B0D2DF8BC1100101CE2 /* VirtualCurrenciesDecodingTests.swift */,
 				758593472E37F77700B8E6CE /* WebBillingProductsDecodingTests.swift */,
+				E31E8A264E9F4375A3B29D78 /* RemoteConfigResponseDecodingTests.swift */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -5127,6 +5141,7 @@
 				FD5EB26F2DFB19B800DA1974 /* BackendGetVirtualCurrenciesTests.swift */,
 				FD25F3772F33D502007C1A91 /* BackendIsPurchaseAllowedByRestoreBehaviorTests.swift */,
 				DB3395E22F840ACD0079250C /* BackendGetWorkflowsTests.swift */,
+				96BC3A5229194DFB9653FC8C /* BackendGetRemoteConfigTests.swift */,
 			);
 			path = Backend;
 			sourceTree = "<group>";
@@ -5335,6 +5350,7 @@
 				FDE57A9F2DF8785000101CE2 /* VirtualCurrenciesResponse.swift */,
 				DB3395D42F840A570079250C /* WorkflowsResponse.swift */,
 				755C26A32E310B19006DD0AE /* WebBillingProductsResponse.swift */,
+				E35BAD07C46D469D8CC7C396 /* RemoteConfigResponse.swift */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -6157,6 +6173,7 @@
 				FDE57A9D2DF8783000101CE2 /* VirtualCurrenciesCallback.swift */,
 				DB3395C92F840A2B0079250C /* WorkflowsCallback.swift */,
 				3752A4A3D77644C8B4BDD44D /* WorkflowsListCallback.swift */,
+				FCF81FAC33B948F0947AE312 /* RemoteConfigCallback.swift */,
 			);
 			path = Caching;
 			sourceTree = "<group>";
@@ -6187,6 +6204,7 @@
 				A56DFDEF286643BF00EF2E32 /* PostAttributionDataOperation.swift */,
 				DB3395D02F840A400079250C /* GetWorkflowOperation.swift */,
 				DC140B430FEE4B5897D7DB00 /* GetWorkflowsListOperation.swift */,
+				077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -7272,6 +7290,10 @@
 				2D11F5E1250FF886005A70E8 /* AttributionStrings.swift in Sources */,
 				DB3395DB2F840A790079250C /* WorkflowDetailProcessor.swift in Sources */,
 				DB3395E12F840AA60079250C /* WorkflowsAPI.swift in Sources */,
+				3B41364A5DFC4039B3026F40 /* RemoteConfigAPI.swift in Sources */,
+				E6B064598F674333A29E0781 /* RemoteConfigCallback.swift in Sources */,
+				A6CC43904EBD4860BFD2BD85 /* GetRemoteConfigOperation.swift in Sources */,
+				D62A9C83BFD14E5FA0452CC7 /* RemoteConfigResponse.swift in Sources */,
 				DB3395DD2F840A790079250C /* WorkflowResponseAction.swift in Sources */,
 				2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */,
 				57069A5428E3918400B86355 /* AsyncExtensions.swift in Sources */,
@@ -7633,6 +7655,7 @@
 				5766AA5A283D4CAB00FA6091 /* IgnoreHashableTests.swift in Sources */,
 				0368727A2D9DCF7100506BBB /* DefaultEnumTests.swift in Sources */,
 				DB3395E32F840ACD0079250C /* BackendGetWorkflowsTests.swift in Sources */,
+				E6A54710537E4AA3810E1CB0 /* BackendGetRemoteConfigTests.swift in Sources */,
 				03C7305B2D35985900297FEC /* TextComponentTests.swift in Sources */,
 				FDE57B0E2DF8BC1100101CE2 /* VirtualCurrenciesDecodingTests.swift in Sources */,
 				75FCD4CE2E37FBE100036C02 /* SimulatedStoreMockData.swift in Sources */,
@@ -7789,6 +7812,7 @@
 				35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift in Sources */,
 				03A98D322D2441B8009BCA61 /* PaywallDataDecodingTests.swift in Sources */,
 				DB7EA7762F964CA200BCC082 /* WorkflowResponseTests.swift in Sources */,
+				858195FCF0E04E3CAA99F9BB /* RemoteConfigResponseDecodingTests.swift in Sources */,
 				DB7EA7772F964CA200BCC082 /* WorkflowDetailProcessorTests.swift in Sources */,
 				4F8DDB692AAA9189000188F2 /* OperationDispatcherTests.swift in Sources */,
 				57FFD2512922DBED00A9A878 /* MockStoreTransaction.swift in Sources */,

--- a/Sources/Logging/Strings/BackendErrorStrings.swift
+++ b/Sources/Logging/Strings/BackendErrorStrings.swift
@@ -30,6 +30,7 @@ enum BackendErrorStrings {
     case unexpected_reward_verification_reward_value
     case unknown_workflow_trigger_type(type: String)
     case unknown_workflow_trigger_action_type(type: String)
+    case unknown_remote_config_topic(key: String)
 
 }
 
@@ -59,6 +60,8 @@ extension BackendErrorStrings: LogMessage {
             return "Received unknown workflow trigger type: \(type)"
         case let .unknown_workflow_trigger_action_type(type):
             return "Received unknown workflow trigger action type: \(type)"
+        case let .unknown_remote_config_topic(key):
+            return "Received unknown remote config topic: \(key)"
         }
     }
 

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -26,6 +26,7 @@ class Backend {
     let virtualCurrenciesAPI: VirtualCurrenciesAPI
     let workflowsAPI: WorkflowsAPI
     let adsAPI: AdsAPI
+    let remoteConfigAPI: RemoteConfigAPI
 
     private let config: BackendConfiguration
 
@@ -67,6 +68,7 @@ class Backend {
         let virtualCurrenciesAPI = VirtualCurrenciesAPI(backendConfig: backendConfig)
         let workflowsAPI = WorkflowsAPI(backendConfig: backendConfig)
         let adsAPI = AdsAPI(backendConfig: backendConfig)
+        let remoteConfigAPI = RemoteConfigAPI(backendConfig: backendConfig)
 
         self.init(backendConfig: backendConfig,
                   customerAPI: customer,
@@ -79,7 +81,8 @@ class Backend {
                   redeemWebPurchaseAPI: redeemWebPurchaseAPI,
                   virtualCurrenciesAPI: virtualCurrenciesAPI,
                   workflowsAPI: workflowsAPI,
-                  adsAPI: adsAPI)
+                  adsAPI: adsAPI,
+                  remoteConfigAPI: remoteConfigAPI)
     }
 
     required init(backendConfig: BackendConfiguration,
@@ -93,7 +96,8 @@ class Backend {
                   redeemWebPurchaseAPI: RedeemWebPurchaseAPI,
                   virtualCurrenciesAPI: VirtualCurrenciesAPI,
                   workflowsAPI: WorkflowsAPI,
-                  adsAPI: AdsAPI) {
+                  adsAPI: AdsAPI,
+                  remoteConfigAPI: RemoteConfigAPI) {
         self.config = backendConfig
 
         self.customer = customerAPI
@@ -107,6 +111,7 @@ class Backend {
         self.virtualCurrenciesAPI = virtualCurrenciesAPI
         self.workflowsAPI = workflowsAPI
         self.adsAPI = adsAPI
+        self.remoteConfigAPI = remoteConfigAPI
     }
 
     func clearHTTPClientCaches() {

--- a/Sources/Networking/Caching/RemoteConfigCallback.swift
+++ b/Sources/Networking/Caching/RemoteConfigCallback.swift
@@ -1,0 +1,15 @@
+//
+//  RemoteConfigCallback.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+struct RemoteConfigCallback: CacheKeyProviding {
+
+    let cacheKey: String
+    let completion: (Result<RemoteConfigResponse, BackendError>) -> Void
+
+}

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -263,6 +263,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postRedeemWebPurchase,
                 .getCustomerCenterConfig,
                 .postCreateTicket,
+                // WIP: Move to true when we have the final endpoint for remote config, and we can remove the fallback
                 .getRemoteConfig:
             return false
         case .rewardVerificationStatus:

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -109,6 +109,8 @@ extension HTTPRequest {
         case postCreateTicket
         case isPurchaseAllowedByRestoreBehavior(appUserID: String)
         case rewardVerificationStatus(appUserID: String, clientTransactionID: String)
+        // WIP: endpoint path and signing requirements subject to change
+        case getRemoteConfig
 
     }
 
@@ -203,6 +205,9 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case .health,
              .appHealthReportAvailability:
             return false
+
+        case .getRemoteConfig:
+            return true
         }
     }
 
@@ -229,7 +234,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .rewardVerificationStatus:
             return true
         case .health,
-             .appHealthReportAvailability:
+             .appHealthReportAvailability,
+             .getRemoteConfig:
             return false
         }
     }
@@ -256,7 +262,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postOfferForSigning,
                 .postRedeemWebPurchase,
                 .getCustomerCenterConfig,
-                .postCreateTicket:
+                .postCreateTicket,
+                .getRemoteConfig:
             return false
         case .rewardVerificationStatus:
             return true
@@ -286,13 +293,19 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .getProductEntitlementMapping,
                 .getCustomerCenterConfig,
                 .appHealthReport,
-                .postCreateTicket:
+                .postCreateTicket,
+                .getRemoteConfig:
             return false
         }
     }
 
     var relativePath: String {
-        return "/v1/\(self.pathComponent)"
+        switch self {
+        case .getRemoteConfig:
+            return "/v2/config"
+        default:
+            return "/v1/\(self.pathComponent)"
+        }
     }
 
     var pathComponent: String {
@@ -362,6 +375,9 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case let .rewardVerificationStatus(appUserID, clientTransactionID):
             return "subscribers/\(Self.escape(appUserID))/ads/reward_verifications/\(Self.escape(clientTransactionID))"
+
+        case .getRemoteConfig:
+            return "config"
         }
     }
 
@@ -428,6 +444,9 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case .rewardVerificationStatus:
             return "get_reward_verification_status"
+
+        case .getRemoteConfig:
+            return "get_remote_config"
         }
     }
 

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -199,15 +199,13 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .appHealthReport,
                 .postCreateTicket,
                 .isPurchaseAllowedByRestoreBehavior,
-                .rewardVerificationStatus:
+                .rewardVerificationStatus,
+                .getRemoteConfig:
             return true
 
         case .health,
              .appHealthReportAvailability:
             return false
-
-        case .getRemoteConfig:
-            return true
         }
     }
 
@@ -231,11 +229,11 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .appHealthReport,
                 .postCreateTicket,
                 .isPurchaseAllowedByRestoreBehavior,
-                .rewardVerificationStatus:
+                .rewardVerificationStatus,
+                .getRemoteConfig:
             return true
         case .health,
-             .appHealthReportAvailability,
-             .getRemoteConfig:
+             .appHealthReportAvailability:
             return false
         }
     }
@@ -303,7 +301,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
     var relativePath: String {
         switch self {
         case .getRemoteConfig:
-            return "/v2/config"
+            return "/v2/\(self.pathComponent)"
         default:
             return "/v1/\(self.pathComponent)"
         }

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -1,0 +1,66 @@
+//
+//  GetRemoteConfigOperation.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+final class GetRemoteConfigOperation: CacheableNetworkOperation {
+
+    private let callbackCache: CallbackCache<RemoteConfigCallback>
+
+    static func createFactory(
+        configuration: NetworkConfiguration,
+        callbackCache: CallbackCache<RemoteConfigCallback>
+    ) -> CacheableNetworkOperationFactory<GetRemoteConfigOperation> {
+        return .init({ cacheKey in
+                .init(
+                    configuration: configuration,
+                    callbackCache: callbackCache,
+                    cacheKey: cacheKey
+                )
+        },
+                     individualizedCacheKeyPart: "")
+    }
+
+    private init(
+        configuration: NetworkConfiguration,
+        callbackCache: CallbackCache<RemoteConfigCallback>,
+        cacheKey: String
+    ) {
+        self.callbackCache = callbackCache
+        super.init(configuration: configuration, cacheKey: cacheKey)
+    }
+
+    override func begin(completion: @escaping () -> Void) {
+        self.getRemoteConfig(completion: completion)
+    }
+
+}
+
+// Restating inherited @unchecked Sendable from Foundation's Operation
+extension GetRemoteConfigOperation: @unchecked Sendable {}
+
+private extension GetRemoteConfigOperation {
+
+    func getRemoteConfig(completion: @escaping () -> Void) {
+        let request = HTTPRequest(method: .get, path: .getRemoteConfig)
+
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfigResponse>.Result) in
+            defer {
+                completion()
+            }
+
+            self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
+                callback.completion(
+                    response
+                        .map { $0.body }
+                        .mapError(BackendError.networkError)
+                )
+            }
+        }
+    }
+
+}

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -1,0 +1,41 @@
+//
+//  RemoteConfigAPI.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+class RemoteConfigAPI {
+
+    typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RemoteConfigResponse>
+
+    private let callbackCache: CallbackCache<RemoteConfigCallback>
+    private let backendConfig: BackendConfiguration
+
+    init(backendConfig: BackendConfiguration) {
+        self.backendConfig = backendConfig
+        self.callbackCache = .init()
+    }
+
+    func getRemoteConfig(
+        isAppBackgrounded: Bool,
+        completion: @escaping RemoteConfigResponseHandler
+    ) {
+        let factory = GetRemoteConfigOperation.createFactory(
+            configuration: self.backendConfig,
+            callbackCache: self.callbackCache
+        )
+
+        let callback = RemoteConfigCallback(cacheKey: factory.cacheKey, completion: completion)
+        let cacheStatus = self.callbackCache.add(callback)
+
+        self.backendConfig.addCacheableOperation(
+            with: factory,
+            delay: .default(forBackgroundedApp: isAppBackgrounded),
+            cacheStatus: cacheStatus
+        )
+    }
+
+}

--- a/Sources/Networking/Responses/RemoteConfigResponse.swift
+++ b/Sources/Networking/Responses/RemoteConfigResponse.swift
@@ -55,14 +55,14 @@ extension RemoteConfigResponse {
 
         case productEntitlementMapping
 
-        var wireKey: String {
+        var rawValue: String {
             switch self {
             case .productEntitlementMapping: return "product_entitlement_mapping"
             }
         }
 
-        init?(wireKey: String) {
-            switch wireKey {
+        init?(rawValue: String) {
+            switch rawValue {
             case "product_entitlement_mapping": self = .productEntitlementMapping
             default: return nil
             }
@@ -106,7 +106,7 @@ extension RemoteConfigResponse.Manifest: Codable {
             forKey: .topics
         ) ?? [:]
         self.topics = rawTopics.reduce(into: [:]) { result, pair in
-            if let topic = RemoteConfigResponse.Topic(wireKey: pair.key) {
+            if let topic = RemoteConfigResponse.Topic(rawValue: pair.key) {
                 result[topic] = pair.value
             } else {
                 Logger.warn(Strings.backendError.unknown_remote_config_topic(key: pair.key))
@@ -116,7 +116,7 @@ extension RemoteConfigResponse.Manifest: Codable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        let rawTopics = Dictionary(uniqueKeysWithValues: topics.map { ($0.key.wireKey, $0.value) })
+        let rawTopics = Dictionary(uniqueKeysWithValues: topics.map { ($0.key.rawValue, $0.value) })
         try container.encode(rawTopics, forKey: .topics)
     }
 

--- a/Sources/Networking/Responses/RemoteConfigResponse.swift
+++ b/Sources/Networking/Responses/RemoteConfigResponse.swift
@@ -1,0 +1,125 @@
+//
+//  RemoteConfigResponse.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+struct RemoteConfigResponse: Equatable {
+
+    let apiSources: [ApiSource]
+    let blobSources: [BlobSource]
+    let manifest: Manifest
+
+    init(
+        apiSources: [ApiSource] = [],
+        blobSources: [BlobSource] = [],
+        manifest: Manifest = Manifest()
+    ) {
+        self.apiSources = apiSources
+        self.blobSources = blobSources
+        self.manifest = manifest
+    }
+
+}
+
+extension RemoteConfigResponse {
+
+    struct ApiSource: Codable, Equatable {
+        let id: String
+        let url: String
+        let priority: Int
+        let weight: Int
+    }
+
+    struct BlobSource: Codable, Equatable {
+        let id: String
+        let urlFormat: String
+        let priority: Int
+        let weight: Int
+    }
+
+    struct Manifest: Equatable {
+
+        let topics: [Topic: [String: TopicEntry]]
+
+        init(topics: [Topic: [String: TopicEntry]] = [:]) {
+            self.topics = topics
+        }
+
+    }
+
+    enum Topic: Hashable {
+
+        case productEntitlementMapping
+
+        var wireKey: String {
+            switch self {
+            case .productEntitlementMapping: return "product_entitlement_mapping"
+            }
+        }
+
+        init?(wireKey: String) {
+            switch wireKey {
+            case "product_entitlement_mapping": self = .productEntitlementMapping
+            default: return nil
+            }
+        }
+
+    }
+
+    struct TopicEntry: Codable, Equatable {
+        let blobRef: String
+    }
+
+}
+
+// MARK: - Codable
+
+extension RemoteConfigResponse: Codable {
+
+    private enum CodingKeys: CodingKey {
+        case apiSources, blobSources, manifest
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.apiSources = try container.decodeIfPresent([ApiSource].self, forKey: .apiSources) ?? []
+        self.blobSources = try container.decodeIfPresent([BlobSource].self, forKey: .blobSources) ?? []
+        self.manifest = try container.decodeIfPresent(Manifest.self, forKey: .manifest) ?? Manifest()
+    }
+
+}
+
+extension RemoteConfigResponse.Manifest: Codable {
+
+    private enum CodingKeys: CodingKey {
+        case topics
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rawTopics = try container.decodeIfPresent(
+            [String: [String: RemoteConfigResponse.TopicEntry]].self,
+            forKey: .topics
+        ) ?? [:]
+        self.topics = rawTopics.reduce(into: [:]) { result, pair in
+            if let topic = RemoteConfigResponse.Topic(wireKey: pair.key) {
+                result[topic] = pair.value
+            }
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        let rawTopics = Dictionary(uniqueKeysWithValues: topics.map { ($0.key.wireKey, $0.value) })
+        try container.encode(rawTopics, forKey: .topics)
+    }
+
+}
+
+// MARK: - HTTPResponseBody
+
+extension RemoteConfigResponse: HTTPResponseBody {}

--- a/Sources/Networking/Responses/RemoteConfigResponse.swift
+++ b/Sources/Networking/Responses/RemoteConfigResponse.swift
@@ -108,6 +108,8 @@ extension RemoteConfigResponse.Manifest: Codable {
         self.topics = rawTopics.reduce(into: [:]) { result, pair in
             if let topic = RemoteConfigResponse.Topic(wireKey: pair.key) {
                 result[topic] = pair.value
+            } else {
+                Logger.warn(Strings.backendError.unknown_remote_config_topic(key: pair.key))
             }
         }
     }

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -48,6 +48,7 @@ class MockBackend: Backend {
         let virtualCurrenciesAPI = MockVirtualCurrenciesAPI()
         let workflowsAPI = MockWorkflowsAPI()
         let adsAPI = MockAdsAPI()
+        let remoteConfigAPI = RemoteConfigAPI(backendConfig: backendConfig)
 
         self.init(backendConfig: backendConfig,
                   customerAPI: customer,
@@ -60,7 +61,8 @@ class MockBackend: Backend {
                   redeemWebPurchaseAPI: redeemWebPurchaseAPI,
                   virtualCurrenciesAPI: virtualCurrenciesAPI,
                   workflowsAPI: workflowsAPI,
-                  adsAPI: adsAPI)
+                  adsAPI: adsAPI,
+                  remoteConfigAPI: remoteConfigAPI)
     }
 
     override func post(receipt: EncodedAppleReceipt,

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -1,0 +1,219 @@
+//
+//  BackendGetRemoteConfigTests.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+final class BackendGetRemoteConfigTests: BaseBackendTests {
+
+    override func createClient() -> MockHTTPClient {
+        super.createClient(#file)
+    }
+
+    // MARK: - Basic request
+
+    func testGetRemoteConfigCallsHTTPMethod() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success, response: Self.fullResponse)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        expect(result).to(beSuccess())
+        expect(self.httpClient.calls).to(haveCount(1))
+    }
+
+    func testGetRemoteConfigUsesCorrectPath() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success, response: Self.fullResponse)
+        )
+
+        waitUntil { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in completed() }
+        }
+
+        expect(self.httpClient.calls.map { $0.request.path as? HTTPRequest.Path }) == [.getRemoteConfig]
+    }
+
+    // MARK: - Jitterable delay
+
+    func testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success, response: Self.fullResponse)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: true, completion: completed)
+        }
+
+        expect(result).to(beSuccess())
+        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadDelayParam) == JitterableDelay.default
+    }
+
+    func testGetRemoteConfigUsesNoDelayWhenNotBackgrounded() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success, response: Self.fullResponse)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        expect(result).to(beSuccess())
+        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadDelayParam) == JitterableDelay.none
+    }
+
+    // MARK: - Request coalescing
+
+    func testGetRemoteConfigCoalescesSimultaneousRequests() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success,
+                            response: Self.fullResponse,
+                            delay: .milliseconds(10))
+        )
+
+        let responses: Atomic<Int> = .init(0)
+
+        self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in responses.value += 1 }
+        self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in responses.value += 1 }
+
+        expect(responses.value).toEventually(equal(2))
+        expect(self.httpClient.calls).to(haveCount(1))
+    }
+
+    func testCoalescedRequestsLogDebugMessage() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success,
+                            response: Self.fullResponse,
+                            delay: .milliseconds(10))
+        )
+
+        self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in }
+        self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in }
+
+        expect(self.httpClient.calls).toEventually(haveCount(1))
+        expect(self.httpClient.calls).toNever(haveCount(2))
+
+        self.logger.verifyMessageWasLogged(
+            "Network operation '\(GetRemoteConfigOperation.self)' found with the same cache key",
+            level: .debug
+        )
+    }
+
+    // MARK: - Response parsing
+
+    func testGetRemoteConfigParsesFullResponse() throws {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success, response: Self.fullResponse)
+        )
+
+        let result: Result<RemoteConfigResponse, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        let response = try XCTUnwrap(result?.value)
+        expect(response.apiSources).to(haveCount(1))
+        expect(response.apiSources[0].id) == "primary"
+        expect(response.blobSources).to(haveCount(1))
+        expect(response.blobSources[0].id) == "cloudfront-primary"
+
+        let pem = response.manifest.topics[.productEntitlementMapping]
+        expect(pem?["DEFAULT"]?.blobRef) == "6a4d0f53d9f6b8e2f4dca0fd1c7c4f5e3e1b1ef0"
+    }
+
+    func testGetRemoteConfigParsesEmptyResponse() throws {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success, response: [:] as [String: Any])
+        )
+
+        let result: Result<RemoteConfigResponse, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        let response = try XCTUnwrap(result?.value)
+        expect(response.apiSources).to(beEmpty())
+        expect(response.blobSources).to(beEmpty())
+        expect(response.manifest.topics).to(beEmpty())
+    }
+
+    // MARK: - Error handling
+
+    func testGetRemoteConfigFailSendsError() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(error: .unexpectedResponse(nil))
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        expect(result).to(beFailure())
+    }
+
+    func testGetRemoteConfigNetworkErrorSendsError() {
+        let mockedError: NetworkError = .unexpectedResponse(nil)
+
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(error: mockedError)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        expect(result).to(beFailure())
+        expect(result?.error) == .networkError(mockedError)
+    }
+
+}
+
+private extension BackendGetRemoteConfigTests {
+
+    static let fullResponse: [String: Any] = [
+        "api_sources": [
+            [
+                "id": "primary",
+                "url": "https://api.revenuecat.com/",
+                "priority": 0,
+                "weight": 100
+            ] as [String: Any]
+        ],
+        "blob_sources": [
+            [
+                "id": "cloudfront-primary",
+                "url_format": "https://assets.revenuecat.com/rc_app_1234/{blob_ref}",
+                "priority": 0,
+                "weight": 100
+            ] as [String: Any]
+        ],
+        "manifest": [
+            "topics": [
+                "product_entitlement_mapping": [
+                    "DEFAULT": [
+                        "blob_ref": "6a4d0f53d9f6b8e2f4dca0fd1c7c4f5e3e1b1ef0"
+                    ]
+                ]
+            ]
+        ] as [String: Any]
+    ]
+
+}

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -134,7 +134,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(response.blobSources[0].id) == "cloudfront-primary"
 
         let pem = response.manifest.topics[.productEntitlementMapping]
-        expect(pem?["DEFAULT"]?.blobRef) == "6a4d0f53d9f6b8e2f4dca0fd1c7c4f5e3e1b1ef0"
+        expect(pem?["default"]?.blobRef) == "6a4d0f53d9f6b8e2f4dca0fd1c7c4f5e3e1b1ef0"
     }
 
     func testGetRemoteConfigParsesEmptyResponse() throws {
@@ -208,7 +208,7 @@ private extension BackendGetRemoteConfigTests {
         "manifest": [
             "topics": [
                 "product_entitlement_mapping": [
-                    "DEFAULT": [
+                    "default": [
                         "blob_ref": "6a4d0f53d9f6b8e2f4dca0fd1c7c4f5e3e1b1ef0"
                     ]
                 ]

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -38,6 +38,7 @@ class BaseBackendTests: TestCase {
     private(set) var virtualCurrenciesAPI: VirtualCurrenciesAPI!
     private(set) var workflowsAPI: WorkflowsAPI!
     private(set) var adsAPI: AdsAPI!
+    private(set) var remoteConfigAPI: RemoteConfigAPI!
     /// Controls what the CDN fetch returns. Tests can reassign this before triggering a `use_cdn` response
     /// because the closure registered with `WorkflowsAPI` captures `self` and reads this property at call time.
     var stubbedCdnFetch: WorkflowCdnFetch = { _, _, completion in completion(.success(Data())) }
@@ -103,6 +104,7 @@ class BaseBackendTests: TestCase {
             self?.stubbedCdnFetch(cdnUrl, hash, completion) ?? completion(.success(Data()))
         })
         self.adsAPI = AdsAPI(backendConfig: backendConfig)
+        self.remoteConfigAPI = RemoteConfigAPI(backendConfig: backendConfig)
 
         self.backend = Backend(backendConfig: backendConfig,
                                customerAPI: customer,
@@ -115,7 +117,8 @@ class BaseBackendTests: TestCase {
                                redeemWebPurchaseAPI: self.redeemWebPurchaseAPI,
                                virtualCurrenciesAPI: self.virtualCurrenciesAPI,
                                workflowsAPI: self.workflowsAPI,
-                               adsAPI: self.adsAPI)
+                               adsAPI: self.adsAPI,
+                               remoteConfigAPI: self.remoteConfigAPI)
     }
 
     var verificationMode: Configuration.EntitlementVerificationMode {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Responses/RemoteConfigResponseDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RemoteConfigResponseDecodingTests.swift
@@ -1,0 +1,253 @@
+//
+//  RemoteConfigResponseDecodingTests.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+final class RemoteConfigResponseDecodingTests: TestCase {
+
+    // MARK: - Full payload
+
+    func testDeserializesFullPayload() throws {
+        let payload = """
+        {
+          "api_sources": [
+            {
+              "id": "primary",
+              "url": "https://api.revenuecat.com/",
+              "priority": 0,
+              "weight": 100
+            }
+          ],
+          "blob_sources": [
+            {
+              "id": "cloudfront-primary",
+              "url_format": "https://assets.revenuecat.com/rc_app_1234/{blob_ref}",
+              "priority": 0,
+              "weight": 100
+            }
+          ],
+          "manifest": {
+            "topics": {
+              "product_entitlement_mapping": {
+                "DEFAULT": {
+                  "blob_ref": "abc123"
+                }
+              }
+            }
+          }
+        }
+        """.asData
+
+        let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: payload)
+
+        expect(response.apiSources).to(haveCount(1))
+        expect(response.apiSources[0].id) == "primary"
+        expect(response.apiSources[0].url) == "https://api.revenuecat.com/"
+        expect(response.apiSources[0].priority) == 0
+        expect(response.apiSources[0].weight) == 100
+
+        expect(response.blobSources).to(haveCount(1))
+        expect(response.blobSources[0].id) == "cloudfront-primary"
+        expect(response.blobSources[0].urlFormat) == "https://assets.revenuecat.com/rc_app_1234/{blob_ref}"
+        expect(response.blobSources[0].priority) == 0
+        expect(response.blobSources[0].weight) == 100
+
+        let pem = try XCTUnwrap(response.manifest.topics[.productEntitlementMapping])
+        expect(pem["DEFAULT"]?.blobRef) == "abc123"
+    }
+
+    // MARK: - Default values
+
+    func testMissingSourcesAndManifestFallBackToDefaults() throws {
+        let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: "{}".asData)
+
+        expect(response.apiSources).to(beEmpty())
+        expect(response.blobSources).to(beEmpty())
+        expect(response.manifest.topics).to(beEmpty())
+    }
+
+    func testMissingManifestTopicsFallsBackToEmpty() throws {
+        let response = try JSONDecoder.default.decode(
+            RemoteConfigResponse.self,
+            from: #"{"manifest": {}}"#.asData
+        )
+
+        expect(response.manifest.topics).to(beEmpty())
+    }
+
+    // MARK: - Unknown fields are ignored
+
+    func testUnknownTopLevelFieldsAreIgnored() throws {
+        let payload = """
+        {
+          "future_top_level": true,
+          "api_sources": [
+            {
+              "id": "primary",
+              "url": "https://api.revenuecat.com/",
+              "priority": 0,
+              "weight": 100,
+              "future_field": "ignored"
+            }
+          ],
+          "blob_sources": [
+            {
+              "id": "primary",
+              "url_format": "https://assets.example/{blob_ref}",
+              "priority": 0,
+              "weight": 100,
+              "future_field": "ignored"
+            }
+          ],
+          "manifest": {
+            "future_manifest_field": [],
+            "topics": {
+              "product_entitlement_mapping": {
+                "DEFAULT": {
+                  "blob_ref": "abc",
+                  "future_per_entry": 7
+                }
+              }
+            }
+          }
+        }
+        """.asData
+
+        let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: payload)
+
+        expect(response.apiSources).to(haveCount(1))
+        expect(response.apiSources[0].id) == "primary"
+        expect(response.blobSources).to(haveCount(1))
+        expect(response.blobSources[0].id) == "primary"
+        expect(response.manifest.topics[.productEntitlementMapping]?["DEFAULT"]?.blobRef) == "abc"
+    }
+
+    // MARK: - Unknown topic keys dropped
+
+    func testUnknownTopicNamesAreDropped() throws {
+        let payload = """
+        {
+          "manifest": {
+            "topics": {
+              "product_entitlement_mapping": {"DEFAULT": {"blob_ref": "abc"}},
+              "future_topic": {"DEFAULT": {"blob_ref": "def"}},
+              "another_unknown": {"DEFAULT": {"blob_ref": "ghi"}}
+            }
+          }
+        }
+        """.asData
+
+        let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: payload)
+
+        expect(response.manifest.topics).to(haveCount(1))
+        expect(response.manifest.topics.keys).to(contain(.productEntitlementMapping))
+    }
+
+    func testAllUnknownTopicsProducesEmptyMap() throws {
+        let payload = """
+        {"manifest": {"topics": {"future_topic": {"DEFAULT": {"blob_ref": "abc"}}}}}
+        """.asData
+
+        let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: payload)
+
+        expect(response.manifest.topics).to(beEmpty())
+    }
+
+    func testEmptyTopicsObjectProducesEmptyMap() throws {
+        let response = try JSONDecoder.default.decode(
+            RemoteConfigResponse.self,
+            from: #"{"manifest": {"topics": {}}}"#.asData
+        )
+
+        expect(response.manifest.topics).to(beEmpty())
+    }
+
+    func testMultipleVariantKeysForKnownTopicArePreserved() throws {
+        let payload = """
+        {
+          "manifest": {
+            "topics": {
+              "product_entitlement_mapping": {
+                "DEFAULT": {"blob_ref": "default-blob"},
+                "EXPERIMENT_A": {"blob_ref": "experiment-blob"}
+              }
+            }
+          }
+        }
+        """.asData
+
+        let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: payload)
+
+        let variants = try XCTUnwrap(response.manifest.topics[.productEntitlementMapping])
+        expect(variants).to(haveCount(2))
+        expect(variants["DEFAULT"]?.blobRef) == "default-blob"
+        expect(variants["EXPERIMENT_A"]?.blobRef) == "experiment-blob"
+    }
+
+    // MARK: - Encoding round-trip
+
+    func testTopicsEncodeBackToWireKey() throws {
+        let manifest = RemoteConfigResponse.Manifest(
+            topics: [.productEntitlementMapping: ["DEFAULT": .init(blobRef: "abc")]]
+        )
+
+        let encoded = try JSONEncoder().encode(manifest)
+        let json = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+
+        expect(json).to(contain("\"product_entitlement_mapping\""))
+        expect(json).toNot(contain("productEntitlementMapping"))
+    }
+
+    func testRoundTripPreservesKnownTopics() throws {
+        let original = RemoteConfigResponse(
+            apiSources: [.init(id: "primary", url: "https://api.revenuecat.com/", priority: 0, weight: 100)],
+            blobSources: [.init(id: "cdn", urlFormat: "https://assets.example/{blob_ref}", priority: 0, weight: 100)],
+            manifest: .init(topics: [.productEntitlementMapping: ["DEFAULT": .init(blobRef: "abc")]])
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: encoded)
+
+        expect(decoded) == original
+    }
+
+    // MARK: - Topic init
+
+    func testTopicInitFromKnownWireKey() {
+        expect(RemoteConfigResponse.Topic(wireKey: "product_entitlement_mapping")) == .productEntitlementMapping
+    }
+
+    func testTopicInitReturnsNilForUnknownWireKey() {
+        expect(RemoteConfigResponse.Topic(wireKey: "future_topic")).to(beNil())
+        expect(RemoteConfigResponse.Topic(wireKey: "PRODUCT_ENTITLEMENT_MAPPING")).to(beNil())
+        expect(RemoteConfigResponse.Topic(wireKey: "")).to(beNil())
+    }
+
+    // MARK: - Type errors are rejected
+
+    func testWrongTypeForBlobSourcesIsRejected() {
+        expect {
+            try JSONDecoder.default.decode(
+                RemoteConfigResponse.self,
+                from: #"{"blob_sources": "not-an-array"}"#.asData
+            )
+        }.to(throwError())
+    }
+
+    func testWrongTypeForApiSourcesIsRejected() {
+        expect {
+            try JSONDecoder.default.decode(
+                RemoteConfigResponse.self,
+                from: #"{"api_sources": "not-an-array"}"#.asData
+            )
+        }.to(throwError())
+    }
+
+}

--- a/Tests/UnitTests/Networking/Responses/RemoteConfigResponseDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RemoteConfigResponseDecodingTests.swift
@@ -36,7 +36,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
           "manifest": {
             "topics": {
               "product_entitlement_mapping": {
-                "DEFAULT": {
+                "default": {
                   "blob_ref": "abc123"
                 }
               }
@@ -60,7 +60,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
         expect(response.blobSources[0].weight) == 100
 
         let pem = try XCTUnwrap(response.manifest.topics[.productEntitlementMapping])
-        expect(pem["DEFAULT"]?.blobRef) == "abc123"
+        expect(pem["default"]?.blobRef) == "abc123"
     }
 
     // MARK: - Default values
@@ -110,7 +110,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
             "future_manifest_field": [],
             "topics": {
               "product_entitlement_mapping": {
-                "DEFAULT": {
+                "default": {
                   "blob_ref": "abc",
                   "future_per_entry": 7
                 }
@@ -126,7 +126,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
         expect(response.apiSources[0].id) == "primary"
         expect(response.blobSources).to(haveCount(1))
         expect(response.blobSources[0].id) == "primary"
-        expect(response.manifest.topics[.productEntitlementMapping]?["DEFAULT"]?.blobRef) == "abc"
+        expect(response.manifest.topics[.productEntitlementMapping]?["default"]?.blobRef) == "abc"
     }
 
     // MARK: - Unknown topic keys dropped
@@ -136,9 +136,9 @@ final class RemoteConfigResponseDecodingTests: TestCase {
         {
           "manifest": {
             "topics": {
-              "product_entitlement_mapping": {"DEFAULT": {"blob_ref": "abc"}},
-              "future_topic": {"DEFAULT": {"blob_ref": "def"}},
-              "another_unknown": {"DEFAULT": {"blob_ref": "ghi"}}
+              "product_entitlement_mapping": {"default": {"blob_ref": "abc"}},
+              "future_topic": {"default": {"blob_ref": "def"}},
+              "another_unknown": {"default": {"blob_ref": "ghi"}}
             }
           }
         }
@@ -152,7 +152,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
 
     func testAllUnknownTopicsProducesEmptyMap() throws {
         let payload = """
-        {"manifest": {"topics": {"future_topic": {"DEFAULT": {"blob_ref": "abc"}}}}}
+        {"manifest": {"topics": {"future_topic": {"default": {"blob_ref": "abc"}}}}}
         """.asData
 
         let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: payload)
@@ -175,7 +175,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
           "manifest": {
             "topics": {
               "product_entitlement_mapping": {
-                "DEFAULT": {"blob_ref": "default-blob"},
+                "default": {"blob_ref": "default-blob"},
                 "EXPERIMENT_A": {"blob_ref": "experiment-blob"}
               }
             }
@@ -187,7 +187,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
 
         let variants = try XCTUnwrap(response.manifest.topics[.productEntitlementMapping])
         expect(variants).to(haveCount(2))
-        expect(variants["DEFAULT"]?.blobRef) == "default-blob"
+        expect(variants["default"]?.blobRef) == "default-blob"
         expect(variants["EXPERIMENT_A"]?.blobRef) == "experiment-blob"
     }
 
@@ -195,7 +195,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
 
     func testTopicsEncodeBackToWireKey() throws {
         let manifest = RemoteConfigResponse.Manifest(
-            topics: [.productEntitlementMapping: ["DEFAULT": .init(blobRef: "abc")]]
+            topics: [.productEntitlementMapping: ["default": .init(blobRef: "abc")]]
         )
 
         let encoded = try JSONEncoder().encode(manifest)
@@ -209,7 +209,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
         let original = RemoteConfigResponse(
             apiSources: [.init(id: "primary", url: "https://api.revenuecat.com/", priority: 0, weight: 100)],
             blobSources: [.init(id: "cdn", urlFormat: "https://assets.example/{blob_ref}", priority: 0, weight: 100)],
-            manifest: .init(topics: [.productEntitlementMapping: ["DEFAULT": .init(blobRef: "abc")]])
+            manifest: .init(topics: [.productEntitlementMapping: ["default": .init(blobRef: "abc")]])
         )
 
         let encoded = try JSONEncoder().encode(original)

--- a/Tests/UnitTests/Networking/Responses/RemoteConfigResponseDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RemoteConfigResponseDecodingTests.swift
@@ -193,7 +193,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
 
     // MARK: - Encoding round-trip
 
-    func testTopicsEncodeBackToWireKey() throws {
+    func testTopicsEncodeBackToRawValue() throws {
         let manifest = RemoteConfigResponse.Manifest(
             topics: [.productEntitlementMapping: ["default": .init(blobRef: "abc")]]
         )
@@ -220,14 +220,14 @@ final class RemoteConfigResponseDecodingTests: TestCase {
 
     // MARK: - Topic init
 
-    func testTopicInitFromKnownWireKey() {
-        expect(RemoteConfigResponse.Topic(wireKey: "product_entitlement_mapping")) == .productEntitlementMapping
+    func testTopicInitFromKnownRawValue() {
+        expect(RemoteConfigResponse.Topic(rawValue: "product_entitlement_mapping")) == .productEntitlementMapping
     }
 
-    func testTopicInitReturnsNilForUnknownWireKey() {
-        expect(RemoteConfigResponse.Topic(wireKey: "future_topic")).to(beNil())
-        expect(RemoteConfigResponse.Topic(wireKey: "PRODUCT_ENTITLEMENT_MAPPING")).to(beNil())
-        expect(RemoteConfigResponse.Topic(wireKey: "")).to(beNil())
+    func testTopicInitReturnsNilForUnknownRawValue() {
+        expect(RemoteConfigResponse.Topic(rawValue: "future_topic")).to(beNil())
+        expect(RemoteConfigResponse.Topic(rawValue: "PRODUCT_ENTITLEMENT_MAPPING")).to(beNil())
+        expect(RemoteConfigResponse.Topic(rawValue: "")).to(beNil())
     }
 
     // MARK: - Type errors are rejected

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -491,6 +491,7 @@ extension BasePurchasesTests {
             let redeemWebPurchaseAPI = RedeemWebPurchaseAPI(backendConfig: backendConfig)
             let virtualCurrenciesAPI = VirtualCurrenciesAPI(backendConfig: backendConfig)
             let workflowsAPI = WorkflowsAPI(backendConfig: backendConfig)
+            let remoteConfigAPI = RemoteConfigAPI(backendConfig: backendConfig)
 
             self.init(backendConfig: backendConfig,
                       customerAPI: customer,
@@ -503,7 +504,8 @@ extension BasePurchasesTests {
                       redeemWebPurchaseAPI: redeemWebPurchaseAPI,
                       virtualCurrenciesAPI: virtualCurrenciesAPI,
                       workflowsAPI: workflowsAPI,
-                      adsAPI: mockAdsAPI)
+                      adsAPI: mockAdsAPI,
+                      remoteConfigAPI: remoteConfigAPI)
         }
 
         var userID: String?


### PR DESCRIPTION
## Summary

This is the first PR in a stacked series implementing remote config support on iOS, mirroring [Android PR #3435](https://github.com/RevenueCat/purchases-android/pull/3435).

Adds the network scaffolding for `GET /v2/config` — response models, endpoint definition, API class, and request coalescing operation. No public API surface is introduced.

**What's included:**
- `RemoteConfigResponse` — response model with `api_sources`, `blob_sources`, and `manifest.topics`. Unknown topic keys are silently dropped for forward compatibility.
- `HTTPRequest.Path.getRemoteConfig` — endpoint at `/v2/config` (authenticated, no etag, no signature verification — matching Android's WIP flags)
- `RemoteConfigAPI` + `GetRemoteConfigOperation` — follows the existing `CacheableNetworkOperation` pattern with request coalescing via `CallbackCache`
- `Backend.remoteConfigAPI` — wired into `Backend` following the same pattern as other API sub-objects
- Unit tests: `BackendGetRemoteConfigTests` + `RemoteConfigResponseDecodingTests`

**What's not included (future PRs):**
- Calling this endpoint from `Purchases` or any consumer
- Caching or persistence of the config response
- Acting on the returned `api_sources` or `blob_sources`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated config endpoint and models that will eventually drive entitlement-related blob routing; risk is limited today because nothing calls it yet, but path/signing flags are still WIP.
> 
> **Overview**
> Adds **network scaffolding** for remote config via authenticated **GET `/v2/config`** (v2 path, no signature verification yet—marked WIP). Introduces **`RemoteConfigResponse`** (`api_sources`, `blob_sources`, `manifest.topics` with `product_entitlement_mapping` only; unknown topics are dropped and logged), **`RemoteConfigAPI`** + **`GetRemoteConfigOperation`** using the existing cacheable/coalescing pattern, and **`Backend.remoteConfigAPI`**.
> 
> Wires the new types into the Xcode project and test harness (`MockBackend`, `BaseBackendTests`, `BasePurchasesTests`). Adds **`BackendGetRemoteConfigTests`** and **`RemoteConfigResponseDecodingTests`** plus request snapshots. **No public `Purchases` API** or persistence/consumer of the response in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe95ebf15a999712f04b45ffec02b26a6151bae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->