### PR TITLE
fix(tests): add missing iOS 14/15 snapshots for BackendGetWorkflowsListTests

### DIFF
--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS14-testGetWorkflowsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS14-testGetWorkflowsCachesForSameUserID.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/workflows"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS14-testGetWorkflowsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS14-testGetWorkflowsCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/workflows"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS14-testGetWorkflowsCallsHTTPMethodWithRandomDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS14-testGetWorkflowsCallsHTTPMethodWithRandomDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/workflows"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS14-testGetWorkflowsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS14-testGetWorkflowsNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/workflows"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS14-testGetWorkflowsReturnsWorkflows.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS14-testGetWorkflowsReturnsWorkflows.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/workflows"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS14-testGetWorkflowsWithTypePassesQueryParameter.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS14-testGetWorkflowsWithTypePassesQueryParameter.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/workflows?type=paywall"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS15-testGetWorkflowsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS15-testGetWorkflowsCachesForSameUserID.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/workflows"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS15-testGetWorkflowsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS15-testGetWorkflowsCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/workflows"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS15-testGetWorkflowsCallsHTTPMethodWithRandomDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS15-testGetWorkflowsCallsHTTPMethodWithRandomDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/workflows"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS15-testGetWorkflowsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS15-testGetWorkflowsNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/workflows"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS15-testGetWorkflowsReturnsWorkflows.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS15-testGetWorkflowsReturnsWorkflows.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/workflows"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS15-testGetWorkflowsWithTypePassesQueryParameter.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/iOS15-testGetWorkflowsWithTypePassesQueryParameter.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/workflows?type=paywall"
+  }
+}


### PR DESCRIPTION
## Summary

PR https://github.com/RevenueCat/purchases-ios/pull/6853 added snapshot tests and reference snapshots for iOS 16 and up, missing the iOS 14 / 15 ones. Causing CI to fail on these iOS versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only snapshot additions with no runtime or networking behavior changes.
> 
> **Overview**
> Adds **12 reference snapshot files** under `Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetWorkflowsTests/` so `BackendGetWorkflowsListTests` (six cases × iOS 14 and iOS 15) can pass on the iOS 14/15 CI job.
> 
> Snapshots record the expected **GET** to `https://api.revenuecat.com/v1/subscribers/user/workflows` (and `?type=paywall` for the type-filter test), with standard RevenueCat client headers including **StoreKit 1** (`X-StoreKit-Version: 1`, `X-StoreKit2-Enabled: false`). No production or test Swift code is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c054ceba60e57f5a8719206850b14801181d7607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->