### PR TITLE
hack to try to run storekit tests in ci

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1016,6 +1016,30 @@ jobs:
           no_output_timeout: 30m
       - slack-notify-on-fail
 
+  storekit-unit-tests-ios-265:
+    executor:
+      name: macos-executor
+      xcode_version: "26.5"
+    steps:
+      - checkout
+      - install-dependencies:
+          install_xcbeautify: false
+      - run:
+          name: StoreKit unit tests iOS 26.5
+          command: bundle exec fastlane storekit_unit_tests_ios_265
+          no_output_timeout: 30m
+          environment:
+            DEVICE: iPhone 17,OS=26.5
+      - compress_result_bundle:
+          directory: fastlane/test_output/xctest/storekit-unit-tests-ios-265
+          bundle_name: StoreKitUnitTests
+      - store_test_results:
+          path: fastlane/test_output
+      - store_artifacts:
+          path: fastlane/test_output/xctest/storekit-unit-tests-ios-265
+          destination: storekit-unit-tests-ios-265
+      - slack-notify-on-fail
+
   run-test-ios-18-and-17:
     executor:
       name: macos-executor
@@ -2201,6 +2225,9 @@ workflows:
       - build-xcode-265:
           context:
             - slack-secrets
+      - storekit-unit-tests-ios-265:
+          context:
+            - slack-secrets
       - pod-lib-lint:
           context:
             - slack-secrets
@@ -2367,6 +2394,7 @@ workflows:
             - check-api-changes-revenuecatui
             - run-test-ios-26
             - build-xcode-265
+            - storekit-unit-tests-ios-265
             - pod-lib-lint
             - run-revenuecat-ui-ios-26
             - emerge_purchases_ui_snapshot_tests

--- a/Tests/StoreKitUnitTests/StoreKit2/Win-Back Offers/WinBackOfferEligibilityCalculatorTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/Win-Back Offers/WinBackOfferEligibilityCalculatorTests.swift
@@ -1,0 +1,20 @@
+//
+//  WinBackOfferEligibilityCalculatorTests.swift
+//  StoreKitUnitTests
+//
+//  Created by Will Taylor on 5/27/26.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+//
+
+import Nimble
+@testable import RevenueCat
+import StoreKitTest
+import XCTest
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+class WinBackOfferEligibilityCalculatorTests: StoreKitConfigTestCase {
+    func test() async throws {
+        let monthlyProduct = try await fetchSk2Product("com.revenuecat.monthly_4.99.1_week_intro")
+        print(monthlyProduct.id)
+    }
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -718,6 +718,74 @@ platform :ios do
     )
   end
 
+  desc "Runs StoreKit unit tests on iOS 26.5 after injecting the StoreKit configuration into the simulator"
+  lane :storekit_unit_tests_ios_265 do
+    device = ENV["DEVICE"] || "iPhone 17,OS=26.5"
+    device_name = device.split(",").first
+    destination = "platform=iOS Simulator,name=#{device}"
+    derived_data_path = "build/storekit-unit-tests-ios-265"
+    test_output_path = "fastlane/test_output/storekit-unit-tests-ios-265"
+    result_bundle_path = "fastlane/test_output/xctest/storekit-unit-tests-ios-265/StoreKitUnitTests.xcresult"
+    host_app_path = "#{derived_data_path}/Build/Products/Debug-iphonesimulator/UnitTestsHostApp.app"
+    host_app_bundle_id = "com.revenuecat.StoreKitUnitTestsHostApp"
+    storekit_config_path = "Tests/StoreKitUnitTests/UnitTestsConfiguration.storekit"
+    previous_storekit_tests_delay = ENV["CIRCLECI_STOREKIT_TESTS_DELAY_SECONDS"]
+
+    FileUtils.mkdir_p(File.dirname(result_bundle_path))
+    FileUtils.mkdir_p(test_output_path)
+
+    sh("xcrun simctl boot '#{device_name}' || true")
+    sh("xcrun", "simctl", "bootstatus", device_name, "-b")
+
+    xcodebuild(
+      project: "Projects/RevenueCatTests/RevenueCatTests.xcodeproj",
+      scheme: "UnitTestsHostApp",
+      destination: destination,
+      configuration: "Debug",
+      derivedDataPath: derived_data_path,
+      build: true,
+      xcargs: "CODE_SIGNING_ALLOWED=NO"
+    )
+
+    sh("xcrun", "simctl", "install", "booted", host_app_path)
+    sh("xcrun simctl launch booted #{host_app_bundle_id} || true")
+
+    watcher_pid = Process.spawn(
+      "ruby",
+      "fastlane/storekit_config_file_watcher.rb",
+      host_app_bundle_id,
+      storekit_config_path
+    )
+
+    begin
+      UI.message("Waiting 30 seconds for StoreKit configuration injection before running StoreKit unit tests...")
+      sleep(30)
+      ENV["CIRCLECI_STOREKIT_TESTS_DELAY_SECONDS"] = "30"
+
+      xcodebuild(
+        project: "Projects/RevenueCatTests/RevenueCatTests.xcodeproj",
+        scheme: "StoreKitUnitTests",
+        destination: destination,
+        configuration: "Debug",
+        derivedDataPath: derived_data_path,
+        result_bundle_path: result_bundle_path,
+        report_formats: [:junit],
+        report_path: "#{test_output_path}/tests.xml",
+        test: true,
+        xcargs: "-only-testing:StoreKitUnitTests"
+      )
+    ensure
+      ENV["CIRCLECI_STOREKIT_TESTS_DELAY_SECONDS"] = previous_storekit_tests_delay
+
+      begin
+        Process.kill("TERM", watcher_pid)
+        Process.wait(watcher_pid)
+      rescue Errno::ESRCH, Errno::ECHILD
+        nil
+      end
+    end
+  end
+
   desc "Runs all the tvOS tests"
   lane :test_tvos do |options|
     generate_snapshots = ENV["CIRCLECI_TESTS_GENERATE_SNAPSHOTS"] == "true"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -720,15 +720,18 @@ platform :ios do
 
   desc "Runs StoreKit unit tests on iOS 26.5 after injecting the StoreKit configuration into the simulator"
   lane :storekit_unit_tests_ios_265 do
+    base_path = File.expand_path("..", __dir__)
     device = ENV["DEVICE"] || "iPhone 17,OS=26.5"
     device_name = device.split(",").first
     destination = "platform=iOS Simulator,name=#{device}"
-    derived_data_path = "build/storekit-unit-tests-ios-265"
-    test_output_path = "fastlane/test_output/storekit-unit-tests-ios-265"
-    result_bundle_path = "fastlane/test_output/xctest/storekit-unit-tests-ios-265/StoreKitUnitTests.xcresult"
+    derived_data_path = "#{base_path}/build/storekit-unit-tests-ios-265"
+    test_output_path = "#{base_path}/fastlane/test_output/storekit-unit-tests-ios-265"
+    result_bundle_path = "#{base_path}/fastlane/test_output/xctest/storekit-unit-tests-ios-265/StoreKitUnitTests.xcresult"
     host_app_path = "#{derived_data_path}/Build/Products/Debug-iphonesimulator/UnitTestsHostApp.app"
     host_app_bundle_id = "com.revenuecat.StoreKitUnitTestsHostApp"
-    storekit_config_path = "Tests/StoreKitUnitTests/UnitTestsConfiguration.storekit"
+    revenuecat_tests_project_path = "#{base_path}/Projects/RevenueCatTests/RevenueCatTests.xcodeproj"
+    storekit_config_path = "#{base_path}/Tests/StoreKitUnitTests/UnitTestsConfiguration.storekit"
+    watcher_script = "#{base_path}/fastlane/storekit_config_file_watcher.rb"
     previous_storekit_tests_delay = ENV["CIRCLECI_STOREKIT_TESTS_DELAY_SECONDS"]
 
     FileUtils.mkdir_p(File.dirname(result_bundle_path))
@@ -738,7 +741,7 @@ platform :ios do
     sh("xcrun", "simctl", "bootstatus", device_name, "-b")
 
     xcodebuild(
-      project: "Projects/RevenueCatTests/RevenueCatTests.xcodeproj",
+      project: revenuecat_tests_project_path,
       scheme: "UnitTestsHostApp",
       destination: destination,
       configuration: "Debug",
@@ -752,7 +755,7 @@ platform :ios do
 
     watcher_pid = Process.spawn(
       "ruby",
-      "fastlane/storekit_config_file_watcher.rb",
+      watcher_script,
       host_app_bundle_id,
       storekit_config_path
     )
@@ -763,7 +766,7 @@ platform :ios do
       ENV["CIRCLECI_STOREKIT_TESTS_DELAY_SECONDS"] = "30"
 
       xcodebuild(
-        project: "Projects/RevenueCatTests/RevenueCatTests.xcodeproj",
+        project: revenuecat_tests_project_path,
         scheme: "StoreKitUnitTests",
         destination: destination,
         configuration: "Debug",


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/Fastlane and a placeholder test; no production SDK or auth paths, though the fixed delay and background watcher may make the new job flaky.
> 
> **Overview**
> Adds a **CircleCI** job (`storekit-unit-tests-ios-265`) on **Xcode 26.5** / **iOS 26.5** that runs a new Fastlane lane and is required by the PR **reduced** suite and **`all-tasks-passed`** gate.
> 
> The lane **`storekit_unit_tests_ios_265`** works around StoreKit test failures on newer Xcode by booting a simulator, building and installing **`UnitTestsHostApp`**, launching it, running **`storekit_config_file_watcher.rb`** to inject **`UnitTestsConfiguration.storekit`**, waiting **30s**, then running **`StoreKitUnitTests`** with JUnit/xcresult output.
> 
> Also adds a stub **`WinBackOfferEligibilityCalculatorTests`** (fetch one SK2 product) under StoreKit unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7a271d9a93d1513cacdf4d62a8788213954545c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->