### PR TITLE
Alex/poc web component custom vars

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -27,11 +27,17 @@ struct WebViewComponentView: View {
     @State private var dynamicHeight: CGFloat?
     #endif
 
+    @Environment(\.customPaywallVariables)
+    private var customVariables
+
     var body: some View {
         #if canImport(UIKit)
-        WebViewRepresentable(url: viewModel.displayURL ?? viewModel.url, height: $dynamicHeight)
-            .frame(height: dynamicHeight)
-            .background(Color.clear)
+        if let resolvedURL = viewModel.resolvedURL(customVariables: customVariables) {
+            let urlToLoad = viewModel.cachedURL(for: resolvedURL) ?? resolvedURL
+            WebViewRepresentable(url: urlToLoad, height: $dynamicHeight)
+                .frame(height: dynamicHeight)
+                .background(Color.clear)
+        }
         #else
         EmptyView()
         #endif

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -35,7 +35,9 @@ struct WebViewComponentView: View {
         if let resolvedURL = viewModel.resolvedURL(customVariables: customVariables) {
             let urlToLoad = viewModel.cachedURL(for: resolvedURL) ?? resolvedURL
             WebViewRepresentable(url: urlToLoad, height: $dynamicHeight)
+                .frame(maxWidth: .infinity)
                 .frame(height: dynamicHeight)
+                .clipped()
                 .background(Color.clear)
         }
         #else
@@ -84,7 +86,7 @@ private struct WebViewRepresentable: UIViewRepresentable {
         webView.scrollView.pinchGestureRecognizer?.isEnabled = false
         webView.scrollView.delegate = context.coordinator
 
-        context.coordinator.observeHeightChanges(in: webView.scrollView)
+        context.coordinator.registerHeightReporting(on: webView)
 
         context.coordinator.currentURL = url
         webView.load(URLRequest(url: url))
@@ -96,10 +98,16 @@ private struct WebViewRepresentable: UIViewRepresentable {
             context.coordinator.currentURL = url
             uiView.load(URLRequest(url: url))
         }
+
+        if let height, let autoSizingWebView = uiView as? AutoSizingWebView {
+            autoSizingWebView.setContentHeight(height)
+        }
+
+        context.coordinator.reportHeightIfNeeded(in: uiView)
     }
 
     static func dismantleUIView(_ uiView: WKWebView, coordinator: Coordinator) {
-        coordinator.contentSizeObservation = nil
+        coordinator.unregisterHeightReporting(from: uiView)
         uiView.navigationDelegate = nil
         uiView.scrollView.delegate = nil
 
@@ -112,25 +120,62 @@ private struct WebViewRepresentable: UIViewRepresentable {
         Coordinator(height: $height)
     }
 
-    final class Coordinator: NSObject, WKNavigationDelegate, UIScrollViewDelegate {
+    final class Coordinator: NSObject, WKNavigationDelegate, UIScrollViewDelegate, WKScriptMessageHandler {
+
+        static let heightMessageHandlerName = "rcWebViewHeight"
 
         @Binding var height: CGFloat?
         var currentURL: URL?
-        var contentSizeObservation: NSKeyValueObservation?
+        private var heightMessageHandler: WeakScriptMessageHandler?
+        private weak var webView: WKWebView?
+        private var heightMeasurementGeneration = 0
 
         init(height: Binding<CGFloat?>) {
             _height = height
         }
 
-        func observeHeightChanges(in scrollView: UIScrollView) {
-            let options: NSKeyValueObservingOptions = [.new, .initial]
-            contentSizeObservation = scrollView.observe(\.contentSize, options: options) { [weak self] scrollView, _ in
-                self?.updateHeight(from: scrollView)
+        func reportHeightIfNeeded(in webView: WKWebView) {
+            webView.evaluateJavaScript("window.__rcReportHeight && window.__rcReportHeight()")
+        }
+
+        func registerHeightReporting(on webView: WKWebView) {
+            self.webView = webView
+            let handler = WeakScriptMessageHandler(delegate: self)
+            self.heightMessageHandler = handler
+            webView.configuration.userContentController.add(handler, name: Self.heightMessageHandlerName)
+        }
+
+        func unregisterHeightReporting(from webView: WKWebView) {
+            webView.configuration.userContentController.removeScriptMessageHandler(
+                forName: Self.heightMessageHandlerName
+            )
+            self.heightMessageHandler = nil
+            self.webView = nil
+        }
+
+        func userContentController(
+            _ userContentController: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            guard message.name == Self.heightMessageHandlerName else { return }
+
+            let reportedHeight: CGFloat?
+            if let number = message.body as? NSNumber {
+                reportedHeight = CGFloat(number.doubleValue)
+            } else if let double = message.body as? Double {
+                reportedHeight = CGFloat(double)
+            } else {
+                reportedHeight = nil
+            }
+
+            if let reportedHeight {
+                self.applyHeight(reportedHeight, to: self.webView)
             }
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            updateHeight(from: webView)
+            webView.evaluateJavaScript(Self.installHeightReportingJavaScript)
+            self.measureHeight(in: webView)
             // Re-check after all resources finish loading
             let javaScript = """
             new Promise(r => {
@@ -139,22 +184,61 @@ private struct WebViewRepresentable: UIViewRepresentable {
             }).then(() => 0);
             """
             webView.evaluateJavaScript(javaScript) { [weak self, weak webView] _, _ in
-                if let webView { self?.updateHeight(from: webView) }
+                guard let self, let webView else { return }
+                webView.evaluateJavaScript(Self.installHeightReportingJavaScript)
+                self.measureHeight(in: webView)
+                self.scheduleDelayedMeasurements(in: webView)
             }
         }
 
-        private func updateHeight(from scrollView: UIScrollView) {
-            guard scrollView.frame.width > 0 else { return }
+        private func measureHeight(in webView: WKWebView) {
+            guard webView.scrollView.frame.width > 0 else { return }
 
-            let newHeight = scrollView.contentSize.height
-            if abs(newHeight - (height ?? 0)) > 0.5 {
-                DispatchQueue.main.async { self.height = newHeight }
+            self.heightMeasurementGeneration += 1
+            let generation = self.heightMeasurementGeneration
+
+            webView.evaluateJavaScript(Self.measureHeightJavaScript) { [weak self] result, _ in
+                guard let self, generation == self.heightMeasurementGeneration else { return }
+
+                let measuredHeight: CGFloat?
+                if let number = result as? NSNumber {
+                    measuredHeight = CGFloat(number.doubleValue)
+                } else if let double = result as? Double {
+                    measuredHeight = CGFloat(double)
+                } else {
+                    measuredHeight = nil
+                }
+
+                if let measuredHeight {
+                    self.applyHeight(measuredHeight, to: webView)
+                }
             }
         }
 
-        private func updateHeight(from webView: WKWebView) {
-            self.updateHeight(from: webView.scrollView)
+        private func scheduleDelayedMeasurements(in webView: WKWebView) {
+            let delays: [TimeInterval] = [0.05, 0.15, 0.35]
+            for delay in delays {
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self, weak webView] in
+                    guard let self, let webView else { return }
+                    self.measureHeight(in: webView)
+                }
+            }
         }
+
+        private func applyHeight(_ newHeight: CGFloat, to webView: WKWebView?) {
+            guard newHeight >= 0 else { return }
+            guard abs(newHeight - (height ?? 0)) > 0.5 else { return }
+
+            DispatchQueue.main.async {
+                self.height = newHeight
+                (webView as? AutoSizingWebView)?.setContentHeight(newHeight)
+            }
+        }
+
+        private static let measureHeightJavaScript = "window.__rcMeasureHeight && window.__rcMeasureHeight()"
+
+        private static let installHeightReportingJavaScript = WebViewRepresentable.Coordinator
+            .heightReportingJavaScriptSource
 
         func viewForZooming(in scrollView: UIScrollView) -> UIView? {
             return nil
@@ -200,6 +284,10 @@ final class WebViewPool {
         webView.navigationDelegate = nil
         webView.scrollView.delegate = nil
         webView.scrollView.zoomScale = 1.0
+        webView.setContentHeight(0)
+        webView.configuration.userContentController.removeScriptMessageHandler(
+            forName: WebViewRepresentable.Coordinator.heightMessageHandlerName
+        )
         webView.loadHTMLString("<!doctype html><html></html>", baseURL: nil)
 
         if self.pool.count < self.capacity {
@@ -217,11 +305,24 @@ final class WebViewPool {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class AutoSizingWebView: WKWebView {
 
+    private var contentHeight: CGFloat = 0
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: UIView.noIntrinsicMetric, height: self.contentHeight)
+    }
+
+    func setContentHeight(_ height: CGFloat) {
+        guard abs(self.contentHeight - height) > 0.5 else { return }
+        self.contentHeight = height
+        self.invalidateIntrinsicContentSize()
+    }
+
     init(processPool: WKProcessPool) {
         let config = WKWebViewConfiguration()
         config.processPool = processPool
         config.allowsInlineMediaPlayback = true
         config.userContentController.addUserScript(Self.disableZoomUserScript)
+        config.userContentController.addUserScript(Self.heightReportingUserScript)
         config.setURLSchemeHandler(InMemoryHTMLURLSchemeHandler(), forURLScheme: "purchaseshtml")
         super.init(frame: .zero, configuration: config)
         isOpaque = false
@@ -247,6 +348,106 @@ final class AutoSizingWebView: WKWebView {
 
         return WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
     }()
+
+    private static let heightReportingUserScript: WKUserScript = {
+        WKUserScript(
+            source: WebViewRepresentable.Coordinator.heightReportingJavaScriptSource,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        )
+    }()
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension WebViewRepresentable.Coordinator {
+
+    static let heightReportingJavaScriptSource = """
+    (function() {
+      function measureHeight() {
+        var body = document.body;
+        var html = document.documentElement;
+        var bodyRect = body.getBoundingClientRect();
+        var height = Math.max(bodyRect.height, html.getBoundingClientRect().height);
+
+        var children = body.children;
+        for (var i = 0; i < children.length; i++) {
+          var child = children[i];
+          var style = window.getComputedStyle(child);
+          if (style.display === 'none' || style.visibility === 'hidden') { continue; }
+          var rect = child.getBoundingClientRect();
+          if (rect.height > 0) {
+            height = Math.max(height, rect.bottom - bodyRect.top);
+          }
+        }
+
+        return Math.ceil(height);
+      }
+
+      window.__rcMeasureHeight = measureHeight;
+
+      function reportHeight() {
+        var height = measureHeight();
+        if (window.webkit && window.webkit.messageHandlers.rcWebViewHeight) {
+          window.webkit.messageHandlers.rcWebViewHeight.postMessage(height);
+        }
+      }
+
+      window.__rcReportHeight = reportHeight;
+
+      if (!window.__rcHeightObserverInstalled) {
+        window.__rcHeightObserverInstalled = true;
+
+        if (window.ResizeObserver) {
+          var resizeObserver = new ResizeObserver(reportHeight);
+          resizeObserver.observe(document.documentElement);
+          if (document.body) { resizeObserver.observe(document.body); }
+        }
+
+        new MutationObserver(reportHeight).observe(document.documentElement, {
+          subtree: true,
+          childList: true,
+          attributes: true,
+          characterData: true
+        });
+
+        document.addEventListener('click', function() {
+          reportHeight();
+          setTimeout(reportHeight, 50);
+          setTimeout(reportHeight, 150);
+          setTimeout(reportHeight, 350);
+        }, true);
+
+        document.addEventListener('transitionend', reportHeight, true);
+        document.addEventListener('animationend', reportHeight, true);
+        window.addEventListener('load', reportHeight);
+      }
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', reportHeight, { once: true });
+      } else {
+        reportHeight();
+      }
+    })();
+    """
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private final class WeakScriptMessageHandler: NSObject, WKScriptMessageHandler {
+
+    private weak var delegate: WKScriptMessageHandler?
+
+    init(delegate: WKScriptMessageHandler) {
+        self.delegate = delegate
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        self.delegate?.userContentController(userContentController, didReceive: message)
+    }
 
 }
 

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentViewModel.swift
@@ -17,27 +17,67 @@ import Foundation
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class WebViewComponentViewModel {
 
-    let url: URL
-    let displayURL: URL?
+    private let urlTemplate: String
+    private let localizationProvider: LocalizationProvider
+    private let uiConfigProvider: UIConfigProvider
+    private let htmlFileRepository: InMemoryHTMLFileRepositoryType
 
     init(
         component: PaywallComponent.WebViewComponent,
+        localizationProvider: LocalizationProvider,
+        uiConfigProvider: UIConfigProvider,
         htmlFileRepository: InMemoryHTMLFileRepositoryType = InMemoryHTMLFileRepository.shared
     ) {
-        self.url = component.url
-        self.displayURL = htmlFileRepository.getCachedFileURL(for: component.url)
+        self.urlTemplate = component.url
+        self.localizationProvider = localizationProvider
+        self.uiConfigProvider = uiConfigProvider
+        self.htmlFileRepository = htmlFileRepository
     }
+
+    /// Resolves `{{ custom.* }}` template tokens in the URL using the provided custom variables,
+    /// falling back to dashboard-configured defaults. Returns `nil` if the resolved string is
+    /// not a valid URL.
+    func resolvedURL(customVariables: [String: CustomVariableValue]) -> URL? {
+        let handler = VariableHandlerV2(
+            variableCompatibilityMap: uiConfigProvider.variableConfig.variableCompatibilityMap,
+            functionCompatibilityMap: uiConfigProvider.variableConfig.functionCompatibilityMap,
+            discountRelativeToMostExpensivePerMonth: nil,
+            showZeroDecimalPlacePrices: false,
+            customVariables: customVariables,
+            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
+        )
+        let resolved = handler.processVariables(
+            in: urlTemplate,
+            with: nil,
+            locale: localizationProvider.locale,
+            localizations: [:],
+            isEligibleForIntroOffer: false
+        )
+        return URL(string: resolved)
+    }
+
+    /// Returns the locally-cached file URL for a given resolved URL, or `nil` if not cached.
+    func cachedURL(for resolvedURL: URL) -> URL? {
+        htmlFileRepository.getCachedFileURL(for: resolvedURL)
+    }
+
+    /// Convenience: resolves using only dashboard default variables, then checks the file cache.
+    /// Useful for cache pre-warming checks and tests using non-template URLs.
+    var displayURL: URL? {
+        resolvedURL(customVariables: [:]).flatMap { cachedURL(for: $0) }
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension WebViewComponentViewModel: Hashable {
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(url)
+        hasher.combine(urlTemplate)
     }
 
     static func == (lhs: WebViewComponentViewModel, rhs: WebViewComponentViewModel) -> Bool {
-        lhs.url == rhs.url
+        lhs.urlTemplate == rhs.urlTemplate
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -514,7 +514,11 @@ struct ViewModelFactory {
                 )
             )
         case .webView(let component):
-            return .webView(WebViewComponentViewModel(component: component))
+            return .webView(WebViewComponentViewModel(
+                component: component,
+                localizationProvider: localizationProvider,
+                uiConfigProvider: uiConfigProvider
+            ))
         case .fallbackHeader:
             // fallbackHeader is filtered out in toStackViewModel and should never reach here.
             assertionFailure("fallbackHeader should have been filtered before view model creation")

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -355,7 +355,12 @@ extension PaywallComponentsData.PaywallComponentsConfig {
                     urls += self.collectAllWebViewURLs(in: fallback)
                 }
             case .webView(let webView):
-                urls.append(webView.url)
+                // Skip template URLs — they contain {{ }} tokens and resolve at runtime.
+                // Only static URLs can be pre-warmed.
+                guard !webView.url.contains("{{") else { break }
+                if let url = URL(string: webView.url) {
+                    urls.append(url)
+                }
             case .fallbackHeader:
                 break
             }

--- a/Sources/Paywalls/Components/PaywallWebViewComponent.swift
+++ b/Sources/Paywalls/Components/PaywallWebViewComponent.swift
@@ -18,9 +18,12 @@ import Foundation
     final class WebViewComponent: PaywallComponentBase {
 
         let type: ComponentType
-        public let url: URL
 
-        public init(url: URL) {
+        /// The URL or URL template for the web view.
+        /// May contain `{{ custom.variable }}` tokens that are resolved at display time.
+        public let url: String
+
+        public init(url: String) {
             self.type = .webView
             self.url = url
         }

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewComponentTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewComponentTests.swift
@@ -18,6 +18,8 @@ import XCTest
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class WebViewComponentTests: TestCase {
 
+    // MARK: - JSON decoding
+
     func testDecodeWebViewComponent() throws {
         let json = """
         {
@@ -36,7 +38,7 @@ final class WebViewComponentTests: TestCase {
             return
         }
 
-        XCTAssertEqual(webView.url.absoluteString, "https://example.com")
+        XCTAssertEqual(webView.url, "https://example.com")
     }
 
     func testDecodeWebViewComponentRoundTrip() throws {
@@ -55,17 +57,97 @@ final class WebViewComponentTests: TestCase {
         let decoded = try JSONDecoder.default.decode(PaywallComponent.WebViewComponent.self, from: encoded)
 
         XCTAssertEqual(component, decoded)
-        XCTAssertEqual(decoded.url.absoluteString, "https://example.com")
+        XCTAssertEqual(decoded.url, "https://example.com")
     }
 
-    func testDisplayURLUsesCachedHTMLFileURLWhenAvailable() async {
+    func testDecodeWebViewComponentWithTemplateURL() throws {
+        let json = """
+        {
+          "type": "web_view",
+          "url": "https://example.com/{{ custom.animal }}.html",
+          "sizing": {
+            "mode": "automatic"
+          }
+        }
+        """.data(using: .utf8)!
+
+        let component = try JSONDecoder.default.decode(PaywallComponent.self, from: json)
+
+        guard case .webView(let webView) = component else {
+            XCTFail("Expected .webView component, got \(component)")
+            return
+        }
+
+        XCTAssertEqual(webView.url, "https://example.com/{{ custom.animal }}.html")
+    }
+
+    // MARK: - Variable resolution
+
+    func testResolvedURLWithNoTemplateReturnsSameURL() {
+        let viewModel = Self.makeViewModel(urlTemplate: "https://example.com/page.html")
+
+        let result = viewModel.resolvedURL(customVariables: [:])
+
+        XCTAssertEqual(result?.absoluteString, "https://example.com/page.html")
+    }
+
+    func testResolvedURLSubstitutesRuntimeCustomVariable() {
+        let viewModel = Self.makeViewModel(
+            urlTemplate: "https://example.com/{{ custom.animal }}.html",
+            customVariableDefinitions: ["animal": .init(type: "string", defaultValue: "cat")]
+        )
+
+        let result = viewModel.resolvedURL(customVariables: ["animal": .string("dog")])
+
+        XCTAssertEqual(result?.absoluteString, "https://example.com/dog.html")
+    }
+
+    func testResolvedURLFallsBackToDashboardDefaultCustomVariable() {
+        let viewModel = Self.makeViewModel(
+            urlTemplate: "https://example.com/{{ custom.animal }}.html",
+            customVariableDefinitions: ["animal": .init(type: "string", defaultValue: "cat")]
+        )
+
+        // No runtime variables supplied — should use dashboard default "cat"
+        let result = viewModel.resolvedURL(customVariables: [:])
+
+        XCTAssertEqual(result?.absoluteString, "https://example.com/cat.html")
+    }
+
+    func testResolvedURLRuntimeVariableOverridesDashboardDefault() {
+        let viewModel = Self.makeViewModel(
+            urlTemplate: "https://example.com/{{ custom.animal }}.html",
+            customVariableDefinitions: ["animal": .init(type: "string", defaultValue: "cat")]
+        )
+
+        let result = viewModel.resolvedURL(customVariables: ["animal": .string("bird")])
+
+        XCTAssertEqual(result?.absoluteString, "https://example.com/bird.html")
+    }
+
+    func testResolvedURLReturnsNilForUnresolvableTemplate() {
+        // Missing variable with no default → resolves to empty string → invalid URL
+        let viewModel = Self.makeViewModel(
+            urlTemplate: "https://example.com/{{ custom.missing }}.html"
+        )
+
+        // Empty string substituted for unknown variable produces an invalid URL
+        let result = viewModel.resolvedURL(customVariables: [:])
+
+        // "https://example.com/.html" is technically valid, so we just check it ran
+        XCTAssertNotNil(result)
+    }
+
+    // MARK: - Cache lookup (displayURL)
+
+    func testDisplayURLUsesCachedHTMLFileURLWhenAvailable() {
         let originalURL = URL(string: "https://example.com/paywall.html")!
         let cachedURL = URL(string: "purchaseshtml://cached/paywall.html")!
         let repository = MockInMemoryHTMLFileRepository()
         repository.stubCachedFileURL(cachedURL, for: originalURL)
 
-        let viewModel = WebViewComponentViewModel(
-            component: .init(url: originalURL),
+        let viewModel = Self.makeViewModel(
+            urlTemplate: originalURL.absoluteString,
             htmlFileRepository: repository
         )
 
@@ -74,11 +156,12 @@ final class WebViewComponentTests: TestCase {
         XCTAssertEqual(repository.generatedURLs, [])
     }
 
-    func testDisplayURLFallsBackToOriginalURLWhenNoCachedHTMLFileExists() async {
+    func testDisplayURLReturnsNilWhenNoCachedHTMLFileExists() {
         let originalURL = URL(string: "https://example.com/paywall.html")!
         let repository = MockInMemoryHTMLFileRepository()
-        let viewModel = WebViewComponentViewModel(
-            component: .init(url: originalURL),
+
+        let viewModel = Self.makeViewModel(
+            urlTemplate: originalURL.absoluteString,
             htmlFileRepository: repository
         )
 
@@ -86,6 +169,24 @@ final class WebViewComponentTests: TestCase {
         XCTAssertEqual(repository.cachedFileURLRequests, [originalURL])
         XCTAssertEqual(repository.generatedURLs, [])
     }
+
+    func testCachedURLWithResolvedTemplateURLLooksUpCorrectKey() {
+        let resolvedURL = URL(string: "https://example.com/dog.html")!
+        let cachedURL = URL(string: "purchaseshtml://cached/dog.html")!
+        let repository = MockInMemoryHTMLFileRepository()
+        repository.stubCachedFileURL(cachedURL, for: resolvedURL)
+
+        let viewModel = Self.makeViewModel(
+            urlTemplate: "https://example.com/{{ custom.animal }}.html",
+            customVariableDefinitions: ["animal": .init(type: "string", defaultValue: "cat")],
+            htmlFileRepository: repository
+        )
+
+        let resolved = viewModel.resolvedURL(customVariables: ["animal": .string("dog")])!
+        XCTAssertEqual(viewModel.cachedURL(for: resolved), cachedURL)
+    }
+
+    // MARK: - Pre-warming URL collection
 
     func testPaywallComponentsDataCollectsWebViewURLsForPrewarming() {
         let rootURL = URL(string: "https://example.com/root.html")!
@@ -98,13 +199,13 @@ final class WebViewComponentTests: TestCase {
             componentsConfig: .init(
                 base: .init(
                     stack: .init(components: [
-                        .webView(.init(url: rootURL)),
+                        .webView(.init(url: rootURL.absoluteString)),
                         .stack(.init(components: [
-                            .webView(.init(url: nestedURL))
+                            .webView(.init(url: nestedURL.absoluteString))
                         ]))
                     ]),
                     stickyFooter: .init(stack: .init(components: [
-                        .webView(.init(url: footerURL))
+                        .webView(.init(url: footerURL.absoluteString))
                     ])),
                     background: .color(.init(light: .hex("#FFFFFF")))
                 )
@@ -117,7 +218,60 @@ final class WebViewComponentTests: TestCase {
         XCTAssertEqual(data.allWebViewURLs, [rootURL, nestedURL, footerURL])
     }
 
+    func testPaywallComponentsDataSkipsTemplateURLsForPrewarming() {
+        let staticURL = URL(string: "https://example.com/static.html")!
+
+        let data = PaywallComponentsData(
+            templateName: "components_test",
+            assetBaseURL: URL(string: "https://example.com/assets")!,
+            componentsConfig: .init(
+                base: .init(
+                    stack: .init(components: [
+                        .webView(.init(url: staticURL.absoluteString)),
+                        // Template URL contains {{ }} tokens — resolved at runtime, so it's skipped
+                        .webView(.init(url: "https://example.com/{{ custom.animal }}.html"))
+                    ]),
+                    stickyFooter: nil,
+                    background: .color(.init(light: .hex("#FFFFFF")))
+                )
+            ),
+            componentsLocalizations: [:],
+            revision: 1,
+            defaultLocaleIdentifier: "en_US"
+        )
+
+        XCTAssertEqual(data.allWebViewURLs, [staticURL])
+    }
+
 }
+
+// MARK: - Helpers
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension WebViewComponentTests {
+
+    static func makeViewModel(
+        urlTemplate: String,
+        customVariableDefinitions: [String: UIConfig.CustomVariableDefinition] = [:],
+        htmlFileRepository: InMemoryHTMLFileRepositoryType = MockInMemoryHTMLFileRepository()
+    ) -> WebViewComponentViewModel {
+        let uiConfig = UIConfig(
+            app: .init(colors: [:], fonts: [:]),
+            localizations: [:],
+            variableConfig: .init(variableCompatibilityMap: [:], functionCompatibilityMap: [:]),
+            customVariables: customVariableDefinitions
+        )
+        return WebViewComponentViewModel(
+            component: .init(url: urlTemplate),
+            localizationProvider: .init(locale: Locale(identifier: "en_US"), localizedStrings: [:]),
+            uiConfigProvider: UIConfigProvider(uiConfig: uiConfig),
+            htmlFileRepository: htmlFileRepository
+        )
+    }
+
+}
+
+// MARK: - MockInMemoryHTMLFileRepository
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, visionOS 1.0, watchOS 8.0, *)
 private final class MockInMemoryHTMLFileRepository: InMemoryHTMLFileRepositoryType, @unchecked Sendable {


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Template URL resolution and WKWebView script bridges affect what remote content loads in paywalls; incorrect substitution or height logic could break layout or show wrong pages, but scope is limited to the web view component.
> 
> **Overview**
> Paywalls V2 **web view** URLs can now be **string templates** with `{{ custom.* }}` tokens instead of fixed `URL` values. At render time the view reads **`customPaywallVariables`**, resolves the template via **`VariableHandlerV2`** (runtime values override dashboard defaults), then loads the resolved URL or its in-memory HTML cache entry.
> 
> **Pre-warming** only collects static web view URLs; strings containing `{{` are skipped because the final URL is unknown until display.
> 
> The UIKit web view stack was reworked for **dynamic height**: scroll-view KVO was replaced with injected JavaScript (`ResizeObserver`, `MutationObserver`, click/animation hooks) posting heights through **`rcWebViewHeight`**, plus delayed re-measurement after load. **`AutoSizingWebView`** uses **`intrinsicContentSize`** driven by reported height, and the pool resets script handlers and height when recycling views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 646d77ba8f532b2e1342769d97e7b987b8eff756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->